### PR TITLE
fix(ci): correct GitHub App secret parameter names

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -19,5 +19,5 @@ jobs:
       repo_name: ${{ github.event.repository.name }}
       ref: ${{ github.ref }}
     secrets:
-      RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
-      RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+      HAVE_RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
+      HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,8 @@ jobs:
       registry-url: 'https://npm.pkg.github.com'
       skip-docs: ${{ github.event.inputs.skip-docs == 'true' }}
     secrets:
-      RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
-      RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+      HAVE_RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
+      HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
   cascade:
     name: Trigger Dependency Cascade

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -41,10 +41,10 @@ on:
         type: boolean
         default: false
     secrets:
-      RELEASE_APP_ID:
+      HAVE_RELEASE_APP_ID:
         description: 'GitHub App ID for release automation'
         required: true
-      RELEASE_APP_PRIVATE_KEY:
+      HAVE_RELEASE_APP_PRIVATE_KEY:
         description: 'GitHub App private key for release automation'
         required: true
     outputs:
@@ -75,8 +75,8 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v2
         with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.HAVE_RELEASE_APP_ID }}
+          private_key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -16,10 +16,10 @@ on:
         required: true
         type: string
     secrets:
-      RELEASE_APP_ID:
+      HAVE_RELEASE_APP_ID:
         description: 'GitHub App ID for release automation'
         required: true
-      RELEASE_APP_PRIVATE_KEY:
+      HAVE_RELEASE_APP_PRIVATE_KEY:
         description: 'GitHub App private key for release automation'
         required: true
 


### PR DESCRIPTION
## Summary
Fixes the workflow failure caused by incorrect GitHub App secret parameter names. Updates all workflow files to use `HAVE_RELEASE_APP_ID` and `HAVE_RELEASE_APP_PRIVATE_KEY` to match the actual repository secrets configured.

## Changes
- **shared-direct-publish.yml**: Updated secret parameter definitions and usage in the `generate_token` step
- **shared-merge-orchestrator.yml**: Updated secret parameter definitions
- **on-merge-main.yml**: Updated secret passing to use correct parameter names
- **publish.yml**: Updated secret passing to use correct parameter names

## Problem
The previous PR #481 used incorrect secret names (`RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`) which caused the `tibdex/github-app-token@v2` action to fail with:
```
Error: Input required and not supplied: app_id
```

## Solution
All workflow files now consistently use `HAVE_RELEASE_APP_ID` and `HAVE_RELEASE_APP_PRIVATE_KEY` throughout the workflow chain:
1. Repository secrets → on-merge-main.yml
2. on-merge-main.yml → shared-merge-orchestrator.yml
3. shared-merge-orchestrator.yml → publish.yml
4. publish.yml → shared-direct-publish.yml

This ensures the GitHub App credentials are properly passed to the token generation step, allowing semantic-release to bypass branch protection and push version commits to the main branch.

## Testing
After merging, the next push to main should successfully:
- Generate a GitHub App token
- Run semantic-release
- Create version commits and tags
- Publish packages to GitHub Packages

closes #482