### PR TITLE
fix(sql): cast Date parameters to TIMESTAMP for DuckDB

### DIFF
--- a/packages/sql/:memory:/poly_events.json
+++ b/packages/sql/:memory:/poly_events.json
@@ -1,3 +1,3 @@
 [
-	{"_meta_type":"Meeting","slug":"team-standup","context":"/meetings","title":"Weekly Standup","count":"5"}
+	{"_meta_type":"Meeting","slug":"team-standup","context":"/meetings","title":"Weekly Standup","count":5}
 ]

--- a/packages/sql/src/index.spec.ts
+++ b/packages/sql/src/index.spec.ts
@@ -97,10 +97,14 @@ it('should handle date filtering with null check', () => {
     deleted_at: null,
   });
 
+  // Date objects are converted to ISO strings with CAST to TIMESTAMP (issue #540)
   expect(result.sql).toBe(
-    'WHERE created_at > $1 AND created_at <= $2 AND deleted_at IS NULL',
+    'WHERE created_at > CAST($1 AS TIMESTAMP) AND created_at <= CAST($2 AS TIMESTAMP) AND deleted_at IS NULL',
   );
-  expect(result.values).toEqual([startDate, endDate]);
+  expect(result.values).toEqual([
+    startDate.toISOString(),
+    endDate.toISOString(),
+  ]);
 });
 
 it('should handle LIKE operators for search', () => {

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -543,8 +543,9 @@ async function insertRecordsWithCast(
           return `CAST($${paramIdx++} AS TEXT)`;
         } else if (value instanceof Date) {
           // Convert Date objects to ISO strings for DuckDB
+          // CAST to TIMESTAMP to prevent DuckDB ANY type inference (issue #540)
           values.push(value.toISOString());
-          return `$${paramIdx++}`;
+          return `CAST($${paramIdx++} AS TIMESTAMP)`;
         } else if (Array.isArray(value)) {
           // CAST arrays to JSON to prevent DuckDB ANY type inference
           values.push(JSON.stringify(value));
@@ -681,8 +682,9 @@ export async function getDatabase(
               return `CAST($${paramIdx++} AS TEXT)`;
             } else if (value instanceof Date) {
               // Convert Date objects to ISO strings for DuckDB (issue #319)
+              // CAST to TIMESTAMP to prevent DuckDB ANY type inference (issue #540)
               values.push(value.toISOString());
-              return `$${paramIdx++}`;
+              return `CAST($${paramIdx++} AS TIMESTAMP)`;
             } else if (Array.isArray(value)) {
               // CAST arrays to JSON to prevent DuckDB ANY type inference
               // DuckDB cannot infer array element types from empty arrays or mixed types
@@ -906,7 +908,8 @@ export async function getDatabase(
           paramIdx++;
         } else if (value instanceof Date) {
           // Convert Date objects to ISO strings for DuckDB
-          placeholders.push(`$${paramIdx}`);
+          // CAST to TIMESTAMP to prevent DuckDB ANY type inference (issue #540)
+          placeholders.push(`CAST($${paramIdx} AS TIMESTAMP)`);
           values.push(value.toISOString());
           paramIdx++;
         } else if (Array.isArray(value)) {
@@ -950,7 +953,8 @@ export async function getDatabase(
           paramIdx++;
         } else if (value instanceof Date) {
           // Convert Date objects to ISO strings for DuckDB
-          updateSetParts.push(`${key} = $${paramIdx}`);
+          // CAST to TIMESTAMP to prevent DuckDB ANY type inference (issue #540)
+          updateSetParts.push(`${key} = CAST($${paramIdx} AS TIMESTAMP)`);
           values.push(value.toISOString());
           paramIdx++;
         } else if (Array.isArray(value)) {

--- a/packages/sql/src/shared/utils.ts
+++ b/packages/sql/src/shared/utils.ts
@@ -40,6 +40,11 @@ const buildCondition = (
     const placeholders = value.map(() => `$${currIndex.value++}`).join(', ');
     sql = `${field} IN (${placeholders})`;
     values.push(...value);
+  } else if (value instanceof Date) {
+    // Convert Date objects to ISO strings and CAST to TIMESTAMP
+    // to prevent DuckDB ANY type inference (issue #540)
+    sql = `${field} ${sqlOperator} CAST($${currIndex.value++} AS TIMESTAMP)`;
+    values.push(value.toISOString());
   } else {
     sql = `${field} ${sqlOperator} $${currIndex.value++}`;
     values.push(value);


### PR DESCRIPTION
## Summary
- Date objects in WHERE clauses were being converted to ISO strings but without type hints
- DuckDB fails with "Cannot create values of type ANY" when comparing string params against TIMESTAMP columns
- Fix adds `CAST($N AS TIMESTAMP)` wrapper for Date parameters

## Changes
- `buildWhere()` shared utility - affects all collection queries
- `json.ts` adapter operations (insert, update, upsert)
- Updated test expectations

## Test plan
- [x] Unit tests pass locally
- [ ] Integration test with ludis hockey agent in bentleyalberta.com

Fixes #540