### PR TITLE
feat(utils): add browser-safe entry point

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,8 +7,16 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "browser": {
+        "import": "./dist/browser.js",
+        "types": "./dist/browser.d.ts"
+      },
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./browser": {
+      "import": "./dist/browser.js",
+      "types": "./dist/browser.d.ts"
     }
   },
   "scripts": {

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -1,0 +1,36 @@
+/**
+ * Browser-safe utilities
+ *
+ * This entry point only exports utilities that work in browser environments.
+ * It excludes Node.js-specific code like:
+ * - cli/parse-args (uses node:path, node:util)
+ * - shared/code/sandbox (uses node:vm)
+ * - web.ts hash functions (uses node:crypto)
+ *
+ * For Node.js environments, use the main entry point instead.
+ */
+
+// Export config utilities (browser-safe)
+export * from './config/env-config';
+// Export code utilities that don't require Node.js
+export {
+  extractAllCodeBlocks,
+  extractCodeBlock,
+  extractFunctionDefinition,
+  extractJSON,
+} from './shared/code/extraction';
+export {
+  isSafeCode,
+  type ValidationOptions,
+  type ValidationResult,
+  validateCode,
+} from './shared/code/validation';
+// Export logger utilities (browser-safe)
+export * from './shared/logger';
+// Export types (browser-safe)
+export * from './shared/types';
+// Export all universal utilities (browser-safe)
+export * from './shared/universal';
+
+/** @internal */
+export const PACKAGE_VERSION_INITIALIZED = true;

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -1,3 +1,93 @@
-import { createPackageConfig } from '../../vite.config.base.js';
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
 
-export default createPackageConfig('utils');
+const packageDir = __dirname;
+
+/**
+ * Custom Vite configuration for utils package with dual entry points:
+ * - index.ts: Full Node.js-compatible exports
+ * - browser.ts: Browser-safe exports (no Node.js built-ins)
+ */
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        index: resolve(packageDir, 'src/index.ts'),
+        browser: resolve(packageDir, 'src/browser.ts'),
+      },
+      formats: ['es'] as const,
+      fileName: (format, entryName) => `${entryName}.js`,
+    },
+    rollupOptions: {
+      output: {
+        dir: resolve(packageDir, 'dist'),
+        format: 'es' as const,
+        preserveModules: false,
+        entryFileNames: '[name].js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+      },
+      external: [
+        // Node.js built-ins - externalize completely
+        /^node:/,
+        /^bun:/,
+        'fs',
+        'path',
+        'url',
+        'os',
+        'crypto',
+        'stream',
+        'util',
+        'events',
+        'child_process',
+        'buffer',
+        'Buffer',
+        'zlib',
+        'assert',
+        'http',
+        'https',
+        'net',
+        'tls',
+        'dns',
+        'cluster',
+        'worker_threads',
+        'perf_hooks',
+        'readline',
+        'repl',
+        'vm',
+        'v8',
+        'inspector',
+
+        // External dependencies - don't bundle these
+        'date-fns',
+        'pluralize',
+        'uuid',
+        '@paralleldrive/cuid2',
+
+        // Internal @happyvertical/* packages
+        /^@happyvertical\//,
+      ],
+    },
+    minify: false,
+    sourcemap: true,
+    target: 'es2022',
+    reportCompressedSize: false,
+  },
+  plugins: [
+    dts({
+      outDir: resolve(packageDir, 'dist'),
+      include: [resolve(packageDir, 'src/**/*.ts')],
+      exclude: [
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/*.test.*.ts',
+        '**/*.config.ts',
+        '**/*.config.js',
+        '**/*.d.ts',
+      ],
+      insertTypesEntry: false,
+      rollupTypes: false,
+      tsconfigPath: resolve(packageDir, 'tsconfig.json'),
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary

Adds a new `browser` export condition that excludes Node.js-only utilities:
- cli/parse-args (uses node:path, node:util)
- shared/code/sandbox (uses node:vm)
- web.ts hash functions (uses node:crypto)

## Problem

Browser builds using `@happyvertical/utils` fail with errors like:
```
"basename" is not exported by "__vite-browser-external"
```

This happens because the main entry point imports Node.js built-ins at the top level, which break in Vite/Rollup browser builds (SvelteKit, etc.).

## Solution

Add conditional exports so bundlers can automatically select the browser-safe entry point:

```json
{
  "exports": {
    ".": {
      "browser": { "import": "./dist/browser.js" },
      "import": "./dist/index.js"
    }
  }
}
```

Bundlers like Vite will automatically use `dist/browser.js` in browser contexts.

## Test Plan

- [x] Build passes
- [x] browser.js contains no Node.js imports
- [x] index.js still exports all utilities for Node.js environments

Related: happyvertical/smrt#681