### PR TITLE
fix: pin @types/node to 24.10.9 for Node 24 LTS compatibility

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -37,7 +37,7 @@
     "@docusaurus/module-type-aliases": "^3.9.2",
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.2",
-    "@types/node": "25.0.9",
+    "@types/node": "24.10.9",
     "@types/react": "19.2.8",
     "@types/react-dom": "19.2.3",
     "docusaurus-plugin-typedoc": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "vitest": "4.0.17"
   },
   "resolutions": {
-    "@types/node": "25.0.9"
+    "@types/node": "24.10.9"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@types/node': 25.0.9
+  '@types/node': 24.10.9
   rollup: 4.55.1
 
 importers:
@@ -113,8 +113,8 @@ importers:
         specifier: ^3.9.2
         version: 3.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       '@types/react':
         specifier: 19.2.8
         version: 19.2.8
@@ -144,20 +144,20 @@ importers:
         version: 4.2.2
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/ai:
     dependencies:
@@ -178,20 +178,20 @@ importers:
         version: 6.16.0(ws@8.19.0)(zod@4.3.5)
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/analytics:
     dependencies:
@@ -203,20 +203,20 @@ importers:
         version: 170.0.0
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/auth:
     dependencies:
@@ -235,20 +235,20 @@ importers:
         version: 2.19.4(typescript@5.9.3)
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/cache:
     dependencies:
@@ -266,20 +266,20 @@ importers:
         version: 5.10.0
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/documents:
     dependencies:
@@ -294,7 +294,7 @@ importers:
         version: 0.60.4(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@napi-rs/canvas@0.1.88)(ws@8.19.0)(zod@4.3.5)
       '@happyvertical/spider':
         specifier: ^0.60.6
-        version: 0.60.6(@types/node@25.0.9)
+        version: 0.60.6(@types/node@24.10.9)
       '@happyvertical/utils':
         specifier: workspace:*
         version: link:../utils
@@ -303,17 +303,17 @@ importers:
         version: 13.0.0
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/email:
     dependencies:
@@ -346,8 +346,8 @@ importers:
         specifier: ^3.4.6
         version: 3.4.6
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       '@types/nodemailer':
         specifier: ^7.0.5
         version: 7.0.5
@@ -359,13 +359,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/encryption:
     dependencies:
@@ -377,7 +377,7 @@ importers:
         version: link:../utils
       '@openpgp/web-stream-tools':
         specifier: ^0.3.0
-        version: 0.3.0(@types/node@25.0.9)(typescript@5.9.3)
+        version: 0.3.0(@types/node@24.10.9)(typescript@5.9.3)
       openpgp:
         specifier: ^6.3.0
         version: 6.3.0
@@ -389,20 +389,20 @@ importers:
         version: 0.15.1
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/files:
     dependencies:
@@ -415,10 +415,10 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: 5.3.1
-        version: 5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2))
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       happy-dom:
         specifier: 20.3.0
         version: 20.3.0
@@ -430,13 +430,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/geo:
     dependencies:
@@ -451,20 +451,20 @@ importers:
         version: link:../utils
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/github-actions:
     dependencies:
@@ -476,38 +476,38 @@ importers:
         version: link:../repos
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: 4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/graphql:
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: 4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/images:
     dependencies:
@@ -519,8 +519,8 @@ importers:
         version: 0.18.3
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       jimp:
         specifier: ^1.6.0
         version: 1.6.0
@@ -532,13 +532,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/jobs:
     dependencies:
@@ -559,8 +559,8 @@ importers:
         specifier: ^4.10.4
         version: 4.10.4
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       bull:
         specifier: ^4.16.5
         version: 4.16.5
@@ -572,13 +572,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/logger:
     dependencies:
@@ -587,17 +587,17 @@ importers:
         version: link:../utils
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/projects:
     dependencies:
@@ -609,20 +609,20 @@ importers:
         version: link:../repos
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: 4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/repos:
     dependencies:
@@ -637,20 +637,20 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: 4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/sdk-mcp:
     dependencies:
@@ -668,20 +668,20 @@ importers:
         version: 1.25.2(hono@4.11.3)(zod@4.3.5)
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/secrets:
     dependencies:
@@ -693,20 +693,20 @@ importers:
         version: link:../utils
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/sql:
     dependencies:
