### PR TITLE
fix(smrt): prevent duplicate timestamp columns in schema generation

### DIFF
--- a/packages/core/smrt/src/__tests__/issue-144-integration.test.ts
+++ b/packages/core/smrt/src/__tests__/issue-144-integration.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration test for Issue #144: Verify fix with real Event and Profile collections
+ *
+ * This test reproduces the original error scenario from the issue and verifies
+ * that collections can be created without duplicate column errors.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { unlinkSync } from 'node:fs';
+import { generateSchema } from '../utils';
+
+describe('Issue #144: Integration Test with Real Collections', () => {
+  const testDbPath = '/tmp/test-issue-144.db';
+
+  afterAll(() => {
+    // Cleanup test database
+    try {
+      unlinkSync(testDbPath);
+    } catch (err) {
+      // Ignore if file doesn't exist
+    }
+  });
+
+  it('should create EventCollection without duplicate column errors', async () => {
+    const { EventCollection } = await import('@have/events');
+
+    // This should not throw "duplicate column name: created_at" error
+    const events = await EventCollection.create({
+      persistence: {
+        type: 'sql',
+        dbType: 'sqlite',
+        url: `file:${testDbPath}`,
+      },
+    });
+
+    expect(events).toBeDefined();
+  });
+
+  it('should create ProfileCollection without duplicate column errors', async () => {
+    const { ProfileCollection } = await import('@have/profiles');
+
+    // This should not throw duplicate column errors
+    const profiles = await ProfileCollection.create({
+      persistence: {
+        type: 'sql',
+        dbType: 'sqlite',
+        url: `file:${testDbPath}`,
+      },
+    });
+
+    expect(profiles).toBeDefined();
+  });
+
+  it('should generate valid schema for Event class', async () => {
+    const { Event } = await import('@have/events');
+
+    const schema = generateSchema(Event);
+
+    // Verify no duplicate columns
+    const createdMatches = schema.match(/created_at/g) || [];
+    const updatedMatches = schema.match(/updated_at/g) || [];
+
+    expect(createdMatches.length).toBe(1);
+    expect(updatedMatches.length).toBe(1);
+
+    // Verify it contains the timestamp columns
+    expect(schema).toContain('created_at DATETIME');
+    expect(schema).toContain('updated_at DATETIME');
+  });
+
+  it('should generate valid schema for Profile class', async () => {
+    const { Profile } = await import('@have/profiles');
+
+    const schema = generateSchema(Profile);
+
+    // Verify no duplicate columns
+    const createdMatches = schema.match(/created_at/g) || [];
+    const updatedMatches = schema.match(/updated_at/g) || [];
+
+    expect(createdMatches.length).toBe(1);
+    expect(updatedMatches.length).toBe(1);
+
+    // Verify it contains the timestamp columns
+    expect(schema).toContain('created_at DATETIME');
+    expect(schema).toContain('updated_at DATETIME');
+  });
+});

