### PR TITLE
docs: comprehensive documentation for smrtConsumer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,41 @@ That's it. Your `Product` class now automatically provides:
 - **Database persistence** with automatic schema generation
 - **Type-safe operations** across all interfaces
 
+## Using SMRT Packages
+
+If you're consuming existing SMRT packages (rather than creating your own objects), use the consumer plugin:
+
+```bash
+bun add @my-org/products  # A package containing SMRT objects
+```
+
+```typescript
+// vite.config.js
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    smrtConsumer({
+      packages: ['@my-org/products'],  // Auto-discovers SMRT packages
+      generateTypes: true,
+      typesDir: 'src/types/smrt-generated'
+    })
+  ]
+};
+
+// Use auto-generated client and types
+import { createClient } from '@smrt/client';
+import type { ProductData } from '@smrt/types';
+
+const client = createClient('/api/v1');
+const products: ProductData[] = await client.products.list();
+```
+
+This automatically provides:
+- **Type-safe API client** for all SMRT objects in consumed packages
+- **TypeScript declarations** for virtual `@smrt/*` modules
+- **Unified interface** across multiple SMRT packages
+
 ## Core Packages
 
 | Package | Purpose |

--- a/docs/docs/getting-started/consuming-packages.md
+++ b/docs/docs/getting-started/consuming-packages.md
@@ -1,0 +1,570 @@
+---
+id: consuming-packages
+title: "Consuming SMRT Packages"
+sidebar_label: "Consuming Packages"
+sidebar_position: 3
+---
+
+# Consuming SMRT Packages
+
+Learn how to integrate existing SMRT packages into your applications using the consumer plugin for automatic type generation and API access.
+
+## Overview
+
+The SMRT consumer plugin enables you to:
+- **🔌 Auto-discover** SMRT packages in your project
+- **🎯 Generate types** automatically from package manifests
+- **⚡ Access APIs** through unified virtual modules
+- **🔄 Hot reload** with full TypeScript support
+
+This approach is perfect when you want to use existing SMRT services without creating your own SMRT objects.
+
+## Quick Setup
+
+### 1. Install SMRT Consumer Tools
+
+```bash
+bun add @have/smrt
+```
+
+### 2. Install SMRT Packages
+
+```bash
+# Install the SMRT packages you want to use
+bun add @my-org/products @my-org/content @my-org/users
+```
+
+### 3. Configure Consumer Plugin
+
+```typescript
+// vite.config.js
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    smrtConsumer({
+      packages: ['@my-org/products', '@my-org/content'], // Optional: specify packages
+      generateTypes: true,
+      typesDir: 'src/types/smrt-generated'
+    })
+  ]
+};
+```
+
+### 4. Use Generated APIs
+
+```typescript
+// TypeScript automatically discovers these virtual modules:
+import { createClient } from '@smrt/client';
+import type { ProductData, ContentData } from '@smrt/types';
+
+const client = createClient('/api/v1');
+
+// Type-safe API calls across all consumed packages
+const products: ProductData[] = await client.products.list();
+const content: ContentData[] = await client.content.list();
+```
+
+## Consumer Plugin Options
+
+```typescript
+interface SmrtConsumerOptions {
+  /** SMRT packages to scan (auto-discovers if not specified) */
+  packages?: string[];
+  /** Generate TypeScript declarations (default: true) */
+  generateTypes?: boolean;
+  /** Output directory for generated types */
+  typesDir?: string;
+  /** Project root path */
+  projectRoot?: string;
+  /** SvelteKit integration mode */
+  svelteKit?: boolean;
+  /** Use static types only (for federation builds) */
+  staticTypes?: boolean;
+  /** Disable file scanning for performance */
+  disableScanning?: boolean;
+}
+```
+
+### Automatic Package Discovery
+
+The consumer plugin can automatically find SMRT packages:
+
+```typescript
+// Scans node_modules for any packages with SMRT manifests
+smrtConsumer({
+  generateTypes: true,
+  typesDir: 'src/types/smrt-generated'
+})
+```
+
+### Explicit Package Specification
+
+For better performance and control:
+
+```typescript
+// Only process specified packages
+smrtConsumer({
+  packages: ['@my-org/products', '@my-org/analytics'],
+  generateTypes: true,
+  typesDir: 'src/types/smrt-generated'
+})
+```
+
+## Generated Virtual Modules
+
+The consumer plugin creates virtual modules that provide unified access to all consumed SMRT packages:
+
+### `@smrt/client` - Unified API Client
+
+```typescript
+import { createClient } from '@smrt/client';
+
+const client = createClient('/api/v1');
+
+// API methods available for all consumed packages
+const products = await client.products.list();
+const categories = await client.categories.list();
+const users = await client.users.list();
+const analytics = await client.analytics.query({});
+```
+
+### `@smrt/types` - TypeScript Definitions
+
+```typescript
+import type {
+  ProductData,
+  CategoryData,
+  UserData
+} from '@smrt/types';
+
+// Use types in your application
+function processProduct(product: ProductData) {
+  console.log(`Processing ${product.name}`);
+}
+
+// Type-safe API responses
+const products: ProductData[] = await client.products.list();
+```
+
+### `@smrt/routes` - Server Route Handlers
+
+```typescript
+import { setupRoutes } from '@smrt/routes';
+import express from 'express';
+
+const app = express();
+
+// Auto-generated routes for all consumed packages
+app.use('/api/v1', setupRoutes());
+
+// Routes available:
+// GET/POST /api/v1/products
+// GET/POST /api/v1/categories
+// GET/POST /api/v1/users
+// etc.
+```
+
+### `@smrt/mcp` - AI Integration Tools
+
+```typescript
+import { tools } from '@smrt/mcp';
+
+// MCP tools for AI integration from all packages
+console.log(tools);
+// [
+//   { name: 'list_products', handler: ... },
+//   { name: 'search_content', handler: ... },
+//   { name: 'get_user', handler: ... }
+// ]
+```
+
+### `@smrt/manifest` - Package Metadata
+
+```typescript
+import { manifest } from '@smrt/manifest';
+
+// Combined manifest from all consumed packages
+console.log(manifest.objects);
+// {
+//   Product: { fields: {...}, methods: {...} },
+//   Category: { fields: {...}, methods: {...} },
+//   User: { fields: {...}, methods: {...} }
+// }
+```
+
+## Integration Patterns
+
+### Svelte/SvelteKit Projects
+
+```typescript
+// vite.config.js
+import { sveltekit } from '@sveltejs/kit/vite';
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    sveltekit(),
+    smrtConsumer({
+      svelteKit: true,
+      typesDir: 'src/lib/types/smrt-generated'
+    })
+  ]
+};
+```
+
+```svelte
+<!-- src/routes/products/+page.svelte -->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { createClient } from '@smrt/client';
+  import type { ProductData } from '@smrt/types';
+
+  let products: ProductData[] = [];
+  const client = createClient('/api/v1');
+
+  onMount(async () => {
+    const response = await client.products.list();
+    products = response.data || [];
+  });
+</script>
+
+<div class="products">
+  {#each products as product (product.id)}
+    <div class="product-card">
+      <h3>{product.name}</h3>
+      <p>{product.description}</p>
+      <span class="price">${product.price}</span>
+    </div>
+  {/each}
+</div>
+```
+
+### React Projects
+
+```typescript
+// vite.config.js
+import react from '@vitejs/plugin-react';
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    react(),
+    smrtConsumer({
+      generateTypes: true,
+      typesDir: 'src/types/smrt-generated'
+    })
+  ]
+};
+```
+
+```typescript
+// src/hooks/useProducts.ts
+import { useState, useEffect } from 'react';
+import { createClient } from '@smrt/client';
+import type { ProductData } from '@smrt/types';
+
+export function useProducts() {
+  const [products, setProducts] = useState<ProductData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const client = createClient('/api/v1');
+
+    client.products.list()
+      .then(response => setProducts(response.data || []))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { products, loading };
+}
+```
+
+### Micro-frontend Architecture
+
+```typescript
+// Host application consuming multiple SMRT microservices
+smrtConsumer({
+  packages: [
+    '@company/products-service',
+    '@company/users-service',
+    '@company/analytics-service',
+    '@company/orders-service'
+  ],
+  generateTypes: true,
+  typesDir: 'src/types/microservices'
+})
+
+// Unified API access across all microservices
+const client = createClient('/api/v1');
+
+// Each service's APIs are available
+const products = await client.products.list();
+const users = await client.users.list();
+const analytics = await client.analytics.dashboard();
+const orders = await client.orders.recent();
+```
+
+### Node.js/Express Applications
+
+```typescript
+// server.js
+import express from 'express';
+import { setupRoutes } from '@smrt/routes';
+import { createClient } from '@smrt/client';
+
+const app = express();
+
+// Auto-generated API routes from consumed packages
+app.use('/api/v1', setupRoutes());
+
+// Use client in server-side logic
+const client = createClient('/api/v1');
+
+app.get('/dashboard', async (req, res) => {
+  const [products, users, analytics] = await Promise.all([
+    client.products.list(),
+    client.users.list(),
+    client.analytics.summary()
+  ]);
+
+  res.json({ products, users, analytics });
+});
+
+app.listen(3000);
+```
+
+## Advanced Configuration
+
+### Federation Builds
+
+For module federation with static types:
+
+```typescript
+smrtConsumer({
+  packages: ['@company/shared-models'],
+  staticTypes: true,        // Use static manifest only
+  disableScanning: true,    // Skip dynamic scanning for performance
+  typesDir: 'src/types/static'
+})
+```
+
+### Library Development
+
+When building libraries that extend SMRT:
+
+```typescript
+smrtConsumer({
+  packages: ['@have/smrt-core-models'],
+  generateTypes: true,
+  typesDir: 'src/types/core',
+  disableScanning: true  // Faster builds
+})
+```
+
+### Monorepo Workspaces
+
+For monorepos with internal SMRT packages:
+
+```typescript
+smrtConsumer({
+  packages: [
+    '@workspace/products',
+    '@workspace/users',
+    '@workspace/shared'
+  ],
+  generateTypes: true,
+  projectRoot: process.cwd(),
+  typesDir: 'packages/app/src/types/workspace'
+})
+```
+
+## TypeScript Configuration
+
+Ensure your `tsconfig.json` includes the generated types:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@smrt/*": ["src/types/smrt-generated/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "src/types/smrt-generated/**/*"
+  ]
+}
+```
+
+## Development Workflow
+
+### Hot Module Replacement
+
+The consumer plugin supports HMR for consumed packages:
+
+```bash
+# Start development server
+npm run dev
+
+# Changes to consumed packages automatically update:
+# - Virtual module exports
+# - TypeScript declarations
+# - API client methods
+```
+
+### Type Generation
+
+```bash
+# Generate types manually (useful for CI/CD)
+npx smrt-prebuild generate-types ./node_modules/@my-org/products/manifest.json src/types/generated
+
+# Or use package.json script
+{
+  "scripts": {
+    "prebuild": "smrt-prebuild generate-types",
+    "build": "npm run prebuild && vite build"
+  }
+}
+```
+
+### Debugging
+
+Enable debug logging to troubleshoot package discovery:
+
+```typescript
+smrtConsumer({
+  packages: ['@my-org/products'],
+  generateTypes: true,
+  // Add debug option in development
+  debug: process.env.NODE_ENV === 'development'
+})
+```
+
+## Best Practices
+
+### Performance Optimization
+
+**Specify packages explicitly** for better performance:
+```typescript
+// ✅ Good - explicit packages
+smrtConsumer({
+  packages: ['@my-org/products', '@my-org/users'],
+  disableScanning: true
+})
+
+// ❌ Slower - scans all node_modules
+smrtConsumer({
+  generateTypes: true
+})
+```
+
+**Use static types for production builds**:
+```typescript
+smrtConsumer({
+  staticTypes: process.env.NODE_ENV === 'production',
+  disableScanning: process.env.NODE_ENV === 'production'
+})
+```
+
+### Type Safety
+
+**Import types explicitly**:
+```typescript
+// ✅ Good - explicit type imports
+import type { ProductData, UserData } from '@smrt/types';
+
+// ❌ Avoid - runtime imports of types
+import { ProductData } from '@smrt/types';
+```
+
+**Use TypeScript strict mode**:
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
+  }
+}
+```
+
+### Error Handling
+
+**Handle API errors gracefully**:
+```typescript
+const client = createClient('/api/v1');
+
+try {
+  const products = await client.products.list();
+  return products.data || [];
+} catch (error) {
+  console.error('Failed to load products:', error);
+  return [];
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: "Cannot find module '@smrt/client'"
+- **Solution**: Ensure consumer plugin is configured and packages are installed
+
+**Issue**: "Types not generated"
+- **Solution**: Check `typesDir` path and ensure `generateTypes: true`
+
+**Issue**: "Package not discovered"
+- **Solution**: Verify package contains SMRT manifest and is installed in `node_modules`
+
+**Issue**: "Build errors in CI/CD"
+- **Solution**: Run `prebuild` step before TypeScript compilation
+
+### Debug Steps
+
+1. **Check package installation**:
+   ```bash
+   ls node_modules/@my-org/products
+   # Should contain package.json and manifest files
+   ```
+
+2. **Verify plugin configuration**:
+   ```typescript
+   // Enable debug logging
+   smrtConsumer({
+     packages: ['@my-org/products'],
+     debug: true
+   })
+   ```
+
+3. **Inspect generated types**:
+   ```bash
+   ls src/types/smrt-generated/
+   # Should contain .d.ts files
+   ```
+
+## Next Steps
+
+<div className="row">
+  <div className="col col--6">
+    <div className="feature-card">
+      <h3>🏗️ Build Your First Agent</h3>
+      <p>Learn to create SMRT objects and agents from scratch</p>
+      <a href="/docs/getting-started/your-first-agent" className="nav-pill">Create Agents →</a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="feature-card">
+      <h3>🔗 Advanced Federation</h3>
+      <p>Master micro-frontend architecture with SMRT packages</p>
+      <a href="/docs/tutorials/module-federation-guide" className="nav-pill">Learn Federation →</a>
+    </div>
+  </div>
+</div>
+
+---
+
+<div className="callout success">
+  <strong>🎉 Package Integration Complete!</strong> You now understand how to seamlessly integrate existing SMRT packages into any application with automatic type generation and unified API access.
+</div>

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -17,14 +17,28 @@ Before installing SMRT, ensure you have:
 - **TypeScript 5.0+** for type safety
 - An **API key** from at least one AI provider (OpenAI, Anthropic, etc.)
 
-## Quick Install
+## Installation Paths
 
-SMRT is designed to be installed with a single command:
+SMRT supports two main usage patterns:
 
-### Using Bun (Recommended)
+### Creating SMRT Objects (Framework Development)
+
+If you're building new SMRT objects and agents:
 
 ```bash
