### PR TITLE
fix(ci): disable body length limits in commitlint for semantic-release commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -83,5 +83,11 @@ export default {
 
     // Footer leading blank - disabled to allow flexible commit message formatting
     'footer-leading-blank': [0, 'always'],
+
+    // Body max length - disable for semantic-release commits with long changelogs
+    'body-max-length': [0],
+
+    // Body max line length - disable for semantic-release commits
+    'body-max-line-length': [0],
   },
 };


### PR DESCRIPTION
## Problem

The semantic-release workflow is failing when trying to commit version changes because commitlint rejects the commit message with the changelog in the body.

semantic-release generates commit messages like:
```
chore(release): 0.56.0 [skip ci]

<thousands of lines of changelog>
```

Commitlint has a body-max-length limit that rejects this.

## Solution

Disable `body-max-length` and `body-max-line-length` rules in commitlint configuration to allow semantic-release commits with long changelogs.

## Testing

This will be tested when the workflow runs again after merging.

Fixes the failure in: https://github.com/happyvertical/sdk/actions/runs/19483192024