### PR TITLE
fix(content): correct build entry point to export all classes

### DIFF
--- a/packages/modules/content/src/index.ts
+++ b/packages/modules/content/src/index.ts
@@ -5,6 +5,3 @@ export { Content } from './content';
 export type { ContentsOptions } from './contents';
 export { Contents } from './contents';
 export { contentToString, stringToContent } from './utils';
-
-// Re-export from @have/documents for convenience
-export { fetchDocument, type FetchDocumentOptions } from '@have/documents';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -265,7 +265,7 @@ const packages = [
   },
   {
     name: 'content',
-    entry: 'packages/modules/content/src/content.ts',
+    entry: 'packages/modules/content/src/index.ts',
     directory: 'modules' as const,
   },
   {


### PR DESCRIPTION
## Problem

Issue #162 reported that @have/content package was only exporting the `Content` class in the built dist/index.js file, despite the source code (src/index.ts) exporting multiple classes and utilities:

**Expected exports:**
- `Content` ✅
- `Contents` ❌ (missing)
- `contentToString` ❌ (missing)
- `stringToContent` ❌ (missing)
- `fetchDocument` ❌ (was re-exported)

This caused runtime errors in downstream packages like praeco when trying to import `Contents` or the utility functions.

## Root Cause

The root `vite.config.ts` had the wrong entry point for the content package:

```typescript
// ❌ WRONG - only exports Content class
entry: 'packages/modules/content/src/content.ts'

// ✅ CORRECT - exports everything from index.ts
entry: 'packages/modules/content/src/index.ts'
```

## Changes

### 1. Fixed vite.config.ts Entry Point
Changed the content package entry from `content.ts` to `index.ts` to include all exports.

### 2. Removed fetchDocument Re-export
Removed the re-export of `fetchDocument` from @have/content since it belongs in @have/documents (created in PR #163). Users should import it directly:

```typescript
// ✅ Correct import
import { fetchDocument } from '@have/documents';

// ❌ No longer supported
import { fetchDocument } from '@have/content';
```

## Result

The dist/index.js now correctly exports:
- `Content` - Main content data model
- `Contents` - Collection manager  
- `contentToString` - Serialize to markdown + frontmatter
- `stringToContent` - Parse markdown + frontmatter

## Testing

Verified that all four exports are present in dist/index.js after rebuild:

```javascript
export {
  Content,
  Contents,
  contentToString,
  stringToContent
};
```

Closes #162