### PR TITLE
fix(ci): replace GITHUB_TOKEN with GH_TOKEN in shared workflows

### DIFF
--- a/.changeset/fix-gh-token-usage.md
+++ b/.changeset/fix-gh-token-usage.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/github-actions": patch
+---
+
+Replace GITHUB_TOKEN with GH_TOKEN in shared workflows to avoid system reserved name collision and gain additional permissions

--- a/.github/workflows/shared-agent-orchestrator.yml
+++ b/.github/workflows/shared-agent-orchestrator.yml
@@ -24,7 +24,7 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for API access'
         required: true
 
@@ -40,7 +40,7 @@ jobs:
         if: inputs.action == 'labeled'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const agentName = '${{ inputs.agent_name }}';
             const issueNumber = ${{ inputs.issue_number }};
@@ -88,7 +88,7 @@ jobs:
         if: inputs.action == 'unlabeled'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const agentName = '${{ inputs.agent_name }}';
             const issueNumber = ${{ inputs.issue_number }}';

--- a/.github/workflows/shared-issue-closer.yml
+++ b/.github/workflows/shared-issue-closer.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for API access'
         required: true
 
@@ -31,7 +31,7 @@ jobs:
       - name: Cleanup Issue
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const issueNumber = ${{ inputs.issue_number }};
 

--- a/.github/workflows/shared-label-handler.yml
+++ b/.github/workflows/shared-label-handler.yml
@@ -24,7 +24,7 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for API access'
         required: true
 
@@ -53,17 +53,17 @@ jobs:
       - name: Install dependencies
         run: |
           echo "@happyvertical:registry=https://npm.pkg.github.com" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }}" >> .npmrc
           npm install @happyvertical/github-actions@0.55.0
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Process Label Change
         uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const labelName = '${{ inputs.label_name }}';
             const action = '${{ inputs.action }}';

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for API access'
         required: true
 

--- a/.github/workflows/shared-pr-handler.yml
+++ b/.github/workflows/shared-pr-handler.yml
@@ -24,7 +24,7 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for API access'
         required: true
 
@@ -40,7 +40,7 @@ jobs:
       - name: Link PR to Issues
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const prNumber = ${{ inputs.pr_number }};
             const prTitle = `${{ inputs.pr_title }}`;

--- a/.github/workflows/shared-triage.yml
+++ b/.github/workflows/shared-triage.yml
@@ -28,7 +28,7 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for API access'
         required: true
 
@@ -57,17 +57,17 @@ jobs:
       - name: Install dependencies
         run: |
           echo "@happyvertical:registry=https://npm.pkg.github.com" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }}" >> .npmrc
           npm install @happyvertical/github-actions@0.55.0
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Triage Issue
         uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const { readFileSync } = require('fs');
             const { triageIssue } = await import('${{ github.workspace }}/node_modules/@happyvertical/github-actions/dist/index.js');


### PR DESCRIPTION
## Summary

Fixes workflow validation failures by replacing `GITHUB_TOKEN` with `GH_TOKEN` in all shared workflows.

## Problem

After merging PR #417 and PR #419, all shared workflows are failing with:

```
"secret name `GITHUB_TOKEN` within `workflow_call` can not be 
 used since it would collide with system reserved name"
```

**Root Cause**: GitHub Actions reserves `GITHUB_TOKEN` as a system secret name and does not allow it to be explicitly defined in `workflow_call` inputs, as this creates a naming conflict.

## Solution

Replace `GITHUB_TOKEN` with `GH_TOKEN` throughout all shared workflows:
- `GH_TOKEN` is available as a repository secret
- Provides additional permissions beyond the default `GITHUB_TOKEN`
- No naming conflict with GitHub's reserved names

## Changes

Updated 6 shared workflows:
- ✅ `shared-agent-orchestrator.yml`
- ✅ `shared-issue-closer.yml`
- ✅ `shared-label-handler.yml`
- ✅ `shared-merge-orchestrator.yml`
- ✅ `shared-pr-handler.yml`
- ✅ `shared-triage.yml`

All references changed from:
```yaml
secrets:
  GITHUB_TOKEN:
    description: 'GitHub token for API access'
    required: true
```

To:
```yaml
secrets:
  GH_TOKEN:
    description: 'GitHub token for API access'
    required: true
```

And usage from `${{ secrets.GITHUB_TOKEN }}` → `${{ secrets.GH_TOKEN }}`

## Impact

- ✅ Resolves workflow validation failures
- ✅ Enables shared workflows to run successfully
- ✅ Maintains all existing functionality
- ✅ Uses more permissive token (GH_TOKEN)

## Testing

After merge, verify:
- [ ] Shared workflows no longer fail validation
- [ ] Workflows can be successfully called from other repositories
- [ ] Token permissions are sufficient for all operations