### PR TITLE
fix(weather): ensure windSpeed is always a number

### DIFF
--- a/.changeset/fix-weather-windspeed-type.md
+++ b/.changeset/fix-weather-windspeed-type.md
@@ -1,0 +1,9 @@
+---
+"@happyvertical/weather": patch
+---
+
+fix(weather): ensure windSpeed is always a number in Environment Canada provider
+
+The Environment Canada API returns wind speed values as strings instead of numbers. This change wraps the wind speed values with Number() to ensure they are always returned as numbers, matching the WeatherForecast type interface.
+
+Fixes test failure in environment-canada.spec.ts where windSpeed type assertion was failing.

--- a/packages/weather/src/providers/environment-canada.ts
+++ b/packages/weather/src/providers/environment-canada.ts
@@ -196,7 +196,7 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
         timestamp: new Date(currentConditions.timestamp?.en || new Date()),
         temperature: currentConditions.temperature?.value?.en || 0,
         humidity: currentConditions.relativeHumidity?.value?.en || 0,
-        windSpeed: currentConditions.wind?.speed?.value?.en || 0,
+        windSpeed: Number(currentConditions.wind?.speed?.value?.en) || 0,
         windDirection: currentConditions.wind?.bearing?.value?.en,
         pressure: (currentConditions.pressure?.value?.en || 0) * 10, // Convert kPa to hPa
         conditions: currentConditions.condition?.en || 'Unknown',
@@ -234,7 +234,8 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
           temperatureMax: highTemp?.value?.en,
           temperatureMin: lowTemp?.value?.en,
           humidity: periodForecast.relativeHumidity?.value?.en || 0,
-          windSpeed: periodForecast.winds?.periods?.[0]?.speed?.value?.en || 0,
+          windSpeed:
+            Number(periodForecast.winds?.periods?.[0]?.speed?.value?.en) || 0,
           windDirection: periodForecast.winds?.periods?.[0]?.bearing?.value?.en,
           conditions:
             periodForecast.cloudPrecip?.en ||


### PR DESCRIPTION
## Summary

Fix type mismatch in Environment Canada weather provider where `windSpeed` values are returned as strings instead of numbers.

## Problem

The Environment Canada API returns wind speed values as strings, but our WeatherForecast interface expects numbers. This was causing test failures:

```
AssertionError: expected 'string' to be 'number'
Expected: "number"
Received: "string"
```

## Solution

Wrap wind speed values with `Number()` to ensure they are always returned as numbers:
- Line 199: Current conditions wind speed
- Line 237: Forecast periods wind speed

## Testing

✅ All environment-canada tests now pass (9/9)
✅ Local test run completed successfully

## Impact

- Fixes failing test in `environment-canada.spec.ts`
- Ensures type consistency with `WeatherForecast` interface
- No breaking changes - API remains the same

Closes #443 (unblocks the release PR)
