### PR TITLE
docs(ci): add version bump rules to auto-changeset script

### DIFF
--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -4,6 +4,11 @@
  *
  * Analyzes commits since last release and creates changeset files
  * based on conventional commit messages (feat:, fix:, etc.)
+ *
+ * Version bump rules for 0.x.x releases:
+ * - Breaking changes (feat!, BREAKING CHANGE) → minor bump (0.x.0)
+ * - Features, fixes, perf → patch bump (0.0.x)
+ * - Other commit types (chore, docs, etc.) → no bump
  */
 
 import { execSync } from 'node:child_process';


### PR DESCRIPTION
## Summary

Adds documentation to the auto-changeset script explaining the version bump rules for 0.x.x releases.

## Changes

- Added JSDoc comments documenting version bump rules:
  - Breaking changes → minor bump (0.x.0)
  - Features, fixes, perf → patch bump (0.0.x)  
  - Other commit types → no bump

## Purpose

**Test Changesets Publishing**: This PR will verify that the Changesets workflow correctly:
1. Auto-generates a changeset from this `docs:` commit
2. Detects no version bump is needed (docs commits don't trigger releases)
3. Completes without errors

## Expected Outcome

Since this is a `docs:` commit type, the workflow should:
- ✅ Run successfully
- ✅ Auto-generate changeset detects no version bump needed
- ✅ No packages published (as expected)