### PR TITLE
fix(ci): add dependency cascade trigger to changesets workflow

### DIFF
--- a/.changeset/add-cascade-trigger.md
+++ b/.changeset/add-cascade-trigger.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add dependency cascade trigger to changesets workflow.
+
+When packages are published via the changesets workflow, the cascade now triggers to update downstream repositories (SMRT, Praeco, Caelus). This was accidentally removed when implementing changesets in #372.

--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -62,3 +62,21 @@ jobs:
           done
 
           git push --tags || echo "No new tags to push"
+
+      - name: Trigger dependency cascade
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          echo "📢 Triggering dependency cascade for downstream repositories..."
+
+          # Trigger SMRT
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/happyvertical/smrt/dispatches \
+            -f event_type='dependency-updated' \
+            -f client_payload='{"repository":"happyvertical/sdk"}'
+
+          echo "✅ Triggered SMRT dependency cascade"


### PR DESCRIPTION
## Problem

When we implemented the changesets workflow in #372, the dependency cascade trigger was accidentally removed as part of removing the manual version bumping logic from `on-merge-main.yml`.

This means that when packages are published via changesets, downstream repositories (SMRT, Praeco, Caelus) are not notified of the updates.

## Solution

Add a new step to `changeset-version.yml` that triggers the dependency cascade when packages are successfully published:

```yaml
- name: Trigger dependency cascade
  if: steps.changesets.outputs.published == 'true'
  env:
    GH_TOKEN: ${{ secrets.GH_TOKEN }}
  run: |
    # Trigger SMRT
    gh api --method POST /repos/happyvertical/smrt/dispatches \
      -f event_type='dependency-updated' \
      -f client_payload='{"repository":"happyvertical/sdk"}'
```

## Key Changes

- The cascade only triggers when `steps.changesets.outputs.published == 'true'`
- This means it runs when the "Version Packages" PR merges and actually publishes packages
- Does NOT trigger on every merge to main (only when versions bump)

## Testing

This will be tested when the next "Version Packages" PR is merged.

## Checklist

- [x] Run `npm test`
- [x] Run `npm run lint`
- [x] Add changeset