### PR TITLE
feat(sql): add 2D array support for OR/AND compound filters

### DIFF
--- a/packages/sql/CLAUDE.md
+++ b/packages/sql/CLAUDE.md
@@ -766,7 +766,7 @@ ON CONFLICT(email) DO UPDATE SET
 ```typescript
 import { buildWhere } from '@happyvertical/sql';
 
-// Build complex WHERE clauses
+// Build complex WHERE clauses (object format - AND-only)
 const { sql, values } = buildWhere({
   status: 'active',                    // equals (default)
   'price >': 100,                     // greater than
@@ -779,6 +779,49 @@ const { sql, values } = buildWhere({
 
 // Use in queries
 const products = await db.many`SELECT * FROM products ${sql}`;
+```
+
+#### 2D Array Format for OR/AND Compound Logic
+
+For complex boolean logic with OR conditions, use 2D arrays where:
+- Inner arrays are AND-joined: `(cond1 AND cond2)`
+- Outer array is OR-joined: `(group1) OR (group2)`
+
+```typescript
+// WHERE (status = 'active' AND price > 100) OR (status = 'pending' AND priority = 'high')
+const where = [
+  [{ status: 'active' }, { 'price >': 100 }],
+  [{ status: 'pending' }, { priority: 'high' }]
+];
+
+const { sql, values } = buildWhere(where);
+// sql: 'WHERE (status = $1 AND price > $2) OR (status = $3 AND priority = $4)'
+// values: ['active', 100, 'pending', 'high']
+
+// Use in database methods
+const products = await db.list('products', where);
+```
+
+**Use Cases**:
+```typescript
+// Find public meetings OR high-priority private meetings
+const meetings = await db.list('meetings', [
+  [{ isPublic: true }],
+  [{ isPublic: false }, { 'priority >=': 5 }]
+]);
+
+// Search by name OR email
+const users = await db.list('users', [
+  [{ 'name like': '%john%' }],
+  [{ 'email like': '%@example.com' }]
+]);
+
+// Complex product filtering
+const products = await db.list('products', [
+  [{ category: 'electronics' }, { 'price <': 500 }, { in_stock: true }],
+  [{ category: 'books' }, { 'rating >=': 4 }],
+  [{ featured: true }]
+]);
 ```
 
 ### Table Interface

--- a/packages/sql/src/index.spec.ts
+++ b/packages/sql/src/index.spec.ts
@@ -129,6 +129,108 @@ it('should handle IN clauses with arrays', () => {
   expect(result.values).toEqual(['admin', 'editor', true]);
 });
 
