### PR TITLE
fix(ci): correct changeset package reference

### DIFF
--- a/.changeset/direct-publish.md
+++ b/.changeset/direct-publish.md
@@ -1,5 +1,5 @@
 ---
-'@happyvertical/sdk': patch
+'@happyvertical/utils': patch
 ---
 
 feat(ci): implement direct publish on merge to main


### PR DESCRIPTION
Fixes #

## Problem
The  changeset referenced `@happyvertical/sdk` which is the root package name but not a workspace package. This caused the `pnpm run version-packages` command to fail with:

```
Found changeset direct-publish for package @happyvertical/sdk which is not in the workspace
```

This error was blocking the publish workflow from completing successfully.

## Solution
Changed the package reference from `@happyvertical/sdk` to `@happyvertical/utils`, following the convention used in other CI-related changesets.

## Testing
- Verified locally that `pnpm run version-packages` now runs successfully
- All files (package.json, CHANGELOG.md) were properly updated
- Changesets were deleted as expected

## Related Issues
- Fixes the workflow failure in run https://github.com/happyvertical/sdk/actions/runs/19452936126
- Related to PR #471 (version script fix)
- Related to PR #469 (GITHUB_TOKEN secret fix)
- Related to PR #467 (original direct publish implementation)