### PR TITLE
fix(ci): make changeset publish idempotent for existing tags

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
+  "gitTag": false,
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -146,9 +146,14 @@ jobs:
 
           # Sync root package.json version with workspace packages
           WORKSPACE_VERSION=$(node -p "require('./packages/utils/package.json').version")
-          if [ -n "$WORKSPACE_VERSION" ] && [ "$WORKSPACE_VERSION" != "$(node -p "require('./package.json').version")" ]; then
+          ROOT_VERSION=$(node -p "require('./package.json').version")
+          if [ -n "$WORKSPACE_VERSION" ] && [ "$WORKSPACE_VERSION" != "$ROOT_VERSION" ]; then
             echo "📝 Syncing root package version to match workspace: $WORKSPACE_VERSION"
-            node -e "const pkg = require('./package.json'); pkg.version = '$WORKSPACE_VERSION'; require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
+            node -e "
+              const pkg = require('./package.json');
+              pkg.version = '$WORKSPACE_VERSION';
+              require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
           fi
 
           # Check if version changed
@@ -168,18 +173,26 @@ jobs:
             # Publish packages
             pnpm run changeset:publish
 
-            # Create and push git tag (explicit push since Changesets tags may prevent --follow-tags)
-            git tag "v$AFTER_VERSION"
-            git push origin "v$AFTER_VERSION"
+            # Create and push git tag (idempotent - skip if tag already exists)
+            if git rev-parse "v$AFTER_VERSION" >/dev/null 2>&1; then
+              echo "ℹ️  Tag v$AFTER_VERSION already exists, skipping tag creation"
+            else
+              git tag "v$AFTER_VERSION"
+              git push origin "v$AFTER_VERSION"
+            fi
             git push origin main
 
-            # Create GitHub Release
-            RELEASE_NOTES="## Published Packages"$'\n\n'"All packages published to GitHub Packages at version $AFTER_VERSION."$'\n\n'"Full Changelog: https://github.com/${GITHUB_REPOSITORY}/compare/v$BEFORE_VERSION...v$AFTER_VERSION"
+            # Create GitHub Release (idempotent - skip if release already exists)
+            if gh release view "v$AFTER_VERSION" >/dev/null 2>&1; then
+              echo "ℹ️  Release v$AFTER_VERSION already exists, skipping release creation"
+            else
+              RELEASE_NOTES="## Published Packages"$'\n\n'"All packages published to GitHub Packages at version $AFTER_VERSION."$'\n\n'"Full Changelog: https://github.com/${GITHUB_REPOSITORY}/compare/v$BEFORE_VERSION...v$AFTER_VERSION"
 
-            gh release create "v$AFTER_VERSION" \
-              --title "v$AFTER_VERSION" \
-              --notes "$RELEASE_NOTES" \
-              --latest
+              gh release create "v$AFTER_VERSION" \
+                --title "v$AFTER_VERSION" \
+                --notes "$RELEASE_NOTES" \
+                --latest
+            fi
 
             echo "published=true" >> $GITHUB_OUTPUT
             echo "version=$AFTER_VERSION" >> $GITHUB_OUTPUT

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,7 +15,7 @@ pre-commit:
         echo "🔍 Validating workflow files..."
         for file in {staged_files}; do
           echo "  Checking $file..."
-          yamllint "$file" || exit 1
+          yamllint -c .github/.yamllint.yml "$file" || exit 1
         done
         echo "  Running act --list to verify workflow parsing..."
         act --list > /dev/null 2>&1 || (echo "❌ act --list failed - workflow syntax issue" && exit 1)


### PR DESCRIPTION
## Summary

- Add `gitTag: false` to changeset config (we create tags explicitly)
- Make explicit tag creation skip if tag already exists
- Make GitHub release creation skip if release already exists
- Use consistent yamllint config in lefthook pre-commit hook
- Fix line length issues in shared-direct-publish.yml

## Problem

The publish workflow fails when trying to republish a version that already has a tag or release created (e.g., after CI fixes where packages were already published by a broken workflow).

This was triggered by PR #669 which fixed the publish-before-test bug. When that fix merged, all packages were already at v0.60.4 from the broken workflow, so the tag already existed.

## Test plan

- [x] Verify yamllint passes locally
- [x] Verify lefthook pre-commit passes
- [ ] Wait for CI to pass
- [ ] Merge and verify publish workflow handles existing tags gracefully