### PR TITLE
feat(content): add variant field for namespaced content classification

### DIFF
--- a/packages/modules/content/src/content.ts
+++ b/packages/modules/content/src/content.ts
@@ -11,6 +11,13 @@ export interface ContentOptions extends SmrtObjectOptions {
   type?: string | null;
 
   /**
+   * Content variant for namespaced classification within types
+   * Format: generator:domain:specific-type
+   * Example: "praeco:meeting:upcoming"
+   */
+  variant?: string | null;
+
+  /**
    * Reference to file storage key
    */
   fileKey?: string | null;
@@ -109,6 +116,13 @@ export class Content extends SmrtObject {
   public type: string | null = null;
 
   /**
+   * Content variant for namespaced classification within types
+   * Format: generator:domain:specific-type
+   * Example: "praeco:meeting:upcoming"
+   */
+  public variant: string | null = null;
+
+  /**
    * Reference to file storage key
    */
   public fileKey: string | null = null;
@@ -184,6 +198,7 @@ export class Content extends SmrtObject {
   constructor(options: ContentOptions = {}) {
     super(options);
     this.type = options.type || null;
+    this.variant = options.variant || null;
     this.fileKey = options.fileKey || null;
     this.author = options.author || null;
     this.title = options.title || '';
@@ -256,6 +271,7 @@ export class Content extends SmrtObject {
       slug: this.slug || '',
       context: this.context || '',
       type: this.type,
+      variant: this.variant || '',
       fileKey: this.fileKey || '',
       author: this.author || '',
       title: this.title || '',

--- a/packages/modules/content/src/contents.spec.ts
+++ b/packages/modules/content/src/contents.spec.ts
@@ -221,3 +221,66 @@ it.skipIf(!process.env.OPENAI_API_KEY)(
     expect(articleCount).toEqual(1);
   },
 );
+
+it.skipIf(!process.env.OPENAI_API_KEY)(
+  'should support variant field for namespaced classification',
+  async () => {
+    const contents = await Contents.create({
+      ai: {
+        type: 'openai',
+        apiKey: process.env.OPENAI_API_KEY!,
+      },
+      db: {
+        url: getTestDbUrl('variant-field'),
+      },
+    });
+
+    // Test 1: Create content with variant
+    const upcomingArticle = await contents.getOrUpsert({
+      type: 'article',
+      variant: 'praeco:meeting:upcoming',
+      title: 'Upcoming Council Meeting',
+      body: 'Meeting preview content',
+      source: 'meeting-123',
+    });
+
+    expect(upcomingArticle.variant).toBe('praeco:meeting:upcoming');
+    expect(upcomingArticle.id).toBeDefined();
+
+    // Test 2: Create different variant for same meeting
+    const summaryArticle = await contents.getOrUpsert({
+      type: 'article',
+      variant: 'praeco:meeting:summary',
+      title: 'Council Meeting Summary',
+      body: 'Meeting summary content',
+      source: 'meeting-123',
+    });
+
+    expect(summaryArticle.variant).toBe('praeco:meeting:summary');
+    expect(summaryArticle.id).not.toBe(upcomingArticle.id);
+
+    // Test 3: Content without variant (null)
+    const regularArticle = await contents.getOrUpsert({
+      type: 'article',
+      title: 'Regular Article',
+      body: 'Regular content',
+    });
+
+    expect(regularArticle.variant).toBeNull();
+
+    // Test 4: Query by specific variant
+    const praecoSummaries = await contents.list({
+      where: {
+        type: 'article',
+        variant: 'praeco:meeting:summary',
+      },
+    });
+
+    expect(praecoSummaries?.length).toBe(1);
+    expect(praecoSummaries?.[0]?.id).toBe(summaryArticle.id);
+
+    // Test 5: toJSON includes variant
+    const json = upcomingArticle.toJSON();
+    expect(json.variant).toBe('praeco:meeting:upcoming');
+  },
+);


### PR DESCRIPTION
## Summary

Implements the `variant` field for the Content class, enabling namespaced classification within content types. This allows generators like praeco to efficiently track specific content variations without relying on JSON metadata parsing.

## Motivation

From issue #200:

The `@have/content` module uses `type` for broad categorization ("article", "agenda", "minutes"). Consumer applications need to query all content of a type regardless of generator.

However, generators like praeco need more specific classification ("meeting summary" vs "meeting preview") to:
- Track which meetings have articles
- Implement priority-based generation
- Enable efficient queries without JSON metadata parsing

## Changes

### 1. ContentOptions Interface

Added `variant` field to interface:

```typescript
/**
 * Content variant for namespaced classification within types
 * Format: generator:domain:specific-type
 * Example: "praeco:meeting:upcoming"
 */
variant?: string | null;
```

### 2. Content Class

**Property Addition:**
```typescript
public variant: string | null = null;
```

**Constructor Initialization:**
```typescript
constructor(options: ContentOptions = {}) {
  super(options);
  this.type = options.type || null;
  this.variant = options.variant || null;  // New
  // ... rest of initialization
}
```

**toJSON Serialization:**
```typescript
public toJSON() {
  return {
    // ... existing fields
    type: this.type,
    variant: this.variant || '',  // New
    // ... rest of fields
  };
}
```

### 3. Test Coverage

Added comprehensive test in `contents.spec.ts`:

```typescript
it('should support variant field for namespaced classification', async () => {
  // Test 1: Create content with variant
  const upcomingArticle = await contents.getOrUpsert({
    type: 'article',
    variant: 'praeco:meeting:upcoming',
    title: 'Upcoming Council Meeting',
    source: 'meeting-123',
  });

  // Test 2: Different variant for same meeting
  const summaryArticle = await contents.getOrUpsert({
    type: 'article',
    variant: 'praeco:meeting:summary',
    source: 'meeting-123',
  });

  // Test 3: Content without variant (null)
  // Test 4: Query by specific variant
  // Test 5: toJSON includes variant
});
```

## Usage Examples

### Source Documents (No Variant)

```typescript
const agenda = await contents.getOrUpsert({
  type: 'agenda',
  variant: null,
  title: 'Council Agenda - Oct 14, 2025'
});

const minutes = await contents.getOrUpsert({
  type: 'minutes',
  variant: null,
  title: 'Council Minutes - Oct 14, 2025'
});
```

### Generated Articles (With Variants)

```typescript
// Preview article before meeting
const preview = await contents.getOrUpsert({
  type: 'article',
  variant: 'praeco:meeting:upcoming',
  title: 'Upcoming Council Meeting Preview',
  source: 'meeting-123',
  body: 'This week's council meeting will discuss...'
});

// Summary article after meeting
const summary = await contents.getOrUpsert({
  type: 'article',
  variant: 'praeco:meeting:summary',
  title: 'Council Meeting Summary',
  source: 'meeting-123',
  body: 'At yesterday's council meeting...'
});
```

### Query Patterns

```sql
-- Consumer: All articles (regardless of generator)
SELECT * FROM contents WHERE type = 'article'

-- Praeco: Specific variant only
SELECT * FROM contents
WHERE type = 'article' AND variant = 'praeco:meeting:summary'
  
-- Consumer: All praeco-generated articles
SELECT * FROM contents WHERE variant LIKE 'praeco:%'
  
-- Find all articles for a meeting
SELECT * FROM contents
WHERE source = 'meeting-123' AND variant LIKE '%:meeting:%'
```

### Code Queries

```typescript
// Get all articles (consumer perspective)
const allArticles = await contents.list({
  where: { type: 'article' }
});

// Get specific variant (generator perspective)
const summaries = await contents.list({
  where: {
    type: 'article',
    variant: 'praeco:meeting:summary'
  }
});

// Pattern matching for generator namespace
const praecoArticles = await contents.list({
  where: {
    variant: { $like: 'praeco:%' }
  }
});
```

## Variant Format Convention

**Format**: `generator:domain:specific-type`

**Components**:
- `generator`: Generator identifier (e.g., "praeco", "summarizer")
- `domain`: Content domain (e.g., "meeting", "budget", "report")
- `specific-type`: Specific classification (e.g., "upcoming", "summary", "analysis")

**Examples**:
- `praeco:meeting:upcoming` - Preview article before meeting
- `praeco:meeting:summary` - Summary article after meeting
- `summarizer:budget:analysis` - Budget analysis article
- `othertool:report:quarterly` - Quarterly report article

## Database Schema

SMRT framework will auto-generate schema changes:

```sql
-- Column addition
ALTER TABLE contents ADD COLUMN variant TEXT;

-- Indexes for efficient querying
CREATE INDEX idx_contents_type_variant ON contents(type, variant);
CREATE INDEX idx_contents_variant ON contents(variant);
```

## Migration Path

**New Installations:**
- Variant column included from start
- No migration needed

**Existing Installations:**
- SMRT generates migration automatically
- Column added with NULL default
- Backward compatible - existing content works unchanged
- Generators can start populating variant immediately

**Rollout Strategy:**
1. Merge PR and deploy
2. SMRT framework runs migration automatically
3. Update generators to populate variant field
4. Old content remains with NULL variant (works fine)
5. New content includes appropriate variant

## Benefits

✅ **Efficient Indexing**: No JSON parsing for queries
✅ **Namespace Isolation**: Multiple generators coexist without conflicts
✅ **Type Hierarchy**: Broad type + specific variant classification
✅ **Pattern Matching**: Simple LIKE queries for namespace filtering
✅ **Backward Compatible**: NULL default for existing content
✅ **Flexible**: Supports any generator namespace format

## Testing

Tests require `OPENAI_API_KEY` for AI integration (Content extends SmrtObject):

```bash
# Run without AI tests (variant tests will be skipped)
bun test packages/modules/content

# Run with AI integration
OPENAI_API_KEY=sk-... bun test packages/modules/content
```

## Breaking Changes

None. This is a purely additive change:
- Existing content works unchanged (variant defaults to NULL)
- Existing queries unaffected
- Optional field in ContentOptions interface

## Related Issues

Fixes #200

## Follow-up Work

1. Update praeco to use variant field for meeting articles
2. Consider adding variant validation (format checking)
3. Add documentation for variant naming conventions
4. Consider helper methods for variant namespacing

## Checklist

- [x] Add variant field to ContentOptions interface
- [x] Add variant property to Content class
- [x] Initialize variant in constructor
- [x] Include variant in toJSON() serialization
- [x] Add comprehensive test coverage
- [x] Document usage patterns and query examples
- [x] Ensure backward compatibility