### PR TITLE
fix(spider): add crawlee to external dependencies in vite config

### DIFF
--- a/packages/core/spider/vite.config.ts
+++ b/packages/core/spider/vite.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
         // External dependencies for spider package
         '@mozilla/readability',
         'cheerio',
+        'crawlee',
         'happy-dom',
         'undici',
 


### PR DESCRIPTION
## Summary
Fixes #187 - TreeScraper Configuration import error due to Vite bundling crawlee instead of treating it as an external dependency.

## Problem
The TreeScraper was failing with this error:
```
SyntaxError: The requested module 'crawlee' does not provide an export named 'Configuration'
```

The root cause was that `crawlee` was not listed in the `external` array of the Vite config, causing Vite to bundle it. This created malformed import paths in the dist output that referenced internal pnpm module paths instead of the package name.

## Solution
Added `'crawlee'` to the `external` array in `vite.config.ts`, ensuring it's treated as an external dependency like other npm packages.

## Changes
- Added `'crawlee'` to external dependencies array in `packages/core/spider/vite.config.ts`
- Rebuilt spider package with correct imports

## Testing
- ✅ Direct import test: `node -e "import('./dist/scrapers/tree.js')"`
- ✅ All 15 TreeScraper tests pass
- ✅ Verified built output has correct import: `import { Configuration, PlaywrightCrawler } from "crawlee";`

## Impact
This unblocks:
- TreeScraper usage in production
- Accordion-style navigation scraping
- Hierarchical page structure extraction
- The praeco sync command with `--fetch-documents`

Closes #187