### PR TITLE
feat(sql): add beginTransaction() for manual transaction control

### DIFF
--- a/packages/sql/src/duckdb.ts
+++ b/packages/sql/src/duckdb.ts
@@ -21,6 +21,7 @@ import type {
   SchemaInitializationOptions,
   TableInterface,
   TableSchemaInfo,
+  TransactionHandle,
 } from './shared/types';
 import { buildWhere } from './shared/utils';
 
@@ -1313,6 +1314,70 @@ export async function getDatabase(
     }
   };
 
+  /**
+   * Begins a new transaction and returns a handle for manual control
+   *
+   * Unlike transaction(), this gives you explicit control over commit/rollback.
+   * Ideal for test isolation where you want to rollback after each test.
+   *
+   * @returns Promise resolving to a TransactionHandle
+   */
+  const beginTransaction = async (): Promise<TransactionHandle> => {
+    await connection.run('BEGIN TRANSACTION');
+
+    let active = true;
+
+    const commit = async (): Promise<void> => {
+      if (!active) {
+        throw new DatabaseError('Transaction already ended', {});
+      }
+      await connection.run('COMMIT');
+      active = false;
+    };
+
+    const rollback = async (): Promise<void> => {
+      if (!active) {
+        throw new DatabaseError('Transaction already ended', {});
+      }
+      await connection.run('ROLLBACK');
+      active = false;
+    };
+
+    const isActive = (): boolean => active;
+
+    // Create a transaction-scoped database interface with commit/rollback
+    const txHandle: TransactionHandle = {
+      url,
+      client: connection,
+      insert,
+      get,
+      list,
+      update,
+      upsert,
+      getOrInsert,
+      delete: deleteRecords,
+      count,
+      table,
+      many,
+      single,
+      pluck,
+      execute,
+      query,
+      oo,
+      oO,
+      ox,
+      xx,
+      tableExists,
+      syncSchema,
+      transaction,
+      commit,
+      rollback,
+      isActive,
+    };
+
+    return txHandle;
+  };
+
   return {
     url,
     client: connection,
@@ -1338,6 +1403,7 @@ export async function getDatabase(
     syncSchema,
     initializeSchemas,
     transaction,
+    beginTransaction,
     getTableSchema,
     alterTable,
     // DuckDB-specific export method

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -9,6 +9,7 @@ import type {
   QueryResult,
   SchemaInitializationOptions,
   TableInterface,
+  TransactionHandle,
 } from './shared/types';
 import { buildWhere } from './shared/utils';
 
@@ -1770,6 +1771,70 @@ export async function getDatabase(
       }
     };
 
+    /**
+     * Begins a new transaction and returns a handle for manual control
+     *
+     * Unlike transaction(), this gives you explicit control over commit/rollback.
+     * Ideal for test isolation where you want to rollback after each test.
+     *
+     * @returns Promise resolving to a TransactionHandle
+     */
+    const beginTransaction = async (): Promise<TransactionHandle> => {
+      await connection.run('BEGIN TRANSACTION');
+
+      let active = true;
+
+      const commit = async (): Promise<void> => {
+        if (!active) {
+          throw new DatabaseError('Transaction already ended', {});
+        }
+        await connection.run('COMMIT');
+        active = false;
+      };
+
+      const rollback = async (): Promise<void> => {
+        if (!active) {
+          throw new DatabaseError('Transaction already ended', {});
+        }
+        await connection.run('ROLLBACK');
+        active = false;
+      };
+
+      const isActive = (): boolean => active;
+
+      // Create a transaction-scoped database interface with commit/rollback
+      const txHandle: TransactionHandle = {
+        url,
+        client: connection,
+        insert,
+        get,
+        list,
+        update,
+        upsert,
+        getOrInsert,
+        delete: deleteRecords,
+        count,
+        table,
+        many,
+        single,
+        pluck,
+        execute,
+        query,
+        oo,
+        oO,
+        ox,
+        xx,
+        tableExists,
+        syncSchema,
+        transaction,
+        commit,
+        rollback,
+        isActive,
+      };
+
+      return txHandle;
+    };
+
     return {
       url,
       client: connection,
@@ -1795,6 +1860,7 @@ export async function getDatabase(
       syncSchema,
       initializeSchemas,
       transaction,
+      beginTransaction,
       // JSON-specific methods
       exportTable,
       inferSchemaFromJSON,

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -17,6 +17,7 @@ import type {
   SchemaInitializationOptions,
   TableInterface,
   TableSchemaInfo,
+  TransactionHandle,
 } from './shared/types';
 import { buildWhere } from './shared/utils';
 
@@ -1007,6 +1008,225 @@ export async function getDatabase(
     }
   };
 
+  /**
+   * Begins a new transaction and returns a handle for manual control
+   *
+   * Unlike transaction(), this gives you explicit control over commit/rollback.
+   * Ideal for test isolation where you want to rollback after each test.
+   *
+   * @returns Promise resolving to a TransactionHandle
+   */
+  const beginTransaction = async (): Promise<TransactionHandle> => {
+    // Get a client from the pool for the transaction
+    const txClient = await client.connect();
+    await txClient.query('BEGIN');
+
+    let active = true;
+
+    const commit = async (): Promise<void> => {
+      if (!active) {
+        throw new DatabaseError('Transaction already ended', {});
+      }
+      await txClient.query('COMMIT');
+      active = false;
+      txClient.release();
+    };
+
+    const rollback = async (): Promise<void> => {
+      if (!active) {
+        throw new DatabaseError('Transaction already ended', {});
+      }
+      await txClient.query('ROLLBACK');
+      active = false;
+      txClient.release();
+    };
+
+    const isActive = (): boolean => active;
+
+    // Create a transaction-scoped database interface with commit/rollback
+    const txHandle: TransactionHandle = {
+      url,
+      client: txClient,
+      insert: async (table, data) => {
+        if (Array.isArray(data)) {
+          const keys = Object.keys(data[0]);
+          const placeholders = data
+            .map(
+              (_, i) =>
+                `(${keys.map((_, j) => `$${i * keys.length + j + 1}`).join(', ')})`,
+            )
+            .join(', ');
+          const query = `INSERT INTO ${table} (${keys.join(', ')}) VALUES ${placeholders}`;
+          const values = data.reduce(
+            (acc, row) => acc.concat(Object.values(row)),
+            [] as any[],
+          );
+          const result = await txClient.query(query, values);
+          return { operation: 'insert', affected: result.rowCount ?? 0 };
+        }
+        const keys = Object.keys(data);
+        const values = Object.values(data);
+        const placeholders = keys.map((_, i) => `$${i + 1}`).join(', ');
+        const query = `INSERT INTO ${table} (${keys.join(', ')}) VALUES (${placeholders})`;
+        const result = await txClient.query(query, values);
+        return { operation: 'insert', affected: result.rowCount ?? 0 };
+      },
+      get: async (table, where) => {
+        const keys = Object.keys(where);
+        const values = Object.values(where);
+        const whereClause = keys
+          .map((key, i) => `${key} = $${i + 1}`)
+          .join(' AND ');
+        const query = `SELECT * FROM ${table} WHERE ${whereClause}`;
+        const result = await txClient.query(query, values);
+        return result.rows[0] || null;
+      },
+      list: async (table, where) => {
+        const { sql: whereClause, values } = buildWhere(where, 1);
+        const query = `SELECT * FROM ${table} ${whereClause}`;
+        const result = await txClient.query(query, values);
+        return result.rows;
+      },
+      update: async (table, where, data) => {
+        const keys = Object.keys(data);
+        const values = Object.values(data);
+        const setClause = keys.map((key, i) => `${key} = $${i + 1}`).join(', ');
+        const whereKeys = Object.keys(where);
+        const whereValues = Object.values(where);
+        const whereClause = whereKeys
+          .map((key, i) => `${key} = $${i + 1 + values.length}`)
+          .join(' AND ');
+        const sql = `UPDATE ${table} SET ${setClause} WHERE ${whereClause}`;
+        const result = await txClient.query(sql, [...values, ...whereValues]);
+        return { operation: 'update', affected: result.rowCount ?? 0 };
+      },
+      upsert: async (table, conflictColumns, data) => {
+        const keys = Object.keys(data);
+        const values = Object.values(data);
+        const placeholders = keys.map((_, i) => `$${i + 1}`).join(', ');
+        const updateSet = keys.map((key, i) => `${key} = $${i + 1}`).join(', ');
+        const conflict = conflictColumns.join(', ');
+        const sql = `INSERT INTO ${table} (${keys.join(', ')}) VALUES (${placeholders}) ON CONFLICT(${conflict}) DO UPDATE SET ${updateSet}`;
+        const result = await txClient.query(sql, values);
+        return { operation: 'upsert', affected: result.rowCount ?? 0 };
+      },
+      getOrInsert: async (table, where, data) => {
+        const result = await txHandle.get(table, where);
+        if (result) return result;
+        await txHandle.insert(table, data);
+        const inserted = await txHandle.get(table, where);
+        if (!inserted) {
+          throw new DatabaseError('Failed to insert and retrieve record', {
+            table,
+            where,
+            data,
+          });
+        }
+        return inserted;
+      },
+      delete: async (table, where) => {
+        validateTableName(table);
+        const keys = Object.keys(where);
+        if (keys.length === 0) {
+          throw new DatabaseError(
+            'DELETE requires at least one WHERE condition to prevent accidental deletion of all records',
+            { table },
+          );
+        }
+        const conditions = keys
+          .map((key, i) => `${key} = $${i + 1}`)
+          .join(' AND ');
+        const values = Object.values(where);
+        const result = await txClient.query(
+          `DELETE FROM ${table} WHERE ${conditions}`,
+          values,
+        );
+        return { operation: 'delete', affected: result.rowCount ?? 0 };
+      },
+      count: async (table, where) => {
+        validateTableName(table);
+        if (!where || Object.keys(where).length === 0) {
+          const result = await txClient.query(
+            `SELECT COUNT(*) as count FROM ${table}`,
+          );
+          return Number(result.rows[0]?.count) || 0;
+        }
+        const keys = Object.keys(where);
+        const conditions = keys
+          .map((key, i) => `${key} = $${i + 1}`)
+          .join(' AND ');
+        const values = Object.values(where);
+        const result = await txClient.query(
+          `SELECT COUNT(*) as count FROM ${table} WHERE ${conditions}`,
+          values,
+        );
+        return Number(result.rows[0]?.count) || 0;
+      },
+      table: (tableName) => ({
+        insert: (data) => txHandle.insert(tableName, data),
+        get: (data) => txHandle.get(tableName, data),
+        list: (data) => txHandle.list(tableName, data),
+      }),
+      many: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        const result = await txClient.query(sql, values);
+        return result.rows;
+      },
+      single: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        const result = await txClient.query(sql, values);
+        return result.rows[0] || null;
+      },
+      pluck: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        const result = await txClient.query(sql, values);
+        const firstRow = result.rows[0];
+        if (!firstRow) return null;
+        return Object.values(firstRow)[0];
+      },
+      execute: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        await txClient.query(sql, values);
+      },
+      query: async (sql, ...values) => {
+        const result = await txClient.query(sql, values);
+        return {
+          rows: result.rows,
+          rowCount: result.rowCount ?? 0,
+        };
+      },
+      oo: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        const result = await txClient.query(sql, values);
+        return result.rows;
+      },
+      oO: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        const result = await txClient.query(sql, values);
+        return result.rows[0] || null;
+      },
+      ox: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        const result = await txClient.query(sql, values);
+        const firstRow = result.rows[0];
+        if (!firstRow) return null;
+        return Object.values(firstRow)[0];
+      },
+      xx: async (strings, ...vars) => {
+        const { sql, values } = parseTemplate(strings, ...vars);
+        await txClient.query(sql, values);
+      },
+      tableExists,
+      syncSchema,
+      transaction,
+      commit,
+      rollback,
+      isActive,
+    };
+
+    return txHandle;
+  };
+
   // Shorthand aliases for query methods
   const oo = many; // (o)bjective-(o)bjects: returns multiple rows
   const oO = single; // (o)bjective-(O)bject: returns a single row
