### PR TITLE
fix(sql): resolve TypeScript build errors

### DIFF
--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -346,7 +346,8 @@ async function getSmrtSchemaForTable(
 ): Promise<SmrtSchemaDefinition | null> {
   try {
     // Try to import ObjectRegistry from @happyvertical/smrt
-    // Use @vite-ignore to prevent Vite from trying to resolve this at build time
+    // Use string literal and @ts-expect-error to prevent TypeScript from resolving at build time
+    // @ts-expect-error - Optional peer dependency, may not be installed
     const smrtPackage = await import(/* @vite-ignore */ '@happyvertical/smrt');
     const { ObjectRegistry } = smrtPackage;
 

--- a/packages/sql/src/sqlite.ts
+++ b/packages/sql/src/sqlite.ts
@@ -288,16 +288,20 @@ export async function getDatabase(
 
       if (Array.isArray(data)) {
         // Serialize all records in the array
-        const serializedData = data.map((record) => serializeRecord(record));
-        const keys = Object.keys(serializedData[0]);
-        const placeholders = serializedData
+        const serializedRecords: Array<Record<string, any>> = data.map(
+          (record) => serializeRecord(record),
+        );
+        const keys = Object.keys(serializedRecords[0]);
+        const placeholders = serializedRecords
           .map(() => `(${keys.map(() => '?').join(', ')})`)
           .join(', ');
         sql = `INSERT INTO ${table} (${keys.join(', ')}) VALUES ${placeholders}`;
-        values = serializedData.reduce(
-          (acc, row) => acc.concat(Object.values(row)),
-          [] as any[],
-        );
+        // Flatten all values into a single array for batch insert
+        const flattenedValues: any[] = [];
+        for (const record of serializedRecords) {
+          flattenedValues.push(...Object.values(record));
+        }
+        values = flattenedValues;
       } else {
         // Serialize the single record
         const serializedData = serializeRecord(data);


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation errors in the sql package that were causing workflow failures.

## Changes
- **json.ts**: Add @ts-expect-error for optional @happyvertical/smrt import
  - The SMRT package is an optional peer dependency that may not be installed
  - Using @ts-expect-error prevents TypeScript from trying to resolve the module at build time
  
- **sqlite.ts**: Refactor array reduce to fix type inference issue
  - Replace reduce with explicit for loop for better type safety
  - TypeScript type narrowing was not working correctly with the reduce pattern
  - New approach is clearer and more maintainable

## Testing
- Build passes without TypeScript errors
- Type declarations generated successfully
- All tests pass
- Pre-push hooks pass

## Related
Fixes build failures from PR #354

closes #355