### PR TITLE
fix(ci): fix Claude Code workflow triggers and self-cancellation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,21 +11,21 @@ on:
     types: [submitted]
 
 # Prevent multiple Claude runs on same issue/PR
+# Uses issue/PR number so all triggers for the same issue share one group
 concurrency:
   group: >-
-    ${{ github.workflow }}-${{
+    claude-${{
     github.event.issue.number ||
-    github.event.pull_request.number ||
-    github.event.comment.id }}
+    github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   claude:
-    # Ignore comments from bots to prevent feedback loops where Claude's own
+    # Filter out ALL bot senders to prevent feedback loops where Claude's own
     # error/status comments trigger new workflow runs that cancel the original
     if: |
-      github.event.comment.user.login != 'github-actions[bot]' &&
       github.event.sender.login != 'github-actions[bot]' &&
+      github.event.sender.login != 'claude[bot]' &&
       (
         (github.event_name == 'issue_comment' &&
           contains(github.event.comment.body, '@claude')) ||
@@ -35,7 +35,7 @@ jobs:
           contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' &&
           github.event.action == 'labeled' &&
-          github.event.label.name == 'blocker') ||
+          github.event.label.name == 'agent: claude') ||
         (github.event_name == 'issues' &&
           (contains(github.event.issue.body, '@claude') ||
           contains(github.event.issue.title, '@claude')))
@@ -51,31 +51,62 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # Fetch full history for better context when creating PRs
           fetch-depth: 0
+
+      - name: Setup Node.js
+        if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
+        run: pnpm install --frozen-lockfile
+        continue-on-error: true
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@01e756b34ef7a1447e9508f674143b07d20c2631 # v1
         with:
-          # Use OAuth token for Claude Max plan subscription
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          timeout_minutes: 55
 
-          # Custom prompt when triggered by "blocker" label
-          # Otherwise Claude uses the @claude mention content
+          # Full implementation prompt when triggered by "agent: claude" label
+          # For @claude mentions, Claude uses the mention content directly
           prompt: >-
             ${{ github.event.action == 'labeled' &&
-            github.event.label.name == 'blocker' &&
-            'This issue has been marked as a blocker (high priority).
-            Please analyze the issue, implement a solution,
-            and create a PR to resolve it.' || '' }}
+            github.event.label.name == 'agent: claude' &&
+            format('You are implementing issue #{0} autonomously.
 
-          # Allow Claude to read CI results on PRs
+            ## Workflow
+
+            1. Read the issue: `gh issue view {0}`
+            2. Read CLAUDE.md for repository guidelines
+            3. Create branch: `git checkout -b feat/issue-{0}-[description]`
+            4. Implement following existing patterns
+            5. Write/update tests
+            6. Quality checks: `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
+            7. Commit with conventional commits referencing the issue
+            8. Push: `git push -u origin [branch]`
+            9. Create PR: `gh pr create --title "..." --body "...Closes #{0}"`
+
+            ## If Blocked
+
+            If you cannot complete (unclear requirements, need decisions):
+            1. Post a comment on the issue explaining what you need
+            2. Remove the `agent: claude` label
+            3. The human can clarify and re-apply the label when ready',
+            github.event.issue.number) || '' }}
+
           additional_permissions: |
             actions: read
 
-          # Configure allowed tools for security and functionality
-          # Allows: git operations, GitHub CLI, package management, and file operations
           claude_args: >-
             --allowed-tools
             "Bash(git *:*)"
@@ -109,3 +140,21 @@ jobs:
             "Bash(grep *:*)"
             --allowed-tools
             "Bash(find *:*)"
+
+      - name: Post Failure Comment
+        if: "failure() && github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "## Implementation Failed
+
+          Claude encountered an error while implementing this issue.
+
+          [View workflow run]($RUN_URL)
+
+          The \`agent: claude\` label remains — remove it to stop automated attempts, or re-apply to retry.
+
+          ---
+          *Automated implementation by Claude*"

--- a/.github/workflows/on-label-changed.yml
+++ b/.github/workflows/on-label-changed.yml
@@ -12,23 +12,8 @@ permissions:
   id-token: write
 
 jobs:
-  # Trigger autopilot when agent: claude label is added
-  autopilot:
-    if: "github.event.label.name == 'agent: claude'"
-    uses: happyvertical/.github/.github/workflows/org-agent-autopilot.yml@main
-    with:
-      issue_number: ${{ github.event.issue.number }}
-      action: ${{ github.event.action }}
-      label_name: ${{ github.event.label.name }}
-      project_id: 'PVT_kwDOB9Y8ns4A8-TY'
-      status_field_id: 'PVTSSF_lADOB9Y8ns4A8-TYzgw0GaY'
-      status_in_progress_id: 'c126de7e'
-      status_review_id: '30a150bf'
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Call existing label handler for other label logic
+  # Handle label changes (enforcement, project board sync)
+  # Note: "agent: claude" label is handled directly by claude.yml workflow
   label-handler:
     if: "github.event.label.name != 'agent: claude'"
     uses: ./.github/workflows/shared-label-handler.yml


### PR DESCRIPTION
## Summary

- **Replace `blocker` label trigger with `agent: claude`** in claude.yml — the intended workflow is to apply the `agent: claude` label to an issue, not `blocker`
- **Filter `claude[bot]` sender** to prevent Claude's own error/status comments from triggering new runs that cancel the active one (was only filtering `github-actions[bot]`)
- **Fix concurrency group** to use issue/PR number only (was including comment ID, causing different triggers on the same issue to not share a concurrency slot)
- **Add full implementation prompt** for label-triggered runs with branch creation, quality checks, and PR creation instructions
- **Add Node.js/pnpm setup** for label-triggered autonomous runs so Claude can build/test
- **Add failure comment** posted to the issue when label-triggered implementation fails
- **Remove broken `org-agent-autopilot.yml` reference** from `on-label-changed.yml` — GitHub validates all `uses:` references at parse time even for jobs with `if: false`, so the broken org workflow reference was causing ALL label handler runs to fail with "workflow file issue", including normal label enforcement (one per category) and project board sync

Also created missing labels on the repo:
- `agent: claude` (updated color/description)
- `size: xs`, `size: s`, `size: m`, `size: l`, `size: xl`

## Test plan

- [ ] Apply `agent: claude` label to an issue with `type:`, `priority:`, and `size:` labels — verify Claude picks it up and begins implementation
- [ ] Comment `@claude` on an issue — verify Claude responds without self-canceling
- [ ] Add a `type:` or `priority:` label to an issue — verify `on-label-changed.yml` no longer fails with "workflow file issue"
- [ ] Verify Claude's error reply comments do NOT trigger new workflow runs