### PR TITLE
fix(spider): correct cheerio ESM import with interop setting

### DIFF
--- a/packages/core/spider/vite.config.ts
+++ b/packages/core/spider/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
         entryFileNames: '[name].js',
         // Preserve the exact module structure for clean subpath exports
         preserveModulesRoot: 'src',
+        // Force ESM-style imports for external dependencies
+        interop: 'esModule',
       },
       external: [
         // Node.js built-ins


### PR DESCRIPTION
## Problem

Issue #166 reported that @have/spider was failing at runtime with an ESM import error for cheerio:

```
SyntaxError: The requested module 'cheerio' does not provide an export named 'default'
    at file:///Users/will/Work/happyvertical/repos/sdk/packages/core/spider/dist/index165.js:3
```

## Root Cause

The spider package's Vite build was generating incorrect imports for cheerio:

```javascript
// ❌ INCORRECT - Generated by Vite/Rollup
import require$$5__default from "cheerio";
```

This was trying to import cheerio as a default export, but cheerio only provides named exports in ESM (`export * from './load-parse.js'`).

## Fix

Added `interop: 'esModule'` to the Rollup output configuration in `packages/core/spider/vite.config.ts`:

```typescript
rollupOptions: {
  output: {
    format: 'es',
    preserveModules: true,
    entryFileNames: '[name].js',
    preserveModulesRoot: 'src',
    // Force ESM-style imports for external dependencies
    interop: 'esModule',  // ← Added this
  },
  // ...
}
```

This ensures Vite/Rollup generates proper ESM namespace imports:

```javascript
// ✅ CORRECT - After fix
import * as require$$5 from "cheerio";

// Usage:
const $ = require$$5.load(html);
```

## Testing

All 22 spider tests pass:
- ✅ SimpleAdapter tests (3 tests)
- ✅ DOMAdapter tests (skipped, not applicable)
- ✅ CrawleeAdapter tests (4 tests)
- ✅ Crawlee integration tests (3 tests, 1 skipped)

## Impact

- Fixes getSpider() for all adapters (simple, dom, crawlee)
- Unblocks praeco's discover command
- Resolves runtime errors when using @have/spider

Closes #166