### PR TITLE
fix(ci): disable npm publishing in semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -38,7 +38,7 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": true
+        "npmPublish": false
       }
     ],
     [


### PR DESCRIPTION
## Summary

Temporarily disable npm publishing in semantic-release to unblock the merge workflow while we investigate proper GitHub Packages configuration.

## Problem

The `on-merge-main.yml` workflow was consistently failing with:
```
ENONPMTOKEN No npm token specified.
An npm token must be created and set in the NPM_TOKEN environment variable.
The token must allow to publish to the registry https://registry.npmjs.org/.
```

## Root Cause

semantic-release is trying to publish to npmjs.org and expects `NPM_TOKEN`, but according to CLAUDE.md:
> **Publishing Platform**: All SDK packages are published to **GitHub Packages** (not npm).

The SDK should publish to `https://npm.pkg.github.com` using `GITHUB_TOKEN`.

## Solution

Disabled npm publishing temporarily by setting `npmPublish: false` in `.releaserc.json`.

## Changes

- Set `npmPublish: false` in `@semantic-release/npm` plugin configuration
- This keeps version bumping and CHANGELOG generation working
- Prevents `ENONPMTOKEN` errors and allows merge workflow to complete

## What Still Works

- ✅ Version number incrementing (via conventional commits)
- ✅ CHANGELOG.md generation
- ✅ Git tagging
- ✅ GitHub release creation
- ✅ Workflow completes successfully

## What's Disabled

- ❌ Package publishing to any registry (npm or GitHub Packages)

## Next Steps

After this PR merges, we need to properly configure GitHub Packages publishing:

1. Update `.releaserc.json` to use GitHub Packages registry
2. Configure npm authentication for GitHub Packages
3. Ensure `GITHUB_TOKEN` is used instead of `NPM_TOKEN`
4. Test publishing process
5. Re-enable `npmPublish: true`

A follow-up issue or PR will be needed to properly configure GitHub Packages publishing.

## Testing

This change will be tested when PR #292 is merged to main - the workflow should complete successfully without the `ENONPMTOKEN` error.

Closes #293