+bun add @have/smrt @have/ai
+```
+
+### Consuming SMRT Packages (Package Integration)
+
+If you're using existing SMRT packages in your project:
+
+```bash
+# Install SMRT consumer tools
 bun add @have/smrt
+
+# Install SMRT packages you want to use
+bun add @my-org/products @my-org/content
 ```
 
 :::info
@@ -39,6 +53,7 @@ When you install `@have/smrt`, you automatically get:
 - **Database Integration**: SQLite for development, PostgreSQL support for production
 - **AI Client**: Unified interface for multiple AI providers
 - **Code Generators**: CLI, REST API, and MCP server generators
+- **Consumer Plugin**: Vite plugin for consuming SMRT packages
 - **Type Definitions**: Full TypeScript support out of the box
 
 ## Environment Setup
@@ -90,6 +105,39 @@ SMRT works best with these TypeScript settings. Add to your `tsconfig.json`:
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }
+```
+
+## Consumer Plugin Configuration
+
+If you're consuming SMRT packages, configure the consumer plugin in your Vite config:
+
+```typescript
+// vite.config.js
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    smrtConsumer({
+      packages: ['@my-org/products'], // SMRT packages to consume
+      generateTypes: true,
+      typesDir: 'src/types/smrt-generated'
+    })
+  ]
+};
+```
+
+This automatically provides:
+- **Type-safe API client** for consumed SMRT packages
+- **TypeScript declarations** for virtual `@smrt/*` modules
+- **Unified interface** across multiple SMRT packages
+
+```typescript
+// Use generated client and types
+import { createClient } from '@smrt/client';
+import type { ProductData } from '@smrt/types';
+
+const client = createClient('/api/v1');
+const products: ProductData[] = await client.products.list();
 ```
 
 ## Verify Installation

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -98,14 +98,49 @@ The `@smrt()` decorator automatically generates everything you need:
 - **Monitoring**: Built-in logging and observability
 - **Scalability**: Horizontal scaling with micro-frontends
 