+// 2D Array WHERE tests (OR/AND compound logic)
+describe('buildWhere 2D array support', () => {
+  it('should handle 2D array with multiple OR groups', () => {
+    const result = buildWhere([
+      [{ status: 'active' }, { 'price >': 100 }],
+      [{ status: 'pending' }, { priority: 'high' }],
+    ]);
+
+    expect(result.sql).toBe(
+      'WHERE (status = $1 AND price > $2) OR (status = $3 AND priority = $4)',
+    );
+    expect(result.values).toEqual(['active', 100, 'pending', 'high']);
+  });
+
+  it('should handle single OR group', () => {
+    const result = buildWhere([[{ status: 'active' }, { 'price >': 100 }]]);
+
+    expect(result.sql).toBe('WHERE (status = $1 AND price > $2)');
+    expect(result.values).toEqual(['active', 100]);
+  });
+
+  it('should handle single condition per group', () => {
+    const result = buildWhere([
+      [{ status: 'active' }],
+      [{ status: 'pending' }],
+    ]);
+
+    expect(result.sql).toBe('WHERE (status = $1) OR (status = $2)');
+    expect(result.values).toEqual(['active', 'pending']);
+  });
+
+  it('should handle empty outer array', () => {
+    const result = buildWhere([]);
+
+    expect(result.sql).toBe('');
+    expect(result.values).toEqual([]);
+  });
+
+  it('should skip empty inner arrays', () => {
+    const result = buildWhere([[], [{ status: 'active' }], []]);
+
+    expect(result.sql).toBe('WHERE (status = $1)');
+    expect(result.values).toEqual(['active']);
+  });
+
+  it('should handle IN operator within 2D array', () => {
+    const result = buildWhere([
+      [{ 'category in': ['A', 'B'] }, { active: true }],
+      [{ 'category in': ['C', 'D'] }],
+    ]);
+
+    expect(result.sql).toBe(
+      'WHERE (category IN ($1, $2) AND active = $3) OR (category IN ($4, $5))',
+    );
+    expect(result.values).toEqual(['A', 'B', true, 'C', 'D']);
+  });
+
+  it('should handle NULL values within 2D array', () => {
+    const result = buildWhere([
+      [{ deleted_at: null }, { status: 'active' }],
+      [{ 'deleted_at !=': null }],
+    ]);
+
+    expect(result.sql).toBe(
+      'WHERE (deleted_at IS NULL AND status = $1) OR (deleted_at IS NOT NULL)',
+    );
+    expect(result.values).toEqual(['active']);
+  });
+
+  it('should handle LIKE operator within 2D array', () => {
+    const result = buildWhere([
+      [{ 'name like': '%john%' }],
+      [{ 'email like': '%@example.com' }],
+    ]);
+
+    expect(result.sql).toBe('WHERE (name LIKE $1) OR (email LIKE $2)');
+    expect(result.values).toEqual(['%john%', '%@example.com']);
+  });
+
+  it('should handle mixed operators within 2D array', () => {
+    const result = buildWhere([
+      [{ 'price >=': 100 }, { 'price <': 500 }, { category: 'electronics' }],
+      [{ 'price >=': 50 }, { 'rating >': 4 }],
+    ]);
+
+    expect(result.sql).toBe(
+      'WHERE (price >= $1 AND price < $2 AND category = $3) OR (price >= $4 AND rating > $5)',
+    );
+    expect(result.values).toEqual([100, 500, 'electronics', 50, 4]);
+  });
+
+  it('should handle startIndex parameter with 2D arrays', () => {
+    const result = buildWhere(
+      [[{ status: 'active' }], [{ status: 'pending' }]],
+      5,
+    );
+
+    expect(result.sql).toBe('WHERE (status = $5) OR (status = $6)');
+    expect(result.values).toEqual(['active', 'pending']);
+  });
+});
+
 describe('Environment variable configuration', () => {
   const originalEnv = { ...process.env };
 

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -1,4 +1,32 @@
 /**
+ * WHERE clause input for database queries
+ *
+ * Supports two formats:
+ * 1. Object format (AND-only): `{ status: 'active', 'price >': 100 }`
+ *    - All conditions are AND-joined
+ *
+ * 2. 2D array format (OR/AND compound logic): `[[cond1, cond2], [cond3, cond4]]`
+ *    - Inner arrays are AND-joined: `(cond1 AND cond2)`
+ *    - Outer array is OR-joined: `(cond1 AND cond2) OR (cond3 AND cond4)`
+ *
+ * @example Object format (backward compatible)
+ * ```typescript
+ * // WHERE status = 'active' AND price > 100
+ * const where = { status: 'active', 'price >': 100 };
+ * ```
+ *
+ * @example 2D array format for OR/AND compound logic
+ * ```typescript
+ * // WHERE (status = 'active' AND price > 100) OR (status = 'pending' AND priority = 'high')
+ * const where = [
+ *   [{ status: 'active' }, { 'price >': 100 }],
+ *   [{ status: 'pending' }, { priority: 'high' }]
+ * ];
+ * ```
+ */
+export type WhereClause = Record<string, any> | Record<string, any>[][];
+
+/**
  * Common database connection options
  */
 export interface DatabaseOptions {
@@ -360,37 +388,34 @@ export interface DatabaseInterface {
    * Retrieves a single record matching the where criteria
    *
    * @param table - Table name
-   * @param where - Criteria to match records
+   * @param where - Criteria to match records (object for AND-only, 2D array for OR/AND)
    * @returns Promise resolving to matching record or null if not found
    */
   get: (
     table: string,
-    where: Record<string, any>,
+    where: WhereClause,
   ) => Promise<Record<string, any> | null>;
 
   /**
    * Retrieves multiple records matching the where criteria
    *
    * @param table - Table name
-   * @param where - Criteria to match records
+   * @param where - Criteria to match records (object for AND-only, 2D array for OR/AND)
    * @returns Promise resolving to array of matching records
    */
-  list: (
-    table: string,
-    where: Record<string, any>,
-  ) => Promise<Record<string, any>[]>;
+  list: (table: string, where: WhereClause) => Promise<Record<string, any>[]>;
 
   /**
    * Updates records matching the where criteria
    *
    * @param table - Table name
-   * @param where - Criteria to match records to update
+   * @param where - Criteria to match records to update (object for AND-only, 2D array for OR/AND)
    * @param data - New data to set
    * @returns Promise resolving to operation result
    */
   update: (
     table: string,
-    where: Record<string, any>,
+    where: WhereClause,
     data: Record<string, any>,
   ) => Promise<QueryResult>;
 
@@ -430,13 +455,13 @@ export interface DatabaseInterface {
    * Gets a record matching the where criteria or inserts it if not found
    *
    * @param table - Table name
-   * @param where - Criteria to match existing record
+   * @param where - Criteria to match existing record (object for AND-only, 2D array for OR/AND)
    * @param data - Data to insert if no record found
    * @returns Promise resolving to the record (either retrieved or newly inserted)
    */
   getOrInsert: (
     table: string,
-    where: Record<string, any>,
+    where: WhereClause,
     data: Record<string, any>,
   ) => Promise<Record<string, any>>;
 
@@ -444,7 +469,7 @@ export interface DatabaseInterface {
    * Deletes records from a table matching the where criteria
    *
    * @param table - Table name
-   * @param where - Criteria to match records for deletion
+   * @param where - Criteria to match records for deletion (object for AND-only, 2D array for OR/AND)
    * @returns Promise resolving to operation result with count of deleted rows
    *
    * @example
@@ -462,13 +487,13 @@ export interface DatabaseInterface {
    * });
    * ```
    */
-  delete: (table: string, where: Record<string, any>) => Promise<QueryResult>;
+  delete: (table: string, where: WhereClause) => Promise<QueryResult>;
 
   /**
    * Counts records in a table matching the where criteria
    *
    * @param table - Table name
-   * @param where - Criteria to match records (optional, counts all if omitted)
+   * @param where - Criteria to match records (optional, counts all if omitted; object for AND-only, 2D array for OR/AND)
    * @returns Promise resolving to count of matching records
    *
    * @example
@@ -486,7 +511,7 @@ export interface DatabaseInterface {
    * });
    * ```
    */
-  count: (table: string, where?: Record<string, any>) => Promise<number>;
+  count: (table: string, where?: WhereClause) => Promise<number>;
 
   /**
    * Creates a table-specific interface for simplified table operations
@@ -665,16 +690,16 @@ export interface TableInterface {
   /**
    * Retrieves a single record from the table matching the where criteria
    *
-   * @param where - Criteria to match records
+   * @param where - Criteria to match records (object for AND-only, 2D array for OR/AND)
    * @returns Promise resolving to matching record or null if not found
    */
-  get: (where: Record<string, any>) => Promise<Record<string, any> | null>;
+  get: (where: WhereClause) => Promise<Record<string, any> | null>;
 
   /**
    * Retrieves multiple records from the table matching the where criteria
    *
-   * @param where - Criteria to match records
+   * @param where - Criteria to match records (object for AND-only, 2D array for OR/AND)
    * @returns Promise resolving to array of matching records
    */
-  list: (where: Record<string, any>) => Promise<Record<string, any>[]>;
+  list: (where: WhereClause) => Promise<Record<string, any>[]>;
 }

--- a/packages/sql/src/shared/utils.ts
+++ b/packages/sql/src/shared/utils.ts
@@ -2,6 +2,8 @@
  * Shared SQL utilities that work in both browser and Node.js environments
  */
 
+import type { WhereClause } from './types.js';
+
 /**
  * Map of valid SQL operators for use in WHERE clauses
  */
@@ -17,13 +19,43 @@ const VALID_OPERATORS = {
 } as const;
 
 /**
+ * Builds a single condition for a WHERE clause
+ * @internal
+ */
+const buildCondition = (
+  fullKey: string,
+  value: any,
+  currIndex: { value: number },
+): { sql: string; values: any[] } => {
+  const [field, operator = '='] = fullKey.split(' ');
+  const sqlOperator =
+    VALID_OPERATORS[operator as keyof typeof VALID_OPERATORS] || '=';
+  const values: any[] = [];
+
+  let sql: string;
+
+  if (value === null) {
+    sql = `${field} IS ${sqlOperator === '=' ? 'NULL' : 'NOT NULL'}`;
+  } else if (sqlOperator === 'IN' && Array.isArray(value)) {
+    const placeholders = value.map(() => `$${currIndex.value++}`).join(', ');
+    sql = `${field} IN (${placeholders})`;
+    values.push(...value);
+  } else {
+    sql = `${field} ${sqlOperator} $${currIndex.value++}`;
+    values.push(value);
+  }
+
+  return { sql, values };
+};
+
+/**
  * Builds a SQL WHERE clause with parameterized values and flexible operators
  *
- * @param where - Record of conditions with optional operators in keys
+ * @param where - Conditions as object (AND-only) or 2D array (OR/AND compound)
  * @param startIndex - Starting index for parameter numbering (default: 1)
  * @returns Object containing the SQL clause and array of values
  *
- * @example Basic Usage:
+ * @example Basic Usage (Object format - AND-only):
  * ```typescript
  * buildWhere({
  *   'status': 'active',           // equals operator is default
@@ -32,6 +64,15 @@ const VALID_OPERATORS = {
  *   'category in': ['A', 'B'],   // IN clause for arrays
  *   'name like': '%shirt%'       // LIKE for pattern matching
  * });
+ * ```
+ *
+ * @example 2D Array Format (OR/AND compound logic):
+ * ```typescript
+ * // WHERE (status = 'active' AND price > 100) OR (status = 'pending' AND priority = 'high')
+ * buildWhere([
+ *   [{ status: 'active' }, { 'price >': 100 }],
+ *   [{ status: 'pending' }, { priority: 'high' }]
+ * ]);
  * ```
  *
  * @example NULL Handling:
@@ -78,34 +119,62 @@ const VALID_OPERATORS = {
  * - NULL checks (IS NULL, IS NOT NULL)
  * - IN clauses for arrays
  * - LIKE for pattern matching
- * - Multiple conditions combined with AND
+ * - Object format: Multiple conditions combined with AND
+ * - 2D array format: Inner arrays ANDed, outer array ORed
  */
-export const buildWhere = (where: Record<string, any>, startIndex = 1) => {
+export const buildWhere = (where: WhereClause, startIndex = 1) => {
   let sql = '';
   const values: any[] = [];
-  let currIndex = startIndex;
+  const currIndex = { value: startIndex };
 
+  // Handle 2D array format for OR/AND compound logic
+  if (Array.isArray(where)) {
+    if (where.length === 0) {
+      return { sql: '', values: [] };
+    }
+
+    const orGroups: string[] = [];
+
+    for (const andGroup of where) {
+      if (!Array.isArray(andGroup) || andGroup.length === 0) {
+        continue;
+      }
+
+      const andConditions: string[] = [];
+
+      for (const conditionObj of andGroup) {
+        for (const [fullKey, value] of Object.entries(conditionObj)) {
+          const result = buildCondition(fullKey, value, currIndex);
+          andConditions.push(result.sql);
+          values.push(...result.values);
+        }
+      }
+
+      if (andConditions.length > 0) {
+        // Wrap AND group in parentheses
+        orGroups.push(`(${andConditions.join(' AND ')})`);
+      }
+    }
+
+    if (orGroups.length > 0) {
+      sql = `WHERE ${orGroups.join(' OR ')}`;
+    }
+
+    return { sql, values };
+  }
+
+  // Handle object format (original behavior - AND-only)
   if (where && Object.keys(where).length > 0) {
     sql = 'WHERE ';
     for (const [fullKey, value] of Object.entries(where)) {
-      const [field, operator = '='] = fullKey.split(' ');
-      const sqlOperator =
-        VALID_OPERATORS[operator as keyof typeof VALID_OPERATORS] || '=';
+      const result = buildCondition(fullKey, value, currIndex);
 
       if (sql !== 'WHERE ') {
         sql += ' AND ';
       }
 
-      if (value === null) {
-        sql += `${field} IS ${sqlOperator === '=' ? 'NULL' : 'NOT NULL'}`;
-      } else if (sqlOperator === 'IN' && Array.isArray(value)) {
-        const placeholders = value.map(() => `$${currIndex++}`).join(', ');
-        sql += `${field} IN (${placeholders})`;
-        values.push(...value);
-      } else {
-        sql += `${field} ${sqlOperator} $${currIndex++}`;
-        values.push(value);
-      }
+      sql += result.sql;
+      values.push(...result.values);
     }
   }
 


### PR DESCRIPTION
## Summary

- Add support for 2D arrays in the `where` clause to enable compound OR/AND filter logic
- Inner arrays are ANDed together, outer array conditions are ORed
- Non-breaking change: existing object-based filters continue to work unchanged

## Example

```typescript
// WHERE (status = 'active' AND price > 100) OR (status = 'pending' AND priority = 'high')
const results = await db.list('products', [
  [{ status: 'active' }, { 'price >': 100 }],
  [{ status: 'pending' }, { priority: 'high' }]
]);
```

## Changes

- Add `WhereClause` type supporting object or 2D array format
- Update `DatabaseInterface` and `TableInterface` method signatures
- Refactor `buildWhere()` to handle both formats
- Add 10 comprehensive tests for 2D array scenarios
- Update CLAUDE.md documentation

## Test plan

- [x] All existing tests pass (28 tests)
- [x] New 2D array tests pass (10 tests)
- [x] Build succeeds
- [x] TypeScript types compile correctly

closes #535