### PR TITLE
chore(ci): optimize workflows for arc-runner pre-installed tools

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -116,8 +116,7 @@ jobs:
           files="${{ steps.changed-files.outputs.all_changed_files }}"
           echo "Changed files: $files"
 
-          # Install yamllint
-          pip install yamllint
+          # yamllint is pre-installed in arc-runner image
 
           # Validate each changed workflow file
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -93,6 +93,8 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install system dependencies for ONNX Runtime
+        # Skip on arc-runners where these are pre-installed
+        if: ${{ !startsWith(inputs.runner, 'arc-') }}
         shell: bash
         run: |
           sudo apt-get update && sudo apt-get install -y \
@@ -113,7 +115,8 @@ jobs:
           ONNXRUNTIME_NODE_INSTALL_CUDA: 'skip'
 
       - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        # Skip on arc-runners where Chromium is pre-installed, or if cache hit
+        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' && !startsWith(inputs.runner, 'arc-') }}
         shell: bash
         run: npx playwright install --with-deps chromium
 


### PR DESCRIPTION
## Summary

Add conditions to skip redundant setup steps when running on arc-runners.

Related: https://github.com/happyvertical/iac/issues/293

## Changes

### test-suite.yml
- ONNX Runtime deps: Add `if` condition to skip apt-get install on arc-runners
- Playwright browser: Add `if` condition to skip install on arc-runners (pre-installed)

### on-pull-request.yml
- yamllint: Remove `pip install yamllint` (pre-installed in arc-runner image)

## Compatibility

These changes maintain compatibility with `ubuntu-latest` for cross-platform testing while optimizing for arc-runners.

Closes #782