### PR TITLE
fix: add JSON serialization for Postgres adapter

### DIFF
--- a/packages/sql/src/postgres.spec.ts
+++ b/packages/sql/src/postgres.spec.ts
@@ -209,3 +209,317 @@ describe('postgres tests', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('postgres JSON serialization', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+  let postgresAvailable = false;
+
+  beforeEach(async () => {
+    postgresAvailable = await checkPostgreSQLConnection();
+    if (!postgresAvailable) {
+      console.log(
+        'PostgreSQL not available, skipping JSON serialization tests',
+      );
+      return;
+    }
+
+    db = await getDatabase({
+      type: 'postgres',
+      database: process.env.SQLOO_DATABASE || 'testdb',
+      host: process.env.SQLOO_HOST || 'localhost',
+      user: process.env.SQLOO_USER || 'postgres',
+      password: process.env.SQLOO_PASSWORD || 'postgres',
+      port: Number(process.env.SQLOO_PORT) || 5432,
+    });
+
+    await db.execute`
+      drop table if exists json_test;
+      create table json_test (
+        id uuid primary key not null,
+        tags json,
+        metadata json,
+        config json,
+        created_at timestamptz
+      )
+    `;
+  });
+
+  afterEach(async () => {
+    if (!postgresAvailable || !db) return;
+
+    await db.execute`drop table if exists json_test`;
+    await db.client.end();
+  });
+
+  it('should serialize arrays as JSON in insert', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    const tags = ['javascript', 'typescript', 'postgres'];
+
+    await db.insert('json_test', {
+      id,
+      tags,
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result).toBeTruthy();
+    expect(result?.tags).toEqual(tags);
+  });
+
+  it('should serialize objects as JSON in insert', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    const metadata = {
+      author: 'Test User',
+      version: 1,
+      published: true,
+    };
+
+    await db.insert('json_test', {
+      id,
+      metadata,
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result).toBeTruthy();
+    expect(result?.metadata).toEqual(metadata);
+  });
+
+  it('should serialize nested objects as JSON in insert', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    const config = {
+      database: {
+        host: 'localhost',
+        port: 5432,
+        credentials: {
+          username: 'admin',
+          roles: ['read', 'write'],
+        },
+      },
+      cache: {
+        enabled: true,
+        ttl: 3600,
+      },
+    };
+
+    await db.insert('json_test', {
+      id,
+      config,
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result).toBeTruthy();
+    expect(result?.config).toEqual(config);
+  });
+
+  it('should serialize Date objects as ISO strings in insert', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    const createdAt = new Date('2026-01-20T12:00:00Z');
+
+    await db.insert('json_test', {
+      id,
+      created_at: createdAt,
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result).toBeTruthy();
+    // Postgres returns timestamptz as Date object
+    expect(result?.created_at).toBeInstanceOf(Date);
+    expect(result?.created_at.toISOString()).toBe(createdAt.toISOString());
+  });
+
+  it('should serialize arrays as JSON in update', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    await db.insert('json_test', { id, tags: [] });
+
+    const newTags = ['updated', 'tags', 'array'];
+    await db.update('json_test', { id }, { tags: newTags });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result?.tags).toEqual(newTags);
+  });
+
+  it('should serialize objects as JSON in update', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    await db.insert('json_test', { id, metadata: {} });
+
+    const newMetadata = {
+      updated: true,
+      timestamp: '2026-01-20T12:00:00Z',
+      count: 42,
+    };
+    await db.update('json_test', { id }, { metadata: newMetadata });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result?.metadata).toEqual(newMetadata);
+  });
+
+  it('should serialize arrays as JSON in upsert', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    const tags = ['upsert', 'test', 'array'];
+
+    await db.upsert('json_test', ['id'], {
+      id,
+      tags,
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result?.tags).toEqual(tags);
+
+    // Update via upsert
+    const updatedTags = ['updated', 'upsert', 'tags'];
+    await db.upsert('json_test', ['id'], {
+      id,
+      tags: updatedTags,
+    });
+
+    const updated = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(updated?.tags).toEqual(updatedTags);
+  });
+
+  it('should serialize objects as JSON in upsert', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+    const config = {
+      feature1: true,
+      feature2: false,
+      settings: { theme: 'dark' },
+    };
+
+    await db.upsert('json_test', ['id'], {
+      id,
+      config,
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result?.config).toEqual(config);
+
+    // Update via upsert
+    const updatedConfig = {
+      feature1: false,
+      feature2: true,
+      settings: { theme: 'light', fontSize: 14 },
+    };
+    await db.upsert('json_test', ['id'], {
+      id,
+      config: updatedConfig,
+    });
+
+    const updated = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(updated?.config).toEqual(updatedConfig);
+  });
+
+  it('should handle empty arrays and objects', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+
+    await db.insert('json_test', {
+      id,
+      tags: [],
+      metadata: {},
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result?.tags).toEqual([]);
+    expect(result?.metadata).toEqual({});
+  });
+
+  it('should handle null values correctly', async () => {
+    if (!postgresAvailable) return;
+
+    const id = randomUUID();
+
+    await db.insert('json_test', {
+      id,
+      tags: null,
+      metadata: null,
+    });
+
+    const result = await db.single`
+      select * from json_test where id = ${id}
+    `;
+
+    expect(result?.tags).toBeNull();
+    expect(result?.metadata).toBeNull();
+  });
+
+  it('should serialize multiple JSON columns in batch insert', async () => {
+    if (!postgresAvailable) return;
+
+    const records = [
+      {
+        id: randomUUID(),
+        tags: ['tag1', 'tag2'],
+        metadata: { index: 0 },
+        config: { enabled: true },
+      },
+      {
+        id: randomUUID(),
+        tags: ['tag3', 'tag4'],
+        metadata: { index: 1 },
+        config: { enabled: false },
+      },
+    ];
+
+    await db.insert('json_test', records);
+
+    const results = await db.many`
+      select * from json_test order by (metadata->>'index')::int
+    `;
+
+    expect(results).toHaveLength(2);
+    expect(results[0].tags).toEqual(['tag1', 'tag2']);
+    expect(results[0].metadata).toEqual({ index: 0 });
+    expect(results[0].config).toEqual({ enabled: true });
+    expect(results[1].tags).toEqual(['tag3', 'tag4']);
+    expect(results[1].metadata).toEqual({ index: 1 });
+    expect(results[1].config).toEqual({ enabled: false });
+  });
+});

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -222,6 +222,42 @@ export async function getDatabase(
   }
 
   /**
+   * Serializes a value for database storage
+   * Converts objects and arrays to JSON strings
+   * Converts Dates to ISO strings
+   * Passes through primitives unchanged
+   */
+  const serializeValue = (value: any): any => {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+    return value;
+  };
+
+  /**
+   * Serializes all values in an object for database storage
+   */
+  const serializeRecord = (
+    record: Record<string, any>,
+  ): Record<string, any> => {
+    const serialized: Record<string, any> = {};
+    for (const [key, value] of Object.entries(record)) {
+      // Skip undefined values - they cannot be passed to the database
+      if (value === undefined) {
+        continue;
+      }
+      serialized[key] = serializeValue(value);
+    }
+    return serialized;
+  };
+
+  /**
    * Inserts one or more records into a table
    *
    * @param table - Table name
@@ -251,8 +287,10 @@ export async function getDatabase(
   ): Promise<BaseQueryResult> => {
     // If data is an array, we need to handle multiple rows
     if (Array.isArray(data)) {
-      const keys = Object.keys(data[0]);
-      const placeholders = data
+      // Serialize all records in the array
+      const serializedRecords = data.map((record) => serializeRecord(record));
+      const keys = Object.keys(serializedRecords[0]);
+      const placeholders = serializedRecords
         .map(
           (_, i) =>
             `(${keys.map((_, j) => `$${i * keys.length + j + 1}`).join(', ')})`,
@@ -261,7 +299,7 @@ export async function getDatabase(
       const query = `INSERT INTO ${table} (${keys.join(
         ', ',
       )}) VALUES ${placeholders}`;
-      const values = data.reduce(
+      const values = serializedRecords.reduce(
         (acc, row) => acc.concat(Object.values(row)),
         [],
       );
@@ -269,8 +307,9 @@ export async function getDatabase(
       return { operation: 'insert', affected: result.rowCount ?? 0 };
     }
     // If data is an object, we handle a single row
-    const keys = Object.keys(data);
-    const values = Object.values(data);
+    const serializedData = serializeRecord(data);
+    const keys = Object.keys(serializedData);
+    const values = Object.values(serializedData);
     const placeholders = keys.map((_, i) => `$${i + 1}`).join(', ');
     const query = `INSERT INTO ${table} (${keys.join(
       ', ',
@@ -348,8 +387,10 @@ export async function getDatabase(
     where: Record<string, any>,
     data: Record<string, any>,
   ): Promise<BaseQueryResult> => {
-    const keys = Object.keys(data);
-    const values = Object.values(data);
+    // Serialize the data to update
+    const serializedData = serializeRecord(data);
+    const keys = Object.keys(serializedData);
+    const values = Object.values(serializedData);
     const setClause = keys.map((key, i) => `${key} = $${i + 1}`).join(', ');
     const whereKeys = Object.keys(where);
     const whereValues = Object.values(where);
@@ -385,21 +426,26 @@ export async function getDatabase(
     conflictColumns: string[],
     data: Record<string, any>,
   ): Promise<BaseQueryResult> => {
+    // Serialize the data to convert objects/arrays to JSON strings
+    const serializedData = serializeRecord(data);
+
     // Validate that all conflict columns are present in the data
-    const missingColumns = conflictColumns.filter((col) => !(col in data));
+    const missingColumns = conflictColumns.filter(
+      (col) => !(col in serializedData),
+    );
 
     if (missingColumns.length > 0) {
       throw new DatabaseError('Conflict columns missing from data', {
         table,
         conflictColumns,
         missingColumns,
-        availableColumns: Object.keys(data),
+        availableColumns: Object.keys(serializedData),
         hint: 'All columns specified in ON CONFLICT must be present in the data being inserted. Undefined values should be replaced with null or an appropriate default.',
       });
     }
 
-    const keys = Object.keys(data);
-    const values = Object.values(data);
+    const keys = Object.keys(serializedData);
+    const values = Object.values(serializedData);
     const placeholders = keys.map((_, i) => `$${i + 1}`).join(', ');
     const updateSet = keys.map((key, i) => `${key} = $${i + 1}`).join(', ');
     const conflict = conflictColumns.join(', ');


### PR DESCRIPTION
## Summary

Adds JSON serialization to the Postgres adapter to match SQLite adapter behavior. This fixes an issue where JavaScript arrays and objects were being treated as Postgres array types instead of JSON, causing database insertion failures.

## Changes

- Added `serializeValue()` and `serializeRecord()` helper functions
- Serialize objects and arrays to JSON strings before database operations
- Apply serialization in `insert()`, `update()`, and `upsert()` methods
- Added comprehensive test suite with 11 tests covering:
  - Array serialization (insert, update, upsert)
  - Object serialization (insert, update, upsert)
  - Nested object serialization
  - Date serialization
  - Empty arrays and objects
  - Null values
  - Batch inserts with multiple JSON columns

## Test Results

All 19 Postgres tests pass (8 existing + 11 new):
```
✓ src/postgres.spec.ts (19 tests) 815ms
```

## Root Cause

When JavaScript arrays like `['press', 'cutter']` are passed to Postgres via parameterized queries (``, ``), the pg driver treats them as Postgres array type instead of JSON. The SQLite adapter already had this serialization logic, but it was missing in the Postgres adapter.

## Related

This fix enables DUMM models with array/object fields (like `requiredEquipmentTypes`) to work correctly with Postgres.