### PR TITLE
refactor(sql): standardize database adapters to use url property

### DIFF
--- a/packages/github-actions/src/triage/analyze.ts
+++ b/packages/github-actions/src/triage/analyze.ts
@@ -65,7 +65,9 @@ function validateAIAnalysis(parsed: unknown): AIAnalysis {
     priority: response.priority,
     urgency: response.urgency,
     reasoning: response.reasoning,
-    ...(response.affected_packages && { affected_packages: response.affected_packages }),
+    ...(response.affected_packages && {
+      affected_packages: response.affected_packages,
+    }),
   } as AIAnalysis;
 }
 

--- a/packages/sql/src/duckdb.ts
+++ b/packages/sql/src/duckdb.ts
@@ -200,6 +200,7 @@ export async function getDatabase(
   const connection = await createDuckDBConnection(options);
   const writeStrategy = options.writeStrategy || 'none';
   const dataDir = options.dataDir || './data';
+  const url = options.url || ':memory:';
 
   /**
    * Inserts one or more records into a table
@@ -704,6 +705,7 @@ export async function getDatabase(
   ): Promise<void> => {
     const schemaManager = new DatabaseSchemaManager();
     const currentDb: DatabaseInterface = {
+      url,
       client: connection,
       query,
       insert,
@@ -950,6 +952,7 @@ export async function getDatabase(
 
       // Create a transaction-scoped database interface
       const txDb: DatabaseInterface = {
+        url,
         client: connection,
         insert,
         get,
@@ -982,6 +985,7 @@ export async function getDatabase(
   };
 
   return {
+    url,
     client: connection,
     query,
     insert,

--- a/packages/sql/src/json.spec.ts
+++ b/packages/sql/src/json.spec.ts
@@ -26,7 +26,7 @@ describe('JSON adapter tests', () => {
     // Initialize JSON database
     db = await getDatabase({
       type: 'json',
-      dataDir: testDataDir,
+      url: testDataDir,
       writeStrategy: 'immediate',
     });
   });
@@ -122,7 +122,7 @@ describe('JSON adapter tests', () => {
     // Reload database to pick up new table
     db = await getDatabase({
       type: 'json',
-      dataDir: testDataDir,
+      url: testDataDir,
       writeStrategy: 'immediate',
     });
 
@@ -169,7 +169,7 @@ describe('JSON adapter tests', () => {
 
   it('should use in-memory database (no WAL files)', async () => {
     // This test verifies the core requirement: no WAL files created
-    // The JSON adapter should only create JSON files in dataDir
+    // The JSON adapter should only create JSON files in the specified directory
 
     const data = {
       id: randomUUID(),
@@ -192,7 +192,7 @@ describe('JSON adapter tests', () => {
   it('should handle read-only mode (writeStrategy: none)', async () => {
     const readOnlyDb = await getDatabase({
       type: 'json',
-      dataDir: testDataDir,
+      url: testDataDir,
       writeStrategy: 'none',
     });
 
@@ -213,7 +213,7 @@ describe('JSON adapter tests', () => {
   it('should support manual export mode (writeStrategy: manual)', async () => {
     const manualDb = await getDatabase({
       type: 'json',
-      dataDir: testDataDir,
+      url: testDataDir,
       writeStrategy: 'manual',
     });
 
@@ -243,7 +243,7 @@ describe('JSON adapter tests', () => {
 
     const emptyDb = await getDatabase({
       type: 'json',
-      dataDir: emptyDir,
+      url: emptyDir,
       writeStrategy: 'immediate',
     });
 
@@ -326,7 +326,7 @@ describe('JSON adapter tests', () => {
       // In production, users would register SMRT objects before initializing the DB
       const testDb = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         writeStrategy: 'immediate',
       });
 
@@ -359,7 +359,7 @@ describe('JSON adapter tests', () => {
       // Note: Without actual SMRT registration, all tables are treated as non-SMRT
       const testDb = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         writeStrategy: 'immediate',
         skipSmrtTables: true,
       });
@@ -473,7 +473,7 @@ describe('JSON adapter tests', () => {
       // For this test, we reload to simulate the fixed behavior
       const testDb = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         writeStrategy: 'immediate',
       });
 
@@ -693,7 +693,7 @@ describe('JSON adapter tests', () => {
       // Initialize database with provided schema
       db = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         writeStrategy: 'immediate',
         schemas,
       });
@@ -745,7 +745,7 @@ describe('JSON adapter tests', () => {
 
       db = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         schemas,
       });
 
@@ -788,7 +788,7 @@ describe('JSON adapter tests', () => {
 
       db = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         schemas,
       });
 
@@ -824,7 +824,7 @@ describe('JSON adapter tests', () => {
       // Create database without auto-registration
       db = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         autoRegister: false, // Don't load JSON files automatically
       });
 
@@ -867,7 +867,7 @@ describe('JSON adapter tests', () => {
       // Create database with immediate write strategy
       db = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         writeStrategy: 'immediate',
         autoRegister: false, // Manual setup for precise control
       });
@@ -902,7 +902,7 @@ describe('JSON adapter tests', () => {
       // Recreate database from JSON files (simulates app restart)
       db = await getDatabase({
         type: 'json',
-        dataDir: testDataDir,
+        url: testDataDir,
         writeStrategy: 'immediate',
         autoRegister: true, // Load JSON files
       });

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -33,14 +33,14 @@ interface SmrtSchemaDefinition {
  */
 async function createJSONConnection(options: JSONOptions) {
   const {
-    dataDir,
+    url,
     autoRegister = true,
     skipSmrtTables = false,
     schemas = {},
   } = options;
 
-  if (!dataDir) {
-    throw new DatabaseError('dataDir is required for JSON adapter', {
+  if (!url) {
+    throw new DatabaseError('url is required for JSON adapter', {
       options,
     });
   }
@@ -56,14 +56,14 @@ async function createJSONConnection(options: JSONOptions) {
 
     // Ensure data directory exists
     try {
-      await mkdir(dataDir, { recursive: true });
+      await mkdir(url, { recursive: true });
     } catch (_error) {
       // Directory might already exist, that's okay
     }
 
     // Load JSON files as in-memory tables
     if (autoRegister) {
-      await loadJSONTables(connection, dataDir, skipSmrtTables, schemas);
+      await loadJSONTables(connection, url, skipSmrtTables, schemas);
     }
 
     return connection;
@@ -72,7 +72,7 @@ async function createJSONConnection(options: JSONOptions) {
     throw new DatabaseError(
       `Failed to create JSON database connection: ${errorMessage}`,
       {
-        dataDir,
+        url,
         originalError: errorMessage,
       },
     );
@@ -502,7 +502,7 @@ export async function getDatabase(
 ): Promise<DatabaseInterface> {
   const connection = await createJSONConnection(options);
   const writeStrategy = options.writeStrategy || 'immediate';
-  const dataDir = options.dataDir;
+  const { url } = options;
 
   /**
    * Inserts one or more records into a table
@@ -563,7 +563,7 @@ export async function getDatabase(
 
       // Handle write-back strategy
       if (writeStrategy === 'immediate') {
-        await exportTableToJSON(connection, table, dataDir);
+        await exportTableToJSON(connection, table, url);
       }
 
       return { operation: 'insert', affected };
@@ -677,7 +677,7 @@ export async function getDatabase(
 
       // Handle write-back strategy
       if (writeStrategy === 'immediate') {
-        await exportTableToJSON(connection, table, dataDir);
+        await exportTableToJSON(connection, table, url);
       }
 
       // DuckDB doesn't return rowsAffected in the same way, estimate from where clause
@@ -794,7 +794,7 @@ export async function getDatabase(
 
       // Handle write-back strategy
       if (writeStrategy === 'immediate') {
-        await exportTableToJSON(connection, table, dataDir);
+        await exportTableToJSON(connection, table, url);
       }
 
       return { operation: 'upsert', affected: 1 };
@@ -941,7 +941,7 @@ export async function getDatabase(
         { table, writeStrategy },
       );
     }
-    await exportTableToJSON(connection, table, dataDir);
+    await exportTableToJSON(connection, table, url);
   };
 
   /**
@@ -1173,6 +1173,7 @@ export async function getDatabase(
   ): Promise<void> => {
     const schemaManager = new DatabaseSchemaManager();
     const currentDb: DatabaseInterface = {
+      url,
       client: connection,
       query,
       insert,
@@ -1212,6 +1213,7 @@ export async function getDatabase(
 
       // Create a transaction-scoped database interface
       const txDb: DatabaseInterface = {
+        url,
         client: connection,
         insert,
         get,
@@ -1244,6 +1246,7 @@ export async function getDatabase(
   };
 
   return {
+    url,
     client: connection,
     query,
     insert,

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -187,32 +187,30 @@ export async function getDatabase(
 
     // Merge legacy config, but don't override user options or HAVE_SQL_* vars
     for (const [key, value] of Object.entries(legacyConfig)) {
-      if (config[key] === undefined && value !== undefined) {
-        config[key] = value;
+      if ((config as any)[key] === undefined && value !== undefined) {
+        (config as any)[key] = value;
       }
     }
   }
 
   // Apply defaults
-  const {
-    url,
-    database,
-    host = 'localhost',
-    user,
-    password,
-    port = 5432,
-  } = config;
+  const { database, host = 'localhost', user, password, port = 5432 } = config;
+
+  // Construct url if not provided (for DatabaseInterface requirement)
+  const url: string =
+    (config.url as string) ||
+    `postgresql://${user}${password ? `:${password}` : ''}@${host}:${port}/${database || 'postgres'}`;
 
   // Create a connection pool
   const client = new Pool(
-    url
-      ? { connectionString: url }
+    config.url
+      ? { connectionString: config.url as string }
       : {
-          host,
-          user,
-          password,
-          port,
-          database,
+          host: host as string,
+          user: user as string,
+          password: password as string,
+          port: port as number,
+          database: database as string,
         },
   );
 
@@ -731,6 +729,7 @@ export async function getDatabase(
 
       // Create a transaction-scoped database interface
       const txDb: DatabaseInterface = {
+        url,
         client: txClient,
         insert: async (table, data) => {
           // Reuse insert logic but with transaction client
@@ -902,6 +901,7 @@ export async function getDatabase(
   ): Promise<void> => {
     const schemaManager = new DatabaseSchemaManager();
     const currentDb: DatabaseInterface = {
+      url,
       client,
       insert,
       update,
@@ -1132,6 +1132,7 @@ export async function getDatabase(
   };
 
   return {
+    url,
     client,
     insert,
     update,

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -73,7 +73,7 @@ export interface JSONOptions {
    * Path to directory containing JSON files (required)
    * JSON files in this directory will be loaded as queryable tables
    */
-  dataDir: string;
+  url: string;
 
   /**
    * Automatically load all JSON files in dataDir as tables
@@ -305,6 +305,15 @@ export interface TableSchemaInfo {
  * Provides a unified API for different database backends
  */
 export interface DatabaseInterface {
+  /**
+   * Database location identifier
+   * For file-based databases: file path
+   * For directory-based databases (JSON/DuckDB with JSON): directory path
+   * For in-memory databases: ':memory:'
+   * For remote databases: connection URL
+   */
+  url: string;
+
   /**
    * Underlying database client instance
    */

--- a/packages/sql/src/sqlite.ts
+++ b/packages/sql/src/sqlite.ts
@@ -636,6 +636,7 @@ export async function getDatabase(
         // Create a transaction-scoped database interface
         // SQLite doesn't have separate transaction clients, so we reuse the same client
         const txDb: DatabaseInterface = {
+          url,
           client,
           insert,
           get,
@@ -850,6 +851,7 @@ export async function getDatabase(
     ): Promise<void> => {
       const schemaManager = new DatabaseSchemaManager();
       const currentDb: DatabaseInterface = {
+        url,
         client,
         query,
         insert,
@@ -1041,6 +1043,7 @@ export async function getDatabase(
     };
 
     return {
+      url,
       client,
       query,
       insert,

--- a/packages/utils/src/config/env-config.ts
+++ b/packages/utils/src/config/env-config.ts
@@ -221,7 +221,9 @@ export function loadEnvConfig<T extends Record<string, any>>(
     }
 
     // Apply transform function if provided
-    const transformFn = (transform as Record<string, (value: string) => any>)[fieldName];
+    const transformFn = (transform as Record<string, (value: string) => any>)[
+      fieldName
+    ];
     if (transformFn) {
       try {
         config[fieldName] = transformFn(envValue);
@@ -235,7 +237,9 @@ export function loadEnvConfig<T extends Record<string, any>>(
     }
 
     // Apply schema type conversion if defined
-    const fieldType = (schema as Record<string, 'string' | 'number' | 'boolean' | 'json'>)[fieldName];
+    const fieldType = (
+      schema as Record<string, 'string' | 'number' | 'boolean' | 'json'>
+    )[fieldName];
     if (fieldType) {
       try {
         config[fieldName] = convertType(envValue, fieldType);


### PR DESCRIPTION
## Summary

Standardizes all database adapters to use `url` as the required property for identifying database location. This fixes inconsistency where SQLite/Postgres used `url` but JSON/DuckDB used `dataDir`.

Issue #308 identified this inconsistency and requested standardization across all adapters.

## Changes

### Type System Updates
- Updated `DatabaseInterface` to require `url: string` property
- Updated `JSONOptions` to use `url` instead of `dataDir` (complete removal, no deprecation)

### Adapter Updates
- **JSON adapter**: Changed from `dataDir` to `url`, updated all usage references
- **DuckDB adapter**: Added `url` property to DatabaseInterface implementation
- **SQLite adapter**: Added `url` property to DatabaseInterface implementation  
- **Postgres adapter**: Added `url` property construction and exposure

### Transaction & Schema Context Fixes
- Added `url` property to all transaction-scoped DatabaseInterface objects (4 adapters)
- Added `url` property to all schema-initialization DatabaseInterface objects (4 adapters)
- Fixed Postgres adapter type assertions for environment config properties

### Test Updates
- Updated all JSON adapter tests (15 occurrences) to use `url` instead of `dataDir`
- All 115 tests passing

## Testing

**Test Results**:
```
✅ All tests pass (115 passing, 4 skipped)
✅ Build succeeds
✅ TypeScript compiles (with expected pre-existing warnings)
```

**Testing Approach**:
- Used real resources: In-memory databases, temp directories
- Integration tests verify all adapters work correctly with `url` property
- Regression protection: Ensures existing functionality maintained

**Files Tested**:
- `packages/sql/src/json.spec.ts` - All JSON adapter tests updated and passing
- `packages/sql/src/sqlite.spec.ts` - SQLite tests passing
- `packages/sql/src/duckdb.spec.ts` - DuckDB tests passing  
- `packages/sql/src/postgres.spec.ts` - Postgres tests passing (4 skipped, require running DB)

## Breaking Changes

### JSONOptions Interface
```typescript
// Before
const db = await getDatabase({
  type: 'json',
  dataDir: './data'
});

// After
const db = await getDatabase({
  type: 'json',
  url: './data'
});
```

### Migration Guide
- Search for `dataDir:` in JSON database configurations
- Replace with `url:` (same value)
- No behavioral changes, only property rename

## Checklist

- [x] Tests pass
- [x] Code linted
- [x] Code formatted
- [x] TypeScript compiles
- [x] Documentation inline (JSDoc comments)
- [x] Conventional commit message
- [x] Issue reference included

Closes #308