### PR TITLE
fix(sql): preserve JSON object structure in JSON adapter export

### DIFF
--- a/packages/sql/src/json-sti-columns.spec.ts
+++ b/packages/sql/src/json-sti-columns.spec.ts
@@ -277,6 +277,126 @@ describe('JSON adapter STI column handling (Issue #518)', () => {
     });
   });
 
+  describe('_meta_data JSON serialization (Issue #542)', () => {
+    it('should serialize _meta_data as JSON object, not string', async () => {
+      // This test verifies the fix for issue #542:
+      // _meta_data should be serialized as {} not "{}" in JSON output
+      writeFileSync(`${testDataDir}/events.json`, JSON.stringify([]));
+
+      const schemas = {
+        events: {
+          tableName: 'events',
+          ddl: `CREATE TABLE events (
+            id TEXT PRIMARY KEY,
+            slug TEXT NOT NULL,
+            context TEXT NOT NULL DEFAULT '',
+            title TEXT,
+            _meta_type TEXT DEFAULT 'Event',
+            _meta_data JSON DEFAULT '{}',
+            UNIQUE(slug, context)
+          )`,
+          indexes: [],
+          fields: {
+            id: { type: 'TEXT', primaryKey: true, notNull: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT', notNull: true },
+            title: { type: 'TEXT' },
+            _meta_type: { type: 'TEXT' },
+            _meta_data: { type: 'JSON' },
+          },
+        },
+      };
+
+      db = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        writeStrategy: 'immediate',
+        schemas,
+      });
+
+      // Insert a record with _meta_data as an object
+      const eventId = randomUUID();
+      await db.upsert('events', ['slug', 'context'], {
+        id: eventId,
+        slug: 'test-meeting',
+        context: '',
+        title: 'Test Meeting',
+        _meta_type: 'Meeting',
+        _meta_data: { customField: 'value' },
+      });
+
+      // Read the JSON file directly to verify serialization
+      const { readFileSync } = await import('node:fs');
+      const jsonContent = readFileSync(`${testDataDir}/events.json`, 'utf-8');
+      const records = JSON.parse(jsonContent);
+
+      // _meta_data should be an object, not a string
+      expect(records[0]._meta_data).toBeDefined();
+      expect(typeof records[0]._meta_data).toBe('object');
+      expect(records[0]._meta_data).not.toBe('{}');
+      expect(records[0]._meta_data).not.toBe('{"customField":"value"}');
+
+      // The actual object structure should be preserved
+      if (typeof records[0]._meta_data === 'object') {
+        expect(records[0]._meta_data.customField).toBe('value');
+      }
+    });
+
+    it('should serialize empty _meta_data as {} not "{}"', async () => {
+      writeFileSync(`${testDataDir}/events.json`, JSON.stringify([]));
+
+      const schemas = {
+        events: {
+          tableName: 'events',
+          ddl: `CREATE TABLE events (
+            id TEXT PRIMARY KEY,
+            slug TEXT NOT NULL,
+            context TEXT NOT NULL DEFAULT '',
+            _meta_type TEXT DEFAULT 'Event',
+            _meta_data JSON DEFAULT '{}',
+            UNIQUE(slug, context)
+          )`,
+          indexes: [],
+          fields: {
+            id: { type: 'TEXT' },
+            slug: { type: 'TEXT' },
+            context: { type: 'TEXT' },
+            _meta_type: { type: 'TEXT' },
+            _meta_data: { type: 'JSON' },
+          },
+        },
+      };
+
+      db = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        writeStrategy: 'immediate',
+        schemas,
+      });
+
+      // Insert a record with empty _meta_data
+      const eventId = randomUUID();
+      await db.upsert('events', ['slug', 'context'], {
+        id: eventId,
+        slug: 'test-event',
+        context: '',
+        _meta_type: 'Event',
+        _meta_data: {},
+      });
+
+      // Read the JSON file directly
+      const { readFileSync } = await import('node:fs');
+      const jsonContent = readFileSync(`${testDataDir}/events.json`, 'utf-8');
+      const records = JSON.parse(jsonContent);
+
+      // _meta_data should be {} (object), not "{}" (string)
+      expect(records[0]._meta_data).toBeDefined();
+      expect(typeof records[0]._meta_data).toBe('object');
+      expect(records[0]._meta_data).toEqual({});
+      expect(records[0]._meta_data).not.toBe('{}');
+    });
+  });
+
   describe('Edge cases', () => {
     it('should handle fields as Map (in addition to Record)', async () => {
       // The SmrtSchemaDefinition interface allows Map<string, any> for fields

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -1151,8 +1151,12 @@ export async function getDatabase(
      * Exports a table to JSON and schema files
      *
      * Exports two files:
-     * 1. {table}.json - Table data with all columns cast to TEXT
+     * 1. {table}.json - Table data with columns cast appropriately
      * 2. {table}.schema.sql - CREATE TABLE statement to preserve constraints
+     *
+     * Note: JSON columns are NOT cast to TEXT to preserve object structure.
+     * Other columns are cast to TEXT to prevent DuckDB from converting UUIDs
+     * and other TEXT values to hugeint representation in JSON output.
      *
      * @param connection - DuckDB connection
      * @param table - Table name
@@ -1182,16 +1186,17 @@ export async function getDatabase(
         );
       }
 
-      // Get column list to cast all as TEXT
-      // This prevents DuckDB from converting UUIDs and other TEXT values to hugeint in JSON
+      // Get column names and types to handle JSON columns specially
+      // JSON columns should NOT be cast to TEXT to preserve object structure (fixes #542)
       const columnsResult = await connection.runAndReadAll(
-        `SELECT column_name FROM information_schema.columns WHERE table_name = '${table}' ORDER BY ordinal_position`,
+        `SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '${table}' ORDER BY ordinal_position`,
       );
-      const columns = columnsResult
-        .getRowObjects()
-        .map((row: any) => row.column_name);
+      const columnInfo = columnsResult.getRowObjects() as {
+        column_name: string;
+        data_type: string;
+      }[];
 
-      if (columns.length === 0) {
+      if (columnInfo.length === 0) {
         // Fallback to SELECT * if we can't get column names
         await connection.run(
           `COPY (SELECT * FROM "${table}") TO '${filePath}' (FORMAT JSON, ARRAY true)`,
@@ -1199,9 +1204,18 @@ export async function getDatabase(
         return;
       }
 
-      // Cast all columns to TEXT to preserve UUID and other TEXT values as strings
-      const selectList = columns
-        .map((col: string) => `CAST(${col} AS TEXT) AS ${col}`)
+      // Cast non-JSON columns to TEXT to preserve UUIDs and other TEXT values as strings
+      // Keep JSON columns as-is to preserve object structure (e.g., _meta_data: {} not "{}")
+      const selectList = columnInfo
+        .map(({ column_name, data_type }) => {
+          const upperType = data_type.toUpperCase();
+          // Don't cast JSON columns - they should remain as objects in output
+          if (upperType === 'JSON' || upperType.startsWith('STRUCT')) {
+            return `"${column_name}"`;
+          }
+          // Cast other columns to TEXT to prevent hugeint conversion
+          return `CAST("${column_name}" AS TEXT) AS "${column_name}"`;
+        })
         .join(', ');
       const sql = `COPY (SELECT ${selectList} FROM "${table}") TO '${filePath}' (FORMAT JSON, ARRAY true)`;
 


### PR DESCRIPTION
## Summary
- Fix JSON adapter export casting ALL columns to TEXT, which converted `_meta_data: {}` to `_meta_data: "{}"`
- Query column types from information_schema during export  
- Skip CAST to TEXT for JSON and STRUCT columns
- Add tests for _meta_data serialization (issue #542)

## Test plan
- [x] Added tests for `_meta_data` serialization (object vs string)
- [x] Added tests for empty `_meta_data: {}` preservation
- [x] All existing tests pass (212 tests)

Closes happyvertical/smrt#542