### PR TITLE
feat(release): enable automated publishing to GitHub Packages

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com'
 
       - name: Build packages
         run: pnpm run build
@@ -75,7 +75,7 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN not needed since npmPublish is disabled
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Job 3: Deploy documentation (only if build succeeds)
   # Note: We deploy docs on every merge to main to ensure they stay in sync

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -38,7 +38,7 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false
+        "npmPublish": true
       }
     ],
     [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,121 @@ The build process follows a specific order to respect internal dependencies:
 - Published packages include dist/, README.md, and LICENSE
 - Users of published packages get the built artifacts
 
+### Package Publishing
+
+**Publishing Platform**: All SDK packages are published to **GitHub Packages** (not npm).
+
+#### Automated Publishing Workflow
+
+Publishing is fully automated using semantic-release:
+
+1. **Trigger**: Merges to `main` branch automatically trigger the release workflow
+2. **Version Detection**: semantic-release analyzes conventional commits to determine version bump
+3. **Build**: All packages are built with `pnpm run build`
+4. **Publish**: Packages are published to GitHub Packages registry
+5. **Changelog**: CHANGELOG.md is automatically updated with release notes
+6. **Git Tag**: A git tag is created for the new version
+
+**GitHub Actions Workflow**: `.github/workflows/on-merge-main.yml`
+
+```yaml
+# Relevant configuration
+- name: Setup Environment
+  uses: ./.github/actions/setup-environment
+  with:
+    node-version: '24'
+    registry-url: 'https://npm.pkg.github.com'  # GitHub Packages
+
+- name: Release packages
+  run: pnpm run release
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # GitHub Packages auth
+```
+
+#### Package Configuration
+
+Each package's `package.json` includes:
+
+```json
+{
+  "name": "@have/{package-name}",
+  "version": "0.45.2",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/{package-name}"
+  }
+}
+```
+
+#### Semantic Versioning
+
+Version bumps follow conventional commits:
+
+- `feat:` → Minor version bump (0.45.0 → 0.46.0)
+- `fix:`, `perf:`, `docs:`, `build:` → Patch version bump (0.45.0 → 0.45.1)
+- `refactor:` → Minor version bump
+- `breaking:` in commit body → Minor version bump (until 1.0.0)
+- `scope: no-release` → No version bump
+
+**Configuration**: `.releaserc.json`
+
+#### Installing Published Packages
+
+Users need to configure npm for GitHub Packages:
+
+**Create `.npmrc` in project root:**
+```
+@have:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN
+```
+
+**Install packages:**
+```bash
+pnpm add @have/ai @have/sql @have/files
+```
+
+**GitHub Token Requirements**:
+- Token needs `read:packages` scope
+- Create at: GitHub Settings → Developer settings → Personal access tokens
+
+#### Manual Publishing (Emergency Use Only)
+
+If automated publishing fails, packages can be published manually:
+
+```bash
+# Build all packages
+pnpm run build
+
+# Dry-run to preview changes
+pnpm run release:dry-run
+
+# Publish (only if automated workflow failed)
+pnpm run release
+```
+
+**Important**: Manual publishing should be rare. Fix the CI/CD workflow instead of routinely publishing manually.
+
+#### Release Scripts
+
+Available in root `package.json`:
+
+- `pnpm run release` - Automated semantic-release
+- `pnpm run release:dry-run` - Preview release without publishing
+- `pnpm run release:packages` - Release individual packages
+- `pnpm run release:preview` - Preview next version
+- `pnpm run release:validate` - Validate release configuration
+
 ### TypeScript Project References
 
 The SDK uses TypeScript project references for proper type resolution across packages. **This is critical for avoiding module resolution conflicts.**

--- a/README.md
+++ b/README.md
@@ -22,8 +22,48 @@ TypeScript SDK for building AI-powered applications.
 
 ## Installation
 
+### Installing from GitHub Packages
+
+All SDK packages are published to GitHub Packages. To install them, you need to configure npm to use GitHub Packages for the `@have` scope.
+
+#### 1. Create a GitHub Personal Access Token
+
+1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. Generate a new token with `read:packages` scope
+3. Copy the token
+
+#### 2. Configure npm registry
+
+Create or update `.npmrc` in your project root:
+
+```bash
+@have:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN
+```
+
+Or set the token via environment variable:
+
+```bash
+echo "@have:registry=https://npm.pkg.github.com" >> .npmrc
+echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+```
+
+#### 3. Install packages
+
 ```bash
 pnpm add @have/ai @have/sql @have/files
+```
+
+### Available Packages
+
+All SDK packages are available:
+
+```bash
+# Core packages
+pnpm add @have/utils @have/logger @have/files @have/sql @have/ai
+
+# Infrastructure packages
+pnpm add @have/cache @have/geo @have/translator @have/ocr @have/pdf @have/spider @have/documents
 ```
 
 ## Development

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -12,8 +12,24 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/ai"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/ai#readme",
+  "license": "MIT",
   "scripts": {
     "test": "npx vitest run",
     "test:watch": "npx vitest",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -12,8 +12,23 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/cache"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/cache#readme",
   "scripts": {
     "test": "npx vitest run",
     "test:watch": "npx vitest",

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -6,8 +6,24 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/documents"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/documents#readme",
+  "license": "MIT",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -36,6 +36,22 @@
     "vitest": "^3.2.4"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/files"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/files#readme",
+  "license": "MIT"
 }

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -12,8 +12,23 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/geo"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/geo#readme",
   "scripts": {
     "test": "npx vitest run",
     "test:watch": "npx vitest",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -16,6 +16,10 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",

--- a/packages/ocr/package.json
+++ b/packages/ocr/package.json
@@ -45,8 +45,19 @@
     "directory": "packages/ocr"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/ocr#readme",
+  "license": "MIT",
   "scripts": {
     "test": "npx vitest run --testTimeout 120000",
     "test:watch": "npx vitest --testTimeout 120000",

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -6,8 +6,24 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/pdf"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/pdf#readme",
+  "license": "MIT",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/sdk-mcp/package.json
+++ b/packages/sdk-mcp/package.json
@@ -15,8 +15,24 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/sdk-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/sdk-mcp#readme",
+  "license": "MIT",
   "scripts": {
     "test": "npx vitest run",
     "test:watch": "npx vitest",

--- a/packages/spider/package.json
+++ b/packages/spider/package.json
@@ -5,8 +5,24 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/spider"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/spider#readme",
+  "license": "MIT",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -6,8 +6,23 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/sql"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/sql#readme",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/translator/package.json
+++ b/packages/translator/package.json
@@ -12,8 +12,23 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/translator"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/translator#readme",
   "scripts": {
     "test": "npx vitest run",
     "test:watch": "npx vitest",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,6 +37,22 @@
     "vitest": "^3.2.4"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/utils"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/utils#readme",
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Implements automated package publishing to GitHub Packages for all SDK packages. This enables semantic-release to automatically publish packages on main branch merges following conventional commit standards.

## Changes

### Package Configuration (All 13 Packages)

Updated all package.json files with GitHub Packages publishing configuration:
- ✅ Added `publishConfig` with GitHub Packages registry URL
- ✅ Updated `files` field to include dist/, README.md, and LICENSE
- ✅ Added `repository` field with monorepo directory structure
- ✅ Added `bugs` and `homepage` fields for GitHub integration
- ✅ Added/updated `license` field (MIT) for all packages

**Packages configured**: logger, utils, files, sql, ai, cache, geo, translator, ocr, pdf, spider, documents, sdk-mcp

### Semantic Release Configuration

- ✅ Enabled npm publishing in `.releaserc.json` (`npmPublish: true`)
- ✅ Configured to publish to GitHub Packages registry (`https://npm.pkg.github.com`)
- ✅ Maintained existing semantic-release workflow and version detection

### GitHub Actions Workflow

Updated `.github/workflows/on-merge-main.yml`:
- ✅ Changed registry URL from npm to GitHub Packages
- ✅ Added `NODE_AUTH_TOKEN` environment variable for authentication
- ✅ Maintained existing `GITHUB_TOKEN` for GitHub operations
- ✅ Preserved existing build and test workflow

### Documentation Updates

**CLAUDE.md** - Added comprehensive "Package Publishing" section:
- Automated publishing workflow explanation
- Package configuration examples
- Semantic versioning rules and commit types
- User installation instructions with .npmrc configuration
- Manual publishing emergency procedures
- Release scripts reference

**README.md** - Added GitHub Packages installation guide:
- Step-by-step GitHub Personal Access Token creation
- .npmrc configuration examples
- Available packages listing
- Installation commands for all package combinations

## Testing

Following [Organization-Wide Testing Standard](../../TESTING_STANDARD.md):

**Quality Checks Completed**:
- ✅ Lint passed (existing warnings unrelated to changes)
- ✅ Format passed (no formatting issues)
- ✅ TypeScript compiles (no type errors)
- ✅ All tests pass (668 passing tests)

**Testing Approach**:
- No new test files needed (configuration-only changes)
- Verified all package.json files are valid JSON
- Validated GitHub Actions workflow syntax
- Confirmed conventional commit format compliance
- Tested build and typecheck in pre-push hook

**Test Results**:
```
Test Files  43 passed | 5 skipped (48)
      Tests  668 passed | 36 skipped (704)
   Duration  55.59s
```

## Deployment Impact

### For Users

Users will need to configure npm for GitHub Packages access:

**Create `.npmrc` in project root:**
```
@have:registry=https://npm.pkg.github.com
//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN
```

**Install packages:**
```bash
pnpm add @have/ai @have/sql @have/files
```

### For CI/CD

The GitHub Actions workflow will automatically:
1. Build all packages on main branch merges
2. Run semantic-release to analyze commits
3. Determine version bump (patch/minor/major)
4. Publish packages to GitHub Packages registry
5. Update CHANGELOG.md
6. Create git tag

### Breaking Changes

None. This is an additive change that enables publishing without affecting existing functionality.

## Semantic Versioning

Version bumps follow these rules:
- `feat:` → Minor version bump (0.45.0 → 0.46.0)
- `fix:`, `perf:`, `docs:`, `build:` → Patch version bump (0.45.0 → 0.45.1)
- `refactor:` → Minor version bump
- `breaking:` in commit body → Minor version bump (until 1.0.0)
- `scope: no-release` → No version bump

## Checklist

- [x] All package.json files updated with publishConfig
- [x] files field includes dist/, README.md, LICENSE
- [x] repository field added to all packages
- [x] semantic-release publishing enabled
- [x] GitHub Actions workflow updated
- [x] NODE_AUTH_TOKEN configured
- [x] Documentation updated (CLAUDE.md)
- [x] Installation guide added (README.md)
- [x] Tests pass
- [x] Code linted
- [x] Code formatted
- [x] TypeScript compiles
- [x] Conventional commit message
- [x] Issue reference included

Closes #281