### PR TITLE
perf: combine build and publish jobs to eliminate redundant build

### DIFF
--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -35,25 +35,18 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
-  build:
+  # Build is combined with publish to avoid redundant builds
+  # The publish workflow handles building before publishing
+  publish:
     needs: test
     if: |
-      always() && (needs.test.result == 'success' ||
-      needs.test.result == 'skipped')
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-
-  publish:
-    needs: [test, build]
-    if: |
       always() &&
-      (needs.test.result == 'success' || needs.test.result == 'skipped') &&
-      (needs.build.result == 'success' || needs.build.result == 'skipped')
+      (needs.test.result == 'success' || needs.test.result == 'skipped')
     uses: ./.github/workflows/publish.yml
     secrets: inherit
 
   summary:
-    needs: [test, build, publish]
+    needs: [test, publish]
     if: always()
     runs-on: arc-happyvertical
     steps:
@@ -63,7 +56,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           test_result="${{ needs.test.result || 'skipped (no test.yml)' }}"
           echo "- **Test**: $test_result" >> $GITHUB_STEP_SUMMARY
-          build_result="${{ needs.build.result || 'skipped (no build.yml)' }}"
-          echo "- **Build**: $build_result" >> $GITHUB_STEP_SUMMARY
           result="${{ needs.publish.result || 'skipped (no publish.yml)' }}"
-          echo "- **Publish**: $result" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build + Publish**: $result" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Remove the separate `build` job from the merge orchestrator and combine it with `publish`.

## Problem
The workflow was building packages **twice**:
1. In the dedicated `build` job (~1.5 minutes)
2. Again inside the `publish` job before publishing (line 171 of `shared-direct-publish.yml`)

This was wasting ~1.5 minutes per merge.

## Solution
- Remove the separate `build` job from `shared-merge-orchestrator.yml`
- Make `publish` depend directly on `test`
- The publish workflow already handles building internally

## Expected improvement
- **Before**: test (2m) → build (1.5m) → publish (3m) = ~6.5m total
- **After**: test (2m) → publish (3m) = ~5m total
- **Savings**: ~1.5 minutes per merge

## Test plan
- [ ] Merge to main and verify the workflow completes successfully
- [ ] Verify packages are still built and published correctly