### PR TITLE
feat: migrate to changesets workflow for version management

### DIFF
--- a/.changeset/migrate-to-changesets.md
+++ b/.changeset/migrate-to-changesets.md
@@ -1,0 +1,6 @@
+---
+---
+
+Migrate from manual version bumping to changesets workflow.
+
+This is a workflow-only change that doesn't affect package functionality, so no version bumps are needed. Future PRs will use changesets to manage versions and changelogs.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,54 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  check:
+    name: Check for Changeset
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changeset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Skip if PR has 'skip-changeset' label
+          if gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep -q 'skip-changeset'; then
+            echo "✅ Skipping changeset check (skip-changeset label present)"
+            exit 0
+          fi
+
+          # Skip if PR title starts with 'chore: version packages'
+          if echo "${{ github.event.pull_request.title }}" | grep -qi '^chore: version packages'; then
+            echo "✅ Skipping changeset check (version packages PR)"
+            exit 0
+          fi
+
+          # Check if changeset files exist (excluding README.md)
+          changeset_count=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l)
+
+          if [ "$changeset_count" -gt 0 ]; then
+            echo "✅ Found $changeset_count changeset(s)"
+            find .changeset -name '*.md' ! -name 'README.md' -exec basename {} \;
+            exit 0
+          else
+            echo "❌ No changeset found"
+            echo ""
+            echo "Please add a changeset by running:"
+            echo "  npx changeset"
+            echo ""
+            echo "Or add the 'skip-changeset' label if this PR doesn't require a version bump"
+            echo "(e.g., documentation changes, test updates, workflow changes)"
+            exit 1
+          fi

--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -1,0 +1,64 @@
+name: Changesets Version
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  version:
+    name: Create Version PR or Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Setup Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Create Version PR or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm run version-packages
+          publish: pnpm run release
+          commit: 'chore: version packages'
+          title: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create git tags
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          # Create tags for each published package
+          echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "\(.name)@\(.version)"' | while read tag; do
+            echo "🏷️  Creating tag: $tag"
+            git tag "$tag" || echo "Tag $tag already exists"
+          done
+
+          git push --tags || echo "No new tags to push"

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -37,129 +37,16 @@ jobs:
       runner: 'ubuntu-latest'
       node-version: '24'
 
