### PR TITLE
chore(deps): bump external package catalog versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,14 @@ settings:
 catalogs:
   default:
     '@happyvertical/ocr':
-      specifier: ^0.60.6
-      version: 0.60.6
+      specifier: ^0.60.8
+      version: 0.60.8
     '@happyvertical/pdf':
-      specifier: ^0.62.0
-      version: 0.62.0
+      specifier: ^0.62.2
+      version: 0.62.2
     '@happyvertical/spider':
-      specifier: ^0.60.7
-      version: 0.60.7
+      specifier: ^0.60.8
+      version: 0.60.8
 
 overrides:
   '@types/node': 24.10.9
@@ -330,13 +330,13 @@ importers:
         version: link:../files
       '@happyvertical/ocr':
         specifier: 'catalog:'
-        version: 0.60.6
+        version: 0.60.8
       '@happyvertical/pdf':
         specifier: 'catalog:'
-        version: 0.62.0(@napi-rs/canvas@0.1.91)
+        version: 0.62.2(@napi-rs/canvas@0.1.91)
       '@happyvertical/spider':
         specifier: 'catalog:'
-        version: 0.60.7(@noble/hashes@2.0.1)(@types/node@24.10.9)
+        version: 0.60.8(@noble/hashes@2.0.1)(@types/node@24.10.9)
       '@happyvertical/utils':
         specifier: workspace:*
         version: link:../utils
@@ -3072,16 +3072,16 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
-  '@happyvertical/ocr@0.60.6':
-    resolution: {integrity: sha512-OZ3HvBpqicSIdIMRq/2gVYgUHLHqtv44TIHfNAHaukEJHywcjWEBPrgi9n3PpSe+jzk3X74eAQNaBp8gjHXvOA==, tarball: https://npm.pkg.github.com/download/@happyvertical/ocr/0.60.6/c427c557a8b1e28a43cf471036b37dc0d706be35}
+  '@happyvertical/ocr@0.60.8':
+    resolution: {integrity: sha512-6YH3TCnI5gAIw2ZCdmUffPQE8kjRBZauAsktGGU3wCT+vhQeu5F3Q/JdcqD3fD110bFC3jRnLnrA4Mv3ls+jCg==, tarball: https://npm.pkg.github.com/download/@happyvertical/ocr/0.60.8/5e90e0cea8b2169d55815f1432a5d7d47602cac6}
     engines: {node: '>=24', pnpm: '>=9'}
 
-  '@happyvertical/pdf@0.62.0':
-    resolution: {integrity: sha512-HMdKjcSt2dxVxuo2mKNTiyQWZ5oikaSyPOohkAQLdWZ0bEQeVD2YoxubMDgnSvDexoUmVLdf6MMq/ZaJbIFZxQ==, tarball: https://npm.pkg.github.com/download/@happyvertical/pdf/0.62.0/4a206a7149364fc7421a2ce769a41df1c88128bd}
+  '@happyvertical/pdf@0.62.2':
+    resolution: {integrity: sha512-29k4yrExfTwa2jpdZkHITqmFiq6KlOGFa1F3qFwI+B42J3oSn3ok7tQDIl5rmrwd251aYBQAr6i6pi3QbDnxmg==, tarball: https://npm.pkg.github.com/download/@happyvertical/pdf/0.62.2/90aea3108f553aed51561754b70db8d3e57c772d}
     engines: {node: '>=24', pnpm: '>=9'}
 
-  '@happyvertical/spider@0.60.7':
-    resolution: {integrity: sha512-4wTSfoRz6ERU0O8pw6Na7gUNviBOerAxN/EuBaJsW3MU/ckDXqFeZVaM/gecg94pJx5MqcnJtfYZDWa92tuirg==, tarball: https://npm.pkg.github.com/download/@happyvertical/spider/0.60.7/2d304d3ee014431feedfb044bf2ab6ab20277bc2}
+  '@happyvertical/spider@0.60.8':
+    resolution: {integrity: sha512-VIoSU0/diDn9UitaKNNNqxY43eZrWrvqRmT14kNlaxW4RLFuj6t3HLn/up0E7XdmnVH/ChKJWxg8WjcZKxhicA==, tarball: https://npm.pkg.github.com/download/@happyvertical/spider/0.60.8/3f7f1036c9db4b0426d70ab0f7530f577e5a7a2b}
     engines: {node: '>=24', pnpm: '>=9'}
 
   '@hono/node-server@1.19.9':
@@ -8844,7 +8844,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -16355,7 +16354,7 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@happyvertical/ocr@0.60.6':
+  '@happyvertical/ocr@0.60.8':
     dependencies:
       '@gutenye/ocr-node': 1.4.8
       '@happyvertical/ai': link:packages/ai
@@ -16366,9 +16365,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@happyvertical/pdf@0.62.0(@napi-rs/canvas@0.1.91)':
+  '@happyvertical/pdf@0.62.2(@napi-rs/canvas@0.1.91)':
     dependencies:
-      '@happyvertical/ocr': 0.60.6
+      '@happyvertical/ocr': 0.60.8
       '@happyvertical/utils': link:packages/utils
       pdf-to-png-converter: 3.11.0
       unpdf: 1.4.0(@napi-rs/canvas@0.1.91)
@@ -16378,7 +16377,7 @@ snapshots:
       - '@napi-rs/canvas'
       - encoding
 
-  '@happyvertical/spider@0.60.7(@noble/hashes@2.0.1)(@types/node@24.10.9)':
+  '@happyvertical/spider@0.60.8(@noble/hashes@2.0.1)(@types/node@24.10.9)':
     dependencies:
       '@happyvertical/cache': link:packages/cache
       '@happyvertical/files': link:packages/files

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,6 @@ packages:
 # These are separate repos (ocr, pdf, spider) whose transitive deps pull in
 # old SDK versions. The catalog + overrides below keep everything aligned.
 catalog:
-  '@happyvertical/ocr': ^0.60.6
-  '@happyvertical/pdf': ^0.62.0
-  '@happyvertical/spider': ^0.60.7
+  '@happyvertical/ocr': ^0.60.8
+  '@happyvertical/pdf': ^0.62.2
+  '@happyvertical/spider': ^0.60.8


### PR DESCRIPTION
## Summary
- ocr: ^0.60.6 → ^0.60.8
- pdf: ^0.62.0 → ^0.62.2
- spider: ^0.60.7 → ^0.60.8