### PR TITLE
fix: add constructors to image adapters to accept options

### DIFF
--- a/packages/images/src/adapters/jimp.ts
+++ b/packages/images/src/adapters/jimp.ts
@@ -17,6 +17,7 @@ import type {
   ImageInput,
   ImageMetadata,
   ImageProcessorInterface,
+  JimpOptions,
   ResizeOptions,
   ThumbnailOptions,
 } from '../shared/types.js';
@@ -71,6 +72,16 @@ interface JimpStatic {
  */
 export class JimpAdapter implements ImageProcessorInterface {
   private jimpStatic: JimpStatic | null = null;
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: Stored for API compatibility and future extensibility
+  private options: JimpOptions;
+
+  /**
+   * Create a new Jimp adapter
+   * @param options - Jimp adapter options
+   */
+  constructor(options: JimpOptions = { type: 'jimp' }) {
+    this.options = options;
+  }
 
   /**
    * Lazily load Jimp module

--- a/packages/images/src/adapters/sharp.ts
+++ b/packages/images/src/adapters/sharp.ts
@@ -13,6 +13,7 @@ import type {
   ImageMetadata,
   ImageProcessorInterface,
   ResizeOptions,
+  SharpOptions,
   ThumbnailOptions,
 } from '../shared/types.js';
 
@@ -33,6 +34,16 @@ import type {
  */
 export class SharpAdapter implements ImageProcessorInterface {
   private sharp: typeof import('sharp') | null = null;
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: Stored for API compatibility and future extensibility
+  private options: SharpOptions;
+
+  /**
+   * Create a new Sharp adapter
+   * @param options - Sharp adapter options
+   */
+  constructor(options: SharpOptions = {}) {
+    this.options = options;
+  }
 
   /**
    * Lazily load sharp module


### PR DESCRIPTION
## Summary

SharpAdapter and JimpAdapter were being instantiated with options by the factory pattern, but had no constructors to accept those options, causing TypeScript errors.

## Changes

- Added constructors to `SharpAdapter` and `JimpAdapter` that accept and store options
- Added biome-ignore comments for the stored options fields (reserved for future use)

## Fixes

Instantiation calls that were failing:
- `new SharpAdapter({})` in index.ts:119
- `new JimpAdapter({ type: 'jimp' })` in index.ts:123  
- `new SharpAdapter(options)` in factory.ts:126
- `new JimpAdapter(options)` in factory.ts:131

## Testing

- Built the @happyvertical/images package successfully
- All linter checks pass