### PR TITLE
chore: enable fixed versioning for all @happyvertical packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@happyvertical/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/unified-versioning.md
+++ b/.changeset/unified-versioning.md
@@ -1,0 +1,34 @@
+---
+"@happyvertical/ai": patch
+"@happyvertical/cache": patch
+"@happyvertical/documents": patch
+"@happyvertical/encryption": patch
+"@happyvertical/files": patch
+"@happyvertical/geo": patch
+"@happyvertical/github-actions": patch
+"@happyvertical/logger": patch
+"@happyvertical/messages": patch
+"@happyvertical/ocr": patch
+"@happyvertical/pdf": patch
+"@happyvertical/projects": patch
+"@happyvertical/repos": patch
+"@happyvertical/sdk-mcp": patch
+"@happyvertical/spider": patch
+"@happyvertical/sql": patch
+"@happyvertical/translator": patch
+"@happyvertical/utils": patch
+"@happyvertical/weather": patch
+---
+
+Enable fixed versioning for all @happyvertical packages
+
+All packages in the SDK monorepo now share the same version number. This simplifies version management and makes it easier to understand which packages work together.
+
+**Changes:**
+- Updated `.changeset/config.json` to enable fixed versioning for all `@happyvertical/*` packages
+- All packages will now be bumped together to the same version
+- Future changesets will automatically synchronize versions across all packages
+
+**Migration:**
+- All packages will be synchronized to the same version on the next release
+- The root `package.json` version will be kept in sync with all packages


### PR DESCRIPTION
## Summary

Enable fixed versioning for all @happyvertical packages in the SDK monorepo. All packages will now share the same version number, simplifying version management and making it easier to understand which packages work together.

## Problem

Currently, packages in the SDK have different version numbers:
- Most packages: 0.55.4
- @happyvertical/sql: 0.55.7
- @happyvertical/sdk-mcp: 0.55.5
- @happyvertical/github-actions: 0.55.5
- New packages: 0.1.0 (encryption, messages)
- Root package.json: 0.55.0

This makes it difficult to understand compatibility and requires tracking multiple version numbers.

## Solution

Configure changesets to use fixed versioning:
- All packages will be bumped together to the same version
- The root `package.json` version will be kept in sync
- Future changesets will automatically synchronize versions

**Changes:**
- Updated `.changeset/config.json` with `"fixed": [["@happyvertical/*"]]`
- Added changeset to trigger version synchronization

## Impact

- Simplifies version management across the monorepo
- Makes package compatibility clearer
- Ensures consistent versioning for all releases
- The next release will synchronize all packages to the same version

## Testing

Once merged:
1. Run `pnpm changeset version` to synchronize all package versions
2. Verify all packages get the same version number
3. Verify root package.json is updated to match
