### PR TITLE
fix(sql): eliminate environment-specific behavior that breaks testing

### DIFF
--- a/packages/sql/src/sqlite.spec.ts
+++ b/packages/sql/src/sqlite.spec.ts
@@ -78,62 +78,29 @@ describe('sqlite tests', () => {
     expect(result).toEqual({ id: data.id, title: 'hi', body: 'universe' });
   });
 
-  it('should handle file URLs in test environment', async () => {
-    // Test that file URLs work (issue #106 fix)
+  it('should handle in-memory databases with :memory: URL', async () => {
+    // Test explicit :memory: URL
     const testDb = await getDatabase({
       type: 'sqlite',
-      url: 'file::memory:', // This should work in test environment
+      url: ':memory:',
     });
 
     await testDb.execute`
-      CREATE TABLE test_file_url (
+      CREATE TABLE test_memory (
         id TEXT PRIMARY KEY,
         data TEXT
       )
     `;
 
-    await testDb.insert('test_file_url', {
+    await testDb.insert('test_memory', {
       id: 'test-1',
-      data: 'file URL test',
+      data: 'memory database test',
     });
 
-    const result = await testDb.get('test_file_url', { id: 'test-1' });
+    const result = await testDb.get('test_memory', { id: 'test-1' });
     expect(result).toEqual({
       id: 'test-1',
-      data: 'file URL test',
+      data: 'memory database test',
     });
-  });
-
-  it('should handle actual file paths', async () => {
-    // Test with a temporary file path
-    const tempFile = '/tmp/test-sqlite-' + randomUUID() + '.db';
-    const testDb = await getDatabase({
-      type: 'sqlite',
-      url: `file:${tempFile}`,
-    });
-
-    await testDb.execute`
-      CREATE TABLE test_file_path (
-        id TEXT PRIMARY KEY,
-        value INTEGER
-      )
-    `;
-
-    await testDb.insert('test_file_path', { id: 'file-test', value: 42 });
-    const result =
-      await testDb.single`SELECT * FROM test_file_path WHERE id = 'file-test'`;
-
-    expect(result).toEqual({
-      id: 'file-test',
-      value: 42,
-    });
-
-    // Clean up
-    try {
-      const fs = await import('node:fs');
-      fs.unlinkSync(tempFile);
-    } catch (e) {
-      // Ignore cleanup errors
-    }
   });
 });

--- a/packages/sql/src/sqlite.ts
+++ b/packages/sql/src/sqlite.ts
@@ -8,56 +8,34 @@ import type {
 import { buildWhere } from './shared/utils';
 
 /**
- * Creates a LibSQL client with intelligent environment detection
- * Automatically selects the appropriate client based on URL and environment
+ * Creates a LibSQL client using the default client implementation
+ * Supports in-memory databases and remote LibSQL URLs
  *
  * @param options - SQLite connection options
  * @returns Promise resolving to a LibSQL client instance
  */
 async function createLibSQLClient(options: SqliteOptions): Promise<Client> {
-  const { url = 'file::memory:', authToken, encryptionKey } = options;
+  const { url = ':memory:', authToken, encryptionKey } = options;
 
-  // Always try the default client first (supports most URLs now)
   try {
     const { createClient } = await import('@libsql/client');
     return createClient({ url, authToken, encryptionKey });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    // If default client fails with URL_SCHEME_NOT_SUPPORTED for file URLs,
-    // try Node.js client only in test environments
-    if (
-      errorMessage?.includes('URL_SCHEME_NOT_SUPPORTED') &&
-      url.startsWith('file:')
-    ) {
-      const isTestEnvironment =
-        process.env.NODE_ENV === 'test' ||
-        process.env.VITEST === 'true' ||
-        process.env.JEST_WORKER_ID !== undefined;
-
-      if (isTestEnvironment) {
-        try {
-          // Try Node.js client for test environments with file URLs
-          const { createClient } = await import('@libsql/client/node');
-          return createClient({ url, authToken, encryptionKey });
-        } catch (nodeError) {
-          // Node.js client failed, provide helpful error message
-          throw new DatabaseError(
-            `File URLs are not fully supported. For testing, use in-memory database (:memory:) or a remote LibSQL URL (libsql://). Original error: ${errorMessage}`,
-            { url, environment: 'test', originalError: errorMessage },
-          );
-        }
-      } else {
-        // Production environment with unsupported file URL
-        throw new DatabaseError(
-          `File URLs are not supported in this environment. Use a remote LibSQL URL (libsql://) instead. Original error: ${errorMessage}`,
-          { url, environment: 'production', originalError: errorMessage },
-        );
-      }
+    // Provide helpful error messages for common issues
+    if (errorMessage?.includes('URL_SCHEME_NOT_SUPPORTED')) {
+      throw new DatabaseError(
+        `Unsupported URL scheme. Use ':memory:' for in-memory databases or 'libsql://' for remote LibSQL databases. Received: ${url}`,
+        { url, originalError: errorMessage },
+      );
     }
 
-    // Re-throw other errors as-is
-    throw error;
+    // Re-throw other errors with context
+    throw new DatabaseError(`Failed to create LibSQL client: ${errorMessage}`, {
+      url,
+      originalError: errorMessage,
+    });
   }
 }
 
@@ -66,7 +44,10 @@ async function createLibSQLClient(options: SqliteOptions): Promise<Client> {
  */
 export interface SqliteOptions {
   /**
-   * Connection URL for SQLite (e.g., "file::memory:", "file:mydb.sqlite")
+   * Connection URL for SQLite database
+   * Supported schemes:
+   * - ':memory:' or 'file::memory:' for in-memory databases
+   * - 'libsql://...' for remote LibSQL/Turso databases
    */
   url?: string;
 


### PR DESCRIPTION
## Summary
Fixes the fundamental testing flaw identified in #106 where environment detection caused tests to pass while production applications failed with dynamic require errors.

## The Core Problem
The previous implementation violated basic testing principles:
- **Tests used different code paths than production** - Environment detection switched between `@libsql/client` and `@libsql/client/node` based on test vs production
- **False test coverage** - Tests passed using Node.js client while production failed with bundled default client
- **Dynamic require failures** - Bundlers couldn't handle platform-specific native modules (`@libsql/darwin-arm64`, etc.)

## The Solution
**Eliminate environment-specific behavior entirely:**

1. **Single code path** - Use only `@libsql/client` (default) in all environments
2. **Consistent behavior** - Tests now verify the same code that runs in production  
3. **No dynamic requires** - Avoid Node.js client that requires native modules
4. **Reliable URL schemes** - Focus on `:memory:` and `libsql://` URLs that actually work

## Key Changes

### Implementation (`sqlite.ts`)
- **Removed environment detection logic** (lines 28-60 in original)
- **Simplified client creation** - Always use default `@libsql/client`
- **Updated default URL** - Changed from `'file::memory:'` to `':memory:'`
- **Clear error messages** - Guidance on supported URL schemes

### Tests (`sqlite.spec.ts`)
- **Removed file URL tests** - These relied on environment-specific behavior
- **Added proper :memory: test** - Verifies actual supported functionality
- **Tests match production** - Same code paths in test and production

### Documentation
- **Updated supported URL schemes** in interface documentation
- **Clear error messages** explaining what URLs are actually supported

## Technical Details

The key insight: **Tests that behave differently than production defeat the purpose of testing.**

### Before (Problematic)
```typescript
// Environment detection that caused test/production divergence
const isTestEnvironment = process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
if (isTestEnvironment) {
  // Use @libsql/client/node (works in tests)
} else {
  // Use @libsql/client (fails with dynamic require in production bundles)
}
```

### After (Correct)
```typescript
// Single, consistent code path
const { createClient } = await import('@libsql/client');
return createClient({ url, authToken, encryptionKey });
```

## Verification

- ✅ All tests pass with simplified implementation
- ✅ Package builds without bundling issues  
- ✅ Consumer applications work without dynamic require errors
- ✅ Same behavior in test and production environments

## Impact

This fix resolves the core issue where bundled applications failed with:
```
Could not dynamically require @libsql/darwin-arm64
```

Now applications can reliably use the SQL package without worrying about environment-specific behavior causing different outcomes in different contexts.

Closes #106