### PR TITLE
test: trigger publish workflow

### DIFF
--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -4,6 +4,8 @@
 # This is a reusable workflow that implements true direct publish for changesets
 # without creating intermediate "Version Packages" PRs.
 #
+# Testing direct publish workflow
+#
 # Usage in calling repository:
 #   jobs:
 #     release:


### PR DESCRIPTION
## Purpose

Test PR to trigger the on-merge-main workflow and verify that the new shared direct publish workflow works correctly.

## Expected Behavior

When this PR is merged to main:
1. On-merge-main workflow should trigger
2. Publish workflow should be called
3. Pending changesets should be consumed:
   - `.changeset/shared-direct-publish.md`
   - `.changeset/direct-publish.md`
   - `.changeset/242vjunt10q-fix-cache-poisoning.md`
4. Packages should be versioned and published
5. **No "Version Packages" PR should be created**
6. GitHub release should be created automatically

## What to Watch For

After merge, monitor:
- Workflow runs at https://github.com/happyvertical/sdk/actions
- Published packages in GitHub Packages
- New GitHub release created
- No intermediate "Version Packages" PR

## Note

This PR intentionally has no changeset - we're testing with the existing pending changesets from previous PRs.