### PR TITLE
fix(release): add package-specific tagFormat for monorepo releases

### DIFF
--- a/packages/ai/.releaserc.json
+++ b/packages/ai/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/ai@${version}"
 }

--- a/packages/cache/.releaserc.json
+++ b/packages/cache/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/cache@${version}"
 }

--- a/packages/documents/.releaserc.json
+++ b/packages/documents/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/documents@${version}"
 }

--- a/packages/files/.releaserc.json
+++ b/packages/files/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/files@${version}"
 }

--- a/packages/geo/.releaserc.json
+++ b/packages/geo/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/geo@${version}"
 }

--- a/packages/github-actions/.releaserc.json
+++ b/packages/github-actions/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/github-actions@${version}"
 }

--- a/packages/logger/.releaserc.json
+++ b/packages/logger/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/logger@${version}"
 }

--- a/packages/ocr/.releaserc.json
+++ b/packages/ocr/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/ocr@${version}"
 }

--- a/packages/pdf/.releaserc.json
+++ b/packages/pdf/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/pdf@${version}"
 }

--- a/packages/sdk-mcp/.releaserc.json
+++ b/packages/sdk-mcp/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/sdk-mcp@${version}"
 }

--- a/packages/spider/.releaserc.json
+++ b/packages/spider/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/spider@${version}"
 }

--- a/packages/sql/.releaserc.json
+++ b/packages/sql/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/sql@${version}"
 }

--- a/packages/translator/.releaserc.json
+++ b/packages/translator/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/translator@${version}"
 }

--- a/packages/utils/.releaserc.json
+++ b/packages/utils/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/utils@${version}"
 }

--- a/packages/weather/.releaserc.json
+++ b/packages/weather/.releaserc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../.releaserc.packages.json"
+  "extends": "../../.releaserc.packages.json",
+  "tagFormat": "@happyvertical/weather@${version}"
 }

--- a/scripts/setup-package-releases.js
+++ b/scripts/setup-package-releases.js
@@ -3,18 +3,14 @@
 /**
  * Sets up semantic-release configuration for all workspace packages
  * Creates .releaserc.json in each package that extends the shared config
+ * and includes package-specific tagFormat for proper monorepo releases
  */
 
-import { existsSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const packagesDir = 'packages';
 const sharedConfig = '../../.releaserc.packages.json';
-
-// Config template for each package
-const packageConfig = {
-  extends: sharedConfig,
-};
 
 // Get all package directories
 const packageDirs = readdirSync(packagesDir, { withFileTypes: true })
@@ -26,6 +22,7 @@ console.log(
 );
 
 let created = 0;
+let updated = 0;
 let skipped = 0;
 
 for (const pkgDir of packageDirs) {
@@ -40,23 +37,45 @@ for (const pkgDir of packageDirs) {
     continue;
   }
 
-  // Check if config already exists
-  if (existsSync(releaseConfigPath)) {
-    console.log(`  ℹ️  ${pkgDir}: .releaserc.json already exists, skipping`);
+  // Read package.json to get package name
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  const packageName = packageJson.name;
+
+  if (!packageName) {
+    console.log(`  ⚠️  ${pkgDir}: No name in package.json, skipping`);
     skipped++;
     continue;
   }
 
-  // Create config
-  writeFileSync(
-    releaseConfigPath,
-    JSON.stringify(packageConfig, null, 2) + '\n',
-  );
-  console.log(`  ✔️  ${pkgDir}: Created .releaserc.json`);
-  created++;
+  // Create package-specific config with tagFormat
+  const packageConfig = {
+    extends: sharedConfig,
+    tagFormat: `${packageName}@\${version}`,
+  };
+
+  const configContent = JSON.stringify(packageConfig, null, 2) + '\n';
+
+  // Check if config needs update
+  if (existsSync(releaseConfigPath)) {
+    const existingConfig = readFileSync(releaseConfigPath, 'utf-8');
+    if (existingConfig === configContent) {
+      console.log(`  ℹ️  ${pkgDir}: .releaserc.json up to date`);
+      skipped++;
+      continue;
+    }
+    console.log(`  🔄  ${pkgDir}: Updating .releaserc.json with tagFormat`);
+    updated++;
+  } else {
+    console.log(`  ✔️  ${pkgDir}: Created .releaserc.json with tagFormat`);
+    created++;
+  }
+
+  // Write config
+  writeFileSync(releaseConfigPath, configContent);
 }
 
 console.log(`\nCompleted:`);
 console.log(`  Created: ${created}`);
+console.log(`  Updated: ${updated}`);
 console.log(`  Skipped: ${skipped}`);
 console.log(`  Total: ${packageDirs.length}`);


### PR DESCRIPTION
## Summary

Fixes package publishing by adding package-specific `tagFormat` to enable semantic-release to properly track releases for each workspace package in the monorepo.

## Problem

PR #342 attempted to initialize individual package publishing, but **all 15 workspace packages failed to publish** with the message:
```
There are no relevant changes, so no new version is released.
```

**Root Cause**:
- Semantic-release couldn't find any previous tags to compare against
- Root package has tags: `v0.52.0`, `v0.53.0`, `v0.54.0`
- Workspace packages had NO tags (no `@happyvertical/ai@0.52.0`, etc.)
- Without tags, semantic-release has no baseline to determine "what's new"

## Solution

Add package-specific `tagFormat` to each package's `.releaserc.json`:

```json
{
  "extends": "../../.releaserc.packages.json",
  "tagFormat": "@happyvertical/ai@${version}"
}
```

This enables semantic-release to:
1. Create package-specific tags (`@happyvertical/ai@0.52.0`)
2. Track releases per package independently
3. Properly detect changes on subsequent releases

## Changes

### Updated Script: `scripts/setup-package-releases.js`
- Reads `package.json` to get package name
- Generates `tagFormat` dynamically for each package
- Updates existing configs instead of skipping them
- Tracks created/updated/skipped counts

### Updated Configs: All 15 Packages
- `packages/ai/.releaserc.json` → Added `tagFormat: "@happyvertical/ai@${version}"`
- `packages/cache/.releaserc.json` → Added `tagFormat: "@happyvertical/cache@${version}"`
- ...15 packages total

## Technical Details

**Tag Format Pattern**: `@happyvertical/{package-name}@${version}`

This pattern:
- Matches npm package naming convention
- Avoids conflicts with root package tags
- Enables per-package version tracking
- Works with semantic-release's version detection

**Semantic Release Behavior**:
- First release: No previous tag → publishes as `0.52.0`
- Subsequent releases: Compares commits since last tag
- Only publishes if there are relevant changes (feat/fix/etc.)

## Expected Behavior After Merge

When merged and workflow runs:
1. ✅ All 15 packages will publish their first tagged release
2. ✅ Tags will be created: `@happyvertical/ai@0.52.0`, `@happyvertical/sql@0.52.0`, etc.
3. ✅ Future changes will trigger version bumps per package
4. ✅ Packages can evolve independently with their own versions

## Test Plan

- [x] Script runs successfully and updates all configs
- [x] All 15 package configs have correct tagFormat
- [x] Build passes and tests run
- [ ] Workflow publishes all packages after merge
- [ ] Tags are created in correct format
- [ ] Subsequent commits trigger proper version detection

## Related

- Fixes: Package publishing failure from PR #342
- Depends on: PR #341 (individual package publishing infrastructure)
- Depends on: PR #340 (GitHub Packages publishing setup)