### PR TITLE
fix(ci): use correct version script name in shared workflow

### DIFF
--- a/.changeset/fix-version-script.md
+++ b/.changeset/fix-version-script.md
@@ -1,0 +1,7 @@
+---
+'@happyvertical/utils': patch
+---
+
+fix(ci): use correct version script name in shared workflow
+
+Change `pnpm run version` to `pnpm run version-packages` to match the actual script name in package.json.

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -148,7 +148,7 @@ jobs:
           echo "🔄 Running changeset version..."
 
           # Run changeset version (updates package.json, CHANGELOG.md, removes changeset files)
-          pnpm run version
+          pnpm run version-packages
 
           # Check if any files were changed
           if git diff --quiet; then


### PR DESCRIPTION
## Problem

The shared-direct-publish.yml workflow is failing with:
```
ERR_PNPM_NO_SCRIPT  Missing script: version
```

Failed run: https://github.com/happyvertical/sdk/actions/runs/19452617221/job/55660657092

## Root Cause

The workflow calls `pnpm run version` but the actual script name in package.json is `version-packages`.

## Solution

Change line 151 from:
```yaml
pnpm run version
```

To:
```yaml
pnpm run version-packages
```

## Testing

After this is merged, the workflow should successfully:
1. Run `pnpm run version-packages` (changeset version)
2. Version the packages
3. Publish them