+## Two Paths to SMRT Development
+
+### Creating SMRT Objects (Framework Development)
+
+Build new SMRT objects and agents with the full framework:
+
+```typescript
+@smrt()
+export class Product extends BaseObject {
+  name: string = '';
+  price: number = 0;
+  // Auto-generates APIs, tools, and more!
+}
+```
+
+### Consuming SMRT Packages (Package Integration)
+
+Use existing SMRT packages in your applications with the consumer plugin:
+
+```typescript
+// Auto-discovered from installed packages
+import { createClient } from '@smrt/client';
+import type { ProductData } from '@smrt/types';
+
+const client = createClient('/api/v1');
+const products: ProductData[] = await client.products.list();
+```
+
 ## Quick Links
 
 <div className="row">
   <div className="col col--4">
     <div className="feature-card">
-      <h3>🎯 Getting Started</h3>
-      <p>Install SMRT and build your first agent in under 5 minutes.</p>
+      <h3>🎯 Build New Agents</h3>
+      <p>Install SMRT and create your first agent in under 5 minutes.</p>
       <a href="/docs/getting-started/installation" className="nav-pill">Start Building →</a>
+    </div>
+  </div>
+  <div className="col col--4">
+    <div className="feature-card">
+      <h3>📦 Use SMRT Packages</h3>
+      <p>Integrate existing SMRT packages with automatic type generation.</p>
+      <a href="/docs/getting-started/consuming-packages" className="nav-pill">Consume Packages →</a>
     </div>
   </div>
   <div className="col col--4">
