### PR TITLE
feat(auth): add Kanidm authentication provider

### DIFF
--- a/.changeset/kanidm-provider.md
+++ b/.changeset/kanidm-provider.md
@@ -1,0 +1,11 @@
+---
+"@happyvertical/auth": minor
+---
+
+Add Kanidm authentication provider with OIDC/OAuth2 support
+
+- Authorization code flow with PKCE (required by Kanidm)
+- Token validation via JWKS (ES256 signing)
+- User management via Kanidm's native /v1/person API
+- Multi-step admin authentication for API access
+- Integration tests against live Kanidm instance

--- a/biome.json
+++ b/biome.json
@@ -185,6 +185,19 @@
     },
     {
       "includes": [
+        "packages/auth/src/shared/providers/**/*.ts",
+        "packages/auth/src/shared/types.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "useNamingConvention": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
         "**/vite.config.ts",
         "**/vitest.config.ts",
         "**/rollup.config.js",

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -4,7 +4,7 @@
 
 The `@happyvertical/auth` package provides a unified authentication interface supporting multiple providers. It is designed to:
 
-- **Unify Auth Provider APIs**: Provide a consistent interface across Keycloak, AWS Cognito, and Nostr
+- **Unify Auth Provider APIs**: Provide a consistent interface across Keycloak, Kanidm, AWS Cognito, and Nostr
 - **Simplify Provider Switching**: Enable seamless switching between auth providers without code changes
 - **Handle OAuth2/OIDC Flows**: Authorization code, token exchange, refresh, and introspection
 - **Support Decentralized Identity**: Nostr public key authentication with NIP-98 tokens
@@ -19,6 +19,7 @@ The package uses a factory pattern with provider-specific implementations:
 ```
 getAuth(options) → AuthInterface
     ├── KeycloakProvider (OIDC/OAuth2)
+    ├── KanidmProvider (OIDC/OAuth2)
     ├── CognitoProvider (AWS OAuth2)
     └── NostrProvider (public key identity)
 ```
@@ -32,12 +33,12 @@ getAuth(options) → AuthInterface
 
 2. **Provider Implementations** (`shared/providers/`)
    - Each provider implements the `AuthInterface` interface
-   - Located in: `keycloak.ts`, `cognito.ts`, `nostr/index.ts`
+   - Located in: `keycloak.ts`, `kanidm.ts`, `cognito.ts`, `nostr/index.ts`
    - All providers handle error mapping to standardized error types
 
 3. **Type Definitions** (`shared/types.ts`)
    - `AuthInterface` - Core interface all providers must implement
-   - Provider options: `KeycloakOptions`, `CognitoOptions`, `NostrOptions`
+   - Provider options: `KeycloakOptions`, `KanidmOptions`, `CognitoOptions`, `NostrOptions`
    - Flow types: `AuthResult`, `TokenClaims`, `UserProfile`, `Session`
 
 4. **Error Classes** (`shared/errors.ts`)
@@ -60,6 +61,18 @@ const keycloak = await getAuth({
   clientId: 'my-app',
   clientSecret: 'secret', // Optional for confidential clients
   redirectUri: 'https://app.example.com/callback'
+});
+
+// Kanidm client
+const kanidm = await getAuth({
+  type: 'kanidm',
+  serverUrl: 'https://idp.example.com',
+  clientId: 'my-app',
+  clientSecret: 'secret', // Optional for confidential clients
+  redirectUri: 'https://app.example.com/callback',
+  // Optional: Admin API credentials for user management
+  adminUsername: 'idm_admin',
+  adminPassword: 'admin-password'
 });
 
 // AWS Cognito client
@@ -85,11 +98,13 @@ The package supports configuration via `HAVE_AUTH_*` environment variables:
 | Variable | Description | Provider |
 |----------|-------------|----------|
 | `HAVE_AUTH_TYPE` | Provider type | All |
-| `HAVE_AUTH_SERVER_URL` | Server URL | Keycloak |
+| `HAVE_AUTH_SERVER_URL` | Server URL | Keycloak, Kanidm |
 | `HAVE_AUTH_REALM` | Realm name | Keycloak |
-| `HAVE_AUTH_CLIENT_ID` | Client ID | Keycloak, Cognito |
-| `HAVE_AUTH_CLIENT_SECRET` | Client secret | Keycloak, Cognito |
-| `HAVE_AUTH_REDIRECT_URI` | OAuth callback | Keycloak, Cognito |
+| `HAVE_AUTH_CLIENT_ID` | Client ID | Keycloak, Kanidm, Cognito |
+| `HAVE_AUTH_CLIENT_SECRET` | Client secret | Keycloak, Kanidm, Cognito |
+| `HAVE_AUTH_REDIRECT_URI` | OAuth callback | Keycloak, Kanidm, Cognito |
+| `HAVE_AUTH_ADMIN_USERNAME` | Admin username | Kanidm |
+| `HAVE_AUTH_ADMIN_PASSWORD` | Admin password | Kanidm |
 | `HAVE_AUTH_REGION` | AWS region | Cognito |
 | `HAVE_AUTH_USER_POOL_ID` | User pool ID | Cognito |
 | `HAVE_AUTH_DOMAIN` | Hosted UI domain | Cognito |
@@ -334,23 +349,25 @@ await auth.refresh(...); // NIP-98 tokens are ephemeral
 
 ## Provider Capabilities
 
-| Capability | Keycloak | Cognito | Nostr |
-|------------|----------|---------|-------|
-| Authorization Code | Yes | Yes | No* |
-| Password Grant | Yes | Yes | No |
-| Token Refresh | Yes | Yes | No |
-| OIDC | Yes | Yes | No |
-| User Management | Yes | Yes | No** |
-| Session Management | Yes | Yes | No*** |
-| RBAC | Yes | Yes | Configurable |
-| Password Reset | Yes | Yes | No |
-| MFA | Yes | Yes | No |
-| Social Login | Yes | Yes | No |
-| Decentralized | No | No | Yes |
+| Capability | Keycloak | Kanidm | Cognito | Nostr |
+|------------|----------|--------|---------|-------|
+| Authorization Code | Yes | Yes | Yes | No* |
+| Password Grant | Yes | No | Yes | No |
+| Token Refresh | Yes | Yes | Yes | No |
+| OIDC | Yes | Yes | Yes | No |
+| User Management | Yes | Yes† | Yes | No** |
+| Session Management | Yes | No | Yes | No*** |
+| RBAC | Yes | Yes‡ | Yes | Configurable |
+| Password Reset | Yes | No | Yes | No |
+| MFA | Yes | Yes | Yes | No |
+| Social Login | Yes | No | Yes | No |
+| Decentralized | No | No | No | Yes |
 
 \* Uses challenge-response signing instead
 \** Users self-manage via keypairs
 \*** Client-side only
+† Via Kanidm's native /v1/ API
+‡ Via groups claim (role assignment requires CLI)
 
 ## Dependencies
 
@@ -374,6 +391,7 @@ packages/auth/
 │   │   ├── errors.ts               # Error classes
 │   │   └── providers/
 │   │       ├── keycloak.ts         # Keycloak provider
+│   │       ├── kanidm.ts           # Kanidm provider
 │   │       ├── cognito.ts          # Cognito provider
 │   │       └── nostr/
 │   │           ├── index.ts        # Nostr provider
@@ -395,22 +413,29 @@ packages/auth/
 - [x] Factory function
 - [x] Documentation
 
-### Phase 2: Keycloak Provider (Pending)
-- [ ] OIDC discovery
-- [ ] Authorization code flow with PKCE
-- [ ] Token validation (JWKS)
-- [ ] User management (Admin API)
-- [ ] Session management
-- [ ] Tests
+### Phase 2: Keycloak Provider (Complete)
+- [x] OIDC discovery
+- [x] Authorization code flow with PKCE
+- [x] Token validation (JWKS)
+- [x] User management (Admin API)
+- [x] Session management
+- [x] Tests
 
-### Phase 3: Cognito Provider (Pending)
+### Phase 3: Kanidm Provider (Complete)
+- [x] OIDC discovery (client-specific endpoints)
+- [x] Authorization code flow with PKCE
+- [x] Token validation (ES256/JWKS)
+- [x] User management (native /v1/ API)
+- [x] Integration tests
+
+### Phase 4: Cognito Provider (Pending)
 - [ ] Hosted UI flow
 - [ ] Cognito Identity Provider SDK
 - [ ] Token validation
 - [ ] User management
 - [ ] Tests
 
-### Phase 4: Nostr Provider (Pending)
+### Phase 5: Nostr Provider (Pending)
 - [ ] Signer abstractions (Extension, PrivateKey, Bunker)
 - [ ] NIP-98 token generation/validation
 - [ ] Profile fetching (kind:0)

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -4,6 +4,7 @@
  * Unified authentication interface supporting:
  * - Keycloak (OIDC/OAuth2)
  * - AWS Cognito (OAuth2)
+ * - Kanidm (OIDC/OAuth2)
  * - Nostr (public key identity)
  *
  * @example
@@ -15,6 +16,13 @@
  *   type: 'keycloak',
  *   serverUrl: 'https://auth.example.com',
  *   realm: 'my-realm',
+ *   clientId: 'my-app'
+ * });
+ *
+ * // Kanidm
+ * const kanidm = await getAuth({
+ *   type: 'kanidm',
+ *   serverUrl: 'https://idp.example.com',
  *   clientId: 'my-app'
  * });
  *
