### PR TITLE
fix(ci): use GITHUB_REPOSITORY env var in release workflow

### DIFF
--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -181,7 +181,7 @@ jobs:
 
 All packages published to GitHub Packages at version $AFTER_VERSION.
 
-Full Changelog: https://github.com/${{ github.repository }}/compare/v$BEFORE_VERSION...v$AFTER_VERSION" \
+Full Changelog: https://github.com/${GITHUB_REPOSITORY}/compare/v$BEFORE_VERSION...v$AFTER_VERSION" \
               --latest
 
             echo "published=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

PR #493 introduced a YAML syntax error that prevents the workflow from running. The workflow uses a GitHub Actions expression inside a multi-line bash string, which is not allowed:

```yaml
--notes "...https://github.com/${{ github.repository }}/compare/..."
```

## Solution

Use the `GITHUB_REPOSITORY` environment variable instead, which is automatically available in all GitHub Actions workflows:

```yaml
--notes "...https://github.com/${GITHUB_REPOSITORY}/compare/..."
```

## Testing

This should fix the workflow file issue and allow the on-merge-main workflow to run successfully.