### PR TITLE
fix(ai): claude-cli provider now handles responseFormat option

### DIFF
--- a/packages/ai/src/shared/providers/claude-cli.ts
+++ b/packages/ai/src/shared/providers/claude-cli.ts
@@ -402,7 +402,18 @@ export class ClaudeCliProvider implements AIInterface {
     messages: AIMessage[],
     options: ChatOptions = {},
   ): Promise<AIResponse> {
-    const { prompt, systemPrompt } = this.mapMessagesToPrompt(messages);
+    let { prompt, systemPrompt } = this.mapMessagesToPrompt(messages);
+
+    // Add JSON format instruction if requested
+    // NOTE: Claude CLI doesn't have native JSON mode like OpenAI. This is a prompt-based
+    // approach that instructs the model to output JSON, similar to Anthropic provider.
+    if (options.responseFormat?.type === 'json_object') {
+      const jsonInstruction =
+        '\n\nIMPORTANT: You must respond with valid JSON only. Do not include any explanatory text outside the JSON object.';
+      systemPrompt = systemPrompt
+        ? systemPrompt + jsonInstruction
+        : jsonInstruction.trim();
+    }
 
     const result = await this.executeCommand(prompt, {
       model: options.model,
@@ -474,7 +485,16 @@ export class ClaudeCliProvider implements AIInterface {
     messages: AIMessage[],
     options: ChatOptions = {},
   ): AsyncIterable<string> {
-    const { prompt, systemPrompt } = this.mapMessagesToPrompt(messages);
+    let { prompt, systemPrompt } = this.mapMessagesToPrompt(messages);
+
+    // Add JSON format instruction if requested
+    if (options.responseFormat?.type === 'json_object') {
+      const jsonInstruction =
+        '\n\nIMPORTANT: You must respond with valid JSON only. Do not include any explanatory text outside the JSON object.';
+      systemPrompt = systemPrompt
+        ? systemPrompt + jsonInstruction
+        : jsonInstruction.trim();
+    }
 
     yield* this.executeStreamingCommand(prompt, {
       model: options.model,


### PR DESCRIPTION
## Summary

Fixes the `claude-cli` provider to properly handle the `responseFormat` option when `{ type: 'json_object' }` is specified. Previously, the provider was ignoring this option, causing the AI to return prose text instead of JSON, which led to JSON parsing errors in downstream applications.

## Problem

The `claude-cli` provider's `chat()` and `stream()` methods were not checking for `options.responseFormat` and therefore not instructing the model to output JSON. This caused:
- JSON parsing errors when applications expected structured output
- praeco report generation failures (see happyvertical/praeco#39)
- Inconsistent behavior compared to other providers

## Solution

Added JSON formatting instructions to the system prompt when `responseFormat: { type: 'json_object' }` is specified, following the same pattern as the Anthropic provider:

```typescript
if (options.responseFormat?.type === 'json_object') {
  const jsonInstruction =
    '\n\nIMPORTANT: You must respond with valid JSON only. Do not include any explanatory text outside the JSON object.';
  systemPrompt = systemPrompt
    ? systemPrompt + jsonInstruction
    : jsonInstruction.trim();
}
```

This prompt-based approach is necessary because Claude CLI doesn't have native JSON mode like OpenAI's API.

## Changes

### Files Modified
- `packages/ai/src/shared/providers/claude-cli.ts`
  - Updated `chat()` method to handle `responseFormat` option (line ~401)
  - Updated `stream()` method to handle `responseFormat` option (line ~484)

### Implementation Details
1. Check if `options.responseFormat?.type === 'json_object'`
2. Append JSON instruction to system prompt
3. Pass modified system prompt to CLI execution

## Testing

### Test Results
```
✅ All tests pass (70 passed | 6 skipped)
✅ No new test failures introduced
✅ TypeScript compilation succeeds
✅ Linting passes
```

### Manual Testing
Tested with praeco-style usage:
```typescript
const ai = await getAI({ type: 'claude-cli' });
const response = await ai.chat(messages, {
  responseFormat: { type: 'json_object' },
});
// response.content now contains valid JSON
```

## Consistency with Other Providers

This fix brings `claude-cli` in line with how other providers handle JSON mode:

| Provider | Implementation |
|----------|----------------|
| **OpenAI** | Native `response_format` API parameter |
| **Gemini** | Native `responseMimeType: 'application/json'` |
| **Anthropic** | Prompt-based instruction (same as this fix) |
| **Claude CLI** | Now uses prompt-based instruction ✅ |

## Impact

### Fixes
- Resolves praeco report generation failures
- Prevents JSON parsing errors when using `claude-cli` with `responseFormat`
- Makes `claude-cli` behavior consistent with other providers

### Breaking Changes
None - this is a bug fix that adds missing functionality

### Backward Compatibility
Full backward compatibility maintained:
- Existing code without `responseFormat` works unchanged
- Only affects requests with `responseFormat: { type: 'json_object' }`

## Checklist

- [x] Code changes implemented
- [x] Tests pass (70/70 passing)
- [x] TypeScript compiles without errors
- [x] Code formatted with Biome
- [x] Conventional commit message
- [x] Issue reference included
- [x] Documentation comments updated

## Related Issues

Closes #323
Related to happyvertical/praeco#39