### PR TITLE
feat(utils): add support for underscore and dot date formats to dateInString

### DIFF
--- a/packages/core/utils/src/index.spec.ts
+++ b/packages/core/utils/src/index.spec.ts
@@ -281,6 +281,68 @@ describe('dateInString', () => {
     });
   });
 
+  describe('DocuShare and CivicWeb formats', () => {
+    it('should extract underscore-separated dates (YYYY_MM_DD)', () => {
+      const date = dateInString('Minutes_2025_01_16.pdf');
+      expect(date).toBeInstanceOf(Date);
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(0); // January (0-based)
+      expect(date?.getDate()).toBe(16);
+    });
+
+    it('should extract underscore dates from complex filenames', () => {
+      const date = dateInString('Council_Meeting_Minutes_2025_10_13.pdf');
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(9); // October (0-based)
+      expect(date?.getDate()).toBe(13);
+    });
+
+    it('should extract US dot format dates (MM.DD.YYYY)', () => {
+      const date = dateInString('02.13.2025.pdf');
+      expect(date).toBeInstanceOf(Date);
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(1); // February (0-based)
+      expect(date?.getDate()).toBe(13);
+    });
+
+    it('should extract US dot dates from complex filenames', () => {
+      const date = dateInString('Agenda_Meeting_10.14.2025.pdf');
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(9); // October (0-based)
+      expect(date?.getDate()).toBe(14);
+    });
+
+    it('should handle single-digit months in underscore format', () => {
+      const date = dateInString('Report_2025_3_5.pdf');
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(2); // March (0-based)
+      expect(date?.getDate()).toBe(5);
+    });
+
+    it('should handle single-digit days in dot format', () => {
+      const date = dateInString('Summary_1.5.2025.pdf');
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(0); // January (0-based)
+      expect(date?.getDate()).toBe(5);
+    });
+
+    it('should prioritize underscore dates over natural language', () => {
+      // Should extract 2025_01_16, not "December 2024"
+      const date = dateInString('December_2024_Minutes_2025_01_16.pdf');
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(0); // January
+      expect(date?.getDate()).toBe(16);
+    });
+
+    it('should prioritize dot dates over natural language', () => {
+      // Should extract 02.13.2025, not "January 2024"
+      const date = dateInString('January_2024_Report_02.13.2025.pdf');
+      expect(date?.getFullYear()).toBe(2025);
+      expect(date?.getMonth()).toBe(1); // February
+      expect(date?.getDate()).toBe(13);
+    });
+  });
+
   describe('Edge cases', () => {
     it('should return null for strings with no date', () => {
       const date = dateInString('no-date-here.pdf');

--- a/packages/core/utils/src/shared/universal.ts
+++ b/packages/core/utils/src/shared/universal.ts
@@ -501,7 +501,33 @@ export const parseAmazonDateString = (dateStr: string): Date => {
 export const dateInString = (str: string): Date | null => {
   const cleanStr = str.toLowerCase();
 
-  // Try standard date formats first (ISO, US, etc.)
+  // Try underscore-separated dates first (YYYY_MM_DD)
+  // Used by DocuShare document management systems
+  const underscoreMatch = str.match(/(\d{4})_(\d{1,2})_(\d{1,2})/);
+  if (underscoreMatch) {
+    const [, year, month, day] = underscoreMatch;
+    const date = new Date(
+      Number.parseInt(year, 10),
+      Number.parseInt(month, 10) - 1,
+      Number.parseInt(day, 10),
+    );
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+
+  // Try US dot format (MM.DD.YYYY)
+  // Used by DocuShare file naming conventions
+  const dotMatch = str.match(/(\d{1,2})\.(\d{1,2})\.(\d{4})/);
+  if (dotMatch) {
+    const [, month, day, year] = dotMatch;
+    const date = new Date(
+      Number.parseInt(year, 10),
+      Number.parseInt(month, 10) - 1,
+      Number.parseInt(day, 10),
+    );
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+
+  // Try standard date formats (ISO, US, etc.)
   // Pattern: YYYY-MM-DD or YYYY/MM/DD
   const isoMatch = cleanStr.match(/(\d{4})[-/](\d{1,2})[-/](\d{1,2})/);
   if (isoMatch) {


### PR DESCRIPTION
## Summary

Adds support for two additional date formats used by DocuShare and CivicWeb document management systems to the `dateInString` utility function.

## Changes

### New Date Format Support

1. **Underscore-separated format (YYYY_MM_DD)**
   - Example: `Minutes_2025_01_16.pdf` → January 16, 2025
   - Used by DocuShare document management systems
   - Handles single and double-digit months/days

2. **US dot format (MM.DD.YYYY)**
   - Example: `02.13.2025.pdf` → February 13, 2025
   - Used by DocuShare file naming conventions
   - Handles single and double-digit months/days

### Implementation Details

- Both formats are checked BEFORE existing natural language parsing
- Priority order: Underscore dates → Dot dates → ISO dates → US slash dates → Natural language
- This ensures DocuShare/CivicWeb formats take precedence over partial matches in natural language

### Test Coverage

Added comprehensive test suite in `packages/core/utils/src/index.spec.ts`:
- ✅ Basic underscore date extraction (YYYY_MM_DD)
- ✅ Complex filenames with underscore dates
- ✅ Basic dot date extraction (MM.DD.YYYY)
- ✅ Complex filenames with dot dates
- ✅ Single-digit month/day handling for both formats
- ✅ Priority over natural language dates

All 131 tests pass including 8 new tests for these formats.

## Test Plan

```bash
npm test
```

**Results**: 
- ✅ All 131 tests pass
- ✅ 8 new tests specifically for underscore and dot formats
- ✅ Existing date parsing tests continue to pass (no regressions)

## Related Issues

Closes #191

## Impact

This enables praeco to successfully extract dates from:
- Canadian municipal documents managed by DocuShare
- CivicWeb meeting minutes and agendas
- Other document management systems using these naming conventions