@@ -111,6 +119,7 @@ export type {
   CreateUserRequest,
   // Provider options
   GetAuthOptions,
+  KanidmOptions,
   KeycloakOptions,
   LogoutOptions,
   NostrOptions,

--- a/packages/auth/src/kanidm.integration.spec.ts
+++ b/packages/auth/src/kanidm.integration.spec.ts
@@ -1,0 +1,388 @@
+/**
+ * Kanidm Integration Tests
+ *
+ * These tests require a running Kanidm instance with proper configuration.
+ *
+ * Environment variables required:
+ * - KANIDM_SERVER_URL: e.g., https://idp.blindmanpress.com
+ * - KANIDM_CLIENT_ID: e.g., dex
+ * - KANIDM_CLIENT_SECRET: (if using confidential client)
+ * - KANIDM_ADMIN_USERNAME: e.g., idm_admin
+ * - KANIDM_ADMIN_PASSWORD: Admin password for API access
+ *
+ * Optional:
+ * - KANIDM_REDIRECT_URI: OAuth callback URL
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { getAuth } from './index.js';
+import { isAuthError, NotImplementedError } from './shared/errors.js';
+import type { AuthInterface, UserProfile } from './shared/types.js';
+
+// Skip tests if environment variables are not set
+const SKIP_INTEGRATION =
+  !process.env.KANIDM_SERVER_URL || !process.env.KANIDM_CLIENT_ID;
+
+const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+
+describeIntegration('Kanidm Integration Tests', () => {
+  let auth: AuthInterface;
+  let createdUserId: string | undefined;
+
+  const config = {
+    serverUrl: process.env.KANIDM_SERVER_URL!,
+    clientId: process.env.KANIDM_CLIENT_ID!,
+    clientSecret: process.env.KANIDM_CLIENT_SECRET,
+    redirectUri:
+      process.env.KANIDM_REDIRECT_URI ||
+      'https://auth.happyvertical.com/callback',
+    adminUsername: process.env.KANIDM_ADMIN_USERNAME || 'idm_admin',
+    adminPassword: process.env.KANIDM_ADMIN_PASSWORD,
+  };
+
+  beforeAll(async () => {
+    // Create auth client
+    auth = await getAuth({
+      type: 'kanidm',
+      serverUrl: config.serverUrl,
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      redirectUri: config.redirectUri,
+      adminUsername: config.adminUsername,
+      adminPassword: config.adminPassword,
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up: delete any users created during tests
+    if (createdUserId && config.adminPassword) {
+      try {
+        await auth.deleteUser(createdUserId, 'admin');
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  // ===========================================================================
+  // OIDC DISCOVERY
+  // ===========================================================================
+
+  describe('OIDC Discovery', () => {
+    it('should fetch discovery document', async () => {
+      const doc = await auth.getDiscoveryDocument();
+
+      expect(doc).not.toBeNull();
+      expect(doc!.issuer).toContain(config.clientId);
+      expect(doc!.authorization_endpoint).toBeDefined();
+      expect(doc!.token_endpoint).toBeDefined();
+      expect(doc!.userinfo_endpoint).toBeDefined();
+      expect(doc!.jwks_uri).toBeDefined();
+    });
+
+    it('should have correct issuer format', async () => {
+      const doc = await auth.getDiscoveryDocument();
+
+      // Kanidm uses client-specific issuers
+      expect(doc!.issuer).toBe(
+        `${config.serverUrl}/oauth2/openid/${config.clientId}`,
+      );
+    });
+
+    it('should report correct capabilities', async () => {
+      const capabilities = await auth.getCapabilities();
+
+      expect(capabilities.authorizationCode).toBe(true);
+      expect(capabilities.passwordGrant).toBe(false); // Not supported
+      expect(capabilities.clientCredentials).toBe(false); // Not supported
+      expect(capabilities.tokenRefresh).toBe(true);
+      expect(capabilities.oidc).toBe(true);
+      expect(capabilities.userManagement).toBe(true);
+      expect(capabilities.sessionManagement).toBe(false);
+      expect(capabilities.rbac).toBe(true);
+      expect(capabilities.decentralized).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // AUTHORIZATION CODE FLOW
+  // ===========================================================================
+
+  describe('Authorization Code Flow', () => {
+    it('should generate authorization URL with PKCE', async () => {
+      const result = await auth.getAuthorizationUrl({
+        redirectUri: config.redirectUri,
+        scopes: ['openid', 'profile', 'email', 'groups'],
+        state: 'test-state',
+      });
+
+      expect(result.url).toContain(config.serverUrl);
+      expect(result.url).toContain('response_type=code');
+      expect(result.url).toContain('client_id=' + config.clientId);
+      expect(result.url).toContain('redirect_uri=');
+      expect(result.url).toContain('scope=');
+      expect(result.url).toContain('state=test-state');
+      expect(result.url).toContain('code_challenge=');
+      expect(result.url).toContain('code_challenge_method=S256');
+
+      // PKCE is always enabled for Kanidm
+      expect(result.codeVerifier).toBeDefined();
+      expect(result.codeVerifier!.length).toBeGreaterThan(40);
+      expect(result.state).toBe('test-state');
+    });
+
+    it('should generate random state if not provided', async () => {
+      const result = await auth.getAuthorizationUrl({
+        redirectUri: config.redirectUri,
+      });
+
+      expect(result.state).toBeDefined();
+      expect(result.state!.length).toBeGreaterThan(10);
+    });
+
+    it('should include nonce for ID token validation', async () => {
+      const result = await auth.getAuthorizationUrl({
+        redirectUri: config.redirectUri,
+        nonce: 'test-nonce',
+      });
+
+      expect(result.url).toContain('nonce=test-nonce');
+      expect(result.nonce).toBe('test-nonce');
+    });
+  });
+
+  // ===========================================================================
+  // AUTHENTICATE (Not Supported)
+  // ===========================================================================
+
+  describe('Direct Authentication', () => {
+    it('should throw NotImplementedError for password grant', async () => {
+      await expect(
+        auth.authenticate({
+          grantType: 'password',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+      ).rejects.toThrow(NotImplementedError);
+    });
+
+    it('should throw NotImplementedError for client credentials', async () => {
+      await expect(
+        auth.authenticate({
+          grantType: 'client_credentials',
+        }),
+      ).rejects.toThrow(NotImplementedError);
+    });
+  });
+
+  // ===========================================================================
+  // USER MANAGEMENT (Admin API)
+  // ===========================================================================
+
+  describe('User Management (Admin API)', () => {
+    const timestamp = Date.now();
+    const testUserData = {
+      username: `integration-test-user-${timestamp}`,
+      email: `test-${timestamp}@example.com`,
+      firstName: 'Integration',
+      lastName: 'Test',
+    };
+
+    // Skip user management tests if admin credentials not provided
+    const skipAdminTests = !config.adminPassword;
+
+    (skipAdminTests ? it.skip : it)('should create a new user', async () => {
+      const user = await auth.createUser(testUserData, 'admin');
+
+      expect(user.id).toBeDefined();
+      expect(user.username).toBe(testUserData.username);
+      expect(user.email).toBe(testUserData.email);
+
+      createdUserId = user.id;
+    });
+
+    (skipAdminTests ? it.skip : it)('should get user by ID', async () => {
+      if (!createdUserId) {
+        console.log('Skipping: user not created');
+        return;
+      }
+
+      const user = await auth.getUser(createdUserId, 'admin');
+
+      expect(user.id).toBeDefined();
+      expect(user.username).toBe(testUserData.username);
+    });
+
+    (skipAdminTests ? it.skip : it)('should list users', async () => {
+      const result = await auth.listUsers({}, 'admin');
+
+      expect(result.users).toBeDefined();
+      expect(Array.isArray(result.users)).toBe(true);
+      expect(result.total).toBeGreaterThanOrEqual(0);
+    });
+
+    (skipAdminTests ? it.skip : it)('should update user', async () => {
+      if (!createdUserId) {
+        console.log('Skipping: user not created');
+        return;
+      }
+
+      const updated = await auth.updateUser(
+        createdUserId,
+        {
+          firstName: 'Updated',
+          lastName: 'User',
+        },
+        'admin',
+      );
+
+      expect(updated.displayName).toContain('Updated');
+    });
+
+    (skipAdminTests ? it.skip : it)('should delete user', async () => {
+      if (!createdUserId) {
+        console.log('Skipping: user not created');
+        return;
+      }
+
+      await auth.deleteUser(createdUserId, 'admin');
+
+      // Verify user is deleted
+      await expect(auth.getUser(createdUserId, 'admin')).rejects.toThrow();
+
+      createdUserId = undefined; // Prevent afterAll cleanup
+    });
+  });
+
+  // ===========================================================================
+  // SESSION MANAGEMENT (Not Supported)
+  // ===========================================================================
+
+  describe('Session Management', () => {
+    it('should throw NotImplementedError for listSessions', async () => {
+      await expect(auth.listSessions('user-id', 'admin')).rejects.toThrow(
+        NotImplementedError,
+      );
+    });
+
+    it('should throw NotImplementedError for revokeSession', async () => {
+      await expect(auth.revokeSession('session-id', 'admin')).rejects.toThrow(
+        NotImplementedError,
+      );
+    });
+
+    it('should throw NotImplementedError for revokeAllSessions', async () => {
+      await expect(auth.revokeAllSessions('user-id', 'admin')).rejects.toThrow(
+        NotImplementedError,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // ROLE-BASED ACCESS CONTROL
+  // ===========================================================================
+
+  describe('Role-Based Access Control', () => {
+    it('should throw NotImplementedError for assignRole', async () => {
+      await expect(auth.assignRole('user-id', 'role', 'admin')).rejects.toThrow(
+        NotImplementedError,
+      );
+    });
+
+    it('should throw NotImplementedError for removeRole', async () => {
+      await expect(auth.removeRole('user-id', 'role', 'admin')).rejects.toThrow(
+        NotImplementedError,
+      );
+    });
+
+    // getRoles and hasRole should work via token claims
+    it('should return empty roles for non-existent user', async () => {
+      const roles = await auth.getRoles('non-existent-user');
+      expect(Array.isArray(roles)).toBe(true);
+      expect(roles.length).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // PASSWORD RESET (Not Supported)
+  // ===========================================================================
+
+  describe('Password Reset', () => {
+    it('should throw NotImplementedError for requestPasswordReset', async () => {
+      await expect(
+        auth.requestPasswordReset('user@example.com'),
+      ).rejects.toThrow(NotImplementedError);
+    });
+
+    it('should throw NotImplementedError for resetPassword', async () => {
+      await expect(auth.resetPassword('token', 'newpass')).rejects.toThrow(
+        NotImplementedError,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // PROFILE UPDATE (Not Supported via OAuth2)
+  // ===========================================================================
+
+  describe('Profile Update', () => {
+    it('should throw NotImplementedError for updateProfile', async () => {
+      await expect(
+        auth.updateProfile('token', { firstName: 'Test' }),
+      ).rejects.toThrow(NotImplementedError);
+    });
+  });
+
+  // ===========================================================================
+  // LOGOUT
+  // ===========================================================================
+
+  describe('Logout', () => {
+    it('should not throw when revoking tokens', async () => {
+      // Logout should succeed even with invalid tokens
+      // (it's a best-effort operation)
+      await expect(
+        auth.logout({
+          token: 'invalid-token',
+          refreshToken: 'invalid-refresh-token',
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  // ===========================================================================
+  // ERROR HANDLING
+  // ===========================================================================
+
+  describe('Error Handling', () => {
+    it('should throw NotImplementedError with proper structure', async () => {
+      try {
+        await auth.authenticate({
+          grantType: 'password',
+          username: 'test',
+          password: 'test',
+        });
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(isAuthError(error)).toBe(true);
+        expect((error as NotImplementedError).provider).toBe('kanidm');
+      }
+    });
+
+    it('should serialize errors to JSON', async () => {
+      try {
+        await auth.authenticate({
+          grantType: 'password',
+          username: 'test',
+          password: 'test',
+        });
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        const json = error.toJSON();
+        expect(json.name).toBe('NotImplementedError');
+        expect(json.provider).toBe('kanidm');
+      }
+    });
+  });
+});

--- a/packages/auth/src/shared/factory.ts
+++ b/packages/auth/src/shared/factory.ts
@@ -11,6 +11,7 @@ import type {
   AuthInterface,
   CognitoOptions,
   GetAuthOptions,
+  KanidmOptions,
   KeycloakOptions,
   NostrOptions,
 } from './types';
@@ -40,6 +41,13 @@ function isCognitoOptions(options: GetAuthOptions): options is CognitoOptions {
  */
 function isNostrOptions(options: GetAuthOptions): options is NostrOptions {
   return options.type === 'nostr';
+}
+
+/**
+ * Checks if the options are for Kanidm provider.
+ */
+function isKanidmOptions(options: GetAuthOptions): options is KanidmOptions {
+  return options.type === 'kanidm';
 }
 
 // =============================================================================
@@ -121,6 +129,9 @@ export async function getAuth(options: GetAuthOptions): Promise<AuthInterface> {
         relayTimeout: 'number',
         timeout: 'number',
         maxRetries: 'number',
+        // Kanidm-specific
+        adminUsername: 'string',
+        adminPassword: 'string',
       },
       transform: {
         // Transform comma-separated strings to arrays
@@ -154,8 +165,13 @@ export async function getAuth(options: GetAuthOptions): Promise<AuthInterface> {
     return new NostrProvider(options);
   }
 
+  if (isKanidmOptions(options)) {
+    const { KanidmProvider } = await import('./providers/kanidm.js');
+    return new KanidmProvider(options);
+  }
+
   throw new ValidationError('Unsupported auth provider type', {
-    supportedTypes: ['keycloak', 'cognito', 'nostr'],
+    supportedTypes: ['keycloak', 'cognito', 'nostr', 'kanidm'],
     providedType: (options as Record<string, unknown>).type,
   });
 }

--- a/packages/auth/src/shared/providers/kanidm.ts
+++ b/packages/auth/src/shared/providers/kanidm.ts
@@ -1,0 +1,1110 @@
+/**
+ * Kanidm Provider - OAuth2/OIDC Authentication
+ *
+ * Implements OAuth2/OIDC authentication with Kanidm server including:
+ * - OIDC Discovery (client-specific endpoints)
+ * - Authorization Code Flow with PKCE (required by Kanidm)
+ * - Token validation using JWKS (ES256)
+ * - Token introspection
+ * - User management via Kanidm's native /v1/ API
+ */
+
+import * as jose from 'jose';
+
+import {
+  AccessDeniedError,
+  ConfigurationError,
+  InvalidClientError,
+  InvalidCredentialsError,
+  InvalidGrantError,
+  InvalidNonceError,
+  InvalidTokenError,
+  NetworkError,
+  NotImplementedError,
+  ProviderError,
+  TokenExpiredError,
+  UserAlreadyExistsError,
+  UserNotFoundError,
+} from '../errors.js';
+import type {
+  AuthCapabilities,
+  AuthCredentials,
+  AuthInterface,
+  AuthorizationOptions,
+  AuthorizationResult,
+  AuthResult,
+  CodeExchangeParams,
+  CreateUserRequest,
+  KanidmOptions,
+  LogoutOptions,
+  OIDCDiscoveryDocument,
+  Session,
+  TokenClaims,
+  TokenIntrospection,
+  TokenPayload,
+  TokenValidationOptions,
+  UserListResult,
+  UserProfile,
+  UserQuery,
+} from '../types.js';
+
+/**
+ * Generate a random string for state/nonce/PKCE.
+ */
+function generateRandomString(length = 32): string {
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join(
+    '',
+  );
+}
+
+/**
+ * Generate PKCE code verifier and challenge.
+ */
+async function generatePKCE(): Promise<{
+  verifier: string;
+  challenge: string;
+}> {
+  const verifier = generateRandomString(32);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  const challenge = btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return { verifier, challenge };
+}
+
+/**
+ * Kanidm authentication provider.
+ *
+ * Implements OAuth2/OIDC authentication with Kanidm server.
+ * Key differences from Keycloak:
+ * - Client-specific OIDC endpoints: /oauth2/openid/{clientId}/...
+ * - ES256 token signing (not RS256)
+ * - Authorization code flow only (no password grant)
+ * - Native /v1/ API for admin operations (multi-step auth)
+ */
+export class KanidmProvider implements AuthInterface {
+  private options: Required<Pick<KanidmOptions, 'serverUrl' | 'clientId'>> &
+    KanidmOptions;
+  private discoveryDocument: OIDCDiscoveryDocument | null = null;
+  private jwks: jose.JWTVerifyGetKey | null = null;
+  private adminToken: string | null = null;
+  private adminTokenExpiry: number = 0;
+
+  constructor(options: KanidmOptions) {
+    if (!options.serverUrl) {
+      throw new ConfigurationError('serverUrl is required', 'kanidm');
+    }
+    if (!options.clientId) {
+      throw new ConfigurationError('clientId is required', 'kanidm');
+    }
+
+    this.options = {
+      usePKCE: true, // Required by Kanidm
+      verifySsl: true,
+      scopes: ['openid', 'profile', 'email', 'groups'],
+      timeout: 30000,
+      maxRetries: 3,
+      ...options,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // INTERNAL HELPERS
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get the OIDC base URL for this client.
+   * Kanidm uses client-specific OIDC endpoints.
+   */
+  private getOidcBaseUrl(): string {
+    return `${this.options.serverUrl}/oauth2/openid/${this.options.clientId}`;
+  }
+
+  /**
+   * Get the native API base URL.
+   */
+  private getApiBaseUrl(): string {
+    return `${this.options.serverUrl}/v1`;
+  }
+
+  /**
+   * Make an HTTP request with error handling.
+   */
+  private async request<T>(
+    url: string,
+    options: RequestInit = {},
+    token?: string,
+  ): Promise<T> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.options.headers,
+      ...(options.headers as Record<string, string>),
+    };
+
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers,
+        signal: AbortSignal.timeout(this.options.timeout || 30000),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => '');
+        let errorData: Record<string, unknown> = {};
+        try {
+          errorData = JSON.parse(errorBody);
+        } catch {
+          // Not JSON
+        }
+
+        this.handleHttpError(response.status, errorData, errorBody);
+      }
+
+      const text = await response.text();
+      if (!text) return {} as T;
+      return JSON.parse(text) as T;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'TimeoutError') {
+        throw new NetworkError('Request timed out', 'kanidm', error);
+      }
+      if (
+        error instanceof InvalidCredentialsError ||
+        error instanceof AccessDeniedError ||
+        error instanceof InvalidGrantError ||
+        error instanceof InvalidClientError ||
+        error instanceof UserNotFoundError ||
+        error instanceof ProviderError
+      ) {
+        throw error;
+      }
+      throw new NetworkError(
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'kanidm',
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Handle HTTP error responses.
+   */
+  private handleHttpError(
+    status: number,
+    data: Record<string, unknown>,
+    rawBody: string,
+  ): never {
+    const error = data.error as string | undefined;
+    const errorDescription =
+      data.message || data.error_description || data.errorMessage || rawBody;
+
+    switch (status) {
+      case 400:
+        if (error === 'invalid_grant') {
+          throw new InvalidGrantError(errorDescription as string, 'kanidm');
+        }
+        if (error === 'invalid_client') {
+          throw new InvalidClientError('kanidm');
+        }
+        throw new ProviderError(`Bad request: ${errorDescription}`, 'kanidm');
+
+      case 401:
+        throw new InvalidCredentialsError('kanidm');
+
+      case 403:
+        throw new AccessDeniedError(errorDescription as string, 'kanidm');
+
+      case 404:
+        throw new UserNotFoundError(undefined, 'kanidm');
+
+      case 409:
+        throw new UserAlreadyExistsError(undefined, 'kanidm');
+
+      default:
+        throw new ProviderError(
+          `Kanidm error (${status}): ${errorDescription}`,
+          'kanidm',
+        );
+    }
+  }
+
+  /**
+   * Fetch and cache the OIDC discovery document.
+   */
+  private async fetchDiscoveryDocument(): Promise<OIDCDiscoveryDocument> {
+    if (this.discoveryDocument) {
+      return this.discoveryDocument;
+    }
+
+    const url = `${this.getOidcBaseUrl()}/.well-known/openid-configuration`;
+    this.discoveryDocument = await this.request<OIDCDiscoveryDocument>(url);
+    return this.discoveryDocument;
+  }
+
+  /**
+   * Get JWKS for token validation.
+   */
+  private async getJWKS(): Promise<jose.JWTVerifyGetKey> {
+    if (this.jwks) {
+      return this.jwks;
+    }
+
+    const discovery = await this.fetchDiscoveryDocument();
+    this.jwks = jose.createRemoteJWKSet(new URL(discovery.jwks_uri));
+    return this.jwks;
+  }
+
+  /**
+   * Authenticate with Kanidm's native API to get an admin token.
+   * Uses the multi-step authentication flow.
+   */
+  private async getAdminToken(): Promise<string> {
+    // Check if we have a valid cached token
+    if (this.adminToken && Date.now() < this.adminTokenExpiry) {
+      return this.adminToken;
+    }
+
+    if (!this.options.adminUsername || !this.options.adminPassword) {
+      throw new ConfigurationError(
+        'adminUsername and adminPassword are required for admin operations',
+        'kanidm',
+      );
+    }
+
+    const authUrl = `${this.getApiBaseUrl()}/auth`;
+
+    // Step 1: Initialize auth
+    const initResponse = await fetch(authUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        step: {
+          init2: {
+            username: this.options.adminUsername,
+            issue: 'token',
+            privileged: true,
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(this.options.timeout || 30000),
+    });
+
+    if (!initResponse.ok) {
+      throw new InvalidCredentialsError('kanidm', {
+        reason: 'Failed to initialize admin authentication',
+      });
+    }
+
+    // Get session cookie from response
+    const cookies = initResponse.headers.get('set-cookie');
+
+    // Step 2: Begin password authentication
+    const beginResponse = await fetch(authUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cookies ? { Cookie: cookies } : {}),
+      },
+      body: JSON.stringify({
+        step: {
+          begin: 'password',
+        },
+      }),
+      signal: AbortSignal.timeout(this.options.timeout || 30000),
+    });
+
+    if (!beginResponse.ok) {
+      throw new InvalidCredentialsError('kanidm', {
+        reason: 'Failed to begin password authentication',
+      });
+    }
+
+    // Step 3: Provide password
+    const credResponse = await fetch(authUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cookies ? { Cookie: cookies } : {}),
+      },
+      body: JSON.stringify({
+        step: {
+          cred: {
+            password: this.options.adminPassword,
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(this.options.timeout || 30000),
+    });
+
+    if (!credResponse.ok) {
+      throw new InvalidCredentialsError('kanidm', {
+        reason: 'Invalid admin credentials',
+      });
+    }
+
+    const result = (await credResponse.json()) as {
+      state?: { success?: string };
+      token?: string;
+    };
+
+    // Extract token from response
+    const token = result.state?.success || result.token;
+    if (!token) {
+      throw new ProviderError(
+        'Failed to obtain admin token from Kanidm',
+        'kanidm',
+      );
+    }
+
+    this.adminToken = token;
+    // Cache for 1 hour (Kanidm tokens typically last longer, but this is safe)
+    this.adminTokenExpiry = Date.now() + 3600000;
+
+    return this.adminToken;
+  }
+
+  // ---------------------------------------------------------------------------
+  // AUTHENTICATION FLOWS
+  // ---------------------------------------------------------------------------
+
+  async getAuthorizationUrl(
+    options?: AuthorizationOptions,
+  ): Promise<AuthorizationResult> {
+    const discovery = await this.fetchDiscoveryDocument();
+
+    const state = options?.state || generateRandomString();
+    const nonce = options?.nonce || generateRandomString();
+    const scopes = options?.scopes ||
+      this.options.scopes || ['openid', 'profile', 'email', 'groups'];
+    const redirectUri = options?.redirectUri || this.options.redirectUri;
+
+    if (!redirectUri) {
+      throw new ConfigurationError('redirectUri is required', 'kanidm');
+    }
+
+    const params = new URLSearchParams({
+      client_id: this.options.clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: scopes.join(' '),
+      state,
+      nonce,
+    });
+
+    if (options?.prompt) {
+      params.set('prompt', options.prompt);
+    }
+
+    if (options?.loginHint) {
+      params.set('login_hint', options.loginHint);
+    }
+
+    // Add extra params
+    if (options?.extraParams) {
+      for (const [key, value] of Object.entries(options.extraParams)) {
+        params.set(key, value);
+      }
+    }
+
+    // PKCE is required by Kanidm
+    const pkce = await generatePKCE();
+    params.set('code_challenge', pkce.challenge);
+    params.set('code_challenge_method', 'S256');
+
+    const url = `${discovery.authorization_endpoint}?${params.toString()}`;
+
+    return {
+      url,
+      state,
+      nonce,
+      codeVerifier: pkce.verifier,
+    };
+  }
+
+  async exchangeCode(params: CodeExchangeParams): Promise<AuthResult> {
+    const discovery = await this.fetchDiscoveryDocument();
+
+    const redirectUri = params.redirectUri || this.options.redirectUri;
+    if (!redirectUri) {
+      throw new ConfigurationError('redirectUri is required', 'kanidm');
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: this.options.clientId,
+      code: params.code,
+      redirect_uri: redirectUri,
+    });
+
+    if (this.options.clientSecret) {
+      body.set('client_secret', this.options.clientSecret);
+    }
+
+    // Code verifier is required for PKCE
+    if (params.codeVerifier) {
+      body.set('code_verifier', params.codeVerifier);
+    }
+
+    const response = await this.request<{
+      access_token: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_in: number;
+      token_type: string;
+      scope?: string;
+    }>(discovery.token_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    // Decode ID token to get user ID
+    let userId = '';
+    if (response.id_token) {
+      const payload = jose.decodeJwt(response.id_token);
+      userId = payload.sub || '';
+    }
+
+    return {
+      accessToken: response.access_token,
+      tokenType: response.token_type || 'Bearer',
+      expiresIn: response.expires_in,
+      refreshToken: response.refresh_token,
+      idToken: response.id_token,
+      scope: response.scope,
+      userId,
+    };
+  }
+
+  async authenticate(_credentials: AuthCredentials): Promise<AuthResult> {
+    // Kanidm only supports authorization_code grant for OAuth2
+    // Direct authentication is not supported via OAuth2
+    throw new NotImplementedError('authenticate', 'kanidm', {
+      reason:
+        'Kanidm only supports authorization code flow. Use getAuthorizationUrl() and exchangeCode() instead.',
+    });
+  }
+
+  async refresh(refreshToken: string): Promise<AuthResult> {
+    const discovery = await this.fetchDiscoveryDocument();
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: this.options.clientId,
+      refresh_token: refreshToken,
+    });
+
+    if (this.options.clientSecret) {
+      body.set('client_secret', this.options.clientSecret);
+    }
+
+    const response = await this.request<{
+      access_token: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_in: number;
+      token_type: string;
+      scope?: string;
+    }>(discovery.token_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    // Decode to get user ID
+    let userId = '';
+    if (response.access_token) {
+      const payload = jose.decodeJwt(response.access_token);
+      userId = payload.sub || '';
+    }
+
+    return {
+      accessToken: response.access_token,
+      tokenType: response.token_type || 'Bearer',
+      expiresIn: response.expires_in,
+      refreshToken: response.refresh_token || refreshToken,
+      idToken: response.id_token,
+      scope: response.scope,
+      userId,
+    };
+  }
+
+  async logout(options?: LogoutOptions): Promise<void> {
+    const discovery = await this.fetchDiscoveryDocument();
+
+    // Revoke refresh token if provided
+    // Silently ignore failures - invalid tokens are effectively already revoked
+    if (options?.refreshToken && discovery.revocation_endpoint) {
+      const body = new URLSearchParams({
+        client_id: this.options.clientId,
+        token: options.refreshToken,
+        token_type_hint: 'refresh_token',
+      });
+
+      if (this.options.clientSecret) {
+        body.set('client_secret', this.options.clientSecret);
+      }
+
+      try {
+        await this.request(discovery.revocation_endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        });
+      } catch {
+        // Ignore revocation errors - token may already be invalid/revoked
+      }
+    }
+
+    // Revoke access token if provided
+    // Silently ignore failures - invalid tokens are effectively already revoked
+    if (options?.token && discovery.revocation_endpoint) {
+      const body = new URLSearchParams({
+        client_id: this.options.clientId,
+        token: options.token,
+        token_type_hint: 'access_token',
+      });
+
+      if (this.options.clientSecret) {
+        body.set('client_secret', this.options.clientSecret);
+      }
+
+      try {
+        await this.request(discovery.revocation_endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        });
+      } catch {
+        // Ignore revocation errors - token may already be invalid/revoked
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // TOKEN OPERATIONS
+  // ---------------------------------------------------------------------------
+
+  async validateToken(
+    token: string,
+    options?: TokenValidationOptions,
+  ): Promise<TokenClaims | null> {
+    try {
+      const jwks = await this.getJWKS();
+      const discovery = await this.fetchDiscoveryDocument();
+
+      const verifyOptions: jose.JWTVerifyOptions = {
+        issuer: options?.issuer || discovery.issuer,
+        clockTolerance: options?.clockTolerance || 0,
+      };
+
+      if (options?.audience) {
+        verifyOptions.audience = options.audience;
+      }
+
+      const { payload } = await jose.jwtVerify(token, jwks, verifyOptions);
+
+      // Check nonce if provided
+      if (options?.nonce && payload.nonce !== options.nonce) {
+        throw new InvalidNonceError('kanidm');
+      }
+
+      // Extract groups from Kanidm token structure
+      // Kanidm uses 'groups' claim directly
+      const groups = (payload.groups as string[]) || [];
+
+      return {
+        sub: payload.sub || '',
+        iss: payload.iss || '',
+        aud: payload.aud || '',
+        exp: payload.exp || 0,
+        iat: payload.iat || 0,
+        nbf: payload.nbf,
+        azp: payload.azp as string | undefined,
+        email: payload.email as string | undefined,
+        email_verified: payload.email_verified as boolean | undefined,
+        preferred_username: payload.preferred_username as string | undefined,
+        name: payload.name as string | undefined,
+        roles: groups, // Map groups to roles for consistency
+        ...payload,
+      };
+    } catch (error) {
+      if (error instanceof jose.errors.JWTExpired) {
+        throw new TokenExpiredError('kanidm');
+      }
+      if (error instanceof jose.errors.JWTClaimValidationFailed) {
+        return null;
+      }
+      if (error instanceof jose.errors.JWSSignatureVerificationFailed) {
+        throw new InvalidTokenError('Invalid token signature', 'kanidm');
+      }
+      if (error instanceof InvalidNonceError) {
+        throw error;
+      }
+      return null;
+    }
+  }
+
+  decodeToken(token: string): TokenPayload {
+    try {
+      const parts = token.split('.');
+      if (parts.length !== 3) {
+        throw new InvalidTokenError('Invalid JWT format', 'kanidm');
+      }
+
+      const header = JSON.parse(atob(parts[0]));
+      const payload = jose.decodeJwt(token);
+
+      return {
+        header: {
+          alg: header.alg,
+          typ: header.typ,
+          kid: header.kid,
+        },
+        payload: payload as unknown as TokenClaims,
+        signature: parts[2],
+      };
+    } catch {
+      throw new InvalidTokenError('Failed to decode token', 'kanidm');
+    }
+  }
+
+  async introspectToken(token: string): Promise<TokenIntrospection> {
+    const discovery = await this.fetchDiscoveryDocument();
+
+    if (!discovery.introspection_endpoint) {
+      // Fallback to local validation
+      const claims = await this.validateToken(token);
+      return {
+        active: claims !== null,
+        claims: claims || undefined,
+      };
+    }
+
+    const body = new URLSearchParams({
+      client_id: this.options.clientId,
+      token,
+    });
+
+    if (this.options.clientSecret) {
+      body.set('client_secret', this.options.clientSecret);
+    }
+
+    const response = await this.request<{
+      active: boolean;
+      sub?: string;
+      iss?: string;
+      aud?: string | string[];
+      exp?: number;
+      iat?: number;
+      client_id?: string;
+      scope?: string;
+      token_type?: string;
+      [key: string]: unknown;
+    }>(discovery.introspection_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.active) {
+      return { active: false };
+    }
+
+    return {
+      active: true,
+      claims: {
+        sub: response.sub || '',
+        iss: response.iss || '',
+        aud: response.aud || '',
+        exp: response.exp || 0,
+        iat: response.iat || 0,
+        ...response,
+      },
+      tokenType: response.token_type,
+      clientId: response.client_id,
+      scope: response.scope,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // USER OPERATIONS
+  // ---------------------------------------------------------------------------
+
+  async getProfile(tokenOrSession: string): Promise<UserProfile> {
+    const discovery = await this.fetchDiscoveryDocument();
+
+    const response = await this.request<{
+      sub: string;
+      preferred_username?: string;
+      email?: string;
+      email_verified?: boolean;
+      name?: string;
+      given_name?: string;
+      family_name?: string;
+      picture?: string;
+      groups?: string[];
+      [key: string]: unknown;
+    }>(discovery.userinfo_endpoint, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${tokenOrSession}` },
+    });
+
+    return {
+      id: response.sub,
+      username: response.preferred_username,
+      email: response.email,
+      emailVerified: response.email_verified,
+      firstName: response.given_name,
+      lastName: response.family_name,
+      displayName: response.name,
+      picture: response.picture,
+      groups: response.groups,
+    };
+  }
+
+  async updateProfile(
+    _tokenOrSession: string,
+    _profile: Partial<UserProfile>,
+  ): Promise<UserProfile> {
+    // Kanidm doesn't expose profile update via OAuth2/OIDC
+    throw new NotImplementedError('updateProfile', 'kanidm', {
+      reason:
+        'Profile updates are not supported via OAuth2. Use admin API with createUser/updateUser.',
+    });
+  }
+
+  async getUser(userId: string, _adminToken?: string): Promise<UserProfile> {
+    const token = await this.getAdminToken();
+
+    const response = await this.request<KanidmPerson>(
+      `${this.getApiBaseUrl()}/person/${userId}`,
+      { method: 'GET' },
+      token,
+    );
+
+    return this.mapKanidmPerson(response);
+  }
+
+  async createUser(
+    user: CreateUserRequest,
+    _adminToken: string,
+  ): Promise<UserProfile> {
+    const token = await this.getAdminToken();
+
+    const kanidmPerson: Partial<KanidmPersonCreate> = {
+      attrs: {
+        name: [user.username],
+        displayname: [
+          user.firstName && user.lastName
+            ? `${user.firstName} ${user.lastName}`
+            : user.username,
+        ],
+      },
+    };
+
+    if (user.email && kanidmPerson.attrs) {
+      kanidmPerson.attrs.mail = [user.email];
+    }
+
+    const response = await fetch(`${this.getApiBaseUrl()}/person`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(kanidmPerson),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      if (response.status === 409) {
+        throw new UserAlreadyExistsError(user.username, 'kanidm');
+      }
+      throw new ProviderError(`Failed to create user: ${errorBody}`, 'kanidm');
+    }
+
+    // Fetch the created user
+    return this.getUser(user.username, token);
+  }
+
+  async updateUser(
+    userId: string,
+    updates: Partial<CreateUserRequest>,
+    _adminToken: string,
+  ): Promise<UserProfile> {
+    const token = await this.getAdminToken();
+
+    const attrs: Record<string, string[]> = {};
+
+    if (updates.email !== undefined) {
+      attrs.mail = [updates.email];
+    }
+
+    if (updates.firstName !== undefined || updates.lastName !== undefined) {
+      const displayName =
+        updates.firstName && updates.lastName
+          ? `${updates.firstName} ${updates.lastName}`
+          : updates.firstName || updates.lastName || '';
+      if (displayName) {
+        attrs.displayname = [displayName];
+      }
+    }
+
+    await this.request(
+      `${this.getApiBaseUrl()}/person/${userId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ attrs }),
+      },
+      token,
+    );
+
+    return this.getUser(userId, token);
+  }
+
+  async deleteUser(userId: string, _adminToken: string): Promise<void> {
+    const token = await this.getAdminToken();
+
+    await this.request(
+      `${this.getApiBaseUrl()}/person/${userId}`,
+      { method: 'DELETE' },
+      token,
+    );
+  }
+
+  async listUsers(
+    query: UserQuery,
+    _adminToken?: string,
+  ): Promise<UserListResult> {
+    const token = await this.getAdminToken();
+
+    // Kanidm uses a different query format
+    let url = `${this.getApiBaseUrl()}/person`;
+
+    // Add search filter if provided
+    // Note: Kanidm API may have different filtering capabilities
+    const params = new URLSearchParams();
+    if (query.search) {
+      params.set('search', query.search);
+    }
+
+    if (params.toString()) {
+      url += `?${params.toString()}`;
+    }
+
+    const response = await this.request<KanidmPerson[]>(
+      url,
+      { method: 'GET' },
+      token,
+    );
+
+    const users = Array.isArray(response) ? response : [];
+
+    // Apply client-side filtering and pagination
+    let filteredUsers = users.map((u) => this.mapKanidmPerson(u));
+
+    if (query.email) {
+      filteredUsers = filteredUsers.filter((u) => u.email === query.email);
+    }
+
+    if (query.username) {
+      filteredUsers = filteredUsers.filter(
+        (u) => u.username === query.username,
+      );
+    }
+
+    const total = filteredUsers.length;
+    const offset = query.offset || 0;
+    const limit = query.limit || 100;
+
+    return {
+      users: filteredUsers.slice(offset, offset + limit),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  async requestPasswordReset(_email: string): Promise<void> {
+    throw new NotImplementedError('requestPasswordReset', 'kanidm', {
+      reason: 'Password reset is not exposed via Kanidm API',
+    });
+  }
+
+  async resetPassword(_token: string, _newPassword: string): Promise<void> {
+    throw new NotImplementedError('resetPassword', 'kanidm', {
+      reason: 'Password reset is not exposed via Kanidm API',
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // SESSION OPERATIONS
+  // ---------------------------------------------------------------------------
+
+  async listSessions(
+    _userId: string,
+    _adminToken?: string,
+  ): Promise<Session[]> {
+    throw new NotImplementedError('listSessions', 'kanidm', {
+      reason: 'Session management is not exposed via Kanidm API',
+    });
+  }
+
+  async revokeSession(_sessionId: string, _adminToken?: string): Promise<void> {
+    throw new NotImplementedError('revokeSession', 'kanidm', {
+      reason: 'Session management is not exposed via Kanidm API',
+    });
+  }
+
+  async revokeAllSessions(
+    _userId: string,
+    _adminToken?: string,
+  ): Promise<void> {
+    throw new NotImplementedError('revokeAllSessions', 'kanidm', {
+      reason: 'Session management is not exposed via Kanidm API',
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // AUTHORIZATION
+  // ---------------------------------------------------------------------------
+
+  async hasRole(tokenOrUserId: string, role: string): Promise<boolean> {
+    const roles = await this.getRoles(tokenOrUserId);
+    return roles.includes(role);
+  }
+
+  async hasPermission(
+    tokenOrUserId: string,
+    permission: string,
+    resource?: string,
+  ): Promise<boolean> {
+    // Check if the user has a group matching the permission
+    const roles = await this.getRoles(tokenOrUserId);
+    const permissionRole = resource ? `${resource}:${permission}` : permission;
+    return roles.includes(permissionRole) || roles.includes(permission);
+  }
+
+  async getRoles(
+    tokenOrUserId: string,
+    _adminToken?: string,
+  ): Promise<string[]> {
+    // First try to decode as JWT
+    try {
+      const claims = await this.validateToken(tokenOrUserId);
+      if (claims) {
+        return claims.roles || [];
+      }
+    } catch {
+      // Not a valid token
+    }
+
+    // Try to get user and return their groups
+    try {
+      const user = await this.getUser(tokenOrUserId);
+      return user.groups || [];
+    } catch {
+      // User not found or other error
+    }
+
+    return [];
+  }
+
+  async assignRole(
+    _userId: string,
+    _role: string,
+    _adminToken: string,
+  ): Promise<void> {
+    throw new NotImplementedError('assignRole', 'kanidm', {
+      reason:
+        'Role assignment via API requires group management. Use Kanidm CLI to add users to groups.',
+    });
+  }
+
+  async removeRole(
+    _userId: string,
+    _role: string,
+    _adminToken: string,
+  ): Promise<void> {
+    throw new NotImplementedError('removeRole', 'kanidm', {
+      reason:
+        'Role removal via API requires group management. Use Kanidm CLI to remove users from groups.',
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // PROVIDER INFORMATION
+  // ---------------------------------------------------------------------------
+
+  async getCapabilities(): Promise<AuthCapabilities> {
+    return {
+      authorizationCode: true,
+      passwordGrant: false, // Not supported
+      clientCredentials: false, // Not supported
+      tokenRefresh: true,
+      oidc: true,
+      userManagement: true, // Via /v1/person API
+      sessionManagement: false, // Not exposed
+      rbac: true, // Via groups claim
+      passwordReset: false, // Not exposed via API
+      mfa: true, // Webauthn/passkeys supported
+      socialLogin: false,
+      federation: true,
+      decentralized: false,
+    };
+  }
+
+  async getDiscoveryDocument(): Promise<OIDCDiscoveryDocument | null> {
+    return this.fetchDiscoveryDocument();
+  }
+
+  // ---------------------------------------------------------------------------
+  // PRIVATE HELPERS
+  // ---------------------------------------------------------------------------
+
+  private mapKanidmPerson(person: KanidmPerson): UserProfile {
+    const attrs = person.attrs || {};
+
+    return {
+      id: attrs.uuid?.[0] || attrs.name?.[0] || '',
+      username: attrs.name?.[0],
+      email: attrs.mail?.[0],
+      displayName: attrs.displayname?.[0],
+      groups: attrs.memberof,
+      enabled: true, // Kanidm doesn't expose this directly
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// KANIDM API TYPES
+// ---------------------------------------------------------------------------
+
+interface KanidmPerson {
+  attrs: {
+    uuid?: string[];
+    name?: string[];
+    displayname?: string[];
+    mail?: string[];
+    memberof?: string[];
+    [key: string]: string[] | undefined;
+  };
+}
+
+interface KanidmPersonCreate {
+  attrs: {
+    name: string[];
+    displayname?: string[];
+    mail?: string[];
+    [key: string]: string[] | undefined;
+  };
+}

--- a/packages/auth/src/shared/types.ts
+++ b/packages/auth/src/shared/types.ts
@@ -391,9 +391,59 @@ export interface SessionStoreConfig {
 }
 
 /**
+ * Kanidm provider options.
+ */
+export interface KanidmOptions extends BaseAuthOptions {
+  type: 'kanidm';
+
+  /** Kanidm server URL (e.g., 'https://idp.example.com') */
+  serverUrl: string;
+
+  /** OAuth2 client ID */
+  clientId: string;
+
+  /** Client secret (for confidential clients) */
+  clientSecret?: string;
+
+  /** OAuth callback URL for this application */
+  redirectUri?: string;
+
+  /** Default scopes to request */
+  scopes?: string[];
+
+  /**
+   * Use PKCE for authorization code flow.
+   * @default true (required by Kanidm)
+   */
+  usePKCE?: boolean;
+
+  /**
+   * Verify SSL certificates.
+   * @default true
+   */
+  verifySsl?: boolean;
+
+  /**
+   * Admin username for Kanidm API operations.
+   * Required for user management operations.
+   */
+  adminUsername?: string;
+
+  /**
+   * Admin password for Kanidm API operations.
+   * Required for user management operations.
+   */
+  adminPassword?: string;
+}
+
+/**
  * Union type for all provider options.
  */
-export type GetAuthOptions = KeycloakOptions | CognitoOptions | NostrOptions;
+export type GetAuthOptions =
+  | KeycloakOptions
+  | CognitoOptions
+  | NostrOptions
+  | KanidmOptions;
 
 // =============================================================================
 // AUTHENTICATION FLOW TYPES


### PR DESCRIPTION
## Summary

Add a new Kanidm provider for the auth package with full OIDC/OAuth2 support.

Kanidm is an identity management server with unique characteristics:
- Client-specific OIDC endpoints: `/oauth2/openid/{clientId}/...`
- ES256 token signing (not RS256)
- Authorization code flow only (no password grant)
- Native `/v1/` API for user management (not SCIM)

### Features
- Authorization code flow with PKCE (required by Kanidm)
- Token validation via JWKS
- User CRUD operations via `/v1/person` API
- Multi-step admin authentication for API access
- Integration tests against live Kanidm instance

### Files Changed
- `packages/auth/src/shared/providers/kanidm.ts` - New provider (~900 lines)
- `packages/auth/src/shared/types.ts` - Added `KanidmOptions` interface
- `packages/auth/src/shared/factory.ts` - Added Kanidm support
- `packages/auth/src/index.ts` - Added exports
- `packages/auth/src/kanidm.integration.spec.ts` - Integration tests
- `packages/auth/CLAUDE.md` - Updated documentation
- `biome.json` - Added naming convention override for auth providers/types

## Test plan
- [x] Build succeeds
- [x] 14/14 factory tests pass
- [x] 25/25 Kanidm integration tests pass against live instance
- [x] Lint clean with biome