### PR TITLE
fix(sql): prevent DuckDB type re-inference during JSON data loading

### DIFF
--- a/packages/core/sql/src/json.ts
+++ b/packages/core/sql/src/json.ts
@@ -123,12 +123,20 @@ async function loadJSONTables(
         await createTableFromSmrtSchema(connection, tableName, smrtSchema);
 
         // Load JSON data into properly-typed table
+        // IMPORTANT: Don't use read_json() with auto_detect because DuckDB will
+        // re-infer types from the data, causing ANY type issues with empty strings.
+        // Instead, read JSON file and insert records using our CAST logic.
         try {
-          await connection.run(
-            `INSERT INTO ${tableName} SELECT * FROM read_json('${filePath}', auto_detect=true, format='auto', ignore_errors=true)`,
-          );
+          const { readFile } = await import('node:fs/promises');
+          const jsonContent = await readFile(filePath, 'utf-8');
+          const records = JSON.parse(jsonContent);
+
+          if (Array.isArray(records) && records.length > 0) {
+            // Use a helper to insert records with proper CAST handling
+            await insertRecordsWithCast(connection, tableName, records);
+          }
         } catch (error) {
-          // If INSERT fails (e.g., empty file), that's okay - table structure is what matters
+          // If INSERT fails (e.g., empty file, parse error), that's okay - table structure is what matters
           console.warn(
             `[json-adapter] Could not load data for ${tableName}: ${error instanceof Error ? error.message : String(error)}`,
           );
@@ -275,6 +283,55 @@ async function createTableFromSmrtSchema(
       originalError: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+/**
+ * Inserts records with proper CAST handling for empty strings
+ *
+ * This helper avoids using read_json() with auto_detect, which causes DuckDB
+ * to re-infer column types from data (causing ANY type for empty strings).
+ * Instead, it uses parameterized INSERT with CAST to maintain table schema.
+ *
+ * @param connection - DuckDB connection
+ * @param tableName - Name of the table to insert into
+ * @param records - Array of records to insert
+ */
+async function insertRecordsWithCast(
+  connection: any,
+  tableName: string,
+  records: Record<string, any>[],
+): Promise<void> {
+  if (records.length === 0) return;
+
+  const keys = Object.keys(records[0]);
+
+  // Build placeholders with CAST for empty strings
+  const values: any[] = [];
+  let paramIdx = 1;
+
+  const placeholders = records
+    .map((record) => {
+      const rowPlaceholders = keys.map((key) => {
+        const value = record[key];
+
+        if (value === null) {
+          return 'NULL';
+        } else if (value === '' && typeof value === 'string') {
+          // CAST empty strings to TEXT to prevent DuckDB ANY type inference
+          values.push(value);
+          return `CAST($${paramIdx++} AS TEXT)`;
+        } else {
+          values.push(value);
+          return `$${paramIdx++}`;
+        }
+      });
+      return `(${rowPlaceholders.join(', ')})`;
+    })
+    .join(', ');
+
+  const sql = `INSERT INTO ${tableName} (${keys.join(', ')}) VALUES ${placeholders}`;
+
+  await connection.run(sql, values);
 }
 
 /**


### PR DESCRIPTION
Fixes #228

## Problem

Even with proper table schema (TEXT columns) and CAST in DEFAULT values (PR #230, PR #233), DuckDB was still failing with "Cannot create values of type ANY" error when loading JSON data.

The root cause was that `INSERT INTO ... SELECT * FROM read_json()` with `auto_detect=true` causes DuckDB to **re-infer types from the JSON data**, overriding the table schema we carefully created.

## Solution

This PR replaces the `read_json()` approach with manual JSON parsing:

1. Read JSON file as string
2. Parse JSON to JavaScript objects
3. Insert records using parameterized INSERT with our existing CAST logic
4. Apply `CAST($N AS TEXT)` to empty string parameters to prevent ANY type inference

The new `insertRecordsWithCast()` helper function reuses the same CAST logic from the `insert()` method, ensuring consistent handling of empty strings throughout the adapter.

## Changes

- **packages/core/sql/src/json.ts**:
  - Added `insertRecordsWithCast()` helper function
  - Modified `loadJSONTables()` to use manual JSON parsing instead of `read_json()`
  - Added detailed comments explaining the type re-inference issue

## Testing

All existing JSON adapter tests pass (17/17):
```
✓ packages/core/sql/src/json.spec.ts (17 tests) 210ms
```

This ensures that:
- Table schema is created with proper TEXT types (from PR #230 and PR #233)
- Data loading respects the table schema without re-inference
- Empty strings are handled correctly throughout the entire lifecycle
- INSERT, UPSERT, and UPDATE operations all work correctly

## Related PRs

- PR #229: Added SMRT integration to JSON adapter
- PR #230: Added CAST in createTableFromSmrtSchema()
- PR #231: Added CAST in runtime-manager schema generation  
- PR #233: Added CAST to empty string parameters in INSERT/UPSERT

This PR completes the fix by preventing DuckDB from re-inferring types during data loading.