### PR TITLE
fix(ci): use GitHub App token for cross-repo dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Trigger dependency cascade
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ needs.release.outputs.app_token }}
         run: |
           echo "📢 Triggering dependency cascade for downstream repositories..."
 

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -55,6 +55,9 @@ on:
       version:
         description: 'The version that was published'
         value: ${{ jobs.release.outputs.version }}
+      app_token:
+        description: 'GitHub App token for cross-repo operations'
+        value: ${{ jobs.release.outputs.app_token }}
 
 permissions:
   contents: write
@@ -70,6 +73,7 @@ jobs:
     outputs:
       published: ${{ steps.publish.outputs.published }}
       version: ${{ steps.get_version.outputs.version }}
+      app_token: ${{ steps.generate_token.outputs.token }}
 
     steps:
       - name: Generate token from GitHub App


### PR DESCRIPTION
## Problem

The cascade job was failing with HTTP 403:
```
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration"}
```

The standard `GITHUB_TOKEN` lacks permissions to trigger `repository_dispatch` events in other repositories (cross-repo operations).

## Solution

Use the GitHub App token that's already being generated in the shared workflow:

1. **Add app_token output** to `shared-direct-publish.yml`
   - Exposes the GitHub App token as a workflow output
   - Token is generated from `HAVE_RELEASE_APP_ID` and `HAVE_RELEASE_APP_PRIVATE_KEY`

2. **Update cascade job** in `publish.yml`
   - Use `needs.release.outputs.app_token` instead of `secrets.GITHUB_TOKEN`
   - Allows triggering repository_dispatch in the SMRT repository

## Prerequisites

The GitHub App must have:
- **Contents: Read & write** permission
- Installation on both SDK and SMRT repositories

## Testing

✅ YAML syntax validated with yamllint
✅ Workflow parsing verified with `act --list`
✅ Typecheck passed

## Related

- Builds on #497 (git hook and dependency trigger fixes)
- Addresses cascade job failure: https://github.com/happyvertical/sdk/actions/runs/19504150427/job/55826832931