### PR TITLE
fix: update documentation deployment workflow to use pnpm

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -53,20 +53,20 @@ jobs:
           path: |
             docs/.docusaurus
             docs/node_modules
-            ~/.npm
-          key: ${{ runner.os }}-docs-build-${{ hashFiles('**/package-lock.json') }}
+            ~/.pnpm
+          key: ${{ runner.os }}-docs-build-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-docs-build-
 
       - name: Install root dependencies
-        run: npm install
+        run: pnpm install
 
       - name: Install docs dependencies
-        run: npm install
+        run: pnpm install
         working-directory: docs
 
       - name: Build documentation site
-        run: npm run docs:site:build
+        run: pnpm run docs:site:build
         env:
           NODE_OPTIONS: --max_old_space_size=8192
 
@@ -101,7 +101,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Restore cache
         uses: actions/cache@v4
@@ -109,19 +109,19 @@ jobs:
           path: |
             docs/.docusaurus
             docs/node_modules
-            ~/.npm
-          key: ${{ runner.os }}-docs-test-${{ hashFiles('**/package-lock.json') }}
+            ~/.pnpm
+          key: ${{ runner.os }}-docs-test-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-docs-test-
 
       - name: Install root dependencies
-        run: npm install
+        run: pnpm install
 
       - name: Install docs dependencies
-        run: npm install
+        run: pnpm install
         working-directory: docs
 
       - name: Test build
-        run: npm run docs:site:build
+        run: pnpm run docs:site:build
         env:
           NODE_OPTIONS: --max_old_space_size=8192


### PR DESCRIPTION
## Summary

Fixes the documentation deployment workflow failure caused by package manager mismatch.

## Problem

The GitHub Actions workflow was configured to use npm with `cache: 'npm'`, but the project uses pnpm as the package manager. The error showed "Dependencies lock file is not found" because it was looking for `package-lock.json` but the project has `pnpm-lock.yaml`.

## Changes Made

- ✅ Changed GitHub Actions setup-node cache from `npm` to `pnpm`
- ✅ Updated cache key patterns to use `pnpm-lock.yaml` instead of `package-lock.json`
- ✅ Replaced all `npm install` commands with `pnpm install`
- ✅ Replaced all `npm run` commands with `pnpm run`
- ✅ Updated cache paths from `~/.npm` to `~/.pnpm`

## Files Modified

- `.github/workflows/deploy-docs.yml` - Complete workflow update for pnpm compatibility

## Test Plan

- [x] Workflow uses correct package manager (pnpm)
- [x] Cache keys reference correct lock file (pnpm-lock.yaml)
- [x] All install and run commands use pnpm
- [x] Cache paths point to pnpm directories

This should resolve the documentation deployment failure and allow the docs site to build and deploy successfully.

Fixes the workflow failure from commit bed5975