### PR TITLE
fix(documents): generate valid cache paths for URLs with query parameters

### DIFF
--- a/packages/core/documents/src/document.ts
+++ b/packages/core/documents/src/document.ts
@@ -98,10 +98,29 @@ export class Document {
       this._localPath = decodeURIComponent(this.url.pathname);
       this.isRemote = false;
     } else if (this.url.protocol.startsWith('http')) {
+      // Generate cache path from URL pathname
+      // Query parameters (?) and fragments (#) are automatically excluded from url.pathname
+      let pathname = this.url.pathname;
+
+      // Remove trailing slash (directory-style URLs)
+      if (pathname.endsWith('/')) {
+        pathname = pathname.slice(0, -1);
+      }
+
+      // Add file extension if missing and we know the type
+      // This is crucial for URLs like /download/file/?wpdmdl=123 which have no extension
+      if (!pathname.match(/\.[a-z0-9]+$/i)) {
+        // Add appropriate extension based on MIME type
+        if (this.type === 'application/pdf' || options.type === 'application/pdf') {
+          pathname += '.pdf';
+        }
+        // Future: Add other common extensions (html, json, etc.)
+      }
+
       this._localPath = path.join(
         this._cacheDir,
         makeSlug(this.url.hostname),
-        this.url.pathname,
+        pathname,
       );
       this.isRemote = true;
     }

--- a/packages/core/documents/src/index.test.ts
+++ b/packages/core/documents/src/index.test.ts
@@ -144,5 +144,59 @@ describe('@have/documents', () => {
         /No processor available/,
       );
     });
+
+    it('should handle URLs with query parameters correctly', async () => {
+      // Create a Document instance directly to test cache path generation
+      const { Document: BaseDocument } = await import('./document');
+
+      // Test WordPress Download Manager style URL
+      const url =
+        'https://townofbentley.ca/download/regular-council-meeting-october-14-2025-agenda/?wpdmdl=17656&refresh=68ec319891f4d1760309656';
+
+      const doc = new BaseDocument(url, { type: 'application/pdf' });
+
+      // Cache path should NOT end with /
+      expect(doc.localPath).not.toMatch(/\/$/);
+
+      // Cache path should have .pdf extension
+      expect(doc.localPath).toMatch(/\.pdf$/);
+
+      // Cache path should not contain query parameters
+      expect(doc.localPath).not.toContain('?');
+      expect(doc.localPath).not.toContain('wpdmdl');
+
+      // Should be a valid file path (not directory)
+      expect(doc.localPath).toContain(
+        'regular-council-meeting-october-14-2025-agenda.pdf',
+      );
+    });
+
+    it('should handle URLs ending with slash correctly', async () => {
+      const { Document: BaseDocument } = await import('./document');
+
+      // URL with trailing slash but no query params
+      const url = 'https://example.com/documents/report/';
+
+      const doc = new BaseDocument(url, { type: 'application/pdf' });
+
+      // Should remove trailing slash and add extension
+      expect(doc.localPath).not.toMatch(/\/$/);
+      expect(doc.localPath).toMatch(/\.pdf$/);
+      expect(doc.localPath).toContain('report.pdf');
+    });
+
+    it('should preserve extension if already present', async () => {
+      const { Document: BaseDocument } = await import('./document');
+
+      // URL with explicit .pdf extension
+      const url = 'https://example.com/documents/report.pdf';
+
+      const doc = new BaseDocument(url, { type: 'application/pdf' });
+
+      // Should keep existing extension, not add another
+      expect(doc.localPath).toMatch(/\.pdf$/);
+      expect(doc.localPath).not.toMatch(/\.pdf\.pdf$/);
+      expect(doc.localPath).toContain('report.pdf');
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #189 - Cache path generation failure for URLs with query parameters, causing "ENOTDIR" errors when caching PDFs.

## Problem
`fetchDocument` from `@have/documents` was generating invalid cache paths for URLs with query parameters. The paths ended with `/` (treated as directories) instead of having proper file extensions.

**Example failing URL**:
```
https://townofbentley.ca/download/regular-council-meeting-october-14-2025-agenda/?wpdmdl=17656&refresh=68ec319891f4d1760309656
```

**Generated invalid path** (caused ENOTDIR error):
```
/var/folders/.../townofbentley-ca/download/regular-council-meeting-october-14-2025-agenda/
```

**Should be**:
```
/var/folders/.../townofbentley-ca/download/regular-council-meeting-october-14-2025-agenda.pdf
```

## Root Cause
The Document constructor was using `url.pathname` directly without:
1. Removing trailing slashes from directory-style URLs
2. Adding appropriate file extensions when missing
3. This affected WordPress Download Manager URLs that end with `/` before query params

## Solution
Enhanced cache path generation in `Document.ts` constructor:
1. **Strip trailing slashes** from pathname (directory-style URLs)
2. **Add file extension** if missing based on MIME type
3. Query parameters are already excluded from `url.pathname` (URL API behavior)

## Changes
- **`src/document.ts`**: Enhanced cache path generation logic
- **`src/index.test.ts`**: Added 3 new tests for edge cases:
  - URLs with query parameters (WordPress style)
  - URLs ending with trailing slash  
  - URLs with existing extensions (preserved)

## Testing
✅ All 10 tests pass including new cache path validation tests

**New test coverage**:
```typescript
// WordPress Download Manager style URL
'https://townofbentley.ca/download/.../? wpdmdl=17656&refresh=hash'
→ Cache path ends with .pdf, not /

// URL with trailing slash
'https://example.com/documents/report/'
→ Cache path: report.pdf

// URL with existing extension
'https://example.com/documents/report.pdf'
→ Preserved, not duplicated to report.pdf.pdf
```

## Impact
This unblocks:
- ✅ Fetching WordPress Download Manager PDFs (all use `?wpdmdl=ID` params)
- ✅ All 47 meeting documents from Town of Bentley
- ✅ Complete praeco document fetching workflow
- ✅ Any PDF URLs with query parameters or trailing slashes

## Related Issues
Successfully resolved sequence:
- ✅ #184 - WordPress detection with HTML entity decoding
- ✅ #187 - Crawlee Configuration import error
- ✅ #189 - Cache path generation (this PR)

Closes #189