### PR TITLE
fix(ci): update happyvertical workflows to use shared paths

### DIFF
--- a/.github/workflows/happyvertical/on-issue-closed.yml
+++ b/.github/workflows/happyvertical/on-issue-closed.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   cleanup:
-    uses: happyvertical/sdk/.github/workflows/issue-closer-reusable.yml@main
+    uses: happyvertical/sdk/.github/workflows/shared/issue-closer-reusable.yml@main
     with:
       issue_number: ${{ github.event.issue.number }}
       repo_owner: ${{ github.repository_owner }}

--- a/.github/workflows/happyvertical/on-issue-opened.yml
+++ b/.github/workflows/happyvertical/on-issue-opened.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   triage:
-    uses: happyvertical/sdk/.github/workflows/triage-reusable.yml@main
+    uses: happyvertical/sdk/.github/workflows/shared/triage-reusable.yml@main
     with:
       issue_number: ${{ github.event.issue.number }}
       issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/happyvertical/on-label-changed.yml
+++ b/.github/workflows/happyvertical/on-label-changed.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   handle-label:
-    uses: happyvertical/sdk/.github/workflows/label-handler-reusable.yml@main
+    uses: happyvertical/sdk/.github/workflows/shared/label-handler-reusable.yml@main
     with:
       issue_number: ${{ github.event.issue.number }}
       label_name: ${{ github.event.label.name }}
@@ -36,7 +36,7 @@ jobs:
 
   orchestrate-agent:
     if: github.event.label.name == 'agent: claude'
-    uses: happyvertical/sdk/.github/workflows/agent-orchestrator-reusable.yml@main
+    uses: happyvertical/sdk/.github/workflows/shared/agent-orchestrator-reusable.yml@main
     with:
       agent_name: claude
       action: ${{ github.event.action }}

--- a/.github/workflows/happyvertical/on-merge-main.yml
+++ b/.github/workflows/happyvertical/on-merge-main.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   orchestrate:
-    uses: happyvertical/sdk/.github/workflows/merge-orchestrator-reusable.yml@main
+    uses: happyvertical/sdk/.github/workflows/shared/merge-orchestrator-reusable.yml@main
     with:
       repo_owner: ${{ github.repository_owner }}
       repo_name: ${{ github.event.repository.name }}

--- a/.github/workflows/happyvertical/on-pr-opened.yml
+++ b/.github/workflows/happyvertical/on-pr-opened.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   handle-pr:
-    uses: happyvertical/sdk/.github/workflows/pr-handler-reusable.yml@main
+    uses: happyvertical/sdk/.github/workflows/shared/pr-handler-reusable.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}
       pr_title: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Problem

After merging #413, the on-merge-main workflow wasn't running because the workflows in `happyvertical/` directory were still referencing the old paths without `/shared/`.

## Fix

Updated all 6 workflows in `.github/workflows/happyvertical/` to use the new paths:
- `happyvertical/sdk/.github/workflows/shared/*-reusable.yml@main`

## Files Changed

- on-issue-opened.yml
- on-issue-closed.yml  
- on-label-changed.yml
- on-merge-main.yml
- on-pr-opened.yml

This should fix on-merge-main not triggering after merges.