### PR TITLE
fix(ci): add GitHub Packages auth and remove invalid input from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,6 +46,7 @@ jobs:
       pull-requests: write   # Allow Claude to create and update PRs
       issues: write          # Allow Claude to comment and update issues
       actions: read          # Allow Claude to read CI results on PRs
+      packages: read         # Allow reading @happyvertical packages from GitHub Packages
       id-token: write        # Required for authentication
     steps:
       - name: Checkout repository
@@ -58,6 +59,8 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@happyvertical'
 
       - name: Setup pnpm
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
@@ -67,13 +70,14 @@ jobs:
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
         run: pnpm install --frozen-lockfile
         continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@01e756b34ef7a1447e9508f674143b07d20c2631 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          timeout_minutes: 55
 
           # Full implementation prompt when triggered by "agent: claude" label
           # For @claude mentions, Claude uses the mention content directly


### PR DESCRIPTION
## Summary

Follow-up to #814 which fixed the `allowedTools` format. These remaining fixes were lost when the original PR was merged before the amended commit could be pushed.

- Add `packages: read` permission so the workflow can access `@happyvertical` packages from GitHub Packages registry
- Configure `setup-node` with `registry-url` and `scope` for `@happyvertical`
- Add `NODE_AUTH_TOKEN` env var for `pnpm install` to authenticate against GitHub Packages (was failing with exit code 1)
- Remove invalid `timeout_minutes` input (not supported by `claude-code-action`, was silently ignored with a warning)

## Test plan

- [ ] Apply `agent: claude` label to a test issue and verify `pnpm install --frozen-lockfile` succeeds
- [ ] Verify no `timeout_minutes` warning in the action logs