### PR TITLE
fix(ci): convert triage script to ES module syntax

### DIFF
--- a/.github/scripts/triage-issue.js
+++ b/.github/scripts/triage-issue.js
@@ -11,7 +11,7 @@
  * - Route critical issues to "To Do" status
  */
 
-const https = require('node:https');
+import https from 'node:https';
 
 // Environment variables
 const {


### PR DESCRIPTION
## Problem

The AI triage workflow (#285) is failing because the triage script uses CommonJS `require()` syntax, but the repository is configured as ESM-only (`"type": "module"` in package.json).

**Error**:
```
ReferenceError: require is not defined in ES module scope, you can use import instead
```

## Solution

Convert the single require statement to ES module import syntax.

**Changed**:
```diff
- const https = require('node:https');
+ import https from 'node:https';
```

## Testing

- [x] Syntax validated locally
- [ ] Will test with issue reopen after merge

## Related

- Fixes workflow added in #285
- Resolves failed run: https://github.com/happyvertical/sdk/actions/runs/18683721181