### PR TITLE
fix(ci): use GH_TOKEN for changesets to trigger PR workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for version PR


### PR DESCRIPTION
## Summary

Fix CI workflows not triggering on changesets version PRs by using `GH_TOKEN` (PAT) instead of `GITHUB_TOKEN`.

## Problem

PR #446 (and #443 before it) showed "no checks reported" because GitHub blocks workflow triggers when PRs are created using `GITHUB_TOKEN`. This is a security feature to prevent infinite workflow loops.

**Evidence:**
```json
{
  "author": {"is_bot": true, "login": "app/github-actions"},
  "statusCheckRollup": []  // ← No checks running
}
```

## Root Cause

The `changesets/action@v1` in `.github/workflows/publish.yml` was using `GITHUB_TOKEN` to create version PRs. This prevents the `on-pull-request.yml` workflow (and other PR workflows) from triggering.

## Solution

Change line 68 in `.github/workflows/publish.yml`:
```diff
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
```

Using `GH_TOKEN` (a Personal Access Token with workflow permissions) allows workflows to trigger normally on the created PR.

## Testing

After merge, the next changesets version PR should:
- ✅ Trigger the Pull Request Validation workflow
- ✅ Run tests via test-suite.yml
- ✅ Show status checks in the PR
- ✅ Auto-merge when checks pass

## Impact

- Unblocks PR #446 (version packages release)
- Future changesets version PRs will run CI checks automatically
- Enables auto-merge for version PRs as intended

Fixes #447
Relates to: #443, #446