### PR TITLE
feat(comfyui): add basic auth support

### DIFF
--- a/packages/comfyui/src/client.ts
+++ b/packages/comfyui/src/client.ts
@@ -61,6 +61,8 @@ export class ComfyUIClient {
     new Map();
   private reconnectAttempts = 0;
   private isConnecting = false;
+  private username?: string;
+  private password?: string;
 
   constructor(options: ComfyUIClientOptions = {}) {
     this.options = {
@@ -73,6 +75,13 @@ export class ComfyUIClient {
         delay: options.reconnect?.delay ?? 1000,
       },
     };
+
+    if (options.username && options.password) {
+      this.username = options.username;
+      this.password = options.password;
+      const credentials = btoa(`${options.username}:${options.password}`);
+      this.options.headers.Authorization = `Basic ${credentials}`;
+    }
 
     this.logger = createLogger({ level: 'info' });
     this.clientId = crypto.randomUUID();
@@ -93,6 +102,10 @@ export class ComfyUIClient {
     url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
     url.pathname = '/ws';
     url.searchParams.set('clientId', this.clientId);
+    if (this.username && this.password) {
+      url.username = this.username;
+      url.password = this.password;
+    }
     return url.toString();
   }
 

--- a/packages/comfyui/src/index.spec.ts
+++ b/packages/comfyui/src/index.spec.ts
@@ -29,6 +29,63 @@ describe('comfyui package', () => {
       });
       expect(client).toBeInstanceOf(ComfyUIClient);
     });
+
+    it('should create client with basic auth credentials', () => {
+      const client = new ComfyUIClient({
+        url: 'http://localhost:8188',
+        username: 'admin',
+        password: 'secret',
+      });
+      expect(client).toBeInstanceOf(ComfyUIClient);
+    });
+
+    it('should generate Authorization header from credentials', () => {
+      const client = new ComfyUIClient({
+        url: 'http://localhost:8188',
+        username: 'admin',
+        password: 'secret',
+      });
+      const options = (client as any).options;
+      const expected = `Basic ${btoa('admin:secret')}`;
+      expect(options.headers.Authorization).toBe(expected);
+    });
+
+    it('should not generate Authorization header without both credentials', () => {
+      const clientNoPass = new ComfyUIClient({
+        url: 'http://localhost:8188',
+        username: 'admin',
+      });
+      expect(
+        (clientNoPass as any).options.headers.Authorization,
+      ).toBeUndefined();
+
+      const clientNoUser = new ComfyUIClient({
+        url: 'http://localhost:8188',
+        password: 'secret',
+      });
+      expect(
+        (clientNoUser as any).options.headers.Authorization,
+      ).toBeUndefined();
+    });
+
+    it('should embed credentials in WebSocket URL', () => {
+      const client = new ComfyUIClient({
+        url: 'http://localhost:8188',
+        username: 'admin',
+        password: 'secret',
+      });
+      const wsUrl = (client as any).wsUrl;
+      expect(wsUrl).toMatch(/^ws:\/\/admin:secret@localhost:8188\/ws/);
+    });
+
+    it('should not embed credentials in WebSocket URL without auth', () => {
+      const client = new ComfyUIClient({
+        url: 'http://localhost:8188',
+      });
+      const wsUrl = (client as any).wsUrl;
+      expect(wsUrl).toMatch(/^ws:\/\/localhost:8188\/ws/);
+      expect(wsUrl).not.toContain('@');
+    });
   });
 
   describe('injectWorkflowParams', () => {

--- a/packages/comfyui/src/types.ts
+++ b/packages/comfyui/src/types.ts
@@ -62,6 +62,16 @@ export interface ComfyUIClientOptions {
    * Reconnection options for WebSocket
    */
   reconnect?: Partial<ReconnectOptions>;
+
+  /**
+   * Username for HTTP Basic authentication
+   */
+  username?: string;
+
+  /**
+   * Password for HTTP Basic authentication
+   */
+  password?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `username` and `password` options to `ComfyUIClientOptions`
- Auto-generate `Authorization: Basic <base64>` header when both are provided, applied to all HTTP requests
- Embed credentials in WebSocket URL (`ws://user:pass@host/ws`) for proxy auth

## Test plan
- [x] Client creation with auth credentials
- [x] Auth header generation from username/password
- [x] No auth header when only one credential is provided
- [x] Credentials embedded in WebSocket URL
- [x] No credentials in WebSocket URL without auth
- [x] Build passes
- [x] Typecheck passes

Closes #795