### PR TITLE
feat(spider): add scraper and spider configuration options to scrapeDocument

### DIFF
--- a/packages/core/spider/src/scrapeDocument.test.ts
+++ b/packages/core/spider/src/scrapeDocument.test.ts
@@ -561,6 +561,133 @@ describe('scrapeDocument', () => {
     });
   });
 
+  describe('Scraper configuration options', () => {
+    it('should use default basic scraper with dom spider when no options provided', async () => {
+      const mockScraper = {
+        scrape: vi.fn().mockResolvedValue({
+          url: 'https://example.com/page',
+          content: '<html><body><p>Content</p></body></html>',
+          links: [],
+          strategy: { type: 'basic', spider: 'dom', config: {}, confidence: 1 },
+          metrics: { duration: 100, linkCount: 0, complete: true },
+        }),
+      };
+
+      vi.mocked(scraperFactory.getScraper).mockResolvedValue(mockScraper as any);
+
+      await scrapeDocument('https://example.com/page');
+
+      // Should request basic scraper with dom spider (defaults)
+      expect(scraperFactory.getScraper).toHaveBeenCalledWith({
+        scraper: 'basic',
+        spider: 'dom',
+      });
+    });
+
+    it('should use crawlee scraper when specified in options', async () => {
+      const mockScraper = {
+        scrape: vi.fn().mockResolvedValue({
+          url: 'https://example.com/js-heavy-page',
+          content: '<html><body><p>JavaScript-generated content</p></body></html>',
+          links: [],
+          strategy: { type: 'basic', spider: 'crawlee', config: {}, confidence: 1 },
+          metrics: { duration: 2000, linkCount: 5, complete: true },
+        }),
+      };
+
+      vi.mocked(scraperFactory.getScraper).mockResolvedValue(mockScraper as any);
+
+      await scrapeDocument('https://example.com/js-heavy-page', {
+        scraper: 'crawlee',
+      });
+
+      // Should request basic scraper with crawlee spider
+      expect(scraperFactory.getScraper).toHaveBeenCalledWith({
+        scraper: 'crawlee',
+        spider: 'dom',  // Default spider when scraper specified
+      });
+    });
+
+    it('should use simple spider when specified in options', async () => {
+      const mockScraper = {
+        scrape: vi.fn().mockResolvedValue({
+          url: 'https://example.com/simple-page',
+          content: '<html><body><p>Simple HTML</p></body></html>',
+          links: [],
+          strategy: { type: 'basic', spider: 'simple', config: {}, confidence: 1 },
+          metrics: { duration: 50, linkCount: 0, complete: true },
+        }),
+      };
+
+      vi.mocked(scraperFactory.getScraper).mockResolvedValue(mockScraper as any);
+
+      await scrapeDocument('https://example.com/simple-page', {
+        spider: 'simple',
+      });
+
+      // Should request basic scraper with simple spider
+      expect(scraperFactory.getScraper).toHaveBeenCalledWith({
+        scraper: 'basic',
+        spider: 'simple',
+      });
+    });
+
+    it('should allow both scraper and spider to be configured', async () => {
+      const mockScraper = {
+        scrape: vi.fn().mockResolvedValue({
+          url: 'https://example.com/custom-config',
+          content: '<html><body><p>Custom scraper config</p></body></html>',
+          links: [],
+          strategy: { type: 'basic', spider: 'crawlee', config: {}, confidence: 1 },
+          metrics: { duration: 1500, linkCount: 3, complete: true },
+        }),
+      };
+
+      vi.mocked(scraperFactory.getScraper).mockResolvedValue(mockScraper as any);
+
+      await scrapeDocument('https://example.com/custom-config', {
+        scraper: 'crawlee',
+        spider: 'crawlee',
+      });
+
+      // Should request specified scraper and spider
+      expect(scraperFactory.getScraper).toHaveBeenCalledWith({
+        scraper: 'crawlee',
+        spider: 'crawlee',
+      });
+    });
+
+    it('should pass through other options like timeout and cache', async () => {
+      const mockScraper = {
+        scrape: vi.fn().mockResolvedValue({
+          url: 'https://example.com/page-with-options',
+          content: '<html><body><p>Content</p></body></html>',
+          links: [],
+          strategy: { type: 'basic', spider: 'dom', config: {}, confidence: 1 },
+          metrics: { duration: 100, linkCount: 0, complete: true },
+        }),
+      };
+
+      vi.mocked(scraperFactory.getScraper).mockResolvedValue(mockScraper as any);
+
+      const options = {
+        scraper: 'basic' as const,
+        spider: 'dom' as const,
+        timeout: 30000,
+        cache: true,
+        headers: { 'User-Agent': 'Test/1.0' },
+      };
+
+      await scrapeDocument('https://example.com/page-with-options', options);
+
+      // scrape() should receive the full options object
+      expect(mockScraper.scrape).toHaveBeenCalledWith(
+        'https://example.com/page-with-options',
+        options
+      );
+    });
+  });
+
   describe('Basic document scraping', () => {
     it('should extract title and description from HTML', async () => {
       const mockScraper = {

--- a/packages/core/spider/src/scrapeDocument.ts
+++ b/packages/core/spider/src/scrapeDocument.ts
@@ -2,6 +2,44 @@ import { getScraper } from './shared/scraper-factory';
 import type { ScrapeOptions } from './shared/types';
 
 /**
+ * Options for document scraping with scraper configuration
+ *
+ * Extends ScrapeOptions with scraper/spider selection capabilities,
+ * allowing callers to choose between different scraping strategies
+ * based on the document source's requirements.
+ */
+export interface DocumentScrapeOptions extends ScrapeOptions {
+  /**
+   * Scraper type to use for content extraction
+   * - 'basic': Fast, static HTML scraping (default)
+   * - 'crawlee': Full browser with JavaScript execution
+   *
+   * @default 'basic'
+   * @example
+   * ```typescript
+   * // Use crawlee for JavaScript-heavy pages
+   * await scrapeDocument(url, { scraper: 'crawlee' });
+   * ```
+   */
+  scraper?: 'basic' | 'crawlee';
+
+  /**
+   * Spider adapter for fetching pages
+   * - 'simple': Basic HTTP fetch
+   * - 'dom': HTML parsing with happy-dom
+   * - 'crawlee': Headless browser (requires scraper: 'crawlee')
+   *
+   * @default 'dom'
+   * @example
+   * ```typescript
+   * // Use simple spider for minimal overhead
+   * await scrapeDocument(url, { spider: 'simple' });
+   * ```
+   */
+  spider?: 'simple' | 'dom' | 'crawlee';
+}
+
+/**
  * Simple document structure returned by scrapeDocument
  */
 export interface DocumentResult {
@@ -269,7 +307,7 @@ function extractDocuShareDocumentUrl(url: string, html: string): string | null {
  * This function provides the foundation for document discovery and basic extraction.
  *
  * @param url - The URL of the document to scrape
- * @param options - Optional scrape configuration
+ * @param options - Optional scrape configuration including scraper/spider selection
  * @returns Promise resolving to document content and metadata
  *
  * @example Basic HTML page
@@ -335,16 +373,37 @@ function extractDocuShareDocumentUrl(url: string, html: string): string | null {
  *   }
  * });
  * ```
+ *
+ * @example Using crawlee for JavaScript-heavy pages
+ * ```typescript
+ * // CivicWeb and other systems that generate content with JavaScript
+ * const doc = await scrapeDocument(
+ *   'https://example.civicweb.net/filepro/documents/?preview=12345',
+ *   { scraper: 'crawlee' }  // Executes JavaScript to get dynamic content
+ * );
+ * ```
+ *
+ * @example Using simple spider for minimal overhead
+ * ```typescript
+ * // Fast scraping without DOM processing
+ * const doc = await scrapeDocument(
+ *   'https://example.com/simple-page.html',
+ *   { spider: 'simple' }  // Faster than 'dom' for basic pages
+ * );
+ * ```
  */
 export async function scrapeDocument(
   url: string,
-  options?: ScrapeOptions,
+  options?: DocumentScrapeOptions,
 ): Promise<DocumentResult> {
-  // Use basic scraper with DOM spider for better content extraction
+  // Use provided scraper config or defaults (basic + dom)
+  const scraperType = options?.scraper || 'basic';
+  const spiderType = options?.spider || 'dom';
+
   const scraper = await getScraper({
-    scraper: 'basic',
-    spider: 'dom',
-  });
+    scraper: scraperType,
+    spider: spiderType,
+  } as any);
 
   let result = await scraper.scrape(url, options);
   let actualUrl = url;


### PR DESCRIPTION
## Summary

Adds ability to configure scraper type (basic/crawlee) and spider type (simple/dom/crawlee) in `scrapeDocument` options, allowing callers to choose between different scraping strategies based on document source requirements.

## Changes

### New Interface
- Added `DocumentScrapeOptions` interface extending `ScrapeOptions`
- Added `scraper` option: 'basic' (default, fast static HTML) or 'crawlee' (full browser with JavaScript)
- Added `spider` option: 'simple' (basic HTTP), 'dom' (HTML parsing, default), or 'crawlee' (headless browser)

### Implementation
- Updated `scrapeDocument` function signature to accept `DocumentScrapeOptions`
- Modified implementation to use provided scraper/spider or sensible defaults
- Added comprehensive JSDoc with multiple usage examples

### Test Coverage
- Added 5 new test cases covering all configuration options:
  - Default basic + dom when no options provided (backward compatibility)
  - Use crawlee scraper when specified
  - Use simple spider when specified
  - Allow both scraper and spider to be configured
  - Pass through other options like timeout and cache

## Test Results

All 25 tests pass:
- 6 WordPress Download Manager tests
- 5 CivicWeb detection tests
- 7 DocuShare detection tests
- 5 Scraper configuration tests (new)
- 2 Basic scraping tests

## Example Usage

```typescript
// Default behavior (backward compatible)
const doc = await scrapeDocument('https://example.com/doc.pdf');

// Use Crawlee for JavaScript-heavy sites
const doc = await scrapeDocument('https://example.com/doc.pdf', {
  scraper: 'crawlee',
  spider: 'crawlee'
});

// Use simple spider for performance
const doc = await scrapeDocument('https://example.com/doc.pdf', {
  spider: 'simple'
});

// Combine with other options
const doc = await scrapeDocument('https://example.com/doc.pdf', {
  scraper: 'crawlee',
  timeout: 30000,
  cache: true
});
```

## Backward Compatibility

✅ Fully backward compatible - all existing calls work unchanged with default values.

Fixes #195