### PR TITLE
fix(ci): use GitHub App for semantic-release authentication

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -19,4 +19,5 @@ jobs:
       repo_name: ${{ github.event.repository.name }}
       ref: ${{ github.ref }}
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,8 @@ jobs:
       registry-url: 'https://npm.pkg.github.com'
       skip-docs: ${{ github.event.inputs.skip-docs == 'true' }}
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
   cascade:
     name: Trigger Dependency Cascade

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -41,8 +41,11 @@ on:
         type: boolean
         default: false
     secrets:
-      GH_TOKEN:
-        description: 'GitHub token with write permissions (for pushing to protected main)'
+      RELEASE_APP_ID:
+        description: 'GitHub App ID for release automation'
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for release automation'
         required: true
     outputs:
       published:
@@ -68,12 +71,19 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
+      - name: Generate token from GitHub App
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use GH_TOKEN to allow pushing to protected main branch
-          token: ${{ secrets.GH_TOKEN }}
+          # Use GitHub App token to allow pushing to protected main branch
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -118,7 +128,7 @@ jobs:
         id: semantic_release
         env:
           CI: true
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -16,8 +16,11 @@ on:
         required: true
         type: string
     secrets:
-      GH_TOKEN:
-        description: 'GitHub token for API access'
+      RELEASE_APP_ID:
+        description: 'GitHub App ID for release automation'
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for release automation'
         required: true
 
 permissions:


### PR DESCRIPTION
## Problem

Semantic-release was failing because GitHub's branch protection rules blocked direct pushes to main:

```
remote: error: GH006: Protected branch update failed for refs/heads/main
remote: - 3 of 3 required status checks are expected
```

## Solution

Use a GitHub App instead of `GH_TOKEN` for authentication. GitHub Apps can be configured to bypass branch protection rules, allowing semantic-release to push directly to protected branches.

## Changes

- Replace `GH_TOKEN` secret with `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`
- Use `tibdex/github-app-token@v2` to generate token from app credentials
- Update all workflows (`on-merge-main.yml`, `shared-merge-orchestrator.yml`, `publish.yml`, `shared-direct-publish.yml`)

## Required GitHub App Permissions

The GitHub App needs these **repository permissions**:
- ✅ **Contents**: Read and write (to push commits and create tags)
- ✅ **Metadata**: Read (automatically required)

Optional (not needed for basic semantic-release):
- **Pull requests**: Read and write (only for PR creation)
- **Issues**: Read and write (only for issue comments)

## Branch Protection Configuration

To allow the app to bypass status checks:

1. Go to: **Settings → Branches → Branch protection rules for `main`**
2. Enable: **"Allow specified actors to bypass required pull requests"**
3. Add your GitHub App to the bypass list
4. Save changes

This allows the app to push directly to main without waiting for PR status checks.

## Testing

Once branch protection is configured, semantic-release should successfully:
1. Analyze commits and determine version bump
2. Update CHANGELOG.md
3. Create release commit
4. Push to main (bypassing branch protection)
5. Create GitHub release and tag
6. Publish packages to GitHub Packages

## Related Issues

Completes the semantic-release migration started in:
- #475: Initial semantic-release migration
- #476: Disable commitlint body length limits
- #477: Skip commit-msg hook in CI (hook-level)
- #478: Explicitly set CI=true environment variable
- #479: Move skip to command level (fixed commitlint issue)