### PR TITLE
docs(repos,projects): fix @have/ scope to @happyvertical/

### DIFF
--- a/packages/projects/README.md
+++ b/packages/projects/README.md
@@ -1,11 +1,11 @@
-# @have/projects
+# @happyvertical/projects
 
 Standardized project management interface for GitHub Projects, Jira, ZenHub, and Linear.
 
 ## Installation
 
 ```bash
-pnpm add @have/projects @have/repos
+pnpm add @happyvertical/projects @happyvertical/repos
 ```
 
 ## Claude Code Context
@@ -23,8 +23,8 @@ This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` meta
 ### Basic Example
 
 ```typescript
-import { getProject } from '@have/projects';
-import { getRepository } from '@have/repos';
+import { getProject } from '@happyvertical/projects';
+import { getRepository } from '@happyvertical/repos';
 
 // Get repository to retrieve issue node IDs
 const repo = await getRepository({
@@ -131,7 +131,7 @@ Get project details including fields and statuses.
 Add an issue or pull request to the project.
 
 **Parameters:**
-- `contentId: string` - Node ID of the issue or PR (from @have/repos)
+- `contentId: string` - Node ID of the issue or PR (from @happyvertical/repos)
 
 **Returns:** Created project item
 
@@ -271,7 +271,7 @@ const project = await getProject({
 The package exports standard kanban status names:
 
 ```typescript
-import { KANBAN_STATUSES } from '@have/projects';
+import { KANBAN_STATUSES } from '@happyvertical/projects';
 
 // ['New', 'Backlog', 'Planning', 'Ready', 'In Progress', 'Review', 'Done']
 ```
@@ -279,7 +279,7 @@ import { KANBAN_STATUSES } from '@have/projects';
 ## Error Handling
 
 ```typescript
-import { ProjectError, ProjectErrorCode } from '@have/projects';
+import { ProjectError, ProjectErrorCode } from '@happyvertical/projects';
 
 try {
   await project.updateItemStatus(itemId, 'Invalid Status');
@@ -300,13 +300,13 @@ try {
 }
 ```
 
-## Integration with @have/repos
+## Integration with @happyvertical/repos
 
 Projects work seamlessly with repositories:
 
 ```typescript
-import { getRepository } from '@have/repos';
-import { getProject } from '@have/projects';
+import { getRepository } from '@happyvertical/repos';
+import { getProject } from '@happyvertical/projects';
 
 const repo = await getRepository({
   type: 'github',

--- a/packages/repos/README.md
+++ b/packages/repos/README.md
@@ -1,11 +1,11 @@
-# @have/repos
+# @happyvertical/repos
 
 Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOps.
 
 ## Installation
 
 ```bash
-npm install @have/repos
+pnpm add @happyvertical/repos
 ```
 
 ## Claude Code Context
@@ -21,7 +21,7 @@ This copies the package's `CLAUDE.md` documentation and `.claude-meta.json` meta
 ## Usage
 
 ```typescript
-import { getRepository } from '@have/repos';
+import { getRepository } from '@happyvertical/repos';
 
 // Create a GitHub repository client
 const repo = await getRepository({


### PR DESCRIPTION
## Summary
- Replace all `@have/repos` references with `@happyvertical/repos` in `packages/repos/README.md`
- Replace all `@have/projects` and `@have/repos` references with `@happyvertical/projects` and `@happyvertical/repos` in `packages/projects/README.md`
- Fix `npm install` to `pnpm add` in repos README install command

Fixes #859

## Test plan
- [ ] Verify no remaining `@have/` references in either README
- [ ] Confirm all import examples use `@happyvertical/` scope
- [ ] Check install commands use `pnpm add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)