### PR TITLE
fix(smrt): replace TypeScript import with JSDoc in @smrt/cli virtual module

### DIFF
--- a/packages/core/smrt/src/vite-plugin/index.ts
+++ b/packages/core/smrt/src/vite-plugin/index.ts
@@ -1171,7 +1171,11 @@ async function generateCLIModule(
 // This file is generated automatically - do not edit
 
 import { CLIGenerator } from '@have/smrt/generators/cli';
-import type { CLIConfig, CLIContext } from '@have/smrt/generators/cli';
+
+/**
+ * @typedef {import('@have/smrt/generators/cli').CLIConfig} CLIConfig
+ * @typedef {import('@have/smrt/generators/cli').CLIContext} CLIContext
+ */
 
 ${objectImports.join('\n')}
 


### PR DESCRIPTION
## Summary

Fixes #149 by replacing TypeScript `import type` syntax with JSDoc `@typedef` in the generated `@smrt/cli` virtual module.

## Problem

The `generateCLIModule()` function in the SMRT vite plugin was generating TypeScript syntax (`import type`) in the virtual module code. This caused Rollup build errors in consuming projects:

```
error during build:
 smrt:cli (6:12): Expected ',', got '{' (Note that you need plugins to import files that are not JavaScript)
```

## Solution

Changed from TypeScript syntax to JSDoc syntax, which provides type hints while keeping the code as pure JavaScript:

**Before:**
```typescript
import type { CLIConfig, CLIContext } from '@have/smrt/generators/cli';
```

**After:**
```typescript
/**
 * @typedef {import('@have/smrt/generators/cli').CLIConfig} CLIConfig
 * @typedef {import('@have/smrt/generators/cli').CLIContext} CLIContext
 */
```

## Testing

- ✅ Build completed successfully without errors
- ✅ Generated module is pure JavaScript compatible with Rollup
- ✅ Type hints preserved via JSDoc comments

## Changes

- Modified `/Users/will/Work/happyvertical/repos/sdk/packages/core/smrt/src/vite-plugin/index.ts:1174`
- Replaced TypeScript import syntax with JSDoc typedef syntax
- No functional changes, only syntax adjustment for compatibility

Closes #149