### PR TITLE
fix(sql): implement smart database instance detection in getDatabase

### DIFF
--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -10,15 +10,36 @@ type GetDatabaseOptions =
   | (SqliteOptions & { type?: 'sqlite' });
 
 /**
- * Creates a database connection based on the provided options
+ * Checks if the provided value is a database instance rather than configuration options
  *
- * @param options - Configuration options for the database connection
+ * @param value - Value to check
+ * @returns True if the value appears to be a DatabaseInterface instance
+ */
+function isDatabaseInstance(value: any): value is DatabaseInterface {
+  return (
+    value &&
+    typeof value === 'object' &&
+    typeof value.client !== 'undefined' &&
+    typeof value.insert === 'function' &&
+    typeof value.get === 'function' &&
+    typeof value.query === 'function'
+  );
+}
+
+/**
+ * Creates a database connection based on the provided options, or returns an existing database instance
+ *
+ * @param options - Configuration options for the database connection or an existing database instance
  * @returns Promise resolving to a DatabaseInterface implementation
  * @throws Error if the database type is invalid
  */
 export async function getDatabase(
-  options: GetDatabaseOptions = {},
+  options: GetDatabaseOptions | DatabaseInterface = {},
 ): Promise<DatabaseInterface> {
+  // If a database instance is passed, return it directly
+  if (isDatabaseInstance(options)) {
+    return options;
+  }
   // if no type but url starts with file:, set to sqlite
   if (
     !options.type &&


### PR DESCRIPTION
## Summary
Resolves issue #112 by implementing smart detection logic in `getDatabase()` to handle both database configuration objects and existing database instances.

## Problem
SMRT objects were passing database instances to child objects, but `getDatabase()` expected configuration objects with a `type` property, causing "Invalid database type" errors when the type was undefined.

## Solution
Added smart detection that:
- ✅ **Detects database instances** using duck typing (checks for `client`, `insert`, `get`, `query` properties)
- ✅ **Returns instances directly** when detected, bypassing configuration logic  
- ✅ **Preserves existing behavior** for configuration objects
- ✅ **Zero breaking changes** - no new parameters or API modifications needed

## Changes
- Added `isDatabaseInstance()` helper function for duck typing detection
- Modified `getDatabase()` to accept `DatabaseInterface | GetDatabaseOptions`
- Enhanced function to return database instances directly when passed
- Maintained full backward compatibility

## Verification
- ✅ **Praeco tests now pass** - No more "Invalid database type" errors
- ✅ **Child object creation works** - Councils, Contents, etc. initialize properly
- ✅ **Type safety preserved** - Full TypeScript support for both patterns
- ✅ **API remains clean** - No additional configuration required

## Impact
This enables proper initialization of complex SMRT object hierarchies where parent objects create child objects with shared database connections.

Fixes #112