@@ -115,11 +150,21 @@ The `@smrt()` decorator automatically generates everything you need:
       <a href="/docs/smrt-framework/overview" className="nav-pill">Learn More →</a>
     </div>
   </div>
-  <div className="col col--4">
+</div>
+
+<div className="row">
+  <div className="col col--6">
     <div className="feature-card">
       <h3>🛠️ Tutorials</h3>
       <p>Build real-world agents with step-by-step project guides.</p>
       <a href="/docs/tutorials/build-research-agent" className="nav-pill">View Tutorials →</a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="feature-card">
+      <h3>🔗 Triple-Purpose Architecture</h3>
+      <p>Learn to build services that work as apps, libraries, and micro-frontends.</p>
+      <a href="/docs/tutorials/triple-purpose-architecture" className="nav-pill">Learn Architecture →</a>
     </div>
   </div>
 </div>

--- a/docs/docs/smrt-framework/code-generators.md
+++ b/docs/docs/smrt-framework/code-generators.md
@@ -55,15 +55,30 @@ DELETE /api/products/:id    // Delete product
 
 ## Generated Client
 
-```typescript
-import { ProductClient } from '@smrt/client';
+### For SMRT Object Creators
 
-const client = new ProductClient();
+```typescript
+import { createClient } from '@smrt/client'; // Auto-generated from local objects
+
+const client = createClient('/api/v1');
 
 // Type-safe API calls
