### PR TITLE
fix(spider): decode HTML entities in WordPress Download Manager URLs

### DIFF
--- a/packages/core/spider/src/scrapeDocument.test.ts
+++ b/packages/core/spider/src/scrapeDocument.test.ts
@@ -142,6 +142,33 @@ describe('scrapeDocument', () => {
       expect(result.text).toBe(''); // No binary content downloaded
     });
 
+    it('should decode HTML entities in extracted WordPress URLs', async () => {
+      const mockScraper = {
+        scrape: vi.fn().mockResolvedValueOnce({
+          url: 'https://example.com/download/meeting/',
+          content: `
+            <html>
+              <body>
+                <a href="https://example.com/download/meeting/?wpdmdl=17656&amp;refresh=68ebf5c3cf&amp;test=value">Download</a>
+              </body>
+            </html>
+          `,
+          links: [],
+          strategy: { type: 'basic', spider: 'dom', config: {}, confidence: 1 },
+          metrics: { duration: 100, linkCount: 0, complete: true },
+        }),
+      };
+
+      vi.mocked(scraperFactory.getScraper).mockResolvedValue(mockScraper as any);
+
+      const result = await scrapeDocument('https://example.com/download/meeting/');
+
+      // Should decode &amp; to &
+      expect(result.url).toBe('https://example.com/download/meeting/?wpdmdl=17656&refresh=68ebf5c3cf&test=value');
+      expect(result.metadata.isPdf).toBe(true);
+      expect(result.metadata.strategy).toBe('wordpress-pdf-link');
+    });
+
     it('should not trigger re-scrape for non-WordPress pages', async () => {
       const mockScraper = {
         scrape: vi.fn().mockResolvedValue({

--- a/packages/core/spider/src/scrapeDocument.ts
+++ b/packages/core/spider/src/scrapeDocument.ts
@@ -66,7 +66,14 @@ function extractWordPressDownloadUrl(url: string, html: string): string | null {
   );
 
   if (wpdmLinkMatch) {
-    const downloadUrl = wpdmLinkMatch[1];
+    let downloadUrl = wpdmLinkMatch[1];
+    // Decode HTML entities (&amp; → &, &quot; → ", etc.)
+    downloadUrl = downloadUrl
+      .replace(/&amp;/g, '&')
+      .replace(/&quot;/g, '"')
+      .replace(/&#039;/g, "'")
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>');
     // Make absolute if relative
     if (downloadUrl.startsWith('/')) {
       const urlObj = new URL(url);
@@ -81,7 +88,14 @@ function extractWordPressDownloadUrl(url: string, html: string): string | null {
   );
 
   if (pdfLinkMatch) {
-    const pdfUrl = pdfLinkMatch[1];
+    let pdfUrl = pdfLinkMatch[1];
+    // Decode HTML entities (&amp; → &, &quot; → ", etc.)
+    pdfUrl = pdfUrl
+      .replace(/&amp;/g, '&')
+      .replace(/&quot;/g, '"')
+      .replace(/&#039;/g, "'")
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>');
     // Make absolute if relative
     if (pdfUrl.startsWith('/')) {
       const urlObj = new URL(url);


### PR DESCRIPTION
## Summary
Fixes #184 - WordPress Download Manager URLs were correctly detected but contained HTML entities that could cause issues when fetching files.

## Problem
The `extractWordPressDownloadUrl` function was successfully detecting WordPress Download Manager pages and extracting download URLs with `wpdmdl` parameters. However, the extracted URLs contained HTML entities (`&amp;`, `&quot;`, etc.) instead of their actual characters, which could cause issues when the URLs are used to fetch files.

## Solution
Added HTML entity decoding to the URL extraction process in two places:
1. **wpdmdl parameter URLs**: Decodes entities in URLs with the `wpdmdl` query parameter
2. **Direct PDF links**: Decodes entities in direct PDF download links

The decoding handles these common HTML entities:
- `&amp;` → `&`
- `&quot;` → `"`
- `&#039;` → `'`
- `&lt;` → `<`
- `&gt;` → `>`

## Changes
- Modified `extractWordPressDownloadUrl` function in `scrapeDocument.ts` to decode HTML entities
- Added test case `should decode HTML entities in extracted WordPress URLs` to verify the fix

## Testing
- ✅ All 46 existing unit tests pass (including 8 in scrapeDocument.test.ts)
- ✅ New test case specifically validates HTML entity decoding
- ✅ Integration test with all 10 failing URLs from issue #184 now succeed

## Example
**Before fix:**
```
https://townofbentley.ca/download/regular-council-meeting-october-14-2025-agenda/?wpdmdl=17656&amp;refresh=68ec17a92dde11760303017
```

**After fix:**
```
https://townofbentley.ca/download/regular-council-meeting-october-14-2025-agenda/?wpdmdl=17656&refresh=68ec17a92dde11760303017
```

## Related Files
- `packages/core/spider/src/scrapeDocument.ts` - Added HTML entity decoding
- `packages/core/spider/src/scrapeDocument.test.ts` - Added test coverage

Closes #184