### PR TITLE
fix(ci): filter all bot senders from Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,11 +21,11 @@ concurrency:
 
 jobs:
   claude:
-    # Filter out ALL bot senders to prevent feedback loops where Claude's own
-    # error/status comments trigger new workflow runs that cancel the original
+    # Filter out bot senders to prevent feedback loops and unnecessary triggers
     if: |
       github.event.sender.login != 'github-actions[bot]' &&
       github.event.sender.login != 'claude[bot]' &&
+      github.event.sender.type != 'Bot' &&
       (
         (github.event_name == 'issue_comment' &&
           contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
## Summary

- Add `github.event.sender.type != 'Bot'` check to the Claude Code workflow's `if` condition, preventing it from triggering on Copilot review comments (and any other bot accounts)

Previously only `github-actions[bot]` and `claude[bot]` were filtered by login name. Copilot's review comments were still triggering the workflow, resulting in `action_required` runs that needed manual approval and served no purpose.

## Test plan

- [ ] Verify Claude Code workflow no longer triggers on Copilot review comments
- [ ] Verify Claude Code workflow still triggers on human `@claude` mentions