### PR TITLE
fix(ci): restore on-merge-main workflow to SDK repository

### DIFF
--- a/.changeset/restore-on-merge-main-workflow.md
+++ b/.changeset/restore-on-merge-main-workflow.md
@@ -1,0 +1,12 @@
+---
+"@happyvertical/github-actions": patch
+---
+
+Restore on-merge-main.yml workflow to SDK repository
+
+The on-merge-main workflow was accidentally removed when workflows were
+converted to templates for other repositories. This caused version bumping
+and package publishing to stop working for SDK merges to main.
+
+This restores the workflow to call the local shared-merge-orchestrator which
+orchestrates test -> build -> publish pipeline.

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -1,0 +1,19 @@
+name: On Merge to Main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  orchestrate:
+    uses: ./.github/workflows/shared-merge-orchestrator.yml
+    with:
+      repo_owner: ${{ github.repository_owner }}
+      repo_name: ${{ github.event.repository.name }}
+      ref: ${{ github.ref }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

Restores the critical `on-merge-main.yml` workflow that was accidentally removed in PR #410. This workflow is responsible for version bumping and package publishing.

## Problem

Since commit f4656af8 (PR #410), the SDK repository has been missing its `on-merge-main.yml` workflow. The workflow was converted to a template (`on-merge-main-template.yml`) for use by other repositories, but the SDK itself was left without a workflow to run on merges to main.

**Impact**: No version bumping or package publishing has occurred for any PRs merged after PR #410:
- PR #417 (fix workflow triggers)
- PR #419 (fix SQL UPSERT)
- PR #420 (fix GH_TOKEN usage)
- PR #421 (fix workflow syntax)

All of these PRs have changesets but versions haven't been bumped and packages haven't been published.

## Solution

Restore the `on-merge-main.yml` workflow that triggers on push to main and calls the local `shared-merge-orchestrator.yml`, which orchestrates:
1. `test.yml` - Run tests
2. `build.yml` - Build packages
3. `publish.yml` - Run changesets (version/publish) + deploy docs

## Changes

- `.github/workflows/on-merge-main.yml` - New workflow triggered on push to main
- Uses local `shared-merge-orchestrator.yml` with `GH_TOKEN` secret
- Includes proper permissions and workflow inputs

## Test Plan

- [x] Workflow validates without syntax errors
- [x] Typecheck passes
- [ ] After merge, verify workflow runs and creates version PR
- [ ] Verify version PR auto-merges
- [ ] Verify packages publish to GitHub Packages

## Related Issues

Fixes the root cause preventing package publishing since PR #410.