@@ -727,8 +727,8 @@ importers:
         version: 0.1.2
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       '@types/pg':
         specifier: ^8.16.0
         version: 8.16.0
@@ -737,13 +737,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/translator:
     dependencies:
@@ -761,20 +761,20 @@ importers:
         version: 1.24.0
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/utils:
     dependencies:
@@ -792,8 +792,8 @@ importers:
         version: 13.0.0
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       '@types/pluralize':
         specifier: ^0.0.33
         version: 0.0.33
@@ -802,13 +802,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   packages/weather:
     dependencies:
@@ -817,8 +817,8 @@ importers:
         version: link:../utils
     devDependencies:
       '@types/node':
-        specifier: 25.0.9
-        version: 25.0.9
+        specifier: 24.10.9
+        version: 24.10.9
       typedoc:
         specifier: ^0.28.16
         version: 0.28.16(typescript@5.9.3)
@@ -830,13 +830,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
 packages:
 
@@ -3348,7 +3348,7 @@ packages:
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3807,7 +3807,7 @@ packages:
     resolution: {integrity: sha512-WGCcIti5uAwySkdny5IJ975Vu6fS45LE9Ce3M7vylIWOZwzL4qFUFclskZ6JU7rQ1zgoze6CQ//QKFc/ML2uqw==}
     engines: {node: '>= 18.0.0'}
     peerDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       typescript: '>=4.7'
     peerDependenciesMeta:
       '@types/node':
@@ -4190,7 +4190,7 @@ packages:
   '@rushstack/node-core-library@5.19.1':
     resolution: {integrity: sha512-ESpb2Tajlatgbmzzukg6zyAhH+sICqJR2CNXNhXcEbz6UGCQfrKCtkxOpJTftWc8RGouroHG0Nud1SJAszvpmA==}
     peerDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4198,7 +4198,7 @@ packages:
   '@rushstack/problem-matcher@0.1.1':
     resolution: {integrity: sha512-Fm5XtS7+G8HLcJHCWpES5VmeMyjAKaWeyZU5qPzZC+22mPlJzAsOxymHiWIfuirtPckX3aptWws+K2d0BzniJA==}
     peerDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4209,7 +4209,7 @@ packages:
   '@rushstack/terminal@0.19.5':
     resolution: {integrity: sha512-6k5tpdB88G0K7QrH/3yfKO84HK9ggftfUZ51p7fePyCE7+RLLHkWZbID9OFWbXuna+eeCFE7AkKnRMHMxNbz7Q==}
     peerDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4857,6 +4857,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@24.10.9':
+    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
 
   '@types/node@25.0.9':
     resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
@@ -5936,7 +5939,7 @@ packages:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
     engines: {node: '>=v18'}
     peerDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       cosmiconfig: '>=9'
       typescript: '>=5'
 
@@ -11383,7 +11386,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       jiti: '>=1.21.0'
       less: ^4.0.0
       lightningcss: ^1.21.0
@@ -11425,7 +11428,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       '@vitest/browser-playwright': 4.0.17
       '@vitest/browser-preview': 4.0.17
       '@vitest/browser-webdriverio': 4.0.17
@@ -14564,12 +14567,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/cli@3.15.3(@types/node@25.0.9)':
+  '@crawlee/cli@3.15.3(@types/node@24.10.9)':
     dependencies:
-      '@crawlee/templates': 3.15.3(@types/node@25.0.9)
+      '@crawlee/templates': 3.15.3(@types/node@24.10.9)
       ansi-colors: 4.1.3
       fs-extra: 11.3.3
-      inquirer: 8.2.7(@types/node@25.0.9)
+      inquirer: 8.2.7(@types/node@24.10.9)
       tslib: 2.8.1
       yargonaut: 1.1.4
       yargs: 17.7.2
@@ -14709,10 +14712,10 @@ snapshots:
       - playwright
       - supports-color
 
-  '@crawlee/templates@3.15.3(@types/node@25.0.9)':
+  '@crawlee/templates@3.15.3(@types/node@24.10.9)':
     dependencies:
       ansi-colors: 4.1.3
-      inquirer: 9.3.8(@types/node@25.0.9)
+      inquirer: 9.3.8(@types/node@24.10.9)
       tslib: 2.8.1
       yargonaut: 1.1.4
       yargs: 17.7.2
@@ -16256,14 +16259,14 @@ snapshots:
       - ws
       - zod
 
-  '@happyvertical/spider@0.60.6(@types/node@25.0.9)':
+  '@happyvertical/spider@0.60.6(@types/node@24.10.9)':
     dependencies:
       '@happyvertical/cache': 0.60.9
       '@happyvertical/files': 0.60.9
       '@happyvertical/utils': 0.60.9
       '@mozilla/readability': 0.6.0
       cheerio: 1.1.2
-      crawlee: 3.15.3(@types/node@25.0.9)(playwright@1.57.0)
+      crawlee: 3.15.3(@types/node@24.10.9)(playwright@1.57.0)
       happy-dom: 20.3.0
       jsdom: 27.3.0
       playwright: 1.57.0
@@ -16467,6 +16470,13 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/external-editor@1.0.3(@types/node@24.10.9)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.10.9
+
   '@inquirer/external-editor@1.0.3(@types/node@25.0.9)':
     dependencies:
       chardet: 2.1.1
@@ -16502,7 +16512,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -16843,7 +16853,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -16896,11 +16906,38 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
+  '@microsoft/api-extractor-model@7.32.2(@types/node@24.10.9)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.0
+      '@rushstack/node-core-library': 5.19.1(@types/node@24.10.9)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor-model@7.32.2(@types/node@25.0.9)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.0
       '@rushstack/node-core-library': 5.19.1(@types/node@25.0.9)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.55.2(@types/node@24.10.9)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.32.2(@types/node@24.10.9)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.0
+      '@rushstack/node-core-library': 5.19.1(@types/node@24.10.9)
+      '@rushstack/rig-package': 0.6.0
+      '@rushstack/terminal': 0.19.5(@types/node@24.10.9)
+      '@rushstack/ts-command-line': 5.1.5(@types/node@24.10.9)
+      diff: 8.0.3
+      lodash: 4.17.21
+      minimatch: 10.0.3
+      resolve: 1.22.11
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -17080,9 +17117,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@openpgp/web-stream-tools@0.3.0(@types/node@25.0.9)(typescript@5.9.3)':
+  '@openpgp/web-stream-tools@0.3.0(@types/node@24.10.9)(typescript@5.9.3)':
     optionalDependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       typescript: 5.9.3
 
   '@opentelemetry/api@1.9.0': {}
@@ -17419,6 +17456,19 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.55.1':
     optional: true
 
+  '@rushstack/node-core-library@5.19.1(@types/node@24.10.9)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.3
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.11
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 24.10.9
+
   '@rushstack/node-core-library@5.19.1(@types/node@25.0.9)':
     dependencies:
       ajv: 8.13.0
@@ -17432,6 +17482,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.9
 
+  '@rushstack/problem-matcher@0.1.1(@types/node@24.10.9)':
+    optionalDependencies:
+      '@types/node': 24.10.9
+
   '@rushstack/problem-matcher@0.1.1(@types/node@25.0.9)':
     optionalDependencies:
       '@types/node': 25.0.9
@@ -17441,6 +17495,14 @@ snapshots:
       resolve: 1.22.11
       strip-json-comments: 3.1.1
 
+  '@rushstack/terminal@0.19.5(@types/node@24.10.9)':
+    dependencies:
+      '@rushstack/node-core-library': 5.19.1(@types/node@24.10.9)
+      '@rushstack/problem-matcher': 0.1.1(@types/node@24.10.9)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 24.10.9
+
   '@rushstack/terminal@0.19.5(@types/node@25.0.9)':
     dependencies:
       '@rushstack/node-core-library': 5.19.1(@types/node@25.0.9)
@@ -17448,6 +17510,15 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 25.0.9
+
+  '@rushstack/ts-command-line@5.1.5(@types/node@24.10.9)':
+    dependencies:
+      '@rushstack/terminal': 0.19.5(@types/node@24.10.9)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@rushstack/ts-command-line@5.1.5(@types/node@25.0.9)':
     dependencies:
@@ -18024,14 +18095,14 @@ snapshots:
     dependencies:
       svelte: 5.46.1
 
-  '@testing-library/svelte@5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@testing-library/svelte@5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.46.1)
       svelte: 5.46.1
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
-      vitest: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+      vitest: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2)
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
@@ -18054,11 +18125,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/bull@4.10.4':
     dependencies:
