### PR TITLE
fix(sql): handle quoted table names in CREATE TABLE regex

### DIFF
--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -1293,7 +1293,7 @@ export async function getDatabase(
         // This ensures SMRT system tables persist even when empty
         if (writeStrategy !== 'none') {
           const createTableMatch = sql.match(
-            /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)/i,
+            /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?(\w+)["']?/i,
           );
           if (createTableMatch) {
             const tableName = createTableMatch[1];
@@ -1407,7 +1407,7 @@ export async function getDatabase(
           // This ensures tables persist even when empty
           if (writeStrategy !== 'none') {
             const createTableMatch = command.match(
-              /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)/i,
+              /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?(\w+)["']?/i,
             );
             if (createTableMatch) {
               const tableName = createTableMatch[1];


### PR DESCRIPTION
## Summary

Fixes a bug in the JSON adapter where quoted table names in CREATE TABLE statements were being incorrectly parsed, causing the adapter to attempt exporting a table named "IF" instead of the actual table name.

## Problem

The JSON adapter uses regex to detect CREATE TABLE statements and automatically export empty tables to JSON. The regex pattern was:

```javascript
/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)/i
```

When SMRT generates schemas with quoted identifiers (e.g., `CREATE TABLE IF NOT EXISTS "meetings"`), the `\w+` pattern fails to match the quoted table name. The regex engine backtracks, making the optional `(?:IF\s+NOT\s+EXISTS\s+)?` group not match, and `(\w+)` captures "IF" as the table name instead.

This resulted in repeated errors:
```
[json-adapter] Could not export newly created table IF: Catalog Error: Table with name IF does not exist!
```

## Solution

Updated regex to handle both quoted and unquoted table names:

```javascript
/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?(\w+)["']?/i
```

This pattern:
- Matches CREATE TABLE statements with optional IF NOT EXISTS clause ✓
- Handles quoted identifiers with single or double quotes ✓
- Still works with unquoted identifiers ✓

## Testing

Tested with SMRT-generated schemas containing quoted table names:
- `CREATE TABLE IF NOT EXISTS "meetings"` → correctly extracts "meetings" ✓
- `CREATE TABLE users` → correctly extracts "users" ✓
- No more "IF" table export errors ✓

## Related Issues

This fix enables proper table export for SMRT-generated schemas with quoted identifiers, which is necessary for proper JSON adapter operation.

Ref: #332 (connection caching)