### PR TITLE
fix(ci): grant write permissions to on-merge-main workflow

### DIFF
--- a/.changeset/fix-on-merge-main-permissions.md
+++ b/.changeset/fix-on-merge-main-permissions.md
@@ -1,0 +1,7 @@
+---
+"@happyvertical/github-actions": patch
+---
+
+Fix permissions in on-merge-main workflow to allow publishing
+
+The on-merge-main workflow needs write permissions for contents, packages, pages, and id-token to allow the publish job to create version PRs and publish packages.

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
-  packages: read
+  contents: write
+  packages: write
+  id-token: write
+  pages: write
 
 jobs:
   orchestrate:


### PR DESCRIPTION
## Summary

Fixes the permissions error that caused the on-merge-main workflow to fail.

## Problem

The on-merge-main workflow failed with:
```
The workflow is requesting 'contents: write, packages: write, 
pages: write, id-token: write', but is only allowed 'contents: read, 
packages: read, pages: none, id-token: none'.
```

The calling workflow (`on-merge-main.yml`) only had read permissions, but the called workflows need write permissions to perform their tasks.

## Solution

Grant all required write permissions to `on-merge-main.yml`:
- `contents: write` - Create version PRs and push tags
- `packages: write` - Publish to GitHub Packages
- `id-token: write` - Authenticate with GitHub  
- `pages: write` - Deploy documentation to GitHub Pages

## Changes

- `.github/workflows/on-merge-main.yml` - Change permissions from read to write

## Test Plan

- [x] Workflow validates without syntax errors
- [x] Typecheck passes
- [ ] After merge, verify on-merge-main workflow runs successfully
- [ ] Verify changesets creates version PR
- [ ] Verify packages publish to GitHub Packages

## Related

Fixes the failure from PR #422: https://github.com/happyvertical/sdk/actions/runs/19271338461