### PR TITLE
fix(ci): add pull-requests permission for version PR creation

### DIFF
--- a/.changeset/add-pull-requests-permission.md
+++ b/.changeset/add-pull-requests-permission.md
@@ -1,0 +1,7 @@
+---
+"@happyvertical/github-actions": patch
+---
+
+Add pull-requests: write permission to allow version PR creation
+
+The changesets action needs pull-requests: write permission to create version PRs. Without it, the workflow fails with "Resource not accessible by integration" when attempting to create the PR.

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
   id-token: write
   pages: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
   id-token: write
   pages: write
 

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -23,6 +23,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
   id-token: write
   pages: write
 


### PR DESCRIPTION
## Summary

Adds the missing `pull-requests: write` permission that the changesets action needs to create version PRs.

## Problem

The on-merge-main workflow made progress - it successfully:
1. ✅ Ran tests
2. ✅ Built packages
3. ✅ Created version branch `changeset-release/main`
4. ✅ Pushed the branch to GitHub

But then failed with:
```
HttpError: Resource not accessible by integration
```

**Root Cause**: Missing `pull-requests: write` permission. The workflows had `contents`, `packages`, `pages`, and `id-token` permissions, but the changesets action specifically needs `pull-requests: write` to create PRs.

## Solution

Add `pull-requests: write` permission to all three workflow files that are involved in the publish pipeline:
- `on-merge-main.yml` - Entry point workflow
- `shared-merge-orchestrator.yml` - Orchestrator that calls publish
- `publish.yml` - Workflow that runs changesets

## Changes

All three files now have complete permissions:
```yaml
permissions:
  contents: write
  packages: write
  pull-requests: write  # ← Added
  id-token: write
  pages: write
```

## Test Plan

- [x] Workflow validates without syntax errors
- [x] Typecheck passes
- [ ] After merge, verify on-merge-main workflow completes successfully
- [ ] Verify changesets creates version PR
- [ ] Verify version PR can be auto-merged
- [ ] Verify packages publish to GitHub Packages

## Related

- Failed after PR #424: https://github.com/happyvertical/sdk/actions/runs/19272267630
- Branch was created successfully: `changeset-release/main`