### PR TITLE
fix(pdf): use root vitest config to prevent channel closed error

### DIFF
--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -31,8 +31,8 @@
     }
   },
   "scripts": {
-    "test": "npx vitest run --testTimeout 60000",
-    "test:watch": "npx vitest --testTimeout 60000",
+    "test": "cd ../.. && npx vitest run --config vitest.config.ts packages/pdf",
+    "test:watch": "cd ../.. && npx vitest --config vitest.config.ts packages/pdf",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "docs": "typedoc --plugin typedoc-plugin-markdown --out docs --entryPoints ./src/index.ts --tsconfig ./tsconfig.json --excludePrivate --excludeInternal --hideGenerator --fileExtension .md --readme none --categorizeByGroup false --includeVersion false --hidePageHeader --hidePageTitle false --outputFileStrategy modules",


### PR DESCRIPTION
## Summary

Fixes the "Channel closed" error in PDF package tests by ensuring they use the root `vitest.config.ts` configuration.

## Problem

After merging PR #387 (dependency updates to vite 7.2.2 and vitest 4.0.8), the on-merge-main workflow was failing with:

```
Error: Channel closed
    at ChildProcess.target.send (node:internal/child_process:753:16)
    at ForksPoolWorker.send
```

The PDF package's test scripts were running `npx vitest run --testTimeout 60000` without specifying a config file, so Vitest 4.x was using default configuration instead of the root config.

## Root Cause

The root `vitest.config.ts` has critical pool configuration for Vitest 4.x compatibility:
- `pool: 'forks'` 
- `singleFork: true`
- `isolate: true`

Without these settings, Vitest 4.x encounters child process/IPC channel communication errors.

## Solution

Updated PDF package test scripts to:
1. Change directory to SDK root
2. Use the proper `vitest.config.ts` configuration
3. Run tests from root with `packages/pdf` filter

This ensures tests use the same pool configuration as other packages.

## Testing

✅ All PDF tests pass locally (40 tests)
✅ No "Channel closed" errors
✅ Tests use proper fork pool configuration

## Closes

fixes #<will determine issue number>