### PR TITLE
test(sql): fix tests that relied on cache miss behavior

### DIFF
--- a/packages/sql/src/json.spec.ts
+++ b/packages/sql/src/json.spec.ts
@@ -815,7 +815,8 @@ describe('JSON adapter tests', () => {
 
   describe('SchemaProvider support', () => {
     it('should create tables from provided schemas', async () => {
-      // Clean up existing db
+      // Clear cache to get fresh connection after modifying underlying files
+      clearConnectionCache();
       if (db) {
         rmSync(testDataDir, { recursive: true, force: true });
       }
@@ -879,7 +880,8 @@ describe('JSON adapter tests', () => {
     });
 
     it('should handle schemas without indexes', async () => {
-      // Clean up
+      // Clear cache to get fresh connection after modifying underlying files
+      clearConnectionCache();
       if (db) {
         rmSync(testDataDir, { recursive: true, force: true });
       }
@@ -915,6 +917,8 @@ describe('JSON adapter tests', () => {
 
     it('should handle schemas with empty strings correctly', async () => {
       // This test verifies the fix for Issue #228
+      // Clear cache to get fresh connection after modifying underlying files
+      clearConnectionCache();
       if (db) {
         rmSync(testDataDir, { recursive: true, force: true });
       }
@@ -970,6 +974,8 @@ describe('JSON adapter tests', () => {
     });
 
     it('should allow manual table creation when autoRegister is false', async () => {
+      // Clear cache to get fresh connection after modifying underlying files
+      clearConnectionCache();
       if (db) {
         rmSync(testDataDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

Fixes tests that were failing after #658 (JSON adapter lost update fix).

## Problem

The SchemaProvider tests were implicitly relying on a bug - when schemas were provided without `dbid`, the JSON adapter wasn't caching connections. Tests exploited this to:

1. Delete the data directory
2. Create new files
3. Call `getDatabase()` expecting fresh state

With the caching fix, they got the cached connection (correct behavior) which still had the old in-memory tables.

## Solution

Add explicit `clearConnectionCache()` calls when tests need fresh state after modifying underlying files.

This is correct behavior - you can't delete a database's storage and expect existing connections to magically see new data without explicit reset. No real database works that way.

## Test Plan

- [x] All SchemaProvider tests now explicitly manage cache state
- [ ] CI passes