### PR TITLE
fix(spider): normalize /download/ URLs for consistent WordPress detection

### DIFF
--- a/.changeset/wordpress-trailing-slash-fix.md
+++ b/.changeset/wordpress-trailing-slash-fix.md
@@ -1,0 +1,9 @@
+---
+'@happyvertical/spider': patch
+---
+
+Fix WordPress detection for URLs without trailing slashes (#454)
+
+WordPress Download Manager detection now works consistently regardless of trailing slashes. URLs like `/download/meeting` and `/download/meeting/` are now both properly detected as WordPress download pages.
+
+This fixes an issue where WordPress servers return different HTML content for URLs with and without trailing slashes, causing detection to fail for URLs without slashes.

--- a/packages/spider/src/scrapeDocument.ts
+++ b/packages/spider/src/scrapeDocument.ts
@@ -429,6 +429,14 @@ export async function scrapeDocument(
   url: string,
   options?: DocumentScrapeOptions,
 ): Promise<DocumentResult> {
+  // Normalize URL for WordPress detection: ensure /download/ paths have trailing slash
+  // This fixes issue #454 where WordPress detection fails without trailing slash
+  // WordPress servers return different content for URLs with/without trailing slashes
+  let normalizedUrl = url;
+  if (url.includes('/download/') && !url.includes('?') && !url.endsWith('/')) {
+    normalizedUrl = url + '/';
+  }
+
   // Use provided scraper config or defaults (basic + dom)
   const scraperType = options?.scraper || 'basic';
   const spiderType = options?.spider || 'dom';
@@ -438,8 +446,8 @@ export async function scrapeDocument(
     spider: spiderType,
   } as any);
 
-  const result = await scraper.scrape(url, options);
-  const actualUrl = url;
+  const result = await scraper.scrape(normalizedUrl, options);
+  const actualUrl = normalizedUrl;
 
   // Defensive check: If result.content looks like HTML (starts with <!DOCTYPE, <html>, etc.),
   // we should be very careful about marking it as a PDF
@@ -450,7 +458,10 @@ export async function scrapeDocument(
     result.content.includes('<body>');
 
   // Check if this is a WordPress Download Manager page
-  const wpDownloadUrl = extractWordPressDownloadUrl(url, result.content);
+  const wpDownloadUrl = extractWordPressDownloadUrl(
+    normalizedUrl,
+    result.content,
+  );
   if (wpDownloadUrl) {
     // IMPORTANT: WordPress Download Manager URLs often return HTML tracking pages
     // before redirecting to the actual PDF. We detect the download page but

--- a/packages/spider/src/wordpress-detection.spec.ts
+++ b/packages/spider/src/wordpress-detection.spec.ts
@@ -79,4 +79,42 @@ describe('WordPress Download Manager detection (issue #449)', () => {
     // Instead, it should be treated as basic HTML content
     expect(result.metadata.strategy).not.toBe('wordpress-pdf-link');
   }, 30000);
+
+  it('should detect WordPress without trailing slash (issue #454)', async () => {
+    // This test verifies the fix for sdk#454: WordPress detection should work
+    // consistently regardless of trailing slash
+    const urlWithoutSlash =
+      'https://townofbentley.ca/download/regular-council-meeting-october-14-2025-agenda';
+
+    const result = await scrapeDocument(urlWithoutSlash, {
+      scraper: 'basic',
+      cache: false,
+    });
+
+    // Should detect WordPress download page even without trailing slash
+    expect(result.metadata.strategy).toBe('wordpress-pdf-link');
+    expect(result.metadata.isPdf).toBe(true);
+    expect(result.url).toContain('wpdmdl=');
+  }, 30000);
+
+  it('should detect WordPress consistently with and without trailing slash', async () => {
+    // This test verifies that both URL forms return the same result
+    const baseUrl =
+      'https://townofbentley.ca/download/regular-council-meeting-october-14-2025-agenda';
+
+    const withSlash = await scrapeDocument(baseUrl + '/', {
+      scraper: 'basic',
+      cache: false,
+    });
+
+    const withoutSlash = await scrapeDocument(baseUrl, {
+      scraper: 'basic',
+      cache: false,
+    });
+
+    // Both should return the same strategy and PDF detection
+    expect(withSlash.metadata.strategy).toBe(withoutSlash.metadata.strategy);
+    expect(withSlash.metadata.isPdf).toBe(withoutSlash.metadata.isPdf);
+    expect(withSlash.metadata.strategy).toBe('wordpress-pdf-link');
+  }, 60000);
 });


### PR DESCRIPTION
## Summary

Fixes #454 

WordPress Download Manager detection now works consistently for URLs with and without trailing slashes.

## Problem

WordPress servers return different HTML content for URLs with and without trailing slashes. This caused `scrapeDocument()` to:
- ✅ Correctly detect `https://example.com/download/meeting/` (with slash)
- ❌ Fail to detect `https://example.com/download/meeting` (without slash)

The issue was discovered when praeco removed trailing slash normalization and WordPress detection stopped working.

## Solution

Normalize URLs containing `/download/` paths by ensuring they have trailing slashes before scraping. This ensures consistent HTML content retrieval from WordPress servers.

Changes:
- Add URL normalization in `scrapeDocument()` before scraping
- Normalize only `/download/` paths without query parameters
- Add regression tests for URLs without trailing slashes
- Add test to verify consistent detection for both URL forms

## Test Plan

- [x] Added test: "should detect WordPress without trailing slash (issue #454)"
- [x] Added test: "should detect WordPress consistently with and without trailing slash"  
- [x] All existing WordPress detection tests pass
- [x] All spider package tests pass (74 passed)

## Related Issues

- Fixes #454
- Related to praeco workaround in `src/meetings.ts:1326`