### PR TITLE
fix(ci): use GH_TOKEN for triage workflow

### DIFF
--- a/.github/workflows/on-issue-opened.yml
+++ b/.github/workflows/on-issue-opened.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run AI triage
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}


### PR DESCRIPTION
## Problem

The AI triage workflow is failing with a 401 error because the default `GITHUB_TOKEN` doesn't have the `models` permission required to access GitHub Models API:

```
The `models` permission is required to access this endpoint
```

## Solution

Use the existing `GH_TOKEN` secret which has the required permissions.

**Changed**:
```diff
- GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
```

## Testing

After merge and ensuring GH_TOKEN has the `models` permission:
```bash
gh issue close 286
gh issue reopen 286  # Should trigger successful triage
```

## Related

- Fixes permission error from #285
- Related to #287 (ESM fix)