### PR TITLE
fix(sql): use globalThis for connection cache to fix cross-module lost updates

### DIFF
--- a/.changeset/globalthis-connection-cache.md
+++ b/.changeset/globalthis-connection-cache.md
@@ -1,0 +1,11 @@
+---
+"@happyvertical/sql": patch
+---
+
+fix(sql): use globalThis for connection cache to fix cross-module lost updates
+
+The JSON adapter's `memoryConnectionCache` was a module-level Map, which caused the "lost update" bug to persist in monorepos where the same package is loaded from different paths (e.g., pnpm store vs workspace symlink). Each module instance had its own cache, so records written through one path were not visible to the other.
+
+This fix uses `globalThis` to store the connection cache, ensuring all module instances share the same cache regardless of how they're loaded.
+
+Fixes #678

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -13,17 +13,53 @@ import type {
 import { buildWhere } from './shared/utils';
 
 /**
+ * Extend globalThis to include our connection cache properties.
+ * Using globalThis ensures all module instances share the same cache,
+ * which is critical in monorepos where the same package can be loaded
+ * from different paths (e.g., pnpm store vs workspace symlink).
+ *
+ * @see https://github.com/happyvertical/sdk/issues/678
+ */
+declare global {
+  // eslint-disable-next-line no-var
+  var __haveSqlMemoryConnectionCache:
+    | Map<string, DatabaseInterface>
+    | undefined;
+  // eslint-disable-next-line no-var
+  var __haveSqlPendingConnections:
+    | Map<string, Promise<DatabaseInterface>>
+    | undefined;
+}
+
+/**
  * Connection cache for in-memory DuckDB instances keyed by data directory URL
  * Enables sharing of in-memory databases across multiple getDatabase() calls
- * with the same data directory
+ * with the same data directory.
+ *
+ * Uses globalThis to ensure cache is shared across all module instances,
+ * fixing the lost update bug in monorepos with workspace symlinks.
+ *
+ * @see https://github.com/happyvertical/sdk/issues/678
  */
-const memoryConnectionCache = new Map<string, DatabaseInterface>();
+globalThis.__haveSqlMemoryConnectionCache ??= new Map<
+  string,
+  DatabaseInterface
+>();
+const memoryConnectionCache = globalThis.__haveSqlMemoryConnectionCache;
 
 /**
  * Pending connection promises to handle concurrent getDatabase() calls
- * Prevents creating duplicate connections when parallel calls happen
+ * Prevents creating duplicate connections when parallel calls happen.
+ *
+ * Uses globalThis to ensure cache is shared across all module instances.
+ *
+ * @see https://github.com/happyvertical/sdk/issues/678
  */
-const pendingConnections = new Map<string, Promise<DatabaseInterface>>();
+globalThis.__haveSqlPendingConnections ??= new Map<
+  string,
+  Promise<DatabaseInterface>
+>();
+const pendingConnections = globalThis.__haveSqlPendingConnections;
 
 /**
  * Clears all cached connections


### PR DESCRIPTION
## Summary

- Uses `globalThis` for connection cache instead of module-level variables
- Ensures all module instances share the same cache regardless of load path
- Fixes lost update bug in monorepos with workspace symlinks

## Problem

The JSON adapter's `memoryConnectionCache` was a module-level Map, which caused the "lost update" bug to persist in monorepos where the same package is loaded from different paths (e.g., pnpm store vs workspace symlink). Each module instance had its own cache, so records written through one path were not visible to the other.

### Evidence

```bash
# Two different module instances:
node_modules/@happyvertical/sql → pnpm store
node_modules/@happyvertical/praeco/node_modules/@happyvertical/sql → workspace symlink
```

## Solution

Use `globalThis` to store the connection cache so all module instances share the same cache:

```typescript
declare global {
  var __haveSqlMemoryConnectionCache: Map<string, DatabaseInterface> | undefined;
  var __haveSqlPendingConnections: Map<string, Promise<DatabaseInterface>> | undefined;
}

globalThis.__haveSqlMemoryConnectionCache ??= new Map();
const memoryConnectionCache = globalThis.__haveSqlMemoryConnectionCache;

globalThis.__haveSqlPendingConnections ??= new Map();
const pendingConnections = globalThis.__haveSqlPendingConnections;
```

## Test plan

- [x] All existing tests pass (210 tests)
- [x] TypeScript compilation succeeds
- [ ] Manual verification in praeco with workspace symlinks

Fixes #678