### PR TITLE
fix(ci): skip commitlint hook in CI environments

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,10 @@ pre-commit:
       stage_fixed: true
 
 # Commit-msg hook: Validate commit message format
+# Skipped in CI to allow semantic-release commits
 commit-msg:
+  skip:
+    - env: CI
   commands:
     validate:
       run: npx --no-install commitlint --edit {1}


### PR DESCRIPTION
## Problem

semantic-release commits are failing in CI because lefthook's commit-msg hook runs commitlint validation, which can cause various issues:
- Large changelog bodies in commit messages
- CI environment differences
- Hook execution timing

## Solution

Skip the commit-msg hook entirely in CI environments by checking the `CI` environment variable.

This allows semantic-release to create commits without validation interference while still maintaining commit message validation for local development.

## Testing

This fix will allow the publish workflow to successfully create release commits.

Related to: https://github.com/happyvertical/sdk/actions/runs/19483969612