--- a/packages/core/smrt/src/__tests__/schema-generation.test.ts
+++ b/packages/core/smrt/src/__tests__/schema-generation.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Test for Issue #144: Schema generation duplicates created_at and updated_at columns
+ *
+ * Verifies that generateSchema() produces valid SQL without duplicate columns.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateSchema, tableNameFromClass } from '../utils';
+import { SmrtObject, smrt, text } from '../index';
+
+describe('Issue #144: Schema Generation Duplicate Columns', () => {
+  @smrt()
+  class TestEvent extends SmrtObject {
+    title = text({ required: true });
+    description = text();
+    startDate = text();
+  }
+
+  it('should not duplicate created_at column in schema', () => {
+    const schema = generateSchema(TestEvent);
+
+    // Count occurrences of 'created_at' in the schema
+    const matches = schema.match(/created_at/g) || [];
+
+    expect(matches.length).toBe(1); // Should appear exactly once
+  });
+
+  it('should not duplicate updated_at column in schema', () => {
+    const schema = generateSchema(TestEvent);
+
+    // Count occurrences of 'updated_at' in the schema
+    const matches = schema.match(/updated_at/g) || [];
+
+    expect(matches.length).toBe(1); // Should appear exactly once
+  });
+
+  it('should include timestamp columns for trigger support', () => {
+    const schema = generateSchema(TestEvent);
+
+    // Verify both timestamp columns exist
+    expect(schema).toContain('created_at DATETIME');
+    expect(schema).toContain('updated_at DATETIME');
+  });
+
+  it('should generate valid SQL without duplicate column errors', () => {
+    const schema = generateSchema(TestEvent);
+
+    // Extract the CREATE TABLE statement (before indexes)
+    const createTableStmt = schema.split('\n).')[0] + '\n);';
+
+    // Parse column names from the CREATE TABLE statement
+    const columnLines = createTableStmt
+      .split('\n')
+      .filter(line => line.trim() && !line.includes('CREATE TABLE') && !line.includes(');'))
+      .map(line => line.trim().split(' ')[0].replace(',', ''));
+
+    // Check for duplicate column names
+    const columnCounts = new Map<string, number>();
+    for (const col of columnLines) {
+      if (col && !col.includes('UNIQUE')) { // Skip UNIQUE constraint line
+        columnCounts.set(col, (columnCounts.get(col) || 0) + 1);
+      }
+    }
+
+    // Verify no duplicates
+    for (const [col, count] of columnCounts.entries()) {
+      expect(count).toBe(1); // Each column should appear exactly once
+    }
+  });
+
+  it('should match expected schema structure', () => {
+    const schema = generateSchema(TestEvent);
+    const tableName = tableNameFromClass(TestEvent);
+
+    // Expected schema should have this structure:
+    // - CREATE TABLE statement
+    // - id, slug, context (base fields)
+    // - title, description, start_date (custom fields)
+    // - created_at, updated_at (timestamp fields - EXACTLY ONCE)
+    // - UNIQUE constraint
+    // - CREATE INDEX statements
+
+    expect(schema).toContain(`CREATE TABLE IF NOT EXISTS ${tableName}`);
+    expect(schema).toContain('id TEXT PRIMARY KEY');
+    expect(schema).toContain('slug TEXT NOT NULL');
+    expect(schema).toContain('context TEXT NOT NULL');
+    expect(schema).toContain('title TEXT NOT NULL'); // required: true
+    expect(schema).toContain('description TEXT');
+    expect(schema).toContain('start_date TEXT');
+    expect(schema).toContain('created_at DATETIME');
+    expect(schema).toContain('updated_at DATETIME');
+    expect(schema).toContain('UNIQUE(slug, context)');
+  });
+
+  it('should handle classes with explicit timestamp field definitions', () => {
+    @smrt()
+    class CustomTimestamps extends SmrtObject {
+      name = text();
+      // Explicitly defining timestamp fields (should still not duplicate)
+      created_at = new Date();
+      updated_at = new Date();
+    }
+
+    const schema = generateSchema(CustomTimestamps);
+
+    // Even with explicit definitions, should only appear once
+    const createdMatches = schema.match(/created_at/g) || [];
+    const updatedMatches = schema.match(/updated_at/g) || [];
+
+    expect(createdMatches.length).toBe(1);
+    expect(updatedMatches.length).toBe(1);
+  });
+
+  it('should work correctly with inherited base class fields', () => {
+    @smrt()
+    class Article extends SmrtObject {
+      title = text({ required: true });
+      body = text();
+    }
+
+    const schema = generateSchema(Article);
+
+    // Verify all base SmrtObject fields are included
+    expect(schema).toContain('id TEXT PRIMARY KEY');
+    expect(schema).toContain('slug TEXT NOT NULL');
+    expect(schema).toContain('context TEXT NOT NULL');
+    expect(schema).toContain('created_at DATETIME');
+    expect(schema).toContain('updated_at DATETIME');
+
+    // Verify custom fields
+    expect(schema).toContain('title TEXT NOT NULL');
+    expect(schema).toContain('body TEXT');
+
+    // Verify no duplicates
+    const createdMatches = schema.match(/created_at/g) || [];
+    const updatedMatches = schema.match(/updated_at/g) || [];
+    expect(createdMatches.length).toBe(1);
+    expect(updatedMatches.length).toBe(1);
+  });
+});

--- a/packages/core/smrt/src/manifest/static-manifest.json
+++ b/packages/core/smrt/src/manifest/static-manifest.json
@@ -1,5 +1,5 @@
 {
   "version": "1.0.0",
-  "timestamp": 1759448574762,
+  "timestamp": 1759945536495,
   "objects": {}
 }

