### PR TITLE
feat(ai): add message() method to AIInterface

### DIFF
--- a/packages/ai/src/shared/providers/anthropic.ts
+++ b/packages/ai/src/shared/providers/anthropic.ts
@@ -17,6 +17,7 @@ import type {
   CompletionOptions,
   EmbeddingOptions,
   EmbeddingResponse,
+  MessageOptions,
 } from '../types';
 import {
   AIError,
@@ -221,6 +222,53 @@ export class AnthropicProvider implements AIInterface {
       stream: options.stream,
       onProgress: options.onProgress,
     });
+  }
+
+  /**
+   * Simple message interface for single-turn interactions with optional history
+   *
+   * @param text - The message text to send
+   * @param options - Configuration options including history, model, etc.
+   * @returns Promise resolving to the response content string
+   *
+   * @example
+   * ```typescript
+   * // Simple usage
+   * const response = await provider.message('Hello!');
+   *
+   * // With history
+   * const response = await provider.message('What was my question?', {
+   *   history: [
+   *     { role: 'user', content: 'What is 2+2?' },
+   *     { role: 'assistant', content: '4' }
+   *   ]
+   * });
+   * ```
+   */
+  async message(text: string, options: MessageOptions = {}): Promise<string> {
+    // Build messages array from history + current message
+    const messages: AIMessage[] = [
+      ...(options.history || []),
+      { role: options.role || 'user', content: text },
+    ];
+
+    const response = await this.chat(messages, {
+      model: options.model,
+      maxTokens: options.maxTokens,
+      temperature: options.temperature,
+      topP: options.topP,
+      stop: options.stop,
+      stream: options.stream,
+      frequencyPenalty: options.frequencyPenalty,
+      presencePenalty: options.presencePenalty,
+      responseFormat: options.responseFormat,
+      seed: options.seed,
+      tools: options.tools,
+      toolChoice: options.toolChoice,
+      onProgress: options.onProgress,
+    });
+
+    return response.content;
   }
 
   async embed(

--- a/packages/ai/src/shared/providers/bedrock.ts
+++ b/packages/ai/src/shared/providers/bedrock.ts
@@ -13,6 +13,7 @@ import type {
   CompletionOptions,
   EmbeddingOptions,
   EmbeddingResponse,
+  MessageOptions,
 } from '../types';
 import {
   AIError,
@@ -122,6 +123,39 @@ export class BedrockProvider implements AIInterface {
       stream: options.stream,
       onProgress: options.onProgress,
     });
+  }
+
+  /**
+   * Simple message interface for single-turn interactions with optional history
+   *
+   * @param text - The message text to send
+   * @param options - Configuration options including history, model, etc.
+   * @returns Promise resolving to the response content string
+   */
+  async message(text: string, options: MessageOptions = {}): Promise<string> {
+    // Build messages array from history + current message
+    const messages: AIMessage[] = [
+      ...(options.history || []),
+      { role: options.role || 'user', content: text },
+    ];
+
+    const response = await this.chat(messages, {
+      model: options.model,
+      maxTokens: options.maxTokens,
+      temperature: options.temperature,
+      topP: options.topP,
+      stop: options.stop,
+      stream: options.stream,
+      frequencyPenalty: options.frequencyPenalty,
+      presencePenalty: options.presencePenalty,
+      responseFormat: options.responseFormat,
+      seed: options.seed,
+      tools: options.tools,
+      toolChoice: options.toolChoice,
+      onProgress: options.onProgress,
+    });
+
+    return response.content;
   }
 
   async embed(

--- a/packages/ai/src/shared/providers/claude-cli.ts
+++ b/packages/ai/src/shared/providers/claude-cli.ts
@@ -26,6 +26,7 @@ import type {
   CompletionOptions,
   EmbeddingOptions,
   EmbeddingResponse,
+  MessageOptions,
 } from '../types';
 import {
   AIError,
@@ -512,6 +513,59 @@ export class ClaudeCliProvider implements AIInterface {
       stream: options.stream,
       onProgress: options.onProgress,
     });
+  }
+
+  /**
+   * Simple message interface for single-turn interactions with optional history
+   *
+   * @param text - The message text to send
+   * @param options - Configuration options including history, model, etc.
+   * @returns Promise resolving to the response content string
+   *
+   * @example
+   * ```typescript
+   * // Simple usage
+   * const response = await provider.message('Hello!');
+   *
+   * // With history
+   * const response = await provider.message('What was my question?', {
+   *   history: [
+   *     { role: 'user', content: 'What is 2+2?' },
+   *     { role: 'assistant', content: '4' }
+   *   ]
+   * });
+   * ```
+   */
+  async message(text: string, options: MessageOptions = {}): Promise<string> {
+    // Check if ANTHROPIC_API_KEY is available and use fallback if so
+    await this.initializeFallback();
+    if (this.anthropicFallback) {
+      return this.anthropicFallback.message(text, options);
+    }
+
+    // Build messages array from history + current message
+    const messages: AIMessage[] = [
+      ...(options.history || []),
+      { role: options.role || 'user', content: text },
+    ];
+
+    const response = await this.chat(messages, {
+      model: options.model,
+      maxTokens: options.maxTokens,
+      temperature: options.temperature,
+      topP: options.topP,
+      stop: options.stop,
+      stream: options.stream,
+      frequencyPenalty: options.frequencyPenalty,
+      presencePenalty: options.presencePenalty,
+      responseFormat: options.responseFormat,
+      seed: options.seed,
+      tools: options.tools,
+      toolChoice: options.toolChoice,
+      onProgress: options.onProgress,
+    });
+
+    return response.content;
   }
 
   /**

--- a/packages/ai/src/shared/providers/gemini.ts
+++ b/packages/ai/src/shared/providers/gemini.ts
@@ -15,6 +15,7 @@ import type {
   EmbeddingOptions,
   EmbeddingResponse,
   GeminiOptions,
+  MessageOptions,
 } from '../types';
 import {
   AIError,
@@ -180,6 +181,53 @@ export class GeminiProvider implements AIInterface {
       stream: options.stream,
       onProgress: options.onProgress,
     });
+  }
+
+  /**
+   * Simple message interface for single-turn interactions with optional history
+   *
+   * @param text - The message text to send
+   * @param options - Configuration options including history, model, etc.
+   * @returns Promise resolving to the response content string
+   *
+   * @example
+   * ```typescript
+   * // Simple usage
+   * const response = await provider.message('Hello!');
+   *
+   * // With history
+   * const response = await provider.message('What was my question?', {
+   *   history: [
+   *     { role: 'user', content: 'What is 2+2?' },
+   *     { role: 'assistant', content: '4' }
+   *   ]
+   * });
+   * ```
+   */
+  async message(text: string, options: MessageOptions = {}): Promise<string> {
+    // Build messages array from history + current message
+    const messages: AIMessage[] = [
+      ...(options.history || []),
+      { role: options.role || 'user', content: text },
+    ];
+
+    const response = await this.chat(messages, {
+      model: options.model,
+      maxTokens: options.maxTokens,
+      temperature: options.temperature,
+      topP: options.topP,
+      stop: options.stop,
+      stream: options.stream,
+      frequencyPenalty: options.frequencyPenalty,
+      presencePenalty: options.presencePenalty,
+      responseFormat: options.responseFormat,
+      seed: options.seed,
+      tools: options.tools,
+      toolChoice: options.toolChoice,
+      onProgress: options.onProgress,
+    });
+
+    return response.content;
   }
 
   async embed(

--- a/packages/ai/src/shared/providers/huggingface.ts
+++ b/packages/ai/src/shared/providers/huggingface.ts
@@ -13,6 +13,7 @@ import type {
   EmbeddingOptions,
   EmbeddingResponse,
   HuggingFaceOptions,
+  MessageOptions,
 } from '../types';
 import {
   AIError,
@@ -106,6 +107,39 @@ export class HuggingFaceProvider implements AIInterface {
       stream: options.stream,
       onProgress: options.onProgress,
     });
+  }
+
+  /**
+   * Simple message interface for single-turn interactions with optional history
+   *
+   * @param text - The message text to send
+   * @param options - Configuration options including history, model, etc.
+   * @returns Promise resolving to the response content string
+   */
+  async message(text: string, options: MessageOptions = {}): Promise<string> {
+    // Build messages array from history + current message
+    const messages: AIMessage[] = [
+      ...(options.history || []),
+      { role: options.role || 'user', content: text },
+    ];
+
+    const response = await this.chat(messages, {
+      model: options.model,
+      maxTokens: options.maxTokens,
+      temperature: options.temperature,
+      topP: options.topP,
+      stop: options.stop,
+      stream: options.stream,
+      frequencyPenalty: options.frequencyPenalty,
+      presencePenalty: options.presencePenalty,
+      responseFormat: options.responseFormat,
+      seed: options.seed,
+      tools: options.tools,
+      toolChoice: options.toolChoice,
+      onProgress: options.onProgress,
+    });
+
+    return response.content;
   }
 
   async embed(

--- a/packages/ai/src/shared/providers/openai.ts
+++ b/packages/ai/src/shared/providers/openai.ts
@@ -19,6 +19,7 @@ import type {
   CompletionOptions,
   EmbeddingOptions,
   EmbeddingResponse,
+  MessageOptions,
   OpenAIOptions,
   TokenUsage,
 } from '../types';
@@ -169,6 +170,59 @@ export class OpenAIProvider implements AIInterface {
       stream: options.stream,
       onProgress: options.onProgress,
     });