@@ -18074,17 +18145,17 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/content-type@1.1.9': {}
 
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/d3-array@3.2.2': {}
 
@@ -18229,7 +18300,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -18259,7 +18330,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -18275,7 +18346,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -18283,7 +18354,7 @@ snapshots:
 
   '@types/mailparser@3.4.6':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       iconv-lite: 0.6.3
 
   '@types/mdast@4.0.4':
@@ -18296,6 +18367,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@24.10.9':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/node@25.0.9':
     dependencies:
       undici-types: 7.16.0
@@ -18303,13 +18378,13 @@ snapshots:
   '@types/nodemailer@7.0.5':
     dependencies:
       '@aws-sdk/client-sesv2': 3.969.0
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
     transitivePeerDependencies:
       - aws-crt
 
   '@types/pg@8.16.0':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
@@ -18352,16 +18427,16 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -18370,12 +18445,12 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       '@types/send': 0.17.6
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -18391,7 +18466,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -18411,6 +18486,14 @@ snapshots:
       '@vitest/utils': 4.0.17
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.17
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))':
     dependencies:
@@ -19504,13 +19587,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  crawlee@3.15.3(@types/node@25.0.9)(playwright@1.57.0):
+  crawlee@3.15.3(@types/node@24.10.9)(playwright@1.57.0):
     dependencies:
       '@crawlee/basic': 3.15.3
       '@crawlee/browser': 3.15.3(playwright@1.57.0)
       '@crawlee/browser-pool': 3.15.3(playwright@1.57.0)
       '@crawlee/cheerio': 3.15.3
