### PR TITLE
fix(ci): pin pnpm/action-setup to avoid version conflict

### DIFF
--- a/.github/workflows/build-json-native.yml
+++ b/.github/workflows/build-json-native.yml
@@ -95,8 +95,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-        with:
-          version: 9
 
       - name: Install dependencies
         working-directory: packages/json

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup pnpm
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
       - name: Install dependencies
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"


### PR DESCRIPTION
## Summary

- Pin `pnpm/action-setup` in `claude.yml` to commit hash `41ff7265` instead of floating `@v4` tag, which recently updated to a stricter version that errors when both a `version` input and `packageManager` in `package.json` are specified
- Remove redundant `version: 9` from `build-json-native.yml` since `packageManager: pnpm@9.15.9` is already defined in `package.json`

Fixes the "Setup pnpm" step failure: https://github.com/happyvertical/sdk/actions/runs/21881969384/job/63166673682

## Test plan

- [ ] Verify `claude.yml` workflow runs successfully with the pinned hash
- [ ] Verify `build-json-native.yml` still installs pnpm correctly without explicit `version`