### PR TITLE
fix(ci): explicitly set CI=true for semantic-release

### DIFF
--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Run semantic-release
         id: semantic_release
         env:
+          CI: true
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,10 @@ pre-commit:
       stage_fixed: true
 
 # Commit-msg hook: Validate commit message format
+# Skipped in CI to allow semantic-release commits
 commit-msg:
+  skip:
+    - env: CI
   commands:
     validate:
       run: npx --no-install commitlint --edit {1}


### PR DESCRIPTION
## Problem

The semantic-release workflow is failing because the commit-msg hook is not being skipped in CI, even though we configured lefthook to skip it when `CI` environment variable is set.

## Root Cause

While GitHub Actions sets the `CI` environment variable globally, it was not explicitly included in the `env` block for the "Run semantic-release" step. Lefthook requires the environment variable to be present in the step's environment.

## Solution

Explicitly add `CI: true` to the environment variables for the semantic-release step in the workflow.

## Testing

This should allow semantic-release to successfully create release commits without being blocked by commitlint validation.

Fixes the issue identified in workflow runs like:
- https://github.com/happyvertical/sdk/actions/runs/19484584778

## Related PRs

- #476: Disabled body length limits in commitlint
- #477: Added skip condition for commit-msg hook in CI