-const products = await client.list();
-const product = await client.get('123');
-await client.create({ name: 'Widget', price: 29.99 });
+const products = await client.products.list();
+const product = await client.products.get('123');
+await client.products.create({ name: 'Widget', price: 29.99 });
+```
+
+### For SMRT Package Consumers
+
+```typescript
+import { createClient } from '@smrt/client'; // Generated from consumed packages
+import type { ProductData } from '@smrt/types';
+
+const client = createClient('/api/v1');
+
+// Type-safe API calls across all consumed SMRT packages
+const products: ProductData[] = await client.products.list();
+const categories = await client.categories.list();
 ```
 
 ## Generated MCP Integration
@@ -84,4 +99,91 @@ tools: [
 ]
 ```
 
-*Full documentation coming soon...*
+## Consumer Plugin for Package Users
+
+The `smrtConsumer` plugin enables projects to consume SMRT packages without defining their own SMRT objects.
+
+### Setup
+
+```typescript
+// vite.config.js
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    smrtConsumer({
+      packages: ['@my-org/products', '@my-org/content'], // Packages to consume
+      generateTypes: true,
+      typesDir: 'src/types/smrt-generated'
+    })
+  ]
+};
+```
+
+### Automatic Package Discovery
+
+The consumer plugin automatically scans `node_modules` for SMRT packages:
+
+```typescript
+// Automatically finds all installed SMRT packages
+smrtConsumer({
+  generateTypes: true,
+  typesDir: 'src/types/smrt-generated'
+})
+
+// Or explicitly specify packages
+smrtConsumer({
+  packages: ['@my-org/products', '@my-org/analytics'],
+  generateTypes: true
+})
+```
+
+### Generated Virtual Modules
+
+The plugin generates virtual modules for consumed packages:
+
+```typescript
+// Virtual modules available after plugin setup:
+import { createClient } from '@smrt/client';       // Unified API client
+import { setupRoutes } from '@smrt/routes';        // Combined routes
+import { tools } from '@smrt/mcp';                 // MCP tools
+import type { ProductData } from '@smrt/types';    // Type definitions
+import { manifest } from '@smrt/manifest';         // Package metadata
+```
+
+### Integration Patterns
+
+#### SvelteKit Projects
+```typescript
+import { sveltekit } from '@sveltejs/kit/vite';
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    sveltekit(),
+    smrtConsumer({
+      typesDir: 'src/lib/types/smrt-generated'
+    })
+  ]
+};
+```
+
+#### Micro-frontend Architecture
+```typescript
+// Host application consuming multiple SMRT microservices
+smrtConsumer({
+  packages: [
+    '@company/products-service',
+    '@company/users-service',
+    '@company/analytics-service'
+  ],
+  generateTypes: true
+})
+
+// Access unified APIs from all services
+const client = createClient('/api/v1');
+const products = await client.products.list();
+const users = await client.users.list();
+```
+
+*Learn more in our [Consuming SMRT Packages](/docs/getting-started/consuming-packages) guide.*

