### PR TITLE
feat: sync root monorepo package version with workspace packages

### DIFF
--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -107,6 +107,7 @@ function generateChangesetContent(
   const breaking = commits.filter((c) => c.breaking);
 
   let content = `---\n`;
+  content += `"@happyvertical/sdk": ${bump}\n`;
   content += `"@happyvertical/*": ${bump}\n`;
   content += `---\n\n`;
 


### PR DESCRIPTION
## Purpose

Keep the root `@happyvertical/sdk` package version in sync with workspace packages when using Changesets auto-generation.

## Changes

Updated `scripts/auto-changeset.ts` to include both:
- `@happyvertical/sdk` (root package)
- `@happyvertical/*` (workspace packages)

in the generated changeset frontmatter.

## Before

```yaml
---
"@happyvertical/*": patch
---
```

## After

```yaml
---
"@happyvertical/sdk": patch
"@happyvertical/*": patch
---
```

## Expected Behavior

When this merges:
1. Future changesets will version both root and workspace packages
2. Root `package.json` version will stay in sync
3. Minor bump expected (0.54.3 → 0.55.0) due to `feat:` commit type

## Related

Addresses question from #486 about keeping monorepo root version in sync with workspace packages.