### PR TITLE
perf(sql): batch index existence checks in PostgreSQL syncSchema

### DIFF
--- a/.changeset/batch-index-checks.md
+++ b/.changeset/batch-index-checks.md
@@ -1,0 +1,9 @@
+---
+'@happyvertical/sql': patch
+---
+
+perf(sql): batch index existence checks in PostgreSQL syncSchema
+
+Pre-scan all CREATE INDEX commands and check existence with a single
+`pg_indexes` query using `ANY($1::text[])` instead of one query per index.
+Reduces ~869 queries per syncSchema call to 1.

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -784,6 +784,33 @@ export async function getDatabase(
       .split(';')
       .filter((command) => command.trim() !== '');
 
+    // Match CREATE INDEX statements (Issue #867)
+    // Supports: CREATE INDEX, CREATE UNIQUE INDEX, with IF NOT EXISTS
+    const createIndexRegex =
+      /CREATE (UNIQUE )?INDEX (IF NOT EXISTS )?"?(\w+)"? ON "?(\w+)"?\s*\(([^)]+)\)/i;
+
+    // Pre-scan commands to collect all index names for batch existence check (Issue #798)
+    const indexNames: string[] = [];
+    for (const command of commands) {
+      const indexMatch = command.trim().match(createIndexRegex);
+      if (indexMatch) {
+        indexNames.push(indexMatch[3]);
+      }
+    }
+
+    // Batch query to check which indexes already exist
+    const existingIndexes = new Set<string>();
+    if (indexNames.length > 0) {
+      const result = await client.query(
+        `SELECT indexname FROM pg_indexes
+         WHERE schemaname = 'public' AND indexname = ANY($1::text[])`,
+        [indexNames],
+      );
+      for (const row of result.rows) {
+        existingIndexes.add(row.indexname);
+      }
+    }
+
     for (const command of commands) {
       const trimmedCommand = command.trim();
 
@@ -855,37 +882,25 @@ export async function getDatabase(
         continue;
       }
 
-      // Match CREATE INDEX statements (Issue #867)
-      // Supports: CREATE INDEX, CREATE UNIQUE INDEX, with IF NOT EXISTS
-      const createIndexRegex =
-        /CREATE (UNIQUE )?INDEX (IF NOT EXISTS )?"?(\w+)"? ON "?(\w+)"?\s*\(([^)]+)\)/i;
       const indexMatch = trimmedCommand.match(createIndexRegex);
 
       if (indexMatch) {
         const indexName = indexMatch[3];
         const indexTableName = indexMatch[4];
 
-        try {
-          // Check if index already exists
-          const indexExists = await client.query(
-            `SELECT EXISTS (
-              SELECT 1 FROM pg_indexes
-              WHERE schemaname = 'public'
-              AND indexname = $1
-            )`,
-            [indexName],
-          );
-
-          if (!indexExists.rows[0].exists) {
-            // Index doesn't exist, create it
+        // Use pre-fetched batch result instead of per-index query
+        if (!existingIndexes.has(indexName)) {
+          try {
             await client.query(trimmedCommand);
+            // Track newly created index for idempotency within this call
+            existingIndexes.add(indexName);
+          } catch (error) {
+            // Log error but continue - index creation failures shouldn't block schema sync
+            console.warn(
+              `Warning: Failed to create index ${indexName} on ${indexTableName}:`,
+              error instanceof Error ? error.message : String(error),
+            );
           }
-        } catch (error) {
-          // Log error but continue - index creation failures shouldn't block schema sync
-          console.warn(
-            `Warning: Failed to create index ${indexName} on ${indexTableName}:`,
-            error instanceof Error ? error.message : String(error),
-          );
         }
         continue;
       }


### PR DESCRIPTION
## Summary

- Pre-scan all `CREATE INDEX` commands to collect index names before the main loop
- Replace N individual `pg_indexes` queries with a single batch query using `ANY($1::text[])` 
- Use a `Set<string>` for O(1) lookups during command processing
- Track newly created indexes in the set for idempotency within the same call

Reduces ~869 per-index queries per `syncSchema()` call down to 1 query, eliminating ~428,000 unnecessary queries across large test suites.

Closes #798

## Test plan

- [x] Build passes (`npm run build`)
- [x] Typecheck passes (via pre-push hook)
- [x] Existing postgres tests pass (`npx vitest run packages/sql/src/postgres.spec.ts` — 28 tests)
- [ ] Integration test with PostgreSQL confirms batch behavior