-  # Job 2: Build and release (only if tests pass)
-  build-and-release:
-    name: Build and Release
-    runs-on: ubuntu-latest
-    needs: [test]
-    if: needs.test.outputs.success == 'true'
-
-    outputs:
-      bump_type: ${{ steps.version.outputs.bump }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          node-version: '24'
-          registry-url: 'https://npm.pkg.github.com'
-
-      - name: Setup Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      - name: Build packages
-        run: pnpm run build
-
-      - name: Determine version bump from commits
-        id: version
-        run: |
-          # Get commit messages from the most recent merge
-          commits=$(git log --merges --max-count=1 --pretty=format:"%b")
-
-          # Determine version bump type
-          bump="patch"
-          if echo "$commits" | grep -qE "^feat(\(.+\))?!?:"; then
-            bump="minor"
-          fi
-
-          if echo "$commits" | grep -qiE "(BREAKING CHANGE|!:)"; then
-            bump="minor"  # Treat as minor until 1.0.0
-          fi
-
-          echo "bump=$bump" >> $GITHUB_OUTPUT
-          echo "📦 Will perform $bump version bump"
-
-      - name: Bump versions in package.json files
-        run: |
-          # Find all package.json files in packages directory
-          for pkg_json in packages/*/package.json; do
-            if [ -f "$pkg_json" ]; then
-              pkg_dir=$(dirname "$pkg_json")
-              pkg_name=$(node -p "require('./$pkg_json').name")
-              current_version=$(node -p "require('./$pkg_json').version")
-
-              # Calculate new version
-              IFS='.' read -r major minor patch <<< "$current_version"
-              if [ "${{ steps.version.outputs.bump }}" = "minor" ]; then
-                minor=$((minor + 1))
-                patch=0
-              else
-                patch=$((patch + 1))
-              fi
-              new_version="$major.$minor.$patch"
-
-              echo "📦 $pkg_name: $current_version → $new_version"
-
-              # Update version in package.json
-              node -e "
-                const fs = require('fs');
-                const pkg = JSON.parse(fs.readFileSync('$pkg_json', 'utf8'));
-                pkg.version = '$new_version';
-                fs.writeFileSync('$pkg_json', JSON.stringify(pkg, null, 2) + '\n');
-              "
-            fi
-          done
-
-      - name: Commit version bumps
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packages/*/package.json
-          git commit -m "chore: bump package versions [${{ steps.version.outputs.bump }}]" || echo "No changes to commit"
-          git push
-
-      - name: Publish packages
-        id: publish
-        run: pnpm run release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create git tags
-        run: |
-          # Create tags for each published package
-          for pkg_json in packages/*/package.json; do
-            if [ -f "$pkg_json" ]; then
-              pkg_name=$(node -p "require('./$pkg_json').name")
-              pkg_version=$(node -p "require('./$pkg_json').version")
-              tag_name="${pkg_name}@${pkg_version}"
-
-              echo "🏷️  Creating tag: $tag_name"
-              git tag "$tag_name" || echo "Tag $tag_name already exists"
-            fi
-          done
-
-          git push --tags || echo "No new tags to push"
-
-  # Job 3: Deploy documentation (only if build succeeds)
+  # Job 2: Deploy documentation (only if tests pass)
   # Note: We deploy docs on every merge to main to ensure they stay in sync
   # Skip only if explicitly requested via workflow_dispatch
   deploy-docs:
     name: Deploy Documentation
     runs-on: ubuntu-latest
-    needs: [build-and-release]
+    needs: [test]
     if: |
       always() &&
-      needs.build-and-release.result == 'success' &&
+      needs.test.outputs.success == 'true' &&
       github.event.inputs.skip-docs != 'true'
 
     environment:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,43 @@ This means you can focus on your changes and let Turborepo handle the build orch
 - Description must start with a capital letter
 
 ## Pull Request Guidelines
+
+### Adding a Changeset
+
+Before merging your PR, you must add a changeset describing your changes:
+
+```bash
+npx changeset
+```
+
+This will prompt you to:
+1. **Select affected packages** - Choose which packages have changed
+2. **Select bump type** for each package:
+   - `patch` - Bug fixes, small changes (0.0.X)
+   - `minor` - New features, non-breaking changes (0.X.0)
+   - `major` - Breaking changes (treated as minor until 1.0.0)
+3. **Write a summary** - Describe the change for the CHANGELOG
+
+Example changeset file (`.changeset/random-words-abc.md`):
+```markdown
+---
+"@happyvertical/ai": minor
+"@happyvertical/sql": patch
+---
+
+Add Claude AI provider support and fix SQL connection pooling issue
+```
+
+### When to Skip Changesets
+
+Add the `skip-changeset` label to your PR if it doesn't require a version bump:
+- Documentation updates
+- Test changes
+- Workflow/CI changes
+- Internal refactoring with no API changes
+
+### PR Requirements
+
 - All pull requests must follow the template:
   ```md
   <!-- Please include a summary of the changes -->
@@ -73,9 +110,23 @@ This means you can focus on your changes and let Turborepo handle the build orch
 
   - [ ] Run `npm test`
   - [ ] Run `npm run lint`
+  - [ ] Add changeset (or add `skip-changeset` label)
   ```
 - Include a clear summary of the changes at the top of the pull request description
-- Reference any related issues using the format `#issue-number` 
+- Reference any related issues using the format `#issue-number`
+
+### Publishing Process
+
+Releases are managed through changesets:
+
+1. **PRs add changesets** - Contributors add `.changeset/*.md` files
+2. **Version Packages PR** - Changesets bot creates/updates a PR that:
+   - Bumps versions in `package.json`
+   - Updates `CHANGELOG.md` files
+   - Deletes changeset files
+3. **Merge to publish** - When the Version Packages PR merges, packages are automatically published to GitHub Packages
+
+This means releases are batched and controlled, not automatic on every merge. 
 
 ## Dependencies and Testing
 - Inject dependencies through a deps object parameter for testability


### PR DESCRIPTION
## Summary

Migrates from manual version bumping to the changesets workflow to fix conflicts on every PR and improve release management.

## Problem

Currently, `on-merge-main.yml` manually bumps versions and commits directly to `main` after every merge. This causes:

1. **Conflicts on every PR** - Post-merge commits change main, causing all open PRs to conflict
2. **No CHANGELOG** - Manual bumps don't update CHANGELOG files
3. **Uncontrolled releases** - Every merge immediately publishes, can't batch releases
4. **Redundant code** - We're maintaining version bump logic that changesets already handles

## Solution

Replace manual version bumping with the industry-standard changesets workflow.

### New Workflow

1. **Contributors add changesets** - Run `npx changeset` in PR to describe changes
2. **Changesets bot creates Version PR** - Automatically aggregates all changes
3. **Merge Version PR to publish** - Controlled release timing, no automatic publishing

### Changes in this PR

- ✅ Add `changeset-version.yml` - Creates Version Packages PR on main pushes
- ✅ Add `changeset-check.yml` - Requires changesets on PRs (or `skip-changeset` label)
- ✅ Update `on-merge-main.yml` - Remove manual version bump logic (lines 73-151)
- ✅ Update `CONTRIBUTING.md` - Add changeset documentation
- ✅ Add changeset for this PR - Demonstrates the new workflow

## Benefits

✅ **No more conflicts** - Main only changes when Version PR merges (controlled)  
✅ **Better changelogs** - Automatic CHANGELOG.md generation  
✅ **Batched releases** - Merge multiple PRs, release once  
✅ **No version collisions** - Each PR adds a unique changeset file  
✅ **Conventional workflow** - Industry standard for monorepos  
✅ **Less code to maintain** - Remove ~80 lines of manual version bump logic  

## Testing Plan

1. Merge this PR
2. Verify changesets bot creates "Version Packages" PR
3. Review the Version PR (check versions, CHANGELOG)
4. Merge Version PR
5. Verify packages publish and cascade triggers

## Breaking Changes

**For contributors:**
- Must run `npx changeset` before merging PR
- Or add `skip-changeset` label for non-publishable changes

**For releases:**
- No longer auto-publishes on every merge
- Must merge "Version Packages" PR to publish
- Can batch multiple changes into one release

## Compatibility

The dependency cascade system works perfectly with changesets:
1. Version Packages PR merges → versions change
2. Packages publish → cascade triggers
3. SMRT/Praeco/Caelus get PRs with updated deps
4. Same cascade flow, just triggered by Version PR instead of every PR

No changes needed to cascade system!

closes #368