### PR TITLE
fix: remove formatting typos from Definition of Ready

### DIFF
--- a/docs/workflow/DEFINITION_OF_READY.md
+++ b/docs/workflow/DEFINITION_OF_READY.md
@@ -53,7 +53,7 @@ The Definition of Ready is checked when transitioning issues from "To Do" to "De
  "When a user clicks the 'Export' button, a CSV file containing all visible table data should download with columns matching the table headers"
 
 ### Poor Acceptance Criteria
-L "Add export functionality"
+"Add export functionality"
 
 ### Good Bug Report
  
@@ -69,7 +69,7 @@ Actual: Application crashes with 500 error
 ```
 
 ### Poor Bug Report
-L "Dashboard is broken"
+"Dashboard is broken"
 
 ## Workflow Integration
 


### PR DESCRIPTION
## Summary
Fix formatting typos in the Definition of Ready documentation that were breaking readability.

## Problem Addressed
The DEFINITION_OF_READY.md file contained formatting errors with errant 'L' characters that made examples confusing and unprofessional.

## Changes Made
Fixed two formatting typos:
1. **Line 56**: Changed `L "Add export functionality"` to `"Add export functionality"`
2. **Line 72**: Changed `L "Dashboard is broken"` to `"Dashboard is broken"`

## Impact
- ✅ Improved readability of documentation
- ✅ Cleaner examples for developers
- ✅ Professional appearance restored
- ✅ Better user experience when reading Definition of Ready

## Files Modified
- `docs/workflow/DEFINITION_OF_READY.md` - Fixed formatting typos on lines 56 and 72

## Test Plan
- [x] Verify examples are now properly formatted
- [x] Confirm readability improvements
- [x] Check that no other formatting issues exist
- [x] Validate documentation structure remains intact

Closes #17