### PR TITLE
fix(ci): explicitly push version tag for GitHub Releases

### DIFF
--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -174,6 +174,16 @@ jobs:
             git push origin "v$AFTER_VERSION"
             git push origin main
 
+            # Create GitHub Release
+            gh release create "v$AFTER_VERSION" \
+              --title "v$AFTER_VERSION" \
+              --notes "## Published Packages
+
+All packages published to GitHub Packages at version $AFTER_VERSION.
+
+Full Changelog: https://github.com/${{ github.repository }}/compare/v$BEFORE_VERSION...v$AFTER_VERSION" \
+              --latest
+
             echo "published=true" >> $GITHUB_OUTPUT
             echo "version=$AFTER_VERSION" >> $GITHUB_OUTPUT
             echo "✅ Published version: v$AFTER_VERSION"


### PR DESCRIPTION
## Problem

The v0.56.6 version tag was created but not pushed to the remote repository, which prevented GitHub Releases from being created.

## Root Cause

The workflow uses `git push origin main --follow-tags`, which only pushes tags that are reachable from new commits being pushed. Since Changesets already creates and pushes per-package tags (e.g., `@happyvertical/ai@0.56.6`), the commit that `v0.56.6` points to has already been pushed, so `--follow-tags` doesn't include it.

## Solution

Changed the workflow to explicitly push the version tag separately:

```bash
git tag "v$AFTER_VERSION"
git push origin "v$AFTER_VERSION"  # Explicit push
git push origin main
```

This ensures the version tag is always pushed, which is needed for creating GitHub Releases.

## Verification

- The version tag will be pushed separately before pushing the main branch
- GitHub can then create releases based on the `v*` tags
- Per-package tags from Changesets will continue to work as before