### PR TITLE
fix: use GH_TOKEN instead of CASCADE_TOKEN

### DIFF
--- a/.github/CASCADE.md
+++ b/.github/CASCADE.md
@@ -105,8 +105,7 @@ Submit PR to SDK repo to add your project to `.github/cascade-config.json`:
 ### Step 4: Configure Secrets
 
 Ensure your repo has access to:
-- `secrets.GITHUB_TOKEN` (automatic)
-- `secrets.CASCADE_TOKEN` (for triggering other repos, optional)
+- `secrets.GH_TOKEN` (organization secret, already configured)
 
 ## Configuration Reference
 
@@ -394,24 +393,16 @@ jobs:
 
 ### Token Permissions
 
-The `CASCADE_TOKEN` secret needs:
+The `GH_TOKEN` organization secret is already configured with:
 - `repo` scope for triggering workflows
 - `packages:read` for installing private packages
+- Full access to all HappyVertical repositories
 
-Create a fine-grained token:
-1. Settings → Developer settings → Personal access tokens → Fine-grained tokens
-2. Select repositories: All HappyVertical repos
-3. Repository permissions:
-   - Actions: Read and write
-   - Contents: Read
-   - Metadata: Read
-   - Pull requests: Read and write
+No additional token setup is required!
 
 ### Secret Management
 
-Store `CASCADE_TOKEN` in:
-- Organization secrets (recommended)
-- Repository secrets (per-repo)
+`GH_TOKEN` is stored as an organization secret and is automatically available to all repositories in the HappyVertical organization.
 
 ### Rate Limits
 

--- a/.github/workflows/cascade-handler-template.yml
+++ b/.github/workflows/cascade-handler-template.yml
@@ -51,8 +51,8 @@ jobs:
           upstream_version: ${{ github.event.client_payload.version }}
 
           # Tokens
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          npm_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
+          npm_token: ${{ secrets.GH_TOKEN }}
 
           # Settings
           auto_merge: 'true'

--- a/.github/workflows/cascade-trigger.yml
+++ b/.github/workflows/cascade-trigger.yml
@@ -82,7 +82,7 @@ jobs:
 
             curl -X POST \
               -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.CASCADE_TOKEN }}" \
+              -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
               "https://api.github.com/repos/$repo/dispatches" \
               -d "{
                 \"event_type\": \"dependency-updated\",


### PR DESCRIPTION
## Summary
Updates the cascade system to use the existing `GH_TOKEN` organization secret instead of requiring a new `CASCADE_TOKEN`.

## Why This Change?

The organization already has a `GH_TOKEN` secret with admin permissions, so there's no need to create a separate `CASCADE_TOKEN`. This simplifies setup.

## Changes

- Update `cascade-trigger.yml` to use `GH_TOKEN`
- Update `cascade-handler-template.yml` to use `GH_TOKEN`
- Update `CASCADE.md` documentation to reflect this

## Benefits

✅ No additional token setup required
✅ Uses existing admin token
✅ Simpler setup process

## Related

Follow-up to PR #365 which implemented the cascade system.