### PR TITLE
test: trigger publish workflow to verify package publishing

### DIFF
--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -28,7 +28,7 @@ interface ParsedCommit {
 function exec(command: string): string {
   try {
     return execSync(command, { encoding: 'utf-8' }).trim();
-  } catch (error) {
+  } catch (_error) {
     return '';
   }
 }


### PR DESCRIPTION
## Purpose

This PR tests the Changesets publishing workflow with a `fix:` commit to verify that:
1. Auto-changeset script generates a changeset from conventional commits
2. Packages are versioned (patch bump expected)
3. All `@happyvertical/*` packages are published to GitHub Packages
4. Git tags are created and pushed

## Changes

- Minor code quality improvement: prefix unused error variable with underscore

## Expected Behavior

After merge to main:
1. Workflow should detect the `fix:` commit
2. Auto-generate changeset with patch bump
3. Version packages from 0.54.2 → 0.54.3
4. Build all packages
5. Publish all packages to GitHub Packages
6. Create v0.54.3 tag
7. Push to main with `[skip ci]`

## Related

- Follows up on #485 which used `docs:` commit (doesn't trigger version bump)
- This tests actual package publishing end-to-end