### PR TITLE
fix: use workspace path for ESM imports in github-script

### DIFF
--- a/.github/workflows/planning.yml
+++ b/.github/workflows/planning.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { startPlanning, completePlanning } = await import('@happyvertical/github-actions');
+            const { startPlanning, completePlanning } = await import('${{ github.workspace }}/node_modules/@happyvertical/github-actions/dist/index.js');
 
             const planningContext = {
               token: process.env.GITHUB_TOKEN,

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { triageIssue } = await import('@happyvertical/github-actions');
+            const { triageIssue } = await import('${{ github.workspace }}/node_modules/@happyvertical/github-actions/dist/index.js');
 
             const triageContext = {
               token: process.env.GITHUB_TOKEN,


### PR DESCRIPTION
## Summary

Fixes ESM import errors in triage and planning workflows.

## Problem

The workflows were using bare module specifiers:
```javascript
await import('@happyvertical/github-actions')
```

This fails with `ERR_MODULE_NOT_FOUND` because github-script v7 supports
dynamic imports only for file paths, not bare module specifiers from
node_modules.

## Solution

Use full workspace paths to the dist file:
```javascript
await import('${{ github.workspace }}/node_modules/@happyvertical/github-actions/dist/index.js')
```

## Testing

- Verified github-script v7 documentation on ESM imports
- Confirmed @happyvertical/github-actions is pure ESM package
- Syntax tested locally (will be validated when workflow runs)

## Related

- Part of #351 (kanban automation)
- Fixes workflows from #367

closes #351