### PR TITLE
fix(ci): use correct allowedTools format for Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,39 +105,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          claude_args: >-
-            --allowed-tools
-            "Bash(git *:*)"
-            --allowed-tools
-            "Bash(gh pr:*)"
-            --allowed-tools
-            "Bash(gh issue:*)"
-            --allowed-tools
-            "Bash(pnpm *:*)"
-            --allowed-tools
-            "Bash(npm *:*)"
-            --allowed-tools
-            "Bash(npx *:*)"
-            --allowed-tools
-            "Bash(node *:*)"
-            --allowed-tools
-            "Read"
-            --allowed-tools
-            "Write"
-            --allowed-tools
-            "Edit"
-            --allowed-tools
-            "Glob"
-            --allowed-tools
-            "Grep"
-            --allowed-tools
-            "Bash(ls *:*)"
-            --allowed-tools
-            "Bash(cat *:*)"
-            --allowed-tools
-            "Bash(grep *:*)"
-            --allowed-tools
-            "Bash(find *:*)"
+          claude_args: |
+            --allowedTools "Bash(git *:*),Bash(gh *:*),Bash(pnpm *:*),Bash(npm *:*),Bash(npx *:*),Bash(node *:*),Bash(ls *:*),Bash(cat *:*),Bash(grep *:*),Bash(find *:*),Bash(cd *:*)"
 
       - name: Post Failure Comment
         if: "failure() && github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"


### PR DESCRIPTION
## Summary

- Switch `claude_args` from multiple `--allowed-tools` flags with `>-` folding to single `--allowedTools` with comma-separated values, matching [Anthropic's documented format](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md#custom-tools)
- Merge `gh pr` and `gh issue` patterns into single `gh *` wildcard
- Add `cd` pattern for compound commands like `cd packages/sql && pnpm typecheck`

The previous format caused permission denials on all `git`, `pnpm`, and other shell commands — Claude could write code but couldn't create branches, run quality checks, commit, or open PRs. See [run #22025300829](https://github.com/happyvertical/sdk/actions/runs/22025300829) where Claude got 7 permission denials and had to comment "awaiting approval" instead of completing the implementation.

## Test plan

- [ ] Re-apply `agent: claude` label on issue #744 to verify Claude can now create branches, run checks, and open PRs