### PR TITLE
fix(ci): skip changeset check for changesets release PRs

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -29,6 +29,12 @@ jobs:
             exit 0
           fi
 
+          # Skip if PR is from changeset-release branch (automated version packages PR)
+          if echo "${{ github.event.pull_request.head.ref }}" | grep -q '^changeset-release/'; then
+            echo "✅ Skipping changeset check (changesets release PR from ${{ github.event.pull_request.head.ref }})"
+            exit 0
+          fi
+
           # Skip if PR title starts with 'chore: version packages'
           if echo "${{ github.event.pull_request.title }}" | grep -qi '^chore: version packages'; then
             echo "✅ Skipping changeset check (version packages PR)"


### PR DESCRIPTION
## Summary

Fix the changeset check workflow to skip validation for automated `changeset-release/*` branches. This prevents release PRs created by changesets from being blocked by the changeset check requirement.

## Problem

PR #433 (automated "chore: version packages" PR) is blocked by the changeset check workflow, which requires a changeset file. This creates a circular dependency:
- Release PRs are created by changesets to publish versions
- But the CI requires a changeset file to pass
- Release PRs shouldn't need changesets since they ARE the version bump

## Solution

Add a branch name check to skip changeset validation when the PR is from a `changeset-release/*` branch.

## Impact

- Unblocks PR #433 and future automated release PRs
- Long-term solution that prevents this issue from recurring
- Complements existing skip conditions (skip-changeset label, title check)

## Testing

Once merged, PR #433 should automatically pass the changeset check and proceed to auto-merge (if enabled).

Closes #433
