### PR TITLE
docs: fix @have/ references in misc documentation

### DIFF
--- a/.devcontainer/ACT_INTEGRATION.md
+++ b/.devcontainer/ACT_INTEGRATION.md
@@ -102,7 +102,7 @@ act --shell -j test --step "Build packages"
 # Inside the container:
 ls -la /home/runner/work/sdk/sdk/packages/sql/dist/
 cat /home/runner/work/sdk/sdk/packages/sql/dist/index.d.ts
-node -e "console.log(require('@have/sql'))"
+node -e "console.log(require('@happyvertical/sql'))"
 ```
 
 ## Configuration Files

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -173,7 +173,7 @@ This ensures a reproducible environment that matches production requirements whi
 
 ## Claude Code Integration
 
-The devcontainer includes Claude Code AI assistant pre-installed and configured for seamless development. Claude has full access to the containerized environment, including PostgreSQL database for testing the @have/sql package.
+The devcontainer includes Claude Code AI assistant pre-installed and configured for seamless development. Claude has full access to the containerized environment, including PostgreSQL database for testing the @happyvertical/sql package.
 
 ### Two Usage Patterns
 
@@ -235,17 +235,17 @@ SQLOO_PORT=65432  # External port mapping
 
 ### Database Testing with Claude
 
-The PostgreSQL database is automatically configured for testing the @have/sql package:
+The PostgreSQL database is automatically configured for testing the @happyvertical/sql package:
 
 ```bash
 # Test database connections
 ./.devcontainer/scripts/test-postgres-connection.sh
 
-# Run @have/sql tests
+# Run @happyvertical/sql tests
 ./.devcontainer/scripts/run-sql-tests.sh
 
 # Claude can now help with database operations:
-claude "Test the PostgreSQL implementation in @have/sql"
+claude "Test the PostgreSQL implementation in @happyvertical/sql"
 claude "Run the database migration tests"
 ```
 
@@ -254,7 +254,7 @@ claude "Run the database migration tests"
 - **`scripts/setup-claude-container.sh`** - Configure Claude inside container
 - **`scripts/setup-claude-host.sh`** - Configure host environment for external Claude
 - **`scripts/test-postgres-connection.sh`** - Test database connectivity
-- **`scripts/run-sql-tests.sh`** - Run @have/sql package tests
+- **`scripts/run-sql-tests.sh`** - Run @happyvertical/sql package tests
 
 ### Claude Credentials
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -43,7 +43,7 @@ echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
 
 **After**:
 ```yaml
-echo "@have:registry=https://npm.pkg.github.com" > .npmrc
+echo "@happyvertical:registry=https://npm.pkg.github.com" > .npmrc
 # Token is passed via environment variables instead
 env:
   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/notes/workflow/KANBAN.md
+++ b/notes/workflow/KANBAN.md
@@ -9,9 +9,9 @@ The HappyVertical Kanban system provides automated issue management across all o
 The system is built on three foundational packages:
 
 ```
-@have/repos (Repository abstraction)
+@happyvertical/repos (Repository abstraction)
     ↓
-@have/projects (Project management abstraction)
+@happyvertical/projects (Project management abstraction)
     ↓
 @happyvertical/github-actions (Workflow automation)
 ```
@@ -629,8 +629,8 @@ If migrating from 8-lane or other workflow:
 ## Package Documentation
 
 For detailed API documentation:
-- [@have/repos](../../packages/repos/README.md) - Repository abstraction
-- [@have/projects](../../packages/projects/README.md) - Project management abstraction
+- [@happyvertical/repos](../../packages/repos/README.md) - Repository abstraction
+- [@happyvertical/projects](../../packages/projects/README.md) - Project management abstraction
 - [@happyvertical/github-actions](../../packages/github-actions/README.md) - Workflow automation
 
 ## References


### PR DESCRIPTION
## Summary
- Replace `@have/sql` with `@happyvertical/sql` in devcontainer README and ACT_INTEGRATION docs
- Replace `@have/repos` and `@have/projects` with `@happyvertical/repos` and `@happyvertical/projects` in KANBAN workflow docs
- Replace `@have:registry` with `@happyvertical:registry` in SECURITY.md

Fixes #860

## Test plan
- [ ] Verify no remaining `@have/` or `@have:` references in the four modified files
- [ ] Confirm "HAVE SDK" product name is preserved where appropriate
- [ ] Confirm `@happyvertical/github-actions` references remain unchanged in KANBAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)