### PR TITLE
feat: integrate Claude Code Action via org workflows

### DIFF
--- a/.github/workflows/on-ci-failure.yml
+++ b/.github/workflows/on-ci-failure.yml
@@ -1,0 +1,27 @@
+name: CI Failure Auto-Fix
+
+on:
+  workflow_run:
+    workflows: ["Test Suite", "Test", "on-pull-request"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  issues: write
+  id-token: write
+
+jobs:
+  auto-fix:
+    if: github.event.workflow_run.conclusion == 'failure'
+    uses: happyvertical/.github/.github/workflows/org-ci-failure-fix.yml@main
+    with:
+      workflow_name: ${{ github.event.workflow_run.name }}
+      run_id: ${{ github.event.workflow_run.id }}
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number || 0 }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-issue-opened.yml
+++ b/.github/workflows/on-issue-opened.yml
@@ -1,0 +1,28 @@
+name: Issue Opened
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+  id-token: write
+
+jobs:
+  triage:
+    uses: happyvertical/.github/.github/workflows/org-issue-triage.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}
+      issue_body: ${{ github.event.issue.body || '' }}
+      issue_author: ${{ github.event.issue.user.login }}
+      repo_description: 'TypeScript monorepo for AI agent development - core SDK packages'
+      package_pattern: '@happyvertical/*'
+      project_id: 'PVT_kwDOB9Y8ns4A8-TY'
+      status_field_id: 'PVTSSF_lADOB9Y8ns4A8-TYzgw0GaY'
+      status_new_id: '3d8ca82c'
+      status_backlog_id: 'c89a2a65'
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-label-changed.yml
+++ b/.github/workflows/on-label-changed.yml
@@ -1,0 +1,42 @@
+name: Label Changed
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+  id-token: write
+
+jobs:
+  # Trigger autopilot when agent: claude label is added
+  autopilot:
+    if: "github.event.label.name == 'agent: claude'"
+    uses: happyvertical/.github/.github/workflows/org-agent-autopilot.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      action: ${{ github.event.action }}
+      label_name: ${{ github.event.label.name }}
+      project_id: 'PVT_kwDOB9Y8ns4A8-TY'
+      status_field_id: 'PVTSSF_lADOB9Y8ns4A8-TYzgw0GaY'
+      status_in_progress_id: 'c126de7e'
+      status_review_id: '30a150bf'
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Call existing label handler for other label logic
+  label-handler:
+    if: "github.event.label.name != 'agent: claude'"
+    uses: ./.github/workflows/shared-label-handler.yml
+    with:
+      label_name: ${{ github.event.label.name }}
+      action: ${{ github.event.action }}
+      issue_number: ${{ github.event.issue.number }}
+      repo_owner: ${{ github.repository_owner }}
+      repo_name: ${{ github.event.repository.name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-test-failure.yml
+++ b/.github/workflows/on-test-failure.yml
@@ -1,0 +1,25 @@
+name: Test Failure Analysis
+
+on:
+  workflow_run:
+    workflows: ["Test Suite", "Test"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+  id-token: write
+
+jobs:
+  analyze:
+    if: github.event.workflow_run.conclusion == 'failure'
+    uses: happyvertical/.github/.github/workflows/org-test-analysis.yml@main
+    with:
+      run_id: ${{ github.event.workflow_run.id }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number || 0 }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Integrate Claude Code Action across the organization by adding caller workflows that use the centralized reusable workflows from the new `happyvertical/.github` repository.

## Changes

### New Workflows Added

| Workflow | Purpose |
|----------|---------|
| `on-issue-opened.yml` | Calls org triage workflow for auto-labeling and project board |
| `on-label-changed.yml` | Triggers autopilot when `agent: claude` label is added |
| `on-ci-failure.yml` | Auto-fix CI failures using Claude |
| `on-test-failure.yml` | Analyze test failures and detect flaky tests |

### Autopilot Mode (`agent: claude` label)

When the `agent: claude` label is added to an issue:
1. Validates Definition of Ready (type, priority, size labels + description)
2. Creates feature branch
3. Implements the solution following CLAUDE.md guidelines
4. Runs quality checks (typecheck, lint, test, build)
5. Creates pull request with conventional commit

### Organization Repository

The reusable workflows are now centralized in `happyvertical/.github`:
- https://github.com/happyvertical/.github

## Testing

- [ ] Create a test issue and verify triage runs
- [ ] Add `agent: claude` label to a Ready issue and verify autopilot
- [ ] Trigger a CI failure and verify auto-fix attempts
- [ ] Verify project board integration

## Checklist

- [x] Workflows validated by lefthook
- [x] Conventional commit format
- [x] Documentation in org .github repo

Part of organization-wide Claude Code Action integration.