### PR TITLE
fix(ci): remove GITHUB_TOKEN from reusable workflow secrets

### DIFF
--- a/.changeset/fix-github-token-secret.md
+++ b/.changeset/fix-github-token-secret.md
@@ -1,0 +1,9 @@
+---
+'@happyvertical/utils': patch
+---
+
+fix(ci): remove GITHUB_TOKEN from reusable workflow secrets
+
+Remove GITHUB_TOKEN from shared-direct-publish.yml secrets since it's a
+reserved system secret that's automatically available. This fixes workflow
+failures with "secret name collision" errors.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,6 @@ jobs:
       skip-docs: ${{ github.event.inputs.skip-docs == 'true' }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   cascade:
     name: Trigger Dependency Cascade

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -13,7 +13,6 @@
 #         registry-url: 'https://npm.pkg.github.com'
 #       secrets:
 #         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 # =============================================================================
 
 name: Shared Direct Publish
@@ -39,9 +38,6 @@ on:
     secrets:
       GH_TOKEN:
         description: 'GitHub token with write permissions (for pushing to protected main)'
-        required: true
-      GITHUB_TOKEN:
-        description: 'GitHub token for package publishing'
         required: true
     outputs:
       published:


### PR DESCRIPTION
## Problem

Both SDK and SMRT workflows were failing with this error:
```
Secret name `GITHUB_TOKEN` within `workflow_call` can not be used 
since it would collide with system reserved name
```

## Root Cause

`GITHUB_TOKEN` is a reserved system secret that's automatically available in all GitHub Actions workflows. Passing it as an explicit secret input to reusable workflows causes a collision error.

## Solution

- Remove `GITHUB_TOKEN` from `shared-direct-publish.yml` secrets inputs
- Remove it from SDK's `publish.yml` caller
- The workflow continues to work because `secrets.GITHUB_TOKEN` is automatically provided by GitHub

## Changes

1. **shared-direct-publish.yml**:
   - Removed `GITHUB_TOKEN` from secrets section
   - Updated usage documentation
   - Workflow still uses `secrets.GITHUB_TOKEN` (automatically available)

2. **publish.yml** (SDK):
   - Removed `GITHUB_TOKEN` from secrets passed to shared workflow

## Testing

This fix is needed for:
- SDK PR #468 to successfully trigger the publish workflow
- SMRT PR #355 to work correctly
- Both repos' on-merge-main workflows to function

## Related

- Fixes workflow failure: https://github.com/happyvertical/smrt/actions/runs/19451015165
- Blocks SDK PR #468
- Blocks SMRT PR #355