### PR TITLE
feat(sql): add requiresSchemaCheck flag to DatabaseInterface

### DIFF
--- a/.changeset/requires-schema-check.md
+++ b/.changeset/requires-schema-check.md
@@ -1,0 +1,10 @@
+---
+"@happyvertical/sql": minor
+---
+
+Add `requiresSchemaCheck` flag to DatabaseInterface
+
+Adapters that auto-create tables at runtime (JSON, DuckDB) now set
+`requiresSchemaCheck: true`. Migration-managed adapters (Postgres, SQLite)
+leave it unset, allowing frameworks to skip redundant `tableExists()` calls
+during collection initialization.

--- a/packages/sql/src/duckdb.ts
+++ b/packages/sql/src/duckdb.ts
@@ -1382,6 +1382,7 @@ export async function getDatabase(
 
   return {
     url,
+    requiresSchemaCheck: true,
     client: connection,
     query,
     insert,

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -1835,6 +1835,7 @@ export async function getDatabase(
 
     return {
       url,
+      requiresSchemaCheck: true,
       client: connection,
       query,
       insert,

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -702,6 +702,22 @@ export interface DatabaseInterface {
   tableExists: (table: string) => Promise<boolean>;
 
   /**
+   * Whether this adapter requires schema existence checks at runtime.
+   *
+   * Set to `true` on adapters where tables may not exist yet and need
+   * to be verified before use (e.g. JSON/DuckDB with auto-created tables).
+   *
+   * When absent or `false`, frameworks skip `tableExists()` calls during
+   * collection initialization — tables are assumed to exist because
+   * schema is managed by migrations (e.g. `smrt db:migrate`).
+   *
+   * - Postgres adapter: not set (migration-managed)
+   * - SQLite adapter: not set (migration-managed)
+   * - JSON/DuckDB adapter: `true` (tables may be auto-created)
+   */
+  requiresSchemaCheck?: boolean;
+
+  /**
    * Executes a SQL query using template literals and returns multiple rows
    *
    * @param strings - Template strings


### PR DESCRIPTION
## Summary
- Adds `requiresSchemaCheck?: boolean` to `DatabaseInterface` in `@happyvertical/sql`
- JSON and DuckDB adapters set `requiresSchemaCheck: true` (they auto-create tables at runtime)
- Postgres and SQLite leave it unset — their schemas are migration-managed

## Why
`Collection.create()` in smrt-core calls `tableExists()` on every initialization, costing ~1s per collection over high-latency connections (e.g. Tailscale). By declaring at the adapter level whether schema checks are needed, smrt-core can skip the overhead entirely for migration-managed databases.

Companion PR: https://github.com/happyvertical/smrt/pull/new/feat/skip-table-exists-for-migration-managed-adapters

## Test plan
- [ ] Verify JSON adapter has `requiresSchemaCheck: true`
- [ ] Verify DuckDB adapter has `requiresSchemaCheck: true`
- [ ] Verify Postgres adapter does NOT have the flag set
- [ ] Verify SQLite adapter does NOT have the flag set
- [ ] Build passes (verified locally)