### PR TITLE
fix(ci): use real package name instead of glob in auto-changesets

### DIFF
--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -115,7 +115,8 @@ function generateChangesetContent(
   const breaking = commits.filter((c) => c.breaking);
 
   let content = `---\n`;
-  content += `"@happyvertical/*": ${bump}\n`;
+  // Use @happyvertical/utils as representative package (all packages in fixed group will bump together)
+  content += `"@happyvertical/utils": ${bump}\n`;
   content += `---\n\n`;
 
   if (breaking.length > 0) {


### PR DESCRIPTION
## Problem

PR #491 fixed the undefined subject crash, but introduced a new error:
```
Error: Found changeset for package @happyvertical/* which is not in the workspace
```

The auto-changeset script was generating changesets with `"@happyvertical/*": patch` (glob pattern), but Changesets requires **actual package names** in changeset files, not glob patterns.

## Solution

Changed the generated changeset frontmatter from:
```yaml
"@happyvertical/*": patch
```

To:
```yaml
"@happyvertical/utils": patch
```

Since all `@happyvertical/*` packages are in a **fixed version group** (see `.changeset/config.json`), bumping any one package bumps all of them together. Using `@happyvertical/utils` as the representative package is sufficient.

## Testing

- [x] Script fix compiles and typechecks
- [ ] Workflow should run successfully after merge

## Related

- Fixes workflow run: https://github.com/happyvertical/sdk/actions/runs/19500495539
- Follows up #491 (undefined subject fix)