--- a/packages/core/smrt/src/manifest/static-manifest.ts
+++ b/packages/core/smrt/src/manifest/static-manifest.ts
@@ -7,9 +7,9 @@
 import type { SmartObjectManifest } from '../scanner/types';
 
 export const staticManifest: SmartObjectManifest = {
-  version: '1.0.0',
-  timestamp: 1759448574762,
-  objects: {},
+  "version": "1.0.0",
+  "timestamp": 1759945536495,
+  "objects": {}
 } as const;
 
 export default staticManifest;

--- a/packages/core/smrt/src/utils.ts
+++ b/packages/core/smrt/src/utils.ts
@@ -293,11 +293,25 @@ export function generateSchema(ClassType: new (...args: any[]) => any) {
     schema += "  context TEXT NOT NULL DEFAULT '',\n";
   }
 
+  // Track which timestamp fields we've added to avoid duplicates
+  let hasCreatedAt = false;
+  let hasUpdatedAt = false;
+
   // Add all fields - convert camelCase property names to snake_case column names
   for (const [key, field] of Object.entries(fields)) {
     // Skip id, slug, context only if we're using default PK behavior
     if (!hasCustomPK && (key === 'id' || key === 'slug' || key === 'context')) {
       continue;
+    }
+
+    // Track timestamp fields and skip duplicates
+    if (key === 'created_at' || key === 'createdAt') {
+      if (hasCreatedAt) continue; // Skip duplicate
+      hasCreatedAt = true;
+    }
+    if (key === 'updated_at' || key === 'updatedAt') {
+      if (hasUpdatedAt) continue; // Skip duplicate
+      hasUpdatedAt = true;
     }
 
     const columnName = toSnakeCase(key);
@@ -306,6 +320,14 @@ export function generateSchema(ClassType: new (...args: any[]) => any) {
     const constraints = fieldDef?.getSqlConstraints() || [];
 
     schema += `  ${columnName} ${sqlType}${constraints.length > 0 ? ' ' + constraints.join(' ') : ''},\n`;
+  }
+
+  // Ensure timestamp columns exist for triggers (if not already added)
+  if (!hasCreatedAt) {
+    schema += '  created_at DATETIME,\n';
+  }
+  if (!hasUpdatedAt) {
+    schema += '  updated_at DATETIME,\n';
   }
 
   // Add composite unique constraint for slug and context only if using default PK


### PR DESCRIPTION
## Summary
Fixes #144 - Schema generation was creating duplicate `created_at` and `updated_at` columns.

## Problem
The `generateSchema()` function walks up the prototype chain via `fieldsFromClass()` and collects properties from the `SmrtObject` base class, including `created_at` and `updated_at`. This caused duplicate column definitions in the generated SQL schema, resulting in errors like:

```
Error: duplicate column name: created_at
```

## Solution
Modified `generateSchema()` in `packages/core/smrt/src/utils.ts` to:

1. **Track timestamp fields**: Maintains flags (`hasCreatedAt`, `hasUpdatedAt`) to detect when these columns have been added
2. **Skip duplicates**: When encountering `created_at`/`createdAt` or `updated_at`/updatedAt` fields after the first occurrence, skip them
3. **Ensure presence**: Add fallback timestamp columns if none were found in the field walk, ensuring database triggers can function properly

## Changes

### Modified Files
- `packages/core/smrt/src/utils.ts` - Updated `generateSchema()` function with duplicate detection logic

### New Test Files
- `packages/core/smrt/src/__tests__/schema-generation.test.ts` - 7 unit tests verifying schema generation
- `packages/core/smrt/src/__tests__/issue-144-integration.test.ts` - 4 integration tests with real Event and Profile collections

## Test Results
✅ All 11 tests passing:
- Schema contains exactly one `created_at DATETIME` column
- Schema contains exactly one `updated_at DATETIME` column
- No duplicate column names in generated SQL
- Works correctly with classes that explicitly define timestamp fields
- Works correctly with inherited base class fields

## Impact
This fix ensures that all SMRT modules (@have/events, @have/profiles, @have/content, etc.) can successfully create their database schemas without duplicate column errors.

## Related
- Resolves #144