### PR TITLE
fix: CLI auto-generation improvements

### DIFF
--- a/packages/core/smrt/src/generators/cli.ts
+++ b/packages/core/smrt/src/generators/cli.ts
@@ -103,16 +103,8 @@ export class CLIGenerator {
     const commands = this.generateCommands();
 
     return async (argv: string[]) => {
-      const [gnodeCommands, generateCommands] = await Promise.all([
-        getGnodeCommands(),
-        getGenerateCommands(),
-      ]);
-      const builtInCommands = {
-        ...gnodeCommands,
-        ...generateCommands,
-      };
-
-      const parsed = parseCliArgs(argv, commands, builtInCommands);
+      // Parse args first without built-in commands to avoid loading them unnecessarily
+      const parsed = parseCliArgs(argv, commands, {});
       await this.executeCommand(parsed, commands);
     };
   }
@@ -308,7 +300,41 @@ export class CLIGenerator {
       return;
     }
 
-    // Check for built-in subcommands first (gnode, generate-*)
+    // First check auto-generated object commands (no dependencies to load)
+    const command = commands.find(
+      (cmd) =>
+        cmd.name === parsed.command ||
+        (parsed.command && cmd.aliases && cmd.aliases.includes(parsed.command)),
+    );
+
+    if (command) {
+      // Validate required arguments
+      if (command.args && parsed.args.length < command.args.length) {
+        this.exitWithError(
+          `Missing required arguments: ${command.args.slice(parsed.args.length).join(', ')}`,
+        );
+        return;
+      }
+
+      // Check if handler exists before invoking
+      if (!command.handler) {
+        this.exitWithError(`Command '${parsed.command}' has no handler defined`);
+        return;
+      }
+
+      try {
+        await command.handler(parsed.args, parsed.options);
+        return;
+      } catch (error) {
+        this.exitWithError(
+          `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+        return;
+      }
+    }
+
+    // Only load built-in commands if not found in object commands
+    // This avoids loading tar dependencies unless actually needed
     const [gnodeCommands, generateCommands] = await Promise.all([
       getGnodeCommands(),
       getGenerateCommands(),
@@ -350,39 +376,8 @@ export class CLIGenerator {
       }
     }
 
-    // Fall back to auto-generated object commands
-    const command = commands.find(
-      (cmd) =>
-        cmd.name === parsed.command ||
-        (parsed.command && cmd.aliases && cmd.aliases.includes(parsed.command)),
-    );
-
-    if (!command) {
-      this.exitWithError(`Unknown command '${parsed.command}'`);
-      return;
-    }
-
-    // Validate required arguments
-    if (command.args && parsed.args.length < command.args.length) {
-      this.exitWithError(
-        `Missing required arguments: ${command.args.slice(parsed.args.length).join(', ')}`,
-      );
-      return;
-    }
-
-    // Check if handler exists before invoking
-    if (!command.handler) {
-      this.exitWithError(`Command '${parsed.command}' has no handler defined`);
-      return;
-    }
-
-    try {
-      await command.handler(parsed.args, parsed.options);
-    } catch (error) {
-      this.exitWithError(
-        `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
+    // Command not found in either object or built-in commands
+    this.exitWithError(`Unknown command '${parsed.command}'`);
   }
 
   /**

--- a/packages/core/smrt/src/manifest/static-manifest.json
+++ b/packages/core/smrt/src/manifest/static-manifest.json
@@ -1,5 +1,5 @@
 {
   "version": "1.0.0",
-  "timestamp": 1759945536495,
+  "timestamp": 1760009093889,
   "objects": {}
 }

--- a/packages/core/smrt/src/manifest/static-manifest.ts
+++ b/packages/core/smrt/src/manifest/static-manifest.ts
@@ -8,7 +8,7 @@ import type { SmartObjectManifest } from '../scanner/types';
 
 export const staticManifest: SmartObjectManifest = {
   "version": "1.0.0",
-  "timestamp": 1759945536495,
+  "timestamp": 1760009093889,
   "objects": {}
 } as const;
 

--- a/packages/core/smrt/src/vite-plugin/index.ts
+++ b/packages/core/smrt/src/vite-plugin/index.ts
@@ -1188,6 +1188,10 @@ export const cliCommands = {${commands.join(',\n')}
 /**
  * Setup CLI with auto-generated commands
  *
+ * @param {CLIConfig} [config={}] - CLI configuration
+ * @param {CLIContext} [context={}] - CLI context
+ * @returns {{run: function(string[]): Promise<void>, generator: *}}
+ *
  * @example
  * import { setupCLI } from '@smrt/cli';
  *
@@ -1198,10 +1202,10 @@ export const cliCommands = {${commands.join(',\n')}
  *
  * cli.run(process.argv);
  */
-export function setupCLI(config: CLIConfig = {}, context: CLIContext = {}) {
+export function setupCLI(config = {}, context = {}) {
   const generator = new CLIGenerator(config, context);
   return {
-    run: async (argv: string[]) => {
+    run: async (argv) => {
       const handler = generator.generateHandler();
       await handler(argv.slice(2)); // Remove 'node' and script name
     },
@@ -1211,8 +1215,12 @@ export function setupCLI(config: CLIConfig = {}, context: CLIContext = {}) {
 
 /**
  * Get CLI handler directly
+ *
+ * @param {CLIConfig} [config={}] - CLI configuration
+ * @param {CLIContext} [context={}] - CLI context
+ * @returns {function(string[]): Promise<void>}
  */
-export function getCLIHandler(config: CLIConfig = {}, context: CLIContext = {}) {
+export function getCLIHandler(config = {}, context = {}) {
   const generator = new CLIGenerator(config, context);
   return generator.generateHandler();
 }


### PR DESCRIPTION
## Summary
Fixes CLI auto-generation issues that prevented using `@smrt/cli` virtual module and `CLIGenerator` directly.

## Issues Fixed
- Closes #149 - TypeScript syntax in `@smrt/cli` virtual module
- Closes #151 - Eager loading of template commands with tar dependencies

## Changes

### 1. Remove TypeScript from Virtual Module (#149)
**Problem**: The `@smrt/cli` virtual module generated TypeScript syntax causing Rollup parse errors:
```
Error [RollupError]: Parse failure: Expected ',', got ':'
export function setupCLI(config: CLIConfig = {}, context: CLIContext = {})
```

**Solution**: 
- Converted TypeScript parameter types to pure JavaScript with JSDoc annotations
- Changed `config: CLIConfig = {}` to `config = {}`
- Added proper `@param` and `@returns` JSDoc comments for type information

### 2. Implement Proper Lazy Loading (#151)
**Problem**: `CLIGenerator.generateHandler()` eagerly loaded gnode/generate commands on every invocation, causing tar dependency errors even for simple commands like `--help`:
```
SyntaxError: The requested module 'tar/dist/esm/extract.js' does not provide an export named 'extract'
```

**Solution**:
- Refactored `executeCommand()` to check auto-generated object commands first
- Only loads built-in commands (gnode/generate) when command is not found in object commands
- Avoids loading tar dependencies unless actually using gnode/generate commands

## Testing

Tested in Praeco project:

**Development Mode (vite-node)**:
```bash
env NODE_ENV=development ./bin.sh --help
# ✅ Shows all commands without errors

env NODE_ENV=development ./bin.sh objects
# ✅ Lists all 9 registered SMRT objects
```

**Commands work without tar dependencies**:
- `--help` - Shows usage information
- `objects` - Lists registered objects  
- `schema <object>` - Shows object schema
- `status` - System status
- Object CRUD commands (when `cli: true` is set)

**Template commands only load when needed**:
- `gnode create <name>` - Lazy loads tar dependencies
- `generate-types` - Lazy loads generation tools

## Migration Notes

Projects using CLI auto-generation should:

1. **Update to use `@smrt/cli` virtual module**:
```typescript
import { setupCLI } from '@smrt/cli';

const cli = setupCLI({
  name: 'my-app',
  version: '1.0.0'
});

cli.run(process.argv);
```

2. **Import objects to populate ObjectRegistry**:
```typescript
import './index.js'; // Import all SMRT objects
import { setupCLI } from '@smrt/cli';
```

3. **Enable CLI for specific objects**:
```typescript
@smrt({ 
  cli: true,  // Enables auto-generated CRUD commands
  // Or customize:
  cli: {
    exclude: ['delete'],  // Exclude specific commands
    include: ['list', 'get']  // Only include specific commands
  }
})
class MyObject extends SmrtObject {
  // ...
}
```

## Breaking Changes
None - this is a pure bug fix

## Related
- Initial implementation: #147