### PR TITLE
fix(ci): grant write permissions to shared-merge-orchestrator

### DIFF
--- a/.changeset/fix-shared-orchestrator-permissions.md
+++ b/.changeset/fix-shared-orchestrator-permissions.md
@@ -1,0 +1,7 @@
+---
+"@happyvertical/github-actions": patch
+---
+
+Fix permissions in shared-merge-orchestrator to allow publishing
+
+The shared-merge-orchestrator workflow was restricting permissions to read-only, which prevented the publish workflow from creating version PRs and publishing packages. Reusable workflows override caller permissions, so the orchestrator needs write permissions.

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -21,8 +21,10 @@ on:
         required: true
 
 permissions:
-  contents: read
-  packages: read
+  contents: write
+  packages: write
+  id-token: write
+  pages: write
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Fixes the actual root cause of the permissions failure - the `shared-merge-orchestrator.yml` itself needs write permissions.

## Problem

Even after granting write permissions to `on-merge-main.yml` in PR #423, the workflow still failed with the same error:
```
The workflow is requesting 'contents: write, packages: write, 
pages: write, id-token: write', but is only allowed 'contents: read, 
packages: read, pages: none, id-token: none'.
```

**Root Cause**: When a reusable workflow is called using `uses:`, the permissions defined in the **called workflow** override the permissions from the **calling workflow**. Even though `on-merge-main.yml` granted write permissions, `shared-merge-orchestrator.yml` was restricting them back to read-only.

## Solution

Update `shared-merge-orchestrator.yml` to grant the write permissions that its called workflows (test, build, publish) need:
- `contents: write` - Create version PRs, push tags
- `packages: write` - Publish to GitHub Packages  
- `pages: write` - Deploy documentation
- `id-token: write` - Authenticate with GitHub

## Changes

- `.github/workflows/shared-merge-orchestrator.yml` - Change permissions from read to write

## Test Plan

- [x] Workflow validates without syntax errors
- [x] Typecheck passes
- [ ] After merge, verify on-merge-main workflow runs successfully
- [ ] Verify test → build → publish pipeline completes
- [ ] Verify changesets creates version PR
- [ ] Verify packages publish to GitHub Packages

## Related

- Failed after PR #422: https://github.com/happyvertical/sdk/actions/runs/19271338461
- Failed after PR #423: https://github.com/happyvertical/sdk/actions/runs/19271841553