-      '@crawlee/cli': 3.15.3(@types/node@25.0.9)
+      '@crawlee/cli': 3.15.3(@types/node@24.10.9)
       '@crawlee/core': 3.15.3
       '@crawlee/http': 3.15.3
       '@crawlee/jsdom': 3.15.3
@@ -19986,7 +20069,7 @@ snapshots:
 
   deepl-node@1.24.0:
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       adm-zip: 0.5.16
       axios: 1.13.2
       form-data: 3.0.4
@@ -20455,7 +20538,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       require-like: 0.1.2
 
   event-stream@3.3.4:
@@ -21106,7 +21189,7 @@ snapshots:
 
   happy-dom@20.3.0:
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       whatwg-mimetype: 3.0.0
@@ -21479,7 +21562,7 @@ snapshots:
 
   image-q@4.0.0:
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
 
   image-size@2.0.2: {}
 
@@ -21527,9 +21610,9 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@8.2.7(@types/node@25.0.9):
+  inquirer@8.2.7(@types/node@24.10.9):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@25.0.9)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.9)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -21547,9 +21630,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  inquirer@9.3.8(@types/node@25.0.9):
+  inquirer@9.3.8(@types/node@24.10.9):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@25.0.9)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.9)
       '@inquirer/figures': 1.0.15
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -21880,7 +21963,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -21888,13 +21971,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -24211,7 +24294,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -25107,7 +25190,7 @@ snapshots:
 
   sitemap@7.1.2:
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 24.10.9
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.4.4
@@ -25996,6 +26079,25 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-plugin-dts@4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)):
+    dependencies:
+      '@microsoft/api-extractor': 7.55.2(@types/node@24.10.9)
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
+      '@volar/typescript': 2.4.27
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      typescript: 5.9.3
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
   vite-plugin-dts@4.5.4(@types/node@25.0.9)(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)):
     dependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@25.0.9)
@@ -26015,6 +26117,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.9
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.45.0
+      yaml: 2.8.2
+
   vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
@@ -26029,6 +26146,46 @@ snapshots:
       jiti: 2.6.1
       terser: 5.45.0
       yaml: 2.8.2
+
+  vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.17
+      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.17
+      '@vitest/runner': 4.0.17
+      '@vitest/snapshot': 4.0.17
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(terser@5.45.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.10.9
+      happy-dom: 20.3.0
+      jsdom: 27.4.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.45.0)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

Pin `@types/node` to 24.10.9 to match the Node 24 LTS runtime.

Type definitions should match the runtime version to avoid referencing APIs that don't exist yet in the current runtime.

## Changes

- Updated `resolutions["@types/node"]` from `25.0.9` to `24.10.9` in root `package.json`
- Updated `@types/node` from `25.0.9` to `24.10.9` in `docs/package.json`
- Regenerated `pnpm-lock.yaml`

## Test plan

- [ ] CI passes
- [ ] No type errors related to missing Node.js APIs