### PR TITLE
ci: use self-hosted arc-happyvertical runners

### DIFF
--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -12,11 +12,9 @@ rules:
   truthy:
     allowed-values: ['true', 'false', 'on']
 
-  # SHA-pinned actions often have long lines with comments
-  line-length:
-    max: 120
-    allow-non-breakable-words: true
-    allow-non-breakable-inline-mappings: true
+  # Disable line-length: GitHub Actions workflows often have long lines
+  # in script blocks, echo commands, and SHA-pinned action comments
+  line-length: disable
 
   # Relaxed comment spacing for SHA comments
   comments:

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - arc-happyvertical

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check:
     name: Check for Changeset
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     # Skip for automated PRs (Renovate, changeset-release)
     # This prevents pnpm install from failing on dependency issues
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       (github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') ||
         contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     permissions:
       contents: write        # Allow Claude to push commits and create branches
       pull-requests: write   # Allow Claude to create and update PRs

--- a/.github/workflows/on-pr-main-dependabot.yml
+++ b/.github/workflows/on-pr-main-dependabot.yml
@@ -2,7 +2,7 @@ name: Dependabot Automation
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 # Only one dependabot run per PR at a time
 concurrency:
@@ -20,12 +20,12 @@ jobs:
     uses: ./.github/workflows/test-suite.yml
     if: ${{ github.actor == 'dependabot[bot]' }}
     with:
-      runner: 'ubuntu-latest'
+      runner: 'arc-happyvertical'
       node-version: '24'
 
   # Handle dependabot-specific automation after tests pass
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     needs: [test]
     if: |
       github.actor == 'dependabot[bot]' &&
@@ -57,7 +57,7 @@ jobs:
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0  # Pinned to specific version
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          
+
       - name: Security scan for dependency changes
         run: |
           echo "::notice::Checking for security vulnerabilities in dependencies"
@@ -78,22 +78,25 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Enable auto-merge for minor and patch updates
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
           echo "::notice::Enabling auto-merge for ${{ steps.metadata.outputs.update-type }} update"
           gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Require manual review for major updates
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-major' }}
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |
           echo "Major version update detected. Manual review required."
           echo "This PR will not be automatically approved or merged."
-          gh pr comment "$PR_URL" --body "⚠️ **Major version update detected**. Manual review is required before merging."
+          gh pr comment "$PR_URL" \
+            --body "Major version update detected. Manual review required."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   validate-commits:
     name: Validate Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout PR branch
@@ -98,7 +98,7 @@ jobs:
 
   validate-workflows:
     name: Validate Workflow Files
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/planning.yml
+++ b/.github/workflows/planning.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   planning:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -50,7 +50,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { startPlanning, completePlanning } = await import('${{ github.workspace }}/node_modules/@happyvertical/github-actions/dist/index.js');
+            const pkgPath = '${{ github.workspace }}/node_modules';
+            const { startPlanning, completePlanning } = await import(
+              `${pkgPath}/@happyvertical/github-actions/dist/index.js`
+            );
 
             const planningContext = {
               token: process.env.GITHUB_TOKEN,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     needs: [release]
     if: github.event.inputs.skip-docs != 'true'
 

--- a/.github/workflows/shared-agent-orchestrator.yml
+++ b/.github/workflows/shared-agent-orchestrator.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   orchestrate:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Agent Assignment
         if: inputs.action == 'labeled'

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -65,7 +65,7 @@ permissions:
 jobs:
   release:
     name: Version and Publish
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     outputs:
       published: ${{ steps.publish.outputs.published }}

--- a/.github/workflows/shared-issue-closer.yml
+++ b/.github/workflows/shared-issue-closer.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Cleanup Issue
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/shared-label-handler.yml
+++ b/.github/workflows/shared-label-handler.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   handle-label:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout calling repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -55,7 +55,7 @@ jobs:
   summary:
     needs: [test, build, publish]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Workflow Summary
         run: |

--- a/.github/workflows/shared-pr-handler.yml
+++ b/.github/workflows/shared-pr-handler.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   handle-pr:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Link PR to Issues
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/shared-triage.yml
+++ b/.github/workflows/shared-triage.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout calling repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
 
     # PostgreSQL service for database tests
     services:


### PR DESCRIPTION
## Summary

Migrate all GitHub Actions workflows from `ubuntu-latest` to the organization's self-hosted `arc-happyvertical` runners for improved performance and cost efficiency.

## Changes

- Update `runs-on` in all workflow files to use `arc-happyvertical`
- Add `.github/actionlint.yaml` to recognize the self-hosted runner label
- Disable yamllint line-length rule (GitHub Actions scripts often exceed 120 chars)
- Fix minor formatting issues (bracket spacing, trailing spaces)

## Testing

- Workflow validation passes locally (yamllint + actionlint)
- Self-hosted runner label is properly configured

Closes #N/A - Organization-wide CI improvement initiative