+  }
+
+  /**
+   * Simple message interface for single-turn interactions with optional history
+   *
+   * @param text - The message text to send
+   * @param options - Configuration options including history, model, etc.
+   * @returns Promise resolving to the response content string
+   *
+   * @example
+   * ```typescript
+   * // Simple usage
+   * const response = await provider.message('Hello!');
+   *
+   * // With options
+   * const response = await provider.message('Analyze this', {
+   *   model: 'gpt-4o',
+   *   responseFormat: { type: 'json_object' }
+   * });
+   *
+   * // With history
+   * const response = await provider.message('What was my question?', {
+   *   history: [
+   *     { role: 'user', content: 'What is 2+2?' },
+   *     { role: 'assistant', content: '4' }
+   *   ]
+   * });
+   * ```
+   */
+  async message(text: string, options: MessageOptions = {}): Promise<string> {
+    // Build messages array from history + current message
+    const messages: AIMessage[] = [
+      ...(options.history || []),
+      { role: options.role || 'user', content: text },
+    ];
+
+    const response = await this.chat(messages, {
+      model: options.model,
+      maxTokens: options.maxTokens,
+      temperature: options.temperature,
+      topP: options.topP,
+      stop: options.stop,
+      stream: options.stream,
+      frequencyPenalty: options.frequencyPenalty,
+      presencePenalty: options.presencePenalty,
+      responseFormat: options.responseFormat,
+      seed: options.seed,
+      tools: options.tools,
+      toolChoice: options.toolChoice,
+      onProgress: options.onProgress,
+    });
+
+    return response.content;
   }
 
   /**

--- a/packages/ai/src/shared/types.ts
+++ b/packages/ai/src/shared/types.ts
@@ -188,6 +188,90 @@ export interface EmbeddingOptions {
 }
 
 /**
+ * Options for simple message requests (convenience method)
+ * This provides a simpler interface than chat() for single-turn interactions
+ */
+export interface MessageOptions {
+  /**
+   * Model to use for completion
+   */
+  model?: string;
+
+  /**
+   * Role of the message sender (default: 'user')
+   */
+  role?: 'user' | 'assistant' | 'system';
+
+  /**
+   * Conversation history (previous messages)
+   */
+  history?: AIMessage[];
+
+  /**
+   * Maximum number of tokens to generate
+   */
+  maxTokens?: number;
+
+  /**
+   * Sampling temperature (0-2)
+   */
+  temperature?: number;
+
+  /**
+   * Top-p sampling parameter
+   */
+  topP?: number;
+
+  /**
+   * Sequences that stop generation
+   */
+  stop?: string | string[];
+
+  /**
+   * Whether to stream the response
+   */
+  stream?: boolean;
+
+  /**
+   * Penalty for frequency of tokens
+   */
+  frequencyPenalty?: number;
+
+  /**
+   * Penalty for presence of tokens
+   */
+  presencePenalty?: number;
+
+  /**
+   * Response format specification
+   */
+  responseFormat?: { type: 'text' | 'json_object' };
+
+  /**
+   * Random seed for deterministic results
+   */
+  seed?: number;
+
+  /**
+   * Available tools/functions
+   */
+  tools?: AITool[];
+
+  /**
+   * Tool choice behavior
+   */
+  toolChoice?:
+    | 'auto'
+    | 'none'
+    | { type: 'function'; function: { name: string } };
+
+  /**
+   * Callback for streaming responses
+   */
+  onProgress?: (chunk: string) => void;
+}
+
+/**
  * Tool/function definition for AI models
  */
 export interface AITool {
@@ -407,6 +491,43 @@ export interface AIInterface {
    * Generate text completion (for non-chat models)
    */
   complete(prompt: string, options?: CompletionOptions): Promise<AIResponse>;
+
+  /**
+   * Simple message interface for single-turn interactions
+   *
+   * This is a convenience method that wraps chat() for simpler use cases.
+   * It accepts a text string and optional configuration, returning just
+   * the response content as a string.
+   *
+   * Supports conversation history via the `history` option for multi-turn
+   * conversations while maintaining a simple API.
+   *
+   * @param text - The message text to send
+   * @param options - Configuration options including history, model, etc.
+   * @returns Promise resolving to the response content string
+   *
+   * @example
+   * ```typescript
+   * // Simple single-turn usage
+   * const response = await ai.message('Hello, how are you?');
+   *
+   * // With options
+   * const response = await ai.message('Analyze this data', {
+   *   model: 'gpt-4o',
+   *   responseFormat: { type: 'json_object' },
+   *   maxTokens: 1000
+   * });
+   *
+   * // With conversation history
+   * const response = await ai.message('What did I ask before?', {
+   *   history: [
+   *     { role: 'user', content: 'Hello' },
+   *     { role: 'assistant', content: 'Hi there!' }
+   *   ]
+   * });
+   * ```
+   */
+  message(text: string, options?: MessageOptions): Promise<string>;
 
   /**
    * Generate embeddings for text


### PR DESCRIPTION
## Summary

Add a standard `message()` method to the `AIInterface` that provides a simpler API for single-turn interactions while supporting conversation history.

This fixes happyvertical/smrt#456 where non-OpenAI providers (Gemini, Anthropic, etc.) failed with `this.ai.message is not a function` because `getAI()` returns `AIInterface` which only had `chat()`/`complete()`/`embed()` methods.

### Changes

- Add `MessageOptions` interface with `history`, `role`, `responseFormat`, `tools`, etc.
- Add `message()` method to `AIInterface` returning `Promise<string>`
- Implement `message()` in all 6 providers:
  - `OpenAIProvider`
  - `AnthropicProvider`
  - `GeminiProvider`
  - `BedrockProvider`
  - `HuggingFaceProvider`
  - `ClaudeCliProvider`

### Usage

```typescript
// Simple single-turn
const response = await ai.message('Hello!');

// With options
const response = await ai.message('Analyze this', {
  responseFormat: { type: 'json_object' },
  maxTokens: 1000
});

// With conversation history
const response = await ai.message('What did I ask?', {
  history: [
    { role: 'user', content: 'What is 2+2?' },
    { role: 'assistant', content: '4' }
  ]
});
```

## Test plan

- [x] All 71 existing tests pass
- [x] Build succeeds
- [ ] Manual testing with SMRT objects using `is()` and `do()` methods

Closes happyvertical/smrt#456