@@ -1282,6 +1502,7 @@ export async function getDatabase(
     syncSchema,
     initializeSchemas,
     transaction,
+    beginTransaction,
     getTableSchema,
     alterTable,
   };

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -656,6 +656,36 @@ export interface DatabaseInterface {
   ) => Promise<T>;
 
   /**
+   * Begins a new transaction and returns a handle for manual control
+   *
+   * Unlike transaction(), this gives you explicit control over commit/rollback.
+   * Ideal for test isolation where you want to rollback after each test.
+   *
+   * @returns Promise resolving to a TransactionHandle
+   *
+   * @example Test isolation pattern
+   * ```typescript
+   * let tx: TransactionHandle;
+   *
+   * beforeEach(async () => {
+   *   tx = await db.beginTransaction();
+   * });
+   *
+   * afterEach(async () => {
+   *   await tx.rollback(); // Discard all test changes
+   * });
+   *
+   * it('creates user', async () => {
+   *   await tx.insert('users', { id: '1', name: 'Test' });
+   *   const user = await tx.get('users', { id: '1' });
+   *   expect(user).toBeDefined();
+   *   // Changes rolled back in afterEach
+   * });
+   * ```
+   */
+  beginTransaction?: () => Promise<TransactionHandle>;
+
+  /**
    * Retrieves the schema information for a table
    *
    * @param table - Table name
@@ -688,6 +718,64 @@ export interface DatabaseInterface {
      */
     addIndex: (table: string, index: IndexDefinition) => Promise<void>;
   };
+}
+
+/**
+ * Transaction handle for manual transaction control
+ *
+ * Extends DatabaseInterface with commit() and rollback() methods.
+ * Use beginTransaction() to obtain a handle, then explicitly
+ * commit or rollback when done.
+ *
+ * @example Test isolation with rollback
+ * ```typescript
+ * const tx = await db.beginTransaction();
+ * try {
+ *   // All operations happen in the transaction
+ *   await tx.insert('users', { id: '1', name: 'Test' });
+ *   const user = await tx.get('users', { id: '1' });
+ *
+ *   // Rollback discards all changes (useful for test isolation)
+ *   await tx.rollback();
+ * } catch (error) {
+ *   await tx.rollback();
+ *   throw error;
+ * }
+ * ```
+ *
+ * @example Manual commit
+ * ```typescript
+ * const tx = await db.beginTransaction();
+ * try {
+ *   await tx.insert('orders', { id: '1', total: 100 });
+ *   await tx.insert('order_items', { order_id: '1', product: 'Widget' });
+ *   await tx.commit(); // Persist changes
+ * } catch (error) {
+ *   await tx.rollback();
+ *   throw error;
+ * }
+ * ```
+ */
+export interface TransactionHandle extends DatabaseInterface {
+  /**
+   * Commits the transaction, persisting all changes
+   *
+   * After commit, the transaction handle should not be used.
+   */
+  commit: () => Promise<void>;
+
+  /**
+   * Rolls back the transaction, discarding all changes
+   *
+   * After rollback, the transaction handle should not be used.
+   * This is the key method for test isolation - rollback after each test.
+   */
+  rollback: () => Promise<void>;
+
+  /**
+   * Whether the transaction is still active (not committed or rolled back)
+   */
+  isActive: () => boolean;
 }
 
 /**

--- a/packages/sql/src/sqlite.ts
+++ b/packages/sql/src/sqlite.ts
@@ -17,6 +17,7 @@ import type {
   SchemaInitializationOptions,
   TableInterface,
   TableSchemaInfo,
+  TransactionHandle,
 } from './shared/types';
 import { buildWhere } from './shared/utils';
 
@@ -763,6 +764,70 @@ export async function getDatabase(
     };
 
     /**
+     * Begins a new transaction and returns a handle for manual control
+     *
+     * Unlike transaction(), this gives you explicit control over commit/rollback.
+     * Ideal for test isolation where you want to rollback after each test.
+     *
+     * @returns Promise resolving to a TransactionHandle
+     */
+    const beginTransaction = async (): Promise<TransactionHandle> => {
+      await client.execute({ sql: 'BEGIN TRANSACTION', args: [] });
+
+      let active = true;
+
+      const commit = async (): Promise<void> => {
+        if (!active) {
+          throw new DatabaseError('Transaction already ended', {});
+        }
+        await client.execute({ sql: 'COMMIT', args: [] });
+        active = false;
+      };
+
+      const rollback = async (): Promise<void> => {
+        if (!active) {
+          throw new DatabaseError('Transaction already ended', {});
+        }
+        await client.execute({ sql: 'ROLLBACK', args: [] });
+        active = false;
+      };
+
+      const isActive = (): boolean => active;
+
+      // Create a transaction-scoped database interface with commit/rollback
+      const txHandle: TransactionHandle = {
+        url,
+        client,
+        insert,
+        get,
+        list,
+        update,
+        upsert,
+        getOrInsert,
+        delete: deleteRecords,
+        count,
+        table,
+        many,
+        single,
+        pluck,
+        execute,
+        query,
+        oo: many,
+        oO: single,
+        ox: pluck,
+        xx: execute,
+        tableExists,
+        syncSchema,
+        transaction,
+        commit,
+        rollback,
+        isActive,
+      };
+
+      return txHandle;
+    };
+
+    /**
      * Creates a table-specific interface for simplified table operations
      *
      * @param tableName - Table name
@@ -1163,6 +1228,7 @@ export async function getDatabase(
       syncSchema,
       initializeSchemas,
       transaction,
+      beginTransaction,
       getTableSchema,
       alterTable,
     };

--- a/packages/sql/src/transaction-handle.spec.ts
+++ b/packages/sql/src/transaction-handle.spec.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { getDatabase, syncSchema } from './index';
+import type { TransactionHandle } from './shared/types';
+
+describe('beginTransaction', () => {
+  describe('SQLite', () => {
+    it('should create a transaction handle with commit/rollback methods', async () => {
+      const db = await getDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+      });
+
+      await syncSchema({
+        db,
+        schema: `
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL
+          )
+        `,
+      });
+
+      expect(db.beginTransaction).toBeDefined();
+      const tx = await db.beginTransaction!();
+
+      expect(tx.commit).toBeDefined();
+      expect(tx.rollback).toBeDefined();
+      expect(tx.isActive).toBeDefined();
+      expect(tx.isActive()).toBe(true);
+
+      await tx.rollback();
+      expect(tx.isActive()).toBe(false);
+    });
+
+    it('should rollback changes when rollback is called', async () => {
+      const db = await getDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+      });
+
+      await syncSchema({
+        db,
+        schema: `
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL
+          )
+        `,
+      });
+
+      // Insert a record outside transaction
+      await db.insert('users', { id: '1', name: 'Alice' });
+
+      // Start transaction and insert
+      const tx = await db.beginTransaction!();
+      await tx.insert('users', { id: '2', name: 'Bob' });
+
+      // Bob should be visible within the transaction
+      const bobInTx = await tx.get('users', { id: '2' });
+      expect(bobInTx).not.toBeNull();
+      expect(bobInTx?.name).toBe('Bob');
+
+      // Rollback the transaction
+      await tx.rollback();
+
+      // Bob should not exist after rollback
+      const bobAfterRollback = await db.get('users', { id: '2' });
+      expect(bobAfterRollback).toBeNull();
+
+      // Alice should still exist
+      const alice = await db.get('users', { id: '1' });
+      expect(alice).not.toBeNull();
+      expect(alice?.name).toBe('Alice');
+    });
+
+    it('should commit changes when commit is called', async () => {
+      const db = await getDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+      });
+
+      await syncSchema({
+        db,
+        schema: `
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL
+          )
+        `,
+      });
+
+      // Start transaction and insert
+      const tx = await db.beginTransaction!();
+      await tx.insert('users', { id: '1', name: 'Charlie' });
+      await tx.commit();
+
+      // Charlie should exist after commit
+      const charlie = await db.get('users', { id: '1' });
+      expect(charlie).not.toBeNull();
+      expect(charlie?.name).toBe('Charlie');
+    });
+
+    it('should throw error when commit/rollback called twice', async () => {
+      const db = await getDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+      });
+
+      await syncSchema({
+        db,
+        schema: `
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL
+          )
+        `,
+      });
+
+      const tx = await db.beginTransaction!();
+      await tx.rollback();
+
+      await expect(tx.rollback()).rejects.toThrow('Transaction already ended');
+      await expect(tx.commit()).rejects.toThrow('Transaction already ended');
+    });
+
+    it('should support multiple sequential transactions with rollback', async () => {
+      const db = await getDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+      });
+
+      await syncSchema({
+        db,
+        schema: `
+          CREATE TABLE items (
+            id TEXT PRIMARY KEY,
+            value INTEGER NOT NULL
+          )
+        `,
+      });
+
+      // First transaction with rollback
+      const tx1 = await db.beginTransaction!();
+      await tx1.insert('items', { id: 'item-1', value: 100 });
+      const item1 = await tx1.get('items', { id: 'item-1' });
+      expect(item1?.value).toBe(100);
+      await tx1.rollback();
+
+      // Item should not persist after rollback
+      const afterRollback1 = await db.get('items', { id: 'item-1' });
+      expect(afterRollback1).toBeNull();
+
+      // Second transaction with rollback
+      const tx2 = await db.beginTransaction!();
+      await tx2.insert('items', { id: 'item-2', value: 200 });
+      const item2 = await tx2.get('items', { id: 'item-2' });
+      expect(item2?.value).toBe(200);
+      await tx2.rollback();
+
+      // Item should not persist after rollback
+      const afterRollback2 = await db.get('items', { id: 'item-2' });
+      expect(afterRollback2).toBeNull();
+
+      // Verify table is empty using list
+      const allItems = await db.list('items', {});
+      expect(allItems).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `TransactionHandle` interface with `commit()`, `rollback()`, and `isActive()` methods
- Implement `beginTransaction()` in all SQL adapters (sqlite, postgres, duckdb, json)
- Unlike `transaction()` callback pattern, this allows manual control over commit/rollback

## Motivation
Enables test isolation via transaction rollback - each test can run in a transaction that gets rolled back, ensuring clean state between tests.

This eliminates SQLite concurrency issues (SQLITE_BUSY, SQLITE_READONLY_DBMOVED) by allowing parallel test execution in CI with Postgres.

## Test plan
- [x] All 5 tests in `transaction-handle.spec.ts` pass
- [x] Tests cover: create handle, rollback, commit, double-end error, sequential transactions