### PR TITLE
fix(ci): use multiline output for cascade handler repositories

### DIFF
--- a/.github/actions/cascade-handler/action.yml
+++ b/.github/actions/cascade-handler/action.yml
@@ -280,8 +280,11 @@ runs:
         done
 
         # Output triggered repositories as JSON array
-        triggered_json=$(printf '%s\n' "${triggered[@]}" | jq -R . | jq -s .)
-        echo "repositories=$triggered_json" >> $GITHUB_OUTPUT
+        # Use GitHub Actions multiline output format to avoid quote escaping issues
+        triggered_json=$(printf '%s\n' "${triggered[@]}" | jq -R . | jq -s . -c)
+        echo "repositories<<EOF" >> $GITHUB_OUTPUT
+        echo "$triggered_json" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Summary
       shell: bash


### PR DESCRIPTION
## Problem

Fixes #400

The cascade handler action was outputting downstream targets using inline JSON format which caused GitHub Actions parsing errors when the JSON contained quotes:

```
##[error]Invalid format '  "blindmanpress/bentleyalberta.com"'
```

This error occurred in `.github/actions/cascade-handler/action.yml` at lines 283-284 where the `repositories` output was being set using inline format:

```bash
triggered_json=$(printf '%s\n' "${triggered[@]}" | jq -R . | jq -s .)
echo "repositories=$triggered_json" >> $GITHUB_OUTPUT
```

When the JSON array contained quoted repository names like `["blindmanpress/bentleyalberta.com"]`, GitHub Actions couldn't parse it correctly.

## Solution

Changed to use GitHub Actions multiline output format with EOF delimiters:

```bash
triggered_json=$(printf '%s\n' "${triggered[@]}" | jq -R . | jq -s . -c)
echo "repositories<<EOF" >> $GITHUB_OUTPUT
echo "$triggered_json" >> $GITHUB_OUTPUT
echo "EOF" >> $GITHUB_OUTPUT
```

This is the standard GitHub Actions approach for multiline or complex outputs and prevents quote escaping issues.

## Changes

- Updated `.github/actions/cascade-handler/action.yml` lines 282-287
- Added `-c` flag to `jq` for compact output
- Used heredoc-style multiline output format

## Testing

This fix will be validated when the cascade workflow runs and triggers downstream repositories (praeco, bentleyalberta.com) after a successful package publish.

Closes #400