### PR TITLE
fix(ci): move skip condition to command level in lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,10 +12,10 @@ pre-commit:
 # Commit-msg hook: Validate commit message format
 # Skipped in CI to allow semantic-release commits
 commit-msg:
-  skip:
-    - env: CI
   commands:
     validate:
+      skip:
+        - run: "[ \"$CI\" = \"true\" ]"
       run: npx --no-install commitlint --edit {1}
 
 # Pre-push hook: Run checks before pushing


### PR DESCRIPTION
## Problem

The hook-level skip condition in lefthook.yml was not working correctly. The commit-msg hook was still running in CI even though we had:

```yaml
commit-msg:
  skip:
    - env: CI
```

## Solution

Move the skip condition to the command level and use an explicit shell test:

```yaml
commit-msg:
  commands:
    validate:
      skip:
        - run: "[ \"$CI\" = \"true\" ]"
      run: npx --no-install commitlint --edit {1}
```

This should be more reliable and explicitly checks if CI equals "true".

## Testing

This should allow semantic-release to successfully create release commits without being blocked by commitlint validation.

## Related PRs

- #476: Disabled body length limits in commitlint  
- #477: Added skip condition for commit-msg hook in CI (hook-level - didn't work)
- #478: Explicitly set CI=true environment variable