### PR TITLE
fix(assets): replace deprecated objectClass with _itemClass

### DIFF
--- a/packages/modules/assets/src/asset-metafields.ts
+++ b/packages/modules/assets/src/asset-metafields.ts
@@ -8,7 +8,7 @@ import { SmrtCollection } from '@have/smrt';
 import { AssetMetafield } from './asset-metafield';
 
 export class AssetMetafieldCollection extends SmrtCollection<AssetMetafield> {
-  static readonly objectClass = AssetMetafield;
+  static readonly _itemClass = AssetMetafield;
 
   /**
    * Get or create an asset metafield by slug

--- a/packages/modules/assets/src/asset-statuses.ts
+++ b/packages/modules/assets/src/asset-statuses.ts
@@ -8,7 +8,7 @@ import { SmrtCollection } from '@have/smrt';
 import { AssetStatus } from './asset-status';
 
 export class AssetStatusCollection extends SmrtCollection<AssetStatus> {
-  static readonly objectClass = AssetStatus;
+  static readonly _itemClass = AssetStatus;
 
   /**
    * Get or create an asset status by slug

--- a/packages/modules/assets/src/asset-types.ts
+++ b/packages/modules/assets/src/asset-types.ts
@@ -8,7 +8,7 @@ import { SmrtCollection } from '@have/smrt';
 import { AssetType } from './asset-type';
 
 export class AssetTypeCollection extends SmrtCollection<AssetType> {
-  static readonly objectClass = AssetType;
+  static readonly _itemClass = AssetType;
 
   /**
    * Get or create an asset type by slug

--- a/packages/modules/assets/src/assets.ts
+++ b/packages/modules/assets/src/assets.ts
@@ -8,7 +8,7 @@ import { SmrtCollection } from '@have/smrt';
 import { Asset } from './asset';
 
 export class AssetCollection extends SmrtCollection<Asset> {
-  static readonly objectClass = Asset;
+  static readonly _itemClass = Asset;
 
   /**
    * Add a tag to an asset (uses @have/tags)


### PR DESCRIPTION
## Summary

Fixes #146 by updating all collection classes in `@have/assets` to use the required `_itemClass` property instead of the deprecated `objectClass` property.

## Changes

Updated four collection classes:
- `AssetCollection` in `src/assets.ts`
- `AssetStatusCollection` in `src/asset-statuses.ts`
- `AssetTypeCollection` in `src/asset-types.ts`
- `AssetMetafieldCollection` in `src/asset-metafields.ts`

Each collection now properly defines:
```typescript
static readonly _itemClass = [ItemClass];
```

## Impact

- Fixes runtime error: "Collection must define a static _itemClass property"
- Unblocks usage of `@have/assets` package
- Enables AssetCollection instantiation for Praeco integration tests
- Brings @have/assets in line with other module packages

## Testing

- ✅ Build successful
- ✅ Lint passed (0 issues)
- ✅ All tests passed (648 passed, only 4 expected LibreTranslate integration failures)

## Context

The `objectClass` property was deprecated in SDK v0.8.0+ when the architecture standardized on `_itemClass` for collection item references. Other module packages (@have/events, @have/profiles, @have/places, @have/accounts, @have/tags) were already updated, but @have/assets was missed in the migration.

This bug was blocking Phase 1 of Praeco's Bentley integration test development which requires AssetCollection for storing PDF documents.

Closes #146