### PR TITLE
fix(ci): remove explicit pnpm version from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,8 +62,6 @@ jobs:
       - name: Setup pnpm
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"


### PR DESCRIPTION
## Summary

- Remove explicit `version: 9` from `pnpm/action-setup@v4` in the Claude Code workflow
- `pnpm/action-setup@v4` reads the `packageManager` field from `package.json` (`pnpm@9.15.9`) and errors when an explicit version is also provided

## Test plan

- [ ] Apply `agent: claude` label to an issue — verify the pnpm setup step passes