### PR TITLE
ci: add concurrency to on-merge-main workflow

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: on-merge-main
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write


### PR DESCRIPTION
## Summary

Adds concurrency settings to the on-merge-main workflow to prevent multiple runs from executing simultaneously.

## Problem

When multiple commits are pushed to main in quick succession (e.g., from Renovate PRs being merged), multiple workflow runs start concurrently. This wastes resources and can cause race conditions during publishing.

## Solution

```yaml
concurrency:
  group: on-merge-main
  cancel-in-progress: true
```

This ensures:
- Only one on-merge-main workflow runs at a time
- Older runs are automatically cancelled when a newer commit is pushed
- The latest commit always gets processed

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] Merge and observe behavior on next concurrent pushes