### PR TITLE
fix(sql): prevent JSON adapter lost update bug with connection caching

### DIFF
--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -549,42 +549,34 @@ function validateTableName(table: string): void {
 export async function getDatabase(
   options: JSONOptions,
 ): Promise<DatabaseInterface> {
-  // Don't cache when explicit schemas are provided
-  // Each schema configuration should get its own connection
-  const hasSchemas = options.schemas && Object.keys(options.schemas).length > 0;
-
   // Generate cache key from URL and options that affect database behavior
-  // If dbid is explicitly provided, use it as the cache key
-  // Otherwise, create a cache key from URL and configuration options
-  let cacheKey: string | undefined;
-
-  if (!hasSchemas) {
-    cacheKey =
-      options.dbid ||
-      `${options.url}:${options.writeStrategy || 'immediate'}:${options.autoRegister !== false}`;
-  } else if (options.dbid) {
-    // If explicit dbid provided with schemas, honor it
-    cacheKey = options.dbid;
-  }
+  // FIX for issues #533/#534: Auto-generate dbid from URL when schemas provided
+  // This ensures connection caching ALWAYS happens for the same URL, preventing
+  // the lost update bug where multiple connections overwrite each other's data.
+  //
+  // Priority:
+  // 1. Explicit dbid from caller
+  // 2. Auto-generated from URL + writeStrategy (ensures caching)
+  const cacheKey =
+    options.dbid ||
+    `json:${options.url}:${options.writeStrategy || 'immediate'}:${options.autoRegister !== false}`;
 
   // If clearCache option is true, clear any cached connection for this key
-  if (options.clearCache && cacheKey) {
+  if (options.clearCache) {
     memoryConnectionCache.delete(cacheKey);
     pendingConnections.delete(cacheKey);
   }
 
   // Check if we have a cached connection for this cache key
-  if (cacheKey) {
-    const cached = memoryConnectionCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
+  const cached = memoryConnectionCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
 
-    // Check if there's a pending connection for this cache key
-    const pending = pendingConnections.get(cacheKey);
-    if (pending) {
-      return pending;
-    }
+  // Check if there's a pending connection for this cache key
+  const pending = pendingConnections.get(cacheKey);
+  if (pending) {
+    return pending;
   }
 
   // Create a new connection promise
@@ -1721,25 +1713,19 @@ export async function getDatabase(
     };
   })();
 
-  // Store the pending connection promise (if caching)
-  if (cacheKey) {
-    pendingConnections.set(cacheKey, connectionPromise);
-  }
+  // Store the pending connection promise for concurrent requests
+  pendingConnections.set(cacheKey, connectionPromise);
 
   try {
     // Wait for the connection to be established
     const db = await connectionPromise;
 
-    // Cache the connection for reuse (if caching)
-    if (cacheKey) {
-      memoryConnectionCache.set(cacheKey, db);
-    }
+    // Cache the connection for reuse
+    memoryConnectionCache.set(cacheKey, db);
 
     return db;
   } finally {
-    // Clean up pending connection promise (if caching)
-    if (cacheKey) {
-      pendingConnections.delete(cacheKey);
-    }
+    // Clean up pending connection promise
+    pendingConnections.delete(cacheKey);
   }
 }


### PR DESCRIPTION
## Summary

Fixes a critical data loss bug in the JSON adapter where multiple connections to the same JSON database could silently lose records.

**Root Cause:**
When multiple connections were created with explicit schemas but no `dbid`, the caching logic was bypassed entirely:
```typescript
// Old code - cacheKey undefined when schemas provided without dbid!
if (!hasSchemas) {
  cacheKey = options.dbid || `...`;
} else if (options.dbid) {
  cacheKey = options.dbid;
}
// hasSchemas && !options.dbid → cacheKey undefined → NO CACHING
```

**The Bug Scenario:**
1. Connection A creates record 1, exports to JSON
2. Connection B is created (gets **new** in-memory DuckDB, loads record 1 from JSON)
3. Connection A creates record 2, exports to JSON (now has records 1 & 2)
4. Connection B creates record 3, exports to JSON (**only has records 1 & 3!**)
5. Record 2 is **permanently lost**

**The Fix:**
Always generate a cache key from the URL, ensuring all connections to the same JSON file share the same in-memory DuckDB instance:
```typescript
// New code - always generates cacheKey
const cacheKey = options.dbid || `json:${options.url}:${options.writeStrategy}:...`;
```

## Test Plan

- [x] Added comprehensive test in SMRT repo that reproduces the bug
- [x] Test confirms fix works: 3 records preserved instead of 2
- [ ] Run SDK test suite
- [ ] Run SMRT test suite after SDK version bump

## Related Issues

Closes: happyvertical/smrt#533
Closes: happyvertical/smrt#534