### PR TITLE
fix: extract only first PR number in cancel-pr-validation job

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Get PR number from merge commit
         id: pr
         run: |
-          # Extract PR number from merge commit message
-          PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '#\K\d+' || echo "")
+          # Extract PR number from merge commit message (first occurrence only)
+          PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '#\K\d+' | head -1 || echo "")
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
           if [ -n "$PR_NUMBER" ]; then


### PR DESCRIPTION
## Problem

The cancel-pr-validation job (added in #370) was failing with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '368'
```

When a PR's commit message contains `closes #XXX` or similar, the grep command was finding multiple PR numbers (e.g., #372 from the merge commit title AND #368 from the body), causing multi-line output to `GITHUB_OUTPUT` which is invalid.

## Solution

Add `| head -1` to extract only the **first** PR number, which is always the actual PR number from the merge commit title (e.g., "Merge pull request #372 from...").

```bash
# Before (broken)
PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '#\K\d+' || echo "")

# After (fixed)
PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '#\K\d+' | head -1 || echo "")
```

## Testing

This will be tested when this PR merges - the cancel-pr-validation job should complete successfully without the "Invalid format" error.