--- a/docs/docs/tutorials/triple-purpose-architecture.md
+++ b/docs/docs/tutorials/triple-purpose-architecture.md
@@ -255,6 +255,7 @@ The core of triple-purpose architecture is the Vite configuration:
 import { defineConfig, type UserConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { smrtPlugin } from '@have/smrt/vite-plugin';
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
 import federation from '@originjs/vite-plugin-federation';
 import federationConfig from './federation.config.js';
 
@@ -263,6 +264,7 @@ export default defineConfig(({ command, mode }): UserConfig => {
   const baseConfig: UserConfig = {
     plugins: [
       svelte(),
+      // SMRT plugin for generating virtual modules from local models
       smrtPlugin({
         include: ['src/lib/models/**/*.ts'],
         exclude: ['**/*.test.ts', '**/*.spec.ts'],
@@ -270,7 +272,13 @@ export default defineConfig(({ command, mode }): UserConfig => {
         generateTypes: true,
         watch: command === 'serve',
         hmr: command === 'serve',
-        mode: 'server'
+        mode: 'server',
+        typeDeclarationsPath: 'src/lib/types'
+      }),
+      // Consumer plugin for resolving virtual modules from external packages
+      smrtConsumer({
+        generateTypes: true,
+        typesDir: 'src/lib/types/smrt-generated'
       })
     ],
     resolve: {
@@ -312,9 +320,15 @@ export default defineConfig(({ command, mode }): UserConfig => {
 
     case 'federation':
       return {
-        ...baseConfig,
         plugins: [
-          ...baseConfig.plugins!,
+          svelte(),
+          // Use consumer plugin for federation builds (static types only)
+          smrtConsumer({
+            generateTypes: true,
+            typesDir: 'src/lib/types/smrt-generated',
+            staticTypes: true,      // Use static manifest only
+            disableScanning: true   // Skip dynamic scanning for performance
+          }),
           federation(federationConfig)
         ],
         build: {
@@ -322,7 +336,7 @@ export default defineConfig(({ command, mode }): UserConfig => {
           minify: false,
           cssCodeSplit: false,
           rollupOptions: {
-            external: ['svelte']
+            external: ['svelte', '@have/smrt', '@smrt/client', '@smrt/routes']
           }
         },
         server: {
@@ -350,6 +364,52 @@ export default defineConfig(({ command, mode }): UserConfig => {
       };
   }
 });
+```
+
+### Dual Plugin Architecture Benefits
+
+The products service demonstrates advanced usage of both SMRT plugins working together:
+
+#### Plugin Responsibilities
+
+**`smrtPlugin` (Object Creator)**:
+- Scans local TypeScript files for `@smrt()` decorated classes
+- Generates virtual modules from local SMRT objects
+- Provides hot module replacement for local development
+- Creates API endpoints, MCP tools, and CLI commands
+
+**`smrtConsumer` (Package Consumer)**:
+- Discovers SMRT packages in `node_modules`
+- Resolves virtual modules from external packages
+- Generates TypeScript declarations for consumed packages
+- Enables federation and library consumption patterns
+
+#### Mode-Specific Optimizations
+
+**Library Mode** - Full dual plugin functionality:
+```typescript
+plugins: [
+  smrtPlugin({ /* local object generation */ }),
+  smrtConsumer({ /* external package consumption */ })
+]
+```
+
+**Federation Mode** - Consumer plugin with optimizations:
+```typescript
+plugins: [
+  smrtConsumer({
+    staticTypes: true,      // Use static manifest only
+    disableScanning: true   // Skip dynamic scanning
+  }),
+  federation(federationConfig)
+]
+```
+
+**Standalone Mode** - SMRT plugin for self-contained apps:
+```typescript
+plugins: [
+  smrtPlugin({ /* local objects only */ })
+]
 ```
 
 ## Step 4: Module Federation Configuration

--- a/packages/products/CLAUDE.md
+++ b/packages/products/CLAUDE.md
@@ -201,6 +201,121 @@ export const exposeConfig = {
 };
 ```
 
+### Dual SMRT Plugin Configuration
+
+The products package demonstrates advanced usage of both SMRT plugins working together:
+
+#### Plugin Architecture
+
+```typescript
+// vite.config.ts - Real configuration from this package
+import { smrtPlugin } from '@have/smrt/vite-plugin';
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default defineConfig(({ command, mode }) => {
+  const baseConfig = {
+    plugins: [
+      svelte(),
+      // SMRT plugin for generating virtual modules from local models
+      smrtPlugin({
+        include: ['src/lib/models/**/*.ts'],
+        exclude: ['**/*.test.ts', '**/*.spec.ts'],
+        baseClasses: ['SmrtObject', 'SmrtCollection'],
+        generateTypes: true,
+        watch: command === 'serve',
+        hmr: command === 'serve',
+        mode: 'server', // Force server mode to enable file scanning
+        typeDeclarationsPath: 'src/lib/types',
+      }),
+      // Consumer plugin for resolving virtual modules
+      smrtConsumer({
+        generateTypes: true,
+        typesDir: 'src/lib/types/smrt-generated',
+      }),
+    ],
+  };
+
+  // Mode-specific configurations...
+});
+```
+
+#### Mode-Specific Plugin Usage
+
+**Library Mode** - Full dual plugin functionality:
+```typescript
+// Uses both plugins for complete SMRT capability
+plugins: [
+  smrtPlugin({ /* local object generation */ }),
+  smrtConsumer({ /* external package consumption */ })
+]
+```
+
+**Federation Mode** - Consumer plugin with static types:
+```typescript
+// Federation builds use consumer plugin with optimizations
+plugins: [
+  smrtConsumer({
+    generateTypes: true,
+    typesDir: 'src/lib/types/smrt-generated',
+    staticTypes: true,      // Use static manifest only
+    disableScanning: true,  // Skip dynamic scanning for performance
+  }),
+  federation(federationConfig)
+]
+```
+
+**Standalone Mode** - SMRT plugin only:
+```typescript
+// Standalone apps use only SMRT plugin for local objects
+plugins: [
+  smrtPlugin({
+    include: ['src/lib/models/**/*.ts'],
+    generateTypes: true,
+    mode: 'server'
+  })
+]
+```
+
+#### Generated Type System
+
+The dual plugin setup creates a comprehensive type system:
+
+```typescript
+// Generated type structure:
+src/lib/types/
+├── smrt-generated/           // From smrtConsumer
+│   ├── smrt-client.d.ts      // External package APIs
+│   ├── smrt-types.d.ts       // External object types
+│   └── smrt-manifest.d.ts    // External manifests
+└── index.d.ts               // From smrtPlugin (local objects)
+
+// Usage in application code:
+import { createClient } from '@smrt/client';           // Combined client
+import type { ProductData } from '@smrt/types';       // Local types
+import type { ExternalData } from '@smrt/types';      // External types
+
+// Type-safe API access
+const client = createClient('/api/v1');
+const products: ProductData[] = await client.products.list();
+```
+
+#### Benefits of Dual Plugin Architecture
+
+**Development Experience:**
+- Hot module replacement for both local and external SMRT objects
+- Unified virtual module resolution across all SMRT packages
+- Type-safe development with full IntelliSense support
+
+**Build Optimization:**
+- Mode-specific plugin configurations for optimal performance
+- Static type generation for federation builds
+- Dynamic scanning disabled when not needed
+
+**Production Flexibility:**
+- Library builds support both creation and consumption patterns
+- Federation builds optimize for runtime module sharing
+- Standalone builds focus on self-contained applications
+
 ### Multi-Mode Development
 
 ```bash

--- a/packages/smrt/CLAUDE.md
+++ b/packages/smrt/CLAUDE.md
@@ -251,8 +251,14 @@ await mcpGenerator.generate();
 
 ### Vite Plugin Integration
 
+The SMRT framework provides two Vite plugins for different use cases:
+
+#### SMRT Plugin (for SMRT Object Creators)
+
+Use `smrtPlugin` when creating SMRT objects in your project:
+
 ```typescript
-// vite.config.js
+// vite.config.js - For projects defining SMRT objects
 import { smrtPlugin } from '@have/smrt/vite-plugin';
 
 export default {
@@ -272,6 +278,67 @@ import { setupRoutes } from '@smrt/routes';        // REST routes
 import { createClient } from '@smrt/client';       // API client
 import { tools } from '@smrt/mcp';                 // MCP tools
 import { manifest } from '@smrt/manifest';         // Object manifest
+```
+
+#### Consumer Plugin (for SMRT Package Users)
+
+Use `smrtConsumer` when consuming packages that contain SMRT objects:
+
+```typescript
+// vite.config.js - For projects consuming SMRT packages
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    smrtConsumer({
+      packages: ['@my-org/products', '@my-org/content'], // SMRT packages to scan
+      generateTypes: true,
+      typesDir: 'src/types/smrt-generated',
+      projectRoot: process.cwd(),
+      disableScanning: false
+    })
+  ]
+};
+
+// Resolves virtual modules from consumed SMRT packages:
+import { createClient } from '@smrt/client';       // Generated from consumed packages
+import { setupRoutes } from '@smrt/routes';        // Combined routes from all packages
+import type { ProductData } from '@smrt/types';    // Generated TypeScript types
+```
+
+#### Dual Plugin Usage
+
+For projects that both define and consume SMRT objects:
+
+```typescript
+// vite.config.js - Using both plugins together
+import { smrtPlugin } from '@have/smrt/vite-plugin';
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    // Generate from local SMRT objects
+    smrtPlugin({
+      include: ['src/lib/models/**/*.ts'],
+      exclude: ['**/*.test.ts'],
+      baseClasses: ['SmrtObject', 'SmrtCollection'],
+      generateTypes: true,
+      watch: true,
+      hmr: true,
+    }),
+    // Consume external SMRT packages
+    smrtConsumer({
+      packages: ['@my-org/shared-models'],
+      generateTypes: true,
+      typesDir: 'src/types/smrt-generated',
+    }),
+  ]
+};
+
+// Access both local and external virtual modules:
+import { setupRoutes as localRoutes } from '@smrt/routes';    // From local objects
+import { createClient } from '@smrt/client';                   // Combined client
+import type { LocalModel, ExternalModel } from '@smrt/types'; // All types
 ```
 
 ### Advanced Querying and Relationships
@@ -339,6 +406,157 @@ const qualityCheck = await documents.bulkAnalyze(`
   - Clear argument structure
   - Adequate supporting evidence
 `);
+```
+
+## Consumer Plugin for Downstream Projects
+
+The `smrtConsumer` plugin enables projects to consume SMRT packages without defining their own SMRT objects. It automatically discovers and resolves virtual modules from installed SMRT packages.
+
+### Consumer Plugin Options
+
+```typescript
+import { smrtConsumer, type SmrtConsumerOptions } from '@have/smrt/consumer-plugin';
+
+interface SmrtConsumerOptions {
+  /** SMRT packages to scan (e.g., ['@my-org/products', '@my-org/content']) */
+  packages?: string[];
+  /** Generate TypeScript declarations (default: true) */
+  generateTypes?: boolean;
+  /** Output directory for generated types (default: 'src/types/smrt-generated') */
+  typesDir?: string;
+  /** Project root path (default: process.cwd()) */
+  projectRoot?: string;
+  /** SvelteKit integration mode (default: false) */
+  svelteKit?: boolean;
+  /** Use static types only for federation builds (default: false) */
+  staticTypes?: boolean;
+  /** Disable file scanning (default: false) */
+  disableScanning?: boolean;
+}
+```
+
+### Automatic Package Discovery
+
+The consumer plugin automatically scans `node_modules` for packages containing SMRT manifests:
+
+```typescript
+// Automatically finds and processes all installed SMRT packages
+smrtConsumer({
+  generateTypes: true,
+  typesDir: 'src/types/smrt-generated'
+})
+
+// Or explicitly specify which packages to process
+smrtConsumer({
+  packages: ['@my-org/products', '@my-org/analytics'],
+  generateTypes: true
+})
+```
+
+### Generated Type Declarations
+
+The plugin generates comprehensive TypeScript declarations for consumed SMRT packages:
+
+```typescript
+// Generated in src/types/smrt-generated/
+├── smrt-client.d.ts      // API client interfaces
+├── smrt-manifest.d.ts    // Manifest metadata
+├── smrt-mcp.d.ts        // MCP tool definitions
+├── smrt-routes.d.ts     // Route handler types
+├── smrt-types.d.ts      // Object type definitions
+└── smrt-objects.d.ts    // Individual object interfaces
+
+// Auto-imported virtual modules:
+import { createClient } from '@smrt/client';
+import { setupRoutes } from '@smrt/routes';
+import { tools } from '@smrt/mcp';
+import type { ProductData, CategoryData } from '@smrt/types';
+```
+
+### Pre-build Type Generation
+
+For projects requiring standalone TypeScript compilation (without Vite), use the pre-build system:
+
+```bash
+# Generate types before TypeScript compilation
+npx smrt-prebuild generate-types ./manifest.json src/types
+
+# Alternative using the main CLI
+npx smrt generate-types ./manifest.json src/types
+
+# Or via package.json script
+{
+  "scripts": {
+    "prebuild": "smrt-prebuild generate-types ./static-manifest.js src/types/generated",
+    "build": "npm run prebuild && tsc"
+  }
+}
+```
+
+### Federation and Library Builds
+
+For module federation or library builds that require static types:
+
+```typescript
+smrtConsumer({
+  packages: ['@my-org/shared-models'],
+  staticTypes: true,        // Use static manifest only
+  disableScanning: true,    // Skip dynamic scanning
+  typesDir: 'src/types/smrt-static'
+})
+```
+
+### Integration Patterns
+
+#### SvelteKit Projects
+```typescript
+// vite.config.js for SvelteKit
+import { sveltekit } from '@sveltejs/kit/vite';
+import { smrtConsumer } from '@have/smrt/consumer-plugin';
+
+export default {
+  plugins: [
+    sveltekit(),
+    smrtConsumer({
+      svelteKit: true,
+      typesDir: 'src/lib/types/smrt-generated'
+    })
+  ]
+};
+```
+
+#### Micro-frontend Architecture
+```typescript
+// Host application consuming multiple SMRT microservices
+smrtConsumer({
+  packages: [
+    '@company/products-service',
+    '@company/users-service',
+    '@company/analytics-service'
+  ],
+  generateTypes: true,
+  typesDir: 'src/types/microservices'
+})
+
+// Access combined APIs from all services
+import { createClient } from '@smrt/client';
+const client = createClient('/api/v1');
+
+// Type-safe access to all service APIs
+const products = await client.products.list();
+const users = await client.users.list();
+const analytics = await client.analytics.query({});
+```
+
+#### Library Development
+```typescript
+// Creating a library that extends SMRT functionality
+smrtConsumer({
+  packages: ['@have/smrt-core-models'],
+  staticTypes: true,
+  typesDir: 'src/types/core',
+  disableScanning: true  // Faster builds for libraries
+})
 ```
 
 ## Internal Architecture


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the `smrtConsumer` plugin that was introduced in v0.7.0 but was completely undocumented. The consumer plugin enables downstream projects to consume SMRT packages without needing the full SMRT plugin, solving virtual module resolution issues and providing proper TypeScript definitions.

## Changes

### Main Documentation Updates
- Updated README with consumer plugin mention in key features
- Added consumer plugin setup instructions to installation guide
- Updated code generators page with consumer plugin section
- Updated triple-purpose architecture tutorial with dual plugin configuration
- Updated main docs index to show both development paths (creating vs consuming)

### New Documentation
- Created comprehensive "Consuming SMRT Packages" guide (400+ lines) covering:
  - Installation and configuration
  - Integration patterns (Vite, SvelteKit, React, micro-frontends)
  - Virtual module resolution
  - Type generation
  - Troubleshooting common issues
- Added SMRT package API documentation to docs/api/

### Package Documentation
- Updated SMRT package CLAUDE.md with consumer plugin details
- Updated Products package CLAUDE.md with dual plugin usage patterns

## Test Plan

- [ ] Documentation builds successfully with Docusaurus
- [ ] All internal links work correctly
- [ ] Code examples are syntactically valid
- [ ] Consumer plugin documentation is discoverable from main docs

## Related Issues

This completes the documentation work started in #104 where the consumer plugin functionality was implemented.