### PR TITLE
fix(ci): use raw JSON for cascade client_payload

### DIFF
--- a/.changeset/fix-cascade-json.md
+++ b/.changeset/fix-cascade-json.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix JSON payload format in dependency cascade trigger.
+
+Use `-F` flag instead of `-f` for client_payload to send raw JSON object rather than JSON string.

--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -77,6 +77,6 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/happyvertical/smrt/dispatches \
             -f event_type='dependency-updated' \
-            -f client_payload='{"repository":"happyvertical/sdk"}'
+            -F client_payload='{"repository":"happyvertical/sdk"}'
 
           echo "✅ Triggered SMRT dependency cascade"


### PR DESCRIPTION
## Problem

This PR fixes two related cascade workflow issues:

### Issue 1: Invalid client_payload format (original issue)

The dependency cascade trigger in `changeset-version.yml` was failing with HTTP 422:

```
For 'properties/client_payload', "{\"repository\":\"happyvertical/sdk\"}" is not an object.
```

The `gh api` command was using `-f` flag which sends the value as a string, not as JSON.

### Issue 2: Invalid cascade handler output format (#400)

The cascade handler action was outputting downstream targets with invalid format:

```
##[error]Invalid format '  "blindmanpress/bentleyalberta.com"'
```

This occurred when the JSON array with quoted repository names was written directly to `$GITHUB_OUTPUT`.

## Solutions

### Fix 1: Use raw JSON for client_payload

Change from `-f` (string field) to `-F` (raw field) for the `client_payload` parameter:

```yaml
# Before (broken)
-f client_payload='{"repository":"happyvertical/sdk"}'

# After (fixed)
-F client_payload='{"repository":"happyvertical/sdk"}'
```

### Fix 2: Use multiline output format for cascade handler

Change from inline JSON to GitHub Actions multiline output format:

```yaml
# Before (broken)
echo "repositories=$triggered_json" >> $GITHUB_OUTPUT

# After (fixed)
echo "repositories<<EOF" >> $GITHUB_OUTPUT
echo "$triggered_json" >> $GITHUB_OUTPUT
echo "EOF" >> $GITHUB_OUTPUT
```

This uses the standard GitHub Actions heredoc-style multiline output format which properly handles JSON data with quotes.

## Testing

Since packages were already published in the previous run, we'll need to manually trigger the cascade to SMRT after this fix merges to verify it works correctly.

Closes #377
Closes #400