### PR TITLE
feat: add Claude Code context CLI for all packages

### DIFF
--- a/.changeset/claude-context-feature.md
+++ b/.changeset/claude-context-feature.md
@@ -1,0 +1,36 @@
+---
+"@happyvertical/accounting": minor
+"@happyvertical/ai": minor
+"@happyvertical/analytics": minor
+"@happyvertical/auth": minor
+"@happyvertical/cache": minor
+"@happyvertical/documents": minor
+"@happyvertical/email": minor
+"@happyvertical/encryption": minor
+"@happyvertical/files": minor
+"@happyvertical/geo": minor
+"@happyvertical/github-actions": minor
+"@happyvertical/graphql": minor
+"@happyvertical/images": minor
+"@happyvertical/jobs": minor
+"@happyvertical/languages": minor
+"@happyvertical/logger": minor
+"@happyvertical/projects": minor
+"@happyvertical/repos": minor
+"@happyvertical/sdk-mcp": minor
+"@happyvertical/secrets": minor
+"@happyvertical/sql": minor
+"@happyvertical/translator": minor
+"@happyvertical/utils": minor
+"@happyvertical/weather": minor
+---
+
+Add Claude Code context installation CLI for each package
+
+Each SDK package now ships with Claude Code context files that can be installed into downstream projects:
+
+- **CLI command**: Run `npx have-{pkgname}-context` (e.g., `npx have-ai-context`)
+- **CLAUDE.md**: Full documentation for AI-assisted development
+- **.claude-meta.json**: Concise metadata with key exports, patterns, and pitfalls
+
+Files are installed to the downstream project's `.claude/` directory as `have-{pkgname}.md` and `have-{pkgname}.meta.json`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,59 @@ pnpm add @happyvertical/utils @happyvertical/logger @happyvertical/files @happyv
 pnpm add @happyvertical/cache @happyvertical/geo @happyvertical/translator @happyvertical/ocr @happyvertical/pdf @happyvertical/spider @happyvertical/documents
 ```
 
+## Claude Code Context
+
+Each SDK package ships with Claude Code context files for AI-assisted development. Install them in your project to help Claude understand the SDK packages you're using.
+
+### Install Context for Individual Packages
+
+```bash
+# Install context for packages you use
+npx have-ai-context
+npx have-sql-context
+npx have-files-context
+```
+
+This copies the package's documentation and metadata to your project's `.claude/` directory:
+
+```
+.claude/
+├── have-ai.md           # Full documentation
+├── have-ai.meta.json    # Concise metadata (exports, patterns, pitfalls)
+├── have-sql.md
+├── have-sql.meta.json
+└── ...
+```
+
+### Automate with package.json
+
+Add a setup script to install context for all SDK packages your project uses:
+
+```json
+{
+  "scripts": {
+    "setup:claude": "npx have-ai-context && npx have-sql-context && npx have-files-context"
+  }
+}
+```
+
+### Available Context Commands
+
+| Package | Command |
+|---------|---------|
+| @happyvertical/ai | `npx have-ai-context` |
+| @happyvertical/sql | `npx have-sql-context` |
+| @happyvertical/files | `npx have-files-context` |
+| @happyvertical/utils | `npx have-utils-context` |
+| @happyvertical/cache | `npx have-cache-context` |
+| @happyvertical/documents | `npx have-documents-context` |
+| @happyvertical/geo | `npx have-geo-context` |
+| @happyvertical/spider | `npx have-spider-context` |
+| @happyvertical/pdf | `npx have-pdf-context` |
+| @happyvertical/translator | `npx have-translator-context` |
+
+All SDK packages include a context command following the pattern `have-{pkgname}-context`.
+
 ## Development
 
 ```bash

--- a/packages/accounting/.claude-meta.json
+++ b/packages/accounting/.claude-meta.json
@@ -1,0 +1,37 @@
+{
+  "name": "@happyvertical/accounting",
+  "description": "Multi-provider accounting integration for QuickBooks, Stripe, PayPal",
+  "purpose": [
+    "Sync AR/AP data with external providers",
+    "Audit and reconciliation",
+    "OAuth token management",
+    "Webhook processing"
+  ],
+  "keyExports": {
+    "functions": [
+      { "name": "getAccountingProvider", "signature": "(options) => Promise<AccountingProvider>" }
+    ],
+    "types": ["AccountingProvider", "CustomerInput", "InvoiceInput", "SyncResult", "AuditReport"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/utils"],
+    "external": ["intuit-oauth"]
+  },
+  "patterns": [
+    { "name": "Sync", "usage": "provider.customers.sync(customer)" },
+    { "name": "Audit", "usage": "provider.audit.reconcileInvoices(localInvoices)" },
+    { "name": "Webhooks", "usage": "provider.webhooks.verify(payload, signature)" }
+  ],
+  "pitfalls": [
+    "QuickBooks OAuth tokens expire - use onTokenRefresh callback",
+    "Store refreshed tokens securely",
+    "Not all providers support all operations"
+  ],
+  "envVars": [
+    "HAVE_ACCOUNTING_TYPE",
+    "HAVE_ACCOUNTING_CLIENT_ID",
+    "HAVE_ACCOUNTING_CLIENT_SECRET",
+    "HAVE_ACCOUNTING_REALM_ID"
+  ],
+  "keywords": ["accounting", "quickbooks", "stripe", "invoice", "sync", "ar", "ap"]
+}

--- a/packages/accounting/package.json
+++ b/packages/accounting/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-accounting-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/accounting/src/cli/claude-context.ts
+++ b/packages/accounting/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/accounting
+ * Run: npx @happyvertical/accounting claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'accounting';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/ai/.claude-meta.json
+++ b/packages/ai/.claude-meta.json
@@ -1,0 +1,57 @@
+{
+  "name": "@happyvertical/ai",
+  "description": "Multi-provider AI client interface for OpenAI, Anthropic, Google Gemini, AWS Bedrock, HuggingFace, and Claude CLI",
+  "purpose": [
+    "Unified interface across multiple AI providers",
+    "Streaming and non-streaming chat completions",
+    "Text and image embeddings generation",
+    "Tool/function calling support",
+    "Image description and generation"
+  ],
+  "keyExports": {
+    "functions": [
+      { "name": "getAI", "signature": "(options: GetAIOptions) => Promise<AIInterface>" },
+      { "name": "getAIAuto", "signature": "(options) => Promise<AIInterface>" }
+    ],
+    "types": [
+      "AIInterface",
+      "AIMessage",
+      "AIResponse",
+      "ChatOptions",
+      "EmbeddingOptions",
+      "AIError",
+      "AuthenticationError",
+      "RateLimitError"
+    ],
+    "classes": ["AIThread", "AIClient"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/utils"],
+    "external": ["openai", "@anthropic-ai/sdk", "@google/genai", "@aws-sdk/client-bedrock-runtime"]
+  },
+  "architecture": {
+    "pattern": "Factory + Provider",
+    "notes": "getAI() creates provider-specific implementation via dynamic imports"
+  },
+  "patterns": [
+    { "name": "Streaming", "usage": "Use async generators: for await (const chunk of client.stream(messages))" },
+    { "name": "Tool Calling", "usage": "Define tools array with JSON schema in ChatOptions" },
+    { "name": "Environment Config", "usage": "HAVE_AI_PROVIDER, HAVE_AI_MODEL, HAVE_AI_API_KEY environment variables" }
+  ],
+  "pitfalls": [
+    "Always specify model - defaults vary by provider",
+    "Anthropic requires alternating user/assistant messages",
+    "Streaming with onProgress callback waits for completion; use stream() for real-time",
+    "Claude CLI requires Claude Code CLI installed for local development",
+    "Embeddings only supported by OpenAI and Gemini"
+  ],
+  "envVars": [
+    "HAVE_AI_PROVIDER",
+    "HAVE_AI_MODEL",
+    "HAVE_AI_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY"
+  ],
+  "keywords": ["ai", "llm", "chat", "streaming", "embeddings", "tools", "openai", "anthropic", "gemini"]
+}

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -41,6 +41,16 @@ npm install @happyvertical/ai
 yarn add @happyvertical/ai
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-ai-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ### Basic Usage (Auto-Detection)

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-ai-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/ai/src/cli/claude-context.ts
+++ b/packages/ai/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/ai
+ * Run: npx @happyvertical/ai claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'ai';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/analytics/.claude-meta.json
+++ b/packages/analytics/.claude-meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "@happyvertical/analytics",
+  "description": "Analytics tracking and reporting",
+  "keyExports": [
+    "trackEvent",
+    "getAnalytics"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "pitfalls": [
+    "Ensure GDPR compliance for user tracking"
+  ],
+  "keywords": ["analytics", "tracking", "events"]
+}

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-analytics-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/analytics/src/cli/claude-context.ts
+++ b/packages/analytics/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/analytics
+ * Run: npx @happyvertical/analytics claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'analytics';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/auth/.claude-meta.json
+++ b/packages/auth/.claude-meta.json
@@ -1,0 +1,39 @@
+{
+  "name": "@happyvertical/auth",
+  "description": "Unified authentication with Keycloak, Kanidm, AWS Cognito, and Nostr providers",
+  "purpose": [
+    "OAuth2/OIDC flows (authorization code, token exchange)",
+    "Nostr public key authentication",
+    "User and session management",
+    "Role-based access control"
+  ],
+  "keyExports": {
+    "functions": [
+      { "name": "getAuth", "signature": "(options: AuthOptions) => Promise<AuthInterface>" }
+    ],
+    "types": ["AuthInterface", "AuthResult", "TokenClaims", "UserProfile"],
+    "errors": ["AuthError", "InvalidCredentialsError", "TokenExpiredError", "AccessDeniedError"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/utils"],
+    "external": ["jose", "@aws-sdk/client-cognito-identity-provider", "nostr-tools"]
+  },
+  "patterns": [
+    { "name": "OAuth Flow", "usage": "getAuthorizationUrl() → exchangeCode()" },
+    { "name": "Token Validation", "usage": "auth.validateToken(accessToken)" },
+    { "name": "Nostr Auth", "usage": "auth.authenticate({ method: 'extension' })" }
+  ],
+  "pitfalls": [
+    "Never expose private keys (especially Nostr)",
+    "Use PKCE for public clients",
+    "Nostr tokens are ephemeral (no refresh)",
+    "Some operations throw NotImplementedError for certain providers"
+  ],
+  "envVars": [
+    "HAVE_AUTH_TYPE",
+    "HAVE_AUTH_SERVER_URL",
+    "HAVE_AUTH_CLIENT_ID",
+    "HAVE_AUTH_CLIENT_SECRET"
+  ],
+  "keywords": ["auth", "oauth", "oidc", "keycloak", "cognito", "nostr", "jwt"]
+}

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -14,6 +14,16 @@ Unified authentication interface supporting multiple providers.
 npm install @happyvertical/auth
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-auth-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ```typescript

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-auth-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/auth/src/cli/claude-context.ts
+++ b/packages/auth/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/auth
+ * Run: npx @happyvertical/auth claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'auth';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/cache/.claude-meta.json
+++ b/packages/cache/.claude-meta.json
@@ -1,0 +1,23 @@
+{
+  "name": "@happyvertical/cache",
+  "description": "Unified caching interface with Memory, File, and Redis providers",
+  "keyExports": [
+    "getCache",
+    "CacheAdapter"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": ["ioredis"]
+  },
+  "pitfalls": [
+    "TTL is in seconds (consistent with Redis)",
+    "Memory cache for development, Redis for production",
+    "Cache failures should not break the application - implement fallback"
+  ],
+  "envVars": [
+    "HAVE_CACHE_TYPE",
+    "HAVE_CACHE_REDIS_HOST",
+    "HAVE_CACHE_REDIS_PORT"
+  ],
+  "keywords": ["cache", "redis", "memory", "ttl"]
+}

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -42,6 +42,16 @@ yarn add @happyvertical/cache
 # For Redis support, redis is already included
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-cache-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ```typescript

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-cache-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/cache/src/cli/claude-context.ts
+++ b/packages/cache/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/cache
+ * Run: npx @happyvertical/cache claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'cache';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/documents/.claude-meta.json
+++ b/packages/documents/.claude-meta.json
@@ -1,0 +1,30 @@
+{
+  "name": "@happyvertical/documents",
+  "description": "High-level document processing combining PDF, web scraping, and OCR into unified interface",
+  "keyExports": {
+    "functions": [
+      { "name": "fetchDocument", "signature": "(source: string, options?: DocumentOptions) => Promise<Document>" }
+    ],
+    "types": ["Document", "DocumentPart", "DocumentSection", "DocumentImage"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/files", "@happyvertical/pdf", "@happyvertical/spider", "@happyvertical/ocr", "@happyvertical/utils"],
+    "external": []
+  },
+  "architecture": {
+    "pattern": "Orchestrator",
+    "notes": "Detects format and delegates to appropriate package (pdf, spider)"
+  },
+  "patterns": [
+    { "name": "URL Processing", "usage": "fetchDocument('https://example.com')" },
+    { "name": "PDF Processing", "usage": "fetchDocument('/path/to/file.pdf')" },
+    { "name": "HTML Processing", "usage": "fetchDocument(html, { documentType: 'html' })" }
+  ],
+  "pitfalls": [
+    "Images are base64-encoded for portability",
+    "PDFs use OCR fallback for scanned documents",
+    "Format auto-detected from extension and content",
+    "Partial documents preferred over complete failure"
+  ],
+  "keywords": ["documents", "pdf", "html", "extraction", "parsing"]
+}

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -37,6 +37,16 @@ pnpm add @happyvertical/documents
 yarn add @happyvertical/documents
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-documents-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ```typescript

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -5,10 +5,15 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "have-documents-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/documents/src/cli/claude-context.ts
+++ b/packages/documents/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/documents
+ * Run: npx @happyvertical/documents claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'documents';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/email/.claude-meta.json
+++ b/packages/email/.claude-meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "@happyvertical/email",
+  "description": "Email utilities and provider integrations",
+  "keyExports": [
+    "sendEmail",
+    "EmailInterface"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "pitfalls": [
+    "SMTP credentials required for most providers"
+  ],
+  "keywords": ["email", "smtp", "mail"]
+}

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -12,8 +12,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-email-context": "./dist/cli/claude-context.js"
+  },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/email/src/cli/claude-context.ts
+++ b/packages/email/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/email
+ * Run: npx @happyvertical/email claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'email';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/encryption/.claude-meta.json
+++ b/packages/encryption/.claude-meta.json
@@ -1,0 +1,17 @@
+{
+  "name": "@happyvertical/encryption",
+  "description": "Encryption utilities for secure data handling",
+  "keyExports": [
+    "encrypt",
+    "decrypt"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "pitfalls": [
+    "Never store encryption keys in code",
+    "Use environment variables or key management services"
+  ],
+  "keywords": ["encryption", "security", "crypto"]
+}

--- a/packages/encryption/README.md
+++ b/packages/encryption/README.md
@@ -27,6 +27,16 @@ pnpm add @happyvertical/encryption
 yarn add @happyvertical/encryption
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-encryption-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ### PGP Encryption

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -12,8 +12,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-encryption-context": "./dist/cli/claude-context.js"
+  },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "scripts": {
     "build": "vite build",

--- a/packages/encryption/src/cli/claude-context.ts
+++ b/packages/encryption/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/encryption
+ * Run: npx @happyvertical/encryption claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'encryption';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/files/.claude-meta.json
+++ b/packages/files/.claude-meta.json
@@ -1,0 +1,43 @@
+{
+  "name": "@happyvertical/files",
+  "description": "File system interface with local and remote provider support, rate-limited fetch, and caching",
+  "purpose": [
+    "Unified API for local and remote file systems",
+    "Cross-platform file operations",
+    "Rate-limited HTTP fetch utilities",
+    "Temporary file management",
+    "File caching"
+  ],
+  "keyExports": {
+    "functions": [
+      { "name": "getFilesystem", "signature": "(options: FilesystemOptions) => Promise<FilesystemInterface>" },
+      { "name": "fetchText", "signature": "(url: string) => Promise<string>" },
+      { "name": "fetchJSON", "signature": "<T>(url: string) => Promise<T>" },
+      { "name": "fetchBuffer", "signature": "(url: string) => Promise<Buffer>" },
+      { "name": "fetchToFile", "signature": "(url: string, path: string) => Promise<void>" },
+      { "name": "addRateLimit", "signature": "(domain: string, limit: number, interval: number) => Promise<void>" }
+    ],
+    "types": ["FilesystemInterface", "FileInfo", "FileStats"],
+    "errors": ["FilesystemError", "FileNotFoundError", "PermissionError"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/utils"],
+    "external": []
+  },
+  "architecture": {
+    "pattern": "Provider + Factory",
+    "notes": "LocalFilesystemProvider is default; S3, WebDAV, Google Drive planned"
+  },
+  "patterns": [
+    { "name": "File Operations", "usage": "fs.read(path), fs.write(path, content), fs.exists(path)" },
+    { "name": "Rate Limiting", "usage": "addRateLimit(domain, limit, interval) before fetch operations" },
+    { "name": "Temp Files", "usage": "Use getTempDirectory() from @happyvertical/utils" }
+  ],
+  "pitfalls": [
+    "Always use path.join() for cross-platform paths",
+    "Use streams for large files to avoid memory issues",
+    "Clean up temporary files in finally blocks",
+    "Rate limits are per-domain; configure before fetch calls"
+  ],
+  "keywords": ["files", "filesystem", "fetch", "download", "upload", "cache"]
+}

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -38,6 +38,16 @@ npm install @happyvertical/files
 yarn add @happyvertical/files
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-files-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Usage
 
 ### Quick Start

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -35,10 +35,15 @@
     "vite-plugin-dts": "4.5.4",
     "vitest": "^4.0.17"
   },
+  "bin": {
+    "have-files-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/files/src/cli/claude-context.ts
+++ b/packages/files/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/files
+ * Run: npx @happyvertical/files claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'files';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/geo/.claude-meta.json
+++ b/packages/geo/.claude-meta.json
@@ -1,0 +1,32 @@
+{
+  "name": "@happyvertical/geo",
+  "description": "Geographical services with Google Maps and OpenStreetMap providers",
+  "keyExports": {
+    "functions": [
+      { "name": "getGeoAdapter", "signature": "(options: GeoAdapterOptions) => Promise<IGeoAdapter>" }
+    ],
+    "types": ["IGeoAdapter", "Location", "LocationType"],
+    "errors": ["GeoError", "RateLimitError", "InvalidQueryError", "AuthenticationError"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/utils"],
+    "external": ["@googlemaps/google-maps-services-js"]
+  },
+  "patterns": [
+    { "name": "Lookup", "usage": "adapter.lookup('Eiffel Tower, Paris')" },
+    { "name": "Reverse Geocode", "usage": "adapter.reverseGeocode(latitude, longitude)" }
+  ],
+  "pitfalls": [
+    "OpenStreetMap has strict rate limits (1 req/second)",
+    "Google Maps requires API key",
+    "Empty results return empty array, not error",
+    "Coordinates validated: lat -90 to 90, lng -180 to 180"
+  ],
+  "envVars": [
+    "HAVE_GEO_PROVIDER",
+    "GOOGLE_MAPS_API_KEY",
+    "HAVE_GEO_TIMEOUT",
+    "HAVE_GEO_MAX_RESULTS"
+  ],
+  "keywords": ["geo", "geocoding", "location", "maps", "coordinates"]
+}

--- a/packages/geo/README.md
+++ b/packages/geo/README.md
@@ -29,6 +29,16 @@ pnpm add @happyvertical/geo
 yarn add @happyvertical/geo
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-geo-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ### Google Maps

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-geo-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/geo/src/cli/claude-context.ts
+++ b/packages/geo/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/geo
+ * Run: npx @happyvertical/geo claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'geo';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/github-actions/.claude-meta.json
+++ b/packages/github-actions/.claude-meta.json
@@ -1,0 +1,35 @@
+{
+  "name": "@happyvertical/github-actions",
+  "description": "Reusable GitHub Actions utilities for issue triage, duplicate detection, and project management",
+  "purpose": [
+    "AI-powered issue triage",
+    "Duplicate issue detection",
+    "Auto-labeling",
+    "Project board management"
+  ],
+  "keyExports": {
+    "functions": [
+      { "name": "triageIssue", "signature": "(options) => Promise<TriageResult>" },
+      { "name": "checkDefinitionOfReady", "signature": "(options) => Promise<ReadyResult>" }
+    ]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/projects", "@happyvertical/repos"],
+    "external": []
+  },
+  "patterns": [
+    { "name": "Triage", "usage": "triageIssue({ owner, repo, issueNumber })" },
+    { "name": "Definition of Ready", "usage": "checkDefinitionOfReady({ owner, repo, issueNumber })" }
+  ],
+  "pitfalls": [
+    "Requires GITHUB_TOKEN with repo and project scopes",
+    "AI triage needs HAVE_AI_* environment variables",
+    "Watch GitHub API rate limits"
+  ],
+  "envVars": [
+    "GITHUB_TOKEN",
+    "HAVE_AI_API_KEY",
+    "HAVE_AI_TYPE"
+  ],
+  "keywords": ["github", "actions", "triage", "issues", "labels", "projects"]
+}

--- a/packages/github-actions/CLAUDE.md
+++ b/packages/github-actions/CLAUDE.md
@@ -1,0 +1,125 @@
+# @happyvertical/github-actions
+
+## Purpose and Responsibilities
+
+The github-actions package provides reusable utilities for GitHub Actions workflows, including AI-powered issue triage, duplicate detection, auto-labeling, and project board management.
+
+## Key Features
+
+- **AI-Powered Triage**: Analyze issues using AI for categorization and labeling
+- **Duplicate Detection**: Find similar existing issues
+- **Auto-Labeling**: Automatically apply labels based on content
+- **Project Board Management**: Move issues/PRs between columns
+- **Planning Workflow**: Definition of ready validation
+
+## Architecture Overview
+
+```
+@happyvertical/github-actions/
+├── triage/     # Issue triage with AI analysis
+├── planning/   # Planning and definition of ready
+└── shared/     # Common utilities and adapters
+```
+
+## Key APIs
+
+### Issue Triage
+
+```typescript
+import { triageIssue } from '@happyvertical/github-actions';
+
+const result = await triageIssue({
+  owner: 'happyvertical',
+  repo: 'sdk',
+  issueNumber: 123,
+  githubToken: process.env.GITHUB_TOKEN,
+  aiOptions: {
+    provider: 'openai',
+    apiKey: process.env.OPENAI_API_KEY
+  }
+});
+
+console.log(result.labels);      // Suggested labels
+console.log(result.priority);    // Suggested priority
+console.log(result.duplicates);  // Similar issues
+```
+
+### Project Board Management
+
+```typescript
+import { moveToColumn } from '@happyvertical/github-actions';
+
+await moveToColumn({
+  owner: 'happyvertical',
+  projectNumber: 1,
+  itemId: 'issue-123',
+  columnName: 'In Progress',
+  githubToken: process.env.GITHUB_TOKEN
+});
+```
+
+### Definition of Ready
+
+```typescript
+import { checkDefinitionOfReady } from '@happyvertical/github-actions/planning';
+
+const result = await checkDefinitionOfReady({
+  owner: 'happyvertical',
+  repo: 'sdk',
+  issueNumber: 123,
+  githubToken: process.env.GITHUB_TOKEN
+});
+
+if (result.isReady) {
+  console.log('Issue meets definition of ready');
+} else {
+  console.log('Missing:', result.missingCriteria);
+}
+```
+
+## CLI Usage
+
+```bash
+# Triage a specific issue
+github-actions triage --owner happyvertical --repo sdk --issue 123
+
+# Check definition of ready
+github-actions planning:ready --owner happyvertical --repo sdk --issue 123
+```
+
+## Environment Variables
+
+```bash
+GITHUB_TOKEN=ghp_xxx          # GitHub Personal Access Token
+HAVE_AI_API_KEY=xxx           # AI provider API key
+HAVE_AI_TYPE=openai           # AI provider type
+```
+
+## Dependencies
+
+- **Internal**:
+  - `@happyvertical/projects` - Project board management
+  - `@happyvertical/repos` - Repository operations
+
+## Development Guidelines
+
+- Use v2 modules (triage/index-v2.js) for new implementations
+- Legacy exports maintained for backward compatibility
+- AI analysis uses @happyvertical/ai indirectly through shared utilities
+- Tests use mocked GitHub API responses
+
+## Expert Agent Expertise
+
+When working with github-actions:
+
+1. **Triage Flow**: Issue → AI Analysis → Labels → Project Column
+2. **Token Permissions**: Needs repo and project scopes
+3. **Rate Limits**: Be mindful of GitHub API rate limits
+4. **AI Provider**: Configure via HAVE_AI_* environment variables
+5. **Duplicate Detection**: Uses embedding similarity when available
+
+## Related Packages
+
+- **@happyvertical/projects**: GitHub Projects V2 integration
+- **@happyvertical/repos**: Repository management
+- **@happyvertical/graphql**: Underlying GraphQL client

--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -54,6 +54,16 @@ jobs:
           npx --yes @happyvertical/github-actions@latest triage
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-github-actions-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ### As a Reusable Composite Action
 
 See `.github/actions/issue-triage/` in the SDK repository for a complete composite action example.

--- a/packages/github-actions/package.json
+++ b/packages/github-actions/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "github-actions": "./dist/cli.js"
+    "github-actions": "./dist/cli.js",
+    "have-github-actions-context": "./dist/cli/claude-context.js"
   },
   "exports": {
     ".": {
@@ -36,7 +37,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/github-actions/src/cli/claude-context.ts
+++ b/packages/github-actions/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/github-actions
+ * Run: npx @happyvertical/github-actions claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(__dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'github-actions';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/graphql/.claude-meta.json
+++ b/packages/graphql/.claude-meta.json
@@ -1,0 +1,25 @@
+{
+  "name": "@happyvertical/graphql",
+  "description": "GitHub GraphQL client for SDK packages",
+  "keyExports": {
+    "functions": [
+      { "name": "getGraphQLClient", "signature": "(options) => GraphQLClient" }
+    ],
+    "types": ["GraphQLClient"]
+  },
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "patterns": [
+    { "name": "Query", "usage": "client.query(queryString, variables)" },
+    { "name": "Mutation", "usage": "client.mutate(mutationString, variables)" }
+  ],
+  "pitfalls": [
+    "GraphQL returns 200 with errors array, not HTTP error codes",
+    "GitHub has separate rate limits for GraphQL API",
+    "Use pagination for large result sets"
+  ],
+  "envVars": ["GITHUB_TOKEN"],
+  "keywords": ["graphql", "github", "api", "query"]
+}

--- a/packages/graphql/CLAUDE.md
+++ b/packages/graphql/CLAUDE.md
@@ -1,0 +1,106 @@
+# @happyvertical/graphql
+
+## Purpose and Responsibilities
+
+The graphql package provides a GitHub GraphQL client for SDK packages, offering a type-safe interface to GitHub's GraphQL API.
+
+## Key Features
+
+- **GitHub GraphQL Client**: Execute GraphQL queries and mutations
+- **Type-Safe**: TypeScript interfaces for common operations
+- **Error Handling**: Structured error classes for API failures
+- **Factory Pattern**: Easy client instantiation
+
+## Architecture Overview
+
+```
+@happyvertical/graphql/
+├── client.ts   # GraphQL client implementation
+├── factory.ts  # Client factory function
+├── types.ts    # TypeScript type definitions
+└── errors.ts   # Error classes
+```
+
+## Key APIs
+
+### Creating a Client
+
+```typescript
+import { getGraphQLClient } from '@happyvertical/graphql';
+
+const client = getGraphQLClient({
+  token: process.env.GITHUB_TOKEN
+});
+```
+
+### Executing Queries
+
+```typescript
+// Execute a query
+const result = await client.query<RepositoryData>(`
+  query GetRepository($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      id
+      name
+      description
+    }
+  }
+`, {
+  owner: 'happyvertical',
+  name: 'sdk'
+});
+
+console.log(result.repository.name);
+```
+
+### Executing Mutations
+
+```typescript
+// Create an issue
+const result = await client.mutate<CreateIssueResult>(`
+  mutation CreateIssue($input: CreateIssueInput!) {
+    createIssue(input: $input) {
+      issue {
+        id
+        number
+        title
+      }
+    }
+  }
+`, {
+  input: {
+    repositoryId: 'repo-id',
+    title: 'New Issue',
+    body: 'Issue description'
+  }
+});
+
+console.log(result.createIssue.issue.number);
+```
+
+## Dependencies
+
+- **Internal**: None
+- **External**: None (uses native fetch)
+
+## Development Guidelines
+
+- Always use GraphQL variables, never string interpolation
+- Handle rate limits gracefully
+- Use pagination for large result sets
+- Check for GraphQL-specific errors in response
+
+## Expert Agent Expertise
+
+When working with graphql:
+
+1. **Authentication**: Use Personal Access Token or GitHub App
+2. **Rate Limits**: GitHub has separate rate limits for GraphQL
+3. **Pagination**: Use cursor-based pagination for lists
+4. **Errors**: GraphQL returns 200 with errors array, not HTTP error codes
+5. **Schema**: Reference GitHub's GraphQL API Explorer for schema
+
+## Related Packages
+
+- **@happyvertical/repos**: Uses this for repository operations
+- **@happyvertical/projects**: Uses this for GitHub Projects V2

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-graphql-context": "./dist/cli/claude-context.js"
+  },
   "scripts": {
     "test": "npx vitest run --passWithNoTests",
     "test:watch": "npx vitest",
@@ -29,7 +32,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/graphql/src/cli/claude-context.ts
+++ b/packages/graphql/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/graphql
+ * Run: npx @happyvertical/graphql claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'graphql';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/images/.claude-meta.json
+++ b/packages/images/.claude-meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "@happyvertical/images",
+  "description": "Image processing utilities",
+  "keyExports": [
+    "processImage",
+    "resizeImage"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "pitfalls": [
+    "Large images can cause memory issues"
+  ],
+  "keywords": ["images", "processing", "resize"]
+}

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -46,10 +46,15 @@
     "vite-plugin-dts": "4.5.4",
     "vitest": "^4.0.17"
   },
+  "bin": {
+    "have-images-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/images/src/cli/claude-context.ts
+++ b/packages/images/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/images
+ * Run: npx @happyvertical/images claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'images';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/jobs/.claude-meta.json
+++ b/packages/jobs/.claude-meta.json
@@ -1,0 +1,41 @@
+{
+  "name": "@happyvertical/jobs",
+  "description": "Job queue abstraction with SQLite, PostgreSQL, Bull, BullMQ, SQS, and Cloud Tasks adapters",
+  "purpose": [
+    "Background job processing",
+    "Retry strategies with exponential/linear backoff",
+    "Priority queues",
+    "Worker management"
+  ],
+  "keyExports": {
+    "classes": [
+      "SqliteJobStore",
+      "PostgresJobStore",
+      "BullJobStore",
+      "BullMQJobStore",
+      "SQSJobStore",
+      "CloudTasksJobStore"
+    ],
+    "functions": [
+      { "name": "createWorker", "signature": "(store, config) => Worker" },
+      { "name": "exponential", "signature": "(options) => RetryStrategy" },
+      { "name": "linear", "signature": "(options) => RetryStrategy" }
+    ],
+    "types": ["Job", "JobStore", "Worker", "RetryStrategy"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/sql", "@happyvertical/utils"],
+    "external": ["bull", "bullmq", "@aws-sdk/client-sqs", "@google-cloud/tasks"]
+  },
+  "patterns": [
+    { "name": "Add Job", "usage": "store.add({ data, priority, delay })" },
+    { "name": "Worker", "usage": "createWorker(store, { handler, concurrency })" },
+    { "name": "Events", "usage": "store.on('completed', callback)" }
+  ],
+  "pitfalls": [
+    "SQLite for dev, PostgreSQL/Redis for production",
+    "Always implement graceful worker shutdown",
+    "External adapters require peer dependencies"
+  ],
+  "keywords": ["jobs", "queue", "worker", "background", "redis", "bull"]
+}

--- a/packages/jobs/CLAUDE.md
+++ b/packages/jobs/CLAUDE.md
@@ -1,0 +1,154 @@
+# @happyvertical/jobs
+
+## Purpose and Responsibilities
+
+The jobs package provides a job queue abstraction with multiple backend adapters. It enables background job processing with features like retry strategies, priority queues, and worker management.
+
+## Key Features
+
+- **Multiple Adapters**: SQLite, PostgreSQL, Bull, BullMQ, SQS, Cloud Tasks
+- **Retry Strategies**: Exponential, linear, custom, and no-retry options
+- **Priority Queues**: Support for job priorities
+- **Worker Management**: Create and manage workers with event listeners
+- **Zero-Config Built-ins**: SQLite and PostgreSQL require no external dependencies
+
+## Architecture Overview
+
+```
+JobStore Interface
+    ├── SqliteJobStore (built-in)
+    ├── PostgresJobStore (built-in)
+    ├── BullJobStore (Redis-based)
+    ├── BullMQJobStore (Redis-based)
+    ├── SQSJobStore (AWS)
+    └── CloudTasksJobStore (GCP)
+```
+
+## Key APIs
+
+### Creating a Job Store
+
+```typescript
+import { SqliteJobStore, PostgresJobStore } from '@happyvertical/jobs';
+import { getDatabase } from '@happyvertical/sql';
+
+// SQLite (zero-config)
+const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+const sqliteStore = new SqliteJobStore({ db, queueName: 'my-queue' });
+
+// PostgreSQL
+const pgDb = await getDatabase({ type: 'postgres', url: process.env.DATABASE_URL });
+const pgStore = new PostgresJobStore({ db: pgDb, queueName: 'my-queue' });
+
+// Bull (requires Redis)
+import { BullJobStore } from '@happyvertical/jobs';
+const bullStore = new BullJobStore({
+  queueName: 'my-queue',
+  redis: { host: 'localhost', port: 6379 }
+});
+```
+
+### Creating and Processing Jobs
+
+```typescript
+// Create a job
+const job = await store.add({
+  data: { userId: '123', action: 'send-email' },
+  priority: 'high',
+  delay: 5000, // 5 seconds delay
+});
+
+// Create a worker
+import { createWorker } from '@happyvertical/jobs';
+
+const worker = createWorker(store, {
+  handler: async (job) => {
+    console.log('Processing job:', job.data);
+    // Do work...
+    return { success: true };
+  },
+  concurrency: 5,
+  pollInterval: 1000,
+});
+
+// Start processing
+await worker.start();
+
+// Stop gracefully
+await worker.stop();
+```
+
+### Retry Strategies
+
+```typescript
+import { exponential, linear, noRetry, custom } from '@happyvertical/jobs';
+
+// Exponential backoff (default)
+const expStrategy = exponential({ maxAttempts: 5, baseDelay: 1000, maxDelay: 60000 });
+
+// Linear backoff
+const linearStrategy = linear({ maxAttempts: 3, delay: 5000 });
+
+// No retry
+const noRetryStrategy = noRetry();
+
+// Custom strategy
+const customStrategy = custom((attempt, error) => {
+  if (error.message.includes('rate limit')) {
+    return { retry: true, delay: 60000 };
+  }
+  return { retry: attempt < 3, delay: 1000 * attempt };
+});
+```
+
+### Event Handling
+
+```typescript
+// Listen for job events
+store.on('completed', (job) => {
+  console.log(`Job ${job.id} completed`);
+});
+
+store.on('failed', (job, error) => {
+  console.log(`Job ${job.id} failed:`, error);
+});
+
+store.on('progress', (job, progress) => {
+  console.log(`Job ${job.id} progress:`, progress);
+});
+```
+
+## Dependencies
+
+- **Internal**:
+  - `@happyvertical/sql` - For SQLite and PostgreSQL adapters
+  - `@happyvertical/utils` - Utilities
+
+- **Peer Dependencies** (optional):
+  - `bull` - For Bull adapter
+  - `bullmq` - For BullMQ adapter
+  - `@aws-sdk/client-sqs` - For SQS adapter
+  - `@google-cloud/tasks` - For Cloud Tasks adapter
+
+## Development Guidelines
+
+- Use SQLite adapter for development and testing
+- Use PostgreSQL or Redis-based adapters for production
+- Always implement graceful shutdown for workers
+- Use appropriate retry strategies based on job type
+- Monitor failed jobs and implement dead-letter handling
+
+## Expert Agent Expertise
+
+When working with jobs:
+
+1. **Adapter Selection**: SQLite for dev, PostgreSQL for persistent queues, Redis for high-throughput
+2. **Retry Strategy**: Match to failure mode (network errors vs validation errors)
+3. **Concurrency**: Tune based on job type and system resources
+4. **Monitoring**: Listen to events for observability
+5. **Cleanup**: Implement job cleanup to prevent storage growth
+
+## Related Packages
+
+- **@happyvertical/sql**: Database adapters use this package
+- **@happyvertical/utils**: Shared utilities

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -8,8 +8,13 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
+  "bin": {
+    "have-jobs-context": "./dist/cli/claude-context.js"
+  },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/packages/jobs/src/cli/claude-context.ts
+++ b/packages/jobs/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/jobs
+ * Run: npx @happyvertical/jobs claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'jobs';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/logger/.claude-meta.json
+++ b/packages/logger/.claude-meta.json
@@ -1,0 +1,17 @@
+{
+  "name": "@happyvertical/logger",
+  "description": "Logging infrastructure with configurable transports and log levels",
+  "keyExports": [
+    "createLogger",
+    "Logger"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "pitfalls": [
+    "Logger configuration is typically set once at application startup",
+    "Use appropriate log levels: debug, info, warn, error"
+  ],
+  "keywords": ["logger", "logging", "debug", "console"]
+}

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -39,6 +39,16 @@ pnpm add @happyvertical/logger
 yarn add @happyvertical/logger
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-logger-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ```typescript

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-logger-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/logger/src/cli/claude-context.ts
+++ b/packages/logger/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/logger
+ * Run: npx @happyvertical/logger claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'logger';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/projects/.claude-meta.json
+++ b/packages/projects/.claude-meta.json
@@ -1,0 +1,25 @@
+{
+  "name": "@happyvertical/projects",
+  "description": "Standardized project management interface for GitHub Projects, Jira, ZenHub, and Linear",
+  "keyExports": {
+    "functions": [
+      { "name": "getProjectsProvider", "signature": "(options) => Promise<ProjectsProvider>" }
+    ],
+    "types": ["ProjectsProvider", "Project", "ProjectItem"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/graphql", "@happyvertical/repos"],
+    "external": []
+  },
+  "patterns": [
+    { "name": "List Projects", "usage": "provider.listProjects({ owner, type })" },
+    { "name": "Move Item", "usage": "provider.moveItem({ projectId, itemId, columnName })" },
+    { "name": "Update Field", "usage": "provider.updateField({ projectId, itemId, fieldName, value })" }
+  ],
+  "pitfalls": [
+    "GitHub Projects V2 uses GraphQL exclusively",
+    "Field IDs required for updates",
+    "Column names are case-sensitive"
+  ],
+  "keywords": ["projects", "github", "jira", "kanban", "board"]
+}

--- a/packages/projects/CLAUDE.md
+++ b/packages/projects/CLAUDE.md
@@ -1,0 +1,113 @@
+# @happyvertical/projects
+
+## Purpose and Responsibilities
+
+The projects package provides a standardized interface for project management across GitHub Projects, Jira, ZenHub, and Linear.
+
+## Key Features
+
+- **Multi-Provider Support**: GitHub Projects V2, Jira, ZenHub, Linear
+- **Unified API**: Same interface regardless of provider
+- **Column/Status Management**: Move items between columns
+- **Field Updates**: Update custom fields on project items
+
+## Architecture Overview
+
+```
+@happyvertical/projects/
+├── providers/
+│   ├── github.ts     # GitHub Projects V2
+│   ├── jira.ts       # Jira (planned)
+│   ├── zenhub.ts     # ZenHub (planned)
+│   └── linear.ts     # Linear (planned)
+└── factory.ts        # Provider factory
+```
+
+## Key APIs
+
+### Creating a Provider
+
+```typescript
+import { getProjectsProvider } from '@happyvertical/projects';
+
+// GitHub Projects
+const provider = await getProjectsProvider({
+  type: 'github',
+  token: process.env.GITHUB_TOKEN
+});
+```
+
+### Project Operations
+
+```typescript
+// List projects
+const projects = await provider.listProjects({
+  owner: 'happyvertical',
+  type: 'organization' // or 'user'
+});
+
+// Get project details
+const project = await provider.getProject({
+  owner: 'happyvertical',
+  projectNumber: 1
+});
+
+// List items in project
+const items = await provider.listItems({
+  projectId: project.id
+});
+```
+
+### Item Management
+
+```typescript
+// Add issue to project
+await provider.addItem({
+  projectId: 'project-id',
+  contentId: 'issue-id'
+});
+
+// Move item to column
+await provider.moveItem({
+  projectId: 'project-id',
+  itemId: 'item-id',
+  columnName: 'In Progress'
+});
+
+// Update custom field
+await provider.updateField({
+  projectId: 'project-id',
+  itemId: 'item-id',
+  fieldName: 'Priority',
+  value: 'High'
+});
+```
+
+## Dependencies
+
+- **Internal**:
+  - `@happyvertical/graphql` - GitHub GraphQL client
+  - `@happyvertical/repos` - Repository utilities
+
+## Development Guidelines
+
+- GitHub Projects V2 uses GraphQL exclusively
+- Field IDs are required for updates (fetch project first)
+- Column names are case-sensitive
+- Rate limits apply per provider
+
+## Expert Agent Expertise
+
+When working with projects:
+
+1. **GitHub V2**: Uses GraphQL, not REST
+2. **Field IDs**: Get from project schema before updates
+3. **Permissions**: Needs project:write scope
+4. **Pagination**: Large projects need cursor pagination
+5. **Single Select Fields**: Values must match exactly
+
+## Related Packages
+
+- **@happyvertical/graphql**: Underlying GraphQL client
+- **@happyvertical/repos**: Repository operations
+- **@happyvertical/github-actions**: Uses this for workflow automation

--- a/packages/projects/README.md
+++ b/packages/projects/README.md
@@ -8,6 +8,16 @@ Standardized project management interface for GitHub Projects, Jira, ZenHub, and
 pnpm add @have/projects @have/repos
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-projects-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Usage
 
 ### Basic Example

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-projects-context": "./dist/cli/claude-context.js"
+  },
   "scripts": {
     "test": "npx vitest run --passWithNoTests",
     "test:watch": "npx vitest",
@@ -33,7 +36,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/projects/src/cli/claude-context.ts
+++ b/packages/projects/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/projects
+ * Run: npx @happyvertical/projects claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'projects';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/repos/.claude-meta.json
+++ b/packages/repos/.claude-meta.json
@@ -1,0 +1,25 @@
+{
+  "name": "@happyvertical/repos",
+  "description": "Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOps",
+  "keyExports": {
+    "functions": [
+      { "name": "getReposProvider", "signature": "(options) => Promise<ReposProvider>" }
+    ],
+    "types": ["ReposProvider", "Repository", "Issue", "Label"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/graphql"],
+    "external": ["js-yaml"]
+  },
+  "patterns": [
+    { "name": "Get Repo", "usage": "provider.getRepository({ owner, repo })" },
+    { "name": "List Issues", "usage": "provider.listIssues({ owner, repo, state })" },
+    { "name": "Create Issue", "usage": "provider.createIssue({ owner, repo, title, body })" }
+  ],
+  "pitfalls": [
+    "GitHub rate limits: 5000 req/hour authenticated",
+    "Label colors without # prefix",
+    "Use pagination for large result sets"
+  ],
+  "keywords": ["repos", "github", "gitlab", "issues", "labels"]
+}

--- a/packages/repos/CLAUDE.md
+++ b/packages/repos/CLAUDE.md
@@ -1,0 +1,138 @@
+# @happyvertical/repos
+
+## Purpose and Responsibilities
+
+The repos package provides a standardized interface for repository operations across GitHub, GitLab, Bitbucket, and Azure DevOps.
+
+## Key Features
+
+- **Multi-Provider Support**: GitHub, GitLab, Bitbucket, Azure DevOps
+- **Issue Management**: Create, update, list issues
+- **Label Management**: Create and manage labels
+- **Repository Info**: Get repository details and metadata
+
+## Architecture Overview
+
+```
+@happyvertical/repos/
+├── providers/
+│   ├── github.ts      # GitHub REST/GraphQL
+│   ├── gitlab.ts      # GitLab (planned)
+│   ├── bitbucket.ts   # Bitbucket (planned)
+│   └── azure.ts       # Azure DevOps (planned)
+└── factory.ts         # Provider factory
+```
+
+## Key APIs
+
+### Creating a Provider
+
+```typescript
+import { getReposProvider } from '@happyvertical/repos';
+
+// GitHub provider
+const provider = await getReposProvider({
+  type: 'github',
+  token: process.env.GITHUB_TOKEN
+});
+```
+
+### Repository Operations
+
+```typescript
+// Get repository info
+const repo = await provider.getRepository({
+  owner: 'happyvertical',
+  repo: 'sdk'
+});
+
+console.log(repo.defaultBranch);
+console.log(repo.description);
+```
+
+### Issue Operations
+
+```typescript
+// List issues
+const issues = await provider.listIssues({
+  owner: 'happyvertical',
+  repo: 'sdk',
+  state: 'open',
+  labels: ['bug']
+});
+
+// Get single issue
+const issue = await provider.getIssue({
+  owner: 'happyvertical',
+  repo: 'sdk',
+  number: 123
+});
+
+// Create issue
+await provider.createIssue({
+  owner: 'happyvertical',
+  repo: 'sdk',
+  title: 'New Issue',
+  body: 'Description',
+  labels: ['enhancement']
+});
+
+// Update issue
+await provider.updateIssue({
+  owner: 'happyvertical',
+  repo: 'sdk',
+  number: 123,
+  state: 'closed',
+  labels: ['resolved']
+});
+```
+
+### Label Operations
+
+```typescript
+// List labels
+const labels = await provider.listLabels({
+  owner: 'happyvertical',
+  repo: 'sdk'
+});
+
+// Create label
+await provider.createLabel({
+  owner: 'happyvertical',
+  repo: 'sdk',
+  name: 'urgent',
+  color: 'ff0000',
+  description: 'Urgent issues'
+});
+```
+
+## Dependencies
+
+- **Internal**:
+  - `@happyvertical/graphql` - GitHub GraphQL client
+
+- **External**:
+  - `js-yaml` - YAML parsing for repository config files
+
+## Development Guidelines
+
+- GitHub provider uses both REST and GraphQL APIs
+- Check rate limits before bulk operations
+- Use pagination for large result sets
+- Handle 404 errors gracefully for non-existent resources
+
+## Expert Agent Expertise
+
+When working with repos:
+
+1. **API Choice**: REST for simple ops, GraphQL for complex queries
+2. **Permissions**: Needs repo scope for private repositories
+3. **Rate Limits**: 5000 req/hour for authenticated requests
+4. **Pagination**: Use per_page and page params for lists
+5. **Labels**: Color without # prefix
+
+## Related Packages
+
+- **@happyvertical/graphql**: Underlying GraphQL client
+- **@happyvertical/projects**: Uses repos for issue integration
+- **@happyvertical/github-actions**: Uses repos for triage

--- a/packages/repos/README.md
+++ b/packages/repos/README.md
@@ -8,6 +8,16 @@ Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOp
 npm install @have/repos
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-repos-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Usage
 
 ```typescript

--- a/packages/repos/package.json
+++ b/packages/repos/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-repos-context": "./dist/cli/claude-context.js"
+  },
   "scripts": {
     "test": "npx vitest run --passWithNoTests",
     "test:watch": "npx vitest",
@@ -34,7 +37,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/repos/src/cli/claude-context.ts
+++ b/packages/repos/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/repos
+ * Run: npx @happyvertical/repos claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'repos';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/sdk-mcp/.claude-meta.json
+++ b/packages/sdk-mcp/.claude-meta.json
@@ -1,0 +1,35 @@
+{
+  "name": "@happyvertical/sdk-mcp",
+  "description": "MCP server providing AI agents with access to SDK package documentation via RAG",
+  "purpose": [
+    "Route queries to relevant SDK packages by keyword matching",
+    "Load CLAUDE.md files as knowledge base",
+    "AI synthesis using @happyvertical/ai"
+  ],
+  "keyExports": {
+    "tools": [
+      { "name": "ask", "description": "Ask questions about SDK packages with AI-powered answers" },
+      { "name": "list-packages", "description": "List available SDK packages" },
+      { "name": "get-docs", "description": "Get raw CLAUDE.md content" }
+    ]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/ai", "@happyvertical/files", "@happyvertical/utils"],
+    "external": ["@modelcontextprotocol/sdk"]
+  },
+  "architecture": {
+    "pattern": "MCP Server + RAG",
+    "notes": "Keyword scoring routes to top 3 relevant packages, AI synthesizes answer"
+  },
+  "pitfalls": [
+    "Requires HAVE_AI_API_KEY environment variable",
+    "First query slow (~100-500ms) due to filesystem scan",
+    "Limited to 3 packages per query for token limits",
+    "Package registry in src/registry.ts needs updates for new packages"
+  ],
+  "envVars": [
+    "HAVE_AI_API_KEY",
+    "HAVE_AI_TYPE"
+  ],
+  "keywords": ["mcp", "ai", "documentation", "rag"]
+}

--- a/packages/sdk-mcp/README.md
+++ b/packages/sdk-mcp/README.md
@@ -17,6 +17,16 @@ The SDK MCP Server implements a RAG (Retrieval-Augmented Generation) pattern whe
 pnpm install @happyvertical/sdk-mcp
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-sdk-mcp-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Usage
 
 ### As an MCP Server

--- a/packages/sdk-mcp/package.json
+++ b/packages/sdk-mcp/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "sdk-mcp": "./dist/index.js"
+    "sdk-mcp": "./dist/index.js",
+    "have-sdk-mcp-context": "./dist/cli/claude-context.js"
   },
   "exports": {
     ".": {
@@ -17,7 +18,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/sdk-mcp/src/cli/claude-context.ts
+++ b/packages/sdk-mcp/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/sdk-mcp
+ * Run: npx @happyvertical/sdk-mcp claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'sdk-mcp';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/secrets/.claude-meta.json
+++ b/packages/secrets/.claude-meta.json
@@ -1,0 +1,30 @@
+{
+  "name": "@happyvertical/secrets",
+  "description": "Envelope encryption for per-tenant secret management with pluggable backends",
+  "purpose": [
+    "Secure storage of API keys and credentials",
+    "Per-tenant encryption isolation",
+    "Key rotation support"
+  ],
+  "keyExports": {
+    "functions": [
+      { "name": "getSecretsManager", "signature": "(options) => Promise<SecretsManager>" }
+    ],
+    "types": ["SecretsManager", "Secret"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/sql", "@happyvertical/utils"],
+    "external": []
+  },
+  "patterns": [
+    { "name": "Store Secret", "usage": "secrets.set({ tenantId, key, value })" },
+    { "name": "Retrieve Secret", "usage": "secrets.get({ tenantId, key })" },
+    { "name": "Key Rotation", "usage": "secrets.rotateKey({ newMasterKey })" }
+  ],
+  "pitfalls": [
+    "Master key must be 32 bytes (256 bits)",
+    "Never log decrypted values",
+    "Store master key in KMS or secure env var"
+  ],
+  "keywords": ["secrets", "encryption", "tenant", "envelope-encryption", "aes-256-gcm"]
+}

--- a/packages/secrets/CLAUDE.md
+++ b/packages/secrets/CLAUDE.md
@@ -1,0 +1,145 @@
+# @happyvertical/secrets
+
+## Purpose and Responsibilities
+
+The secrets package provides envelope encryption for per-tenant secret management with pluggable backends. It enables secure storage of sensitive data like API keys and credentials.
+
+## Key Features
+
+- **Envelope Encryption**: AES-256-GCM for data, separate key encryption
+- **Per-Tenant Keys**: Each tenant has isolated encryption keys
+- **Pluggable Backends**: Database adapter with more planned (KMS, HashiCorp Vault)
+- **Key Rotation**: Support for rotating encryption keys
+
+## Architecture Overview
+
+```
+Secret Storage
+    ↓
+Envelope Encryption
+├── Data Encryption Key (DEK) - encrypts data
+└── Key Encryption Key (KEK) - encrypts DEK
+    ↓
+Backend Storage (Database, KMS, etc.)
+```
+
+## Key APIs
+
+### Creating a Secrets Manager
+
+```typescript
+import { getSecretsManager } from '@happyvertical/secrets';
+import { getDatabase } from '@happyvertical/sql';
+
+const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+
+const secrets = await getSecretsManager({
+  type: 'database',
+  db,
+  masterKey: process.env.MASTER_KEY // 32 bytes, base64 encoded
+});
+```
+
+### Storing Secrets
+
+```typescript
+// Store a secret for a tenant
+await secrets.set({
+  tenantId: 'tenant-123',
+  key: 'stripe-api-key',
+  value: 'sk_live_xxx'
+});
+
+// Store with metadata
+await secrets.set({
+  tenantId: 'tenant-123',
+  key: 'database-password',
+  value: 'supersecret',
+  metadata: {
+    rotatedAt: new Date().toISOString(),
+    version: 2
+  }
+});
+```
+
+### Retrieving Secrets
+
+```typescript
+// Get a secret
+const apiKey = await secrets.get({
+  tenantId: 'tenant-123',
+  key: 'stripe-api-key'
+});
+
+if (apiKey) {
+  console.log(apiKey.value);     // Decrypted value
+  console.log(apiKey.metadata);  // Associated metadata
+}
+
+// List secrets for tenant (values not returned)
+const keys = await secrets.list({
+  tenantId: 'tenant-123'
+});
+```
+
+### Deleting Secrets
+
+```typescript
+// Delete a specific secret
+await secrets.delete({
+  tenantId: 'tenant-123',
+  key: 'old-api-key'
+});
+
+// Delete all secrets for a tenant
+await secrets.deleteAll({
+  tenantId: 'tenant-123'
+});
+```
+
+### Key Rotation
+
+```typescript
+// Rotate the master key
+await secrets.rotateKey({
+  newMasterKey: process.env.NEW_MASTER_KEY
+});
+```
+
+## Dependencies
+
+- **Internal**:
+  - `@happyvertical/sql` - Database adapter storage
+  - `@happyvertical/utils` - Utilities
+
+## Development Guidelines
+
+- Master key must be 32 bytes (256 bits)
+- Store master key in secure environment variable or KMS
+- Never log decrypted values
+- Use separate tenants for isolation
+- Implement key rotation policy
+
+## Expert Agent Expertise
+
+When working with secrets:
+
+1. **Master Key**: Generate with `crypto.randomBytes(32).toString('base64')`
+2. **Tenant Isolation**: Each tenant has separate DEKs
+3. **Envelope Encryption**: DEK encrypted by KEK for rotation
+4. **Database Storage**: Encrypted data stored as base64
+5. **Key Rotation**: Re-encrypts all DEKs with new KEK
+
+## Security Considerations
+
+- Master key compromise requires key rotation
+- Database adapter stores encrypted values only
+- AES-256-GCM provides authenticated encryption
+- IV (nonce) is unique per encryption operation
+- Consider HSM or KMS for production master keys
+
+## Related Packages
+
+- **@happyvertical/sql**: Database storage backend
+- **@happyvertical/encryption**: Lower-level encryption utilities
+- **@happyvertical/utils**: Error handling

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -10,6 +10,16 @@ npm install @happyvertical/secrets
 pnpm add @happyvertical/secrets
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-secrets-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Overview
 
 This package provides envelope encryption primitives for secure, per-tenant secret management. It uses a two-tier key hierarchy:

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -12,8 +12,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-secrets-context": "./dist/cli/claude-context.js"
+  },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "scripts": {
     "build": "vite build",

--- a/packages/secrets/src/cli/claude-context.ts
+++ b/packages/secrets/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/secrets
+ * Run: npx @happyvertical/secrets claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'secrets';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/sql/.claude-meta.json
+++ b/packages/sql/.claude-meta.json
@@ -1,0 +1,55 @@
+{
+  "name": "@happyvertical/sql",
+  "description": "Database interface for SQLite (LibSQL), PostgreSQL, DuckDB, and JSON with unified API",
+  "purpose": [
+    "Unified database interface across multiple backends",
+    "Template literal queries with automatic parameter binding",
+    "Object-relational methods (insert, get, list, update, upsert, delete)",
+    "JSON manifest-based schema management",
+    "Vector search with SQLite-VSS"
+  ],
+  "keyExports": {
+    "functions": [
+      { "name": "getDatabase", "signature": "(options: GetDatabaseOptions) => Promise<DatabaseInterface>" },
+      { "name": "buildWhere", "signature": "(criteria: object, startIndex?: number) => { sql: string, values: any[] }" },
+      { "name": "syncSchema", "signature": "(options: { db, schema }) => Promise<void>" }
+    ],
+    "types": [
+      "DatabaseInterface",
+      "TableInterface",
+      "QueryResult",
+      "SchemaManifest"
+    ],
+    "classes": ["DatabaseSchemaManager"]
+  },
+  "dependencies": {
+    "internal": ["@happyvertical/utils"],
+    "external": ["@libsql/client", "pg", "sqlite-vss"]
+  },
+  "architecture": {
+    "pattern": "Adapter",
+    "notes": "Each database type (SQLite, PostgreSQL, DuckDB, JSON) has its own adapter implementing DatabaseInterface"
+  },
+  "patterns": [
+    { "name": "Template Literals", "usage": "db.many`SELECT * FROM users WHERE id = ${id}`" },
+    { "name": "Object Methods", "usage": "db.insert('users', data), db.list('users', where)" },
+    { "name": "Transactions", "usage": "db.transaction(async (tx) => { ... })" },
+    { "name": "Table Interface", "usage": "const users = db.table('users'); users.get({ id })" }
+  ],
+  "pitfalls": [
+    "SQLite uses ? placeholders, PostgreSQL uses $1, $2 - template literals handle this",
+    "delete() requires WHERE condition for safety",
+    "dbid parameter enables sharing in-memory databases between instances",
+    "JSON adapter loads all data into RAM - watch memory usage",
+    "SMRT integration fixes DuckDB type inference for empty strings"
+  ],
+  "envVars": [
+    "HAVE_SQL_TYPE",
+    "HAVE_SQL_URL",
+    "HAVE_SQL_HOST",
+    "HAVE_SQL_DATABASE",
+    "HAVE_SQL_USER",
+    "HAVE_SQL_PASSWORD"
+  ],
+  "keywords": ["sql", "database", "sqlite", "postgres", "duckdb", "json", "query", "orm"]
+}

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -43,6 +43,16 @@ yarn add @happyvertical/sql
 bun add @happyvertical/sql
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-sql-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Usage
 
 ### Connecting to a Database

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -5,10 +5,15 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "have-sql-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/sql/src/cli/claude-context.ts
+++ b/packages/sql/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/sql
+ * Run: npx @happyvertical/sql claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'sql';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/translator/.claude-meta.json
+++ b/packages/translator/.claude-meta.json
@@ -1,0 +1,17 @@
+{
+  "name": "@happyvertical/translator",
+  "description": "Translation services integration with multiple provider support",
+  "keyExports": [
+    "getTranslator",
+    "TranslatorInterface"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "pitfalls": [
+    "API keys required for most translation providers",
+    "Consider caching frequently translated text"
+  ],
+  "keywords": ["translator", "translation", "i18n", "language"]
+}

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -27,6 +27,16 @@ npm install @happyvertical/translator
 pnpm add @happyvertical/translator
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-translator-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Quick Start
 
 ### Using Environment Variables (Recommended)

--- a/packages/translator/package.json
+++ b/packages/translator/package.json
@@ -11,10 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "have-translator-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/translator/src/cli/claude-context.ts
+++ b/packages/translator/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/translator
+ * Run: npx @happyvertical/translator claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'translator';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/utils/.claude-meta.json
+++ b/packages/utils/.claude-meta.json
@@ -1,0 +1,45 @@
+{
+  "name": "@happyvertical/utils",
+  "description": "Foundation utilities for ID generation, date parsing, URL handling, string conversion, error handling, and logging",
+  "keyExports": [
+    "makeId",
+    "createId",
+    "isCuid",
+    "makeSlug",
+    "camelCase",
+    "snakeCase",
+    "keysToCamel",
+    "keysToSnake",
+    "dateInString",
+    "prettyDate",
+    "formatDate",
+    "parseDate",
+    "urlPath",
+    "urlFilename",
+    "getTempDirectory",
+    "isArray",
+    "isPlainObject",
+    "isUrl",
+    "sleep",
+    "waitFor",
+    "getLogger",
+    "setLogger",
+    "ValidationError",
+    "NetworkError",
+    "TimeoutError",
+    "ParsingError",
+    "DatabaseError"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": ["@paralleldrive/cuid2", "date-fns", "pluralize", "uuid"]
+  },
+  "pitfalls": [
+    "Use makeId() or createId() for CUID2 (default), makeId('uuid') for RFC4122 UUID",
+    "waitFor() returns undefined to continue polling - null/false/0 resolve the promise",
+    "Logger is global - set once at application startup",
+    "Ampersands in makeSlug() become '-38-' for uniqueness",
+    "dateInString() requires both year (20XX) and month name to work"
+  ],
+  "keywords": ["utils", "id", "cuid", "uuid", "string", "date", "slug", "error", "logging"]
+}

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -40,6 +40,16 @@ npm install @happyvertical/utils
 yarn add @happyvertical/utils
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-utils-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Usage
 
 ### ID Generation

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,10 +43,15 @@
     "vite-plugin-dts": "4.5.4",
     "vitest": "^4.0.17"
   },
+  "bin": {
+    "have-utils-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/utils/src/cli/claude-context.ts
+++ b/packages/utils/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/utils
+ * Run: npx @happyvertical/utils claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'utils';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);

--- a/packages/weather/.claude-meta.json
+++ b/packages/weather/.claude-meta.json
@@ -1,0 +1,17 @@
+{
+  "name": "@happyvertical/weather",
+  "description": "Weather data provider integration",
+  "keyExports": [
+    "getWeatherAdapter",
+    "WeatherInterface"
+  ],
+  "dependencies": {
+    "internal": [],
+    "external": []
+  },
+  "pitfalls": [
+    "API keys required for weather providers",
+    "Rate limits vary by provider"
+  ],
+  "keywords": ["weather", "forecast", "climate"]
+}

--- a/packages/weather/README.md
+++ b/packages/weather/README.md
@@ -19,6 +19,16 @@ The `@happyvertical/weather` package provides a unified interface for fetching w
 pnpm add @happyvertical/weather
 ```
 
+## Claude Code Context
+
+Install Claude Code context files for AI-assisted development:
+
+```bash
+npx have-weather-context
+```
+
+This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` metadata to your project's `.claude/` directory, enabling Claude to provide better assistance when working with this package.
+
 ## Usage
 
 ### Basic Example

--- a/packages/weather/package.json
+++ b/packages/weather/package.json
@@ -5,10 +5,15 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "have-weather-context": "./dist/cli/claude-context.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CLAUDE.md",
+    ".claude-meta.json"
   ],
   "exports": {
     ".": {

--- a/packages/weather/src/cli/claude-context.ts
+++ b/packages/weather/src/cli/claude-context.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * CLI script to install Claude Code context for @happyvertical/weather
+ * Run: npx @happyvertical/weather claude-context
+ */
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const Dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(Dirname, '../..');
+const targetDir = join(process.cwd(), '.claude');
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+}
+
+const pkgName = 'weather';
+const claudeMdSrc = join(pkgRoot, 'CLAUDE.md');
+const metaSrc = join(pkgRoot, '.claude-meta.json');
+
+if (existsSync(claudeMdSrc)) {
+  copyFileSync(claudeMdSrc, join(targetDir, `have-${pkgName}.md`));
+}
+
+if (existsSync(metaSrc)) {
+  copyFileSync(metaSrc, join(targetDir, `have-${pkgName}.meta.json`));
+}
+
+console.log(`✓ Installed @happyvertical/${pkgName} context to .claude/`);


### PR DESCRIPTION
## Summary

Each SDK package now ships with Claude Code context files that can be installed into downstream projects via CLI commands.

- Add `.claude-meta.json` metadata files for all 24 packages
- Add `CLAUDE.md` documentation for 6 packages that were missing it
- Add `src/cli/claude-context.ts` CLI script to each package
- Update `package.json` with bin field and files array
- Add Claude Code Context section to README files
- Update main SDK README with usage instructions

## Usage

```bash
# Install context for packages you use
npx have-ai-context
npx have-sql-context
npx have-files-context
```

Files are installed to `.claude/` directory:
```
.claude/
├── have-ai.md           # Full documentation
├── have-ai.meta.json    # Concise metadata
├── have-sql.md
└── ...
```

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] Pack test shows CLAUDE.md and .claude-meta.json in published files
- [x] All 24 .claude-meta.json files are valid JSON