### PR TITLE
fix(sql): convert ? placeholders to $1 style for postgres

### DIFF
--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -692,7 +692,11 @@ export async function getDatabase(
     ...values: any[]
   ): Promise<{ rows: Record<string, any>[]; rowCount: number }> => {
     try {
-      const result = await client.query(sql, values);
+      // Convert ? placeholders to $1, $2, etc for PostgreSQL compatibility
+      let paramIndex = 0;
+      const pgSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
+
+      const result = await client.query(pgSql, values);
       return {
         rows: result.rows,
         rowCount: result.rowCount ?? 0,


### PR DESCRIPTION
## Summary
- Fix PostgreSQL query() method to convert `?` placeholders to `$1, $2` style before executing

## Problem
The raw `query()` method in the postgres adapter was passing SQL with `?` placeholders directly to PostgreSQL, which doesn't understand them. This caused `"syntax error at or near"` errors when smrt-core collections called `query()` with SQLite-style placeholders.

## Solution
Convert `?` to `$1, $2, $3`, etc. before executing the query, matching the behavior of all other methods in the postgres adapter (insert, get, list, update, etc. all already do this conversion).

## Test plan
- [x] Tested in blindmanpress dashboard with PostgreSQL backend
- [ ] Unit tests should be added