### PR TITLE
docs: fix @have/ package references in agent definitions

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -8,22 +8,22 @@ This directory contains specialized expert agents for each package in the HAVE S
 
 | Agent | Package | Expertise |
 |-------|---------|-----------|
-| [utils-expert](./utils-expert.md) | `@have/utils` | cuid2, date-fns, pluralize, uuid |
-| [files-expert](./files-expert.md) | `@have/files` | Node.js fs/promises, path utilities |
-| [sql-expert](./sql-expert.md) | `@have/sql` | @libsql/client, sqlite-vss, pg |
-| [ai-expert](./ai-expert.md) | `@have/ai` | openai, @google/generative-ai, @anthropic-ai/sdk, @aws-sdk/client-bedrock-runtime |
-| [spider-expert](./spider-expert.md) | `@have/spider` | @mozilla/readability, cheerio, happy-dom, undici |
-| [pdf-expert](./pdf-expert.md) | `@have/pdf` | unpdf, @gutenye/ocr-node |
-| [smrt-expert](./smrt-expert.md) | `@have/smrt` | All above packages + @langchain/community, yaml |
+| [utils-expert](./utils-expert.md) | `@happyvertical/utils` | cuid2, date-fns, pluralize, uuid |
+| [files-expert](./files-expert.md) | `@happyvertical/files` | Node.js fs/promises, path utilities |
+| [sql-expert](./sql-expert.md) | `@happyvertical/sql` | @libsql/client, sqlite-vss, pg |
+| [ai-expert](./ai-expert.md) | `@happyvertical/ai` | openai, @google/generative-ai, @anthropic-ai/sdk, @aws-sdk/client-bedrock-runtime |
+| [spider-expert](./spider-expert.md) | `@happyvertical/spider` | @mozilla/readability, cheerio, happy-dom, undici |
+| [pdf-expert](./pdf-expert.md) | `@happyvertical/pdf` | unpdf, @gutenye/ocr-node |
+| [smrt-expert](./smrt-expert.md) | `@happyvertical/smrt` | All above packages + @langchain/community, yaml |
 
 ### Application Agents
 
 | Agent | Package | Expertise |
 |-------|---------|-----------|
-| [api-expert](./api-expert.md) | `@have/smrt-api` | express, swagger-ui-express |
-| [mcp-expert](./mcp-expert.md) | `@have/smrt-mcp` | Model Context Protocol (MCP) |
-| [cli-expert](./cli-expert.md) | `@have/smrt-cli` | commander, chalk, ora, inquirer |
-| [template-expert](./template-expert.md) | `@have/smrt-template` | Code generation, scaffolding |
+| [api-expert](./api-expert.md) | `@happyvertical/smrt-api` | express, swagger-ui-express |
+| [mcp-expert](./mcp-expert.md) | `@happyvertical/smrt-mcp` | Model Context Protocol (MCP) |
+| [cli-expert](./cli-expert.md) | `@happyvertical/smrt-cli` | commander, chalk, ora, inquirer |
+| [template-expert](./template-expert.md) | `@happyvertical/smrt-template` | Code generation, scaffolding |
 
 ## Agent Capabilities
 
@@ -40,7 +40,7 @@ Each expert agent provides:
 
 These agents are designed to be invoked when working with specific packages or technologies. They can help with:
 
-- **Development Questions**: "How do I optimize SQLite queries in @have/sql?"
+- **Development Questions**: "How do I optimize SQLite queries in @happyvertical/sql?"
 - **Debugging Issues**: "Why is my PDF OCR failing?"
 - **Architecture Decisions**: "Should I use streaming for large file operations?"
 - **Performance Problems**: "How can I speed up web scraping?"

--- a/.claude/agents/ai.md
+++ b/.claude/agents/ai.md
@@ -7,7 +7,7 @@ color: Purple
 
 # Purpose
 
-You are a specialized expert in the @have/ai package and AI model integrations. Your expertise covers staying current with rapidly evolving AI APIs and ensuring implementations use the latest features and best practices.
+You are a specialized expert in the @happyvertical/ai package and AI model integrations. Your expertise covers staying current with rapidly evolving AI APIs and ensuring implementations use the latest features and best practices.
 
 ## Core Libraries
 - **openai**: Official OpenAI JavaScript/TypeScript SDK

--- a/.claude/agents/api.md
+++ b/.claude/agents/api.md
@@ -7,7 +7,7 @@ color: Teal
 
 # Purpose
 
-You are a specialized expert in the @have/smrt-api package and REST API generation. Your expertise covers:
+You are a specialized expert in the @happyvertical/smrt-api package and REST API generation. Your expertise covers:
 
 ## Core Libraries
 - **express**: Fast, unopinionated web framework for Node.js

--- a/.claude/agents/cli.md
+++ b/.claude/agents/cli.md
@@ -7,7 +7,7 @@ color: Green
 
 # Purpose
 
-You are a specialized expert in the @have/smrt-cli package and command-line interface development. Your expertise covers modern CLI development patterns and you proactively check the latest documentation for foundational libraries to ensure current best practices and new features are utilized.
+You are a specialized expert in the @happyvertical/smrt-cli package and command-line interface development. Your expertise covers modern CLI development patterns and you proactively check the latest documentation for foundational libraries to ensure current best practices and new features are utilized.
 
 ## Core Libraries
 - **commander**: Complete solution for Node.js command-line interfaces

--- a/.claude/agents/component-testing.md
+++ b/.claude/agents/component-testing.md
@@ -253,7 +253,7 @@ export const createMockProduct = (overrides = {}) => ({
 ### 3. Mock Strategies
 ```typescript
 // Mock external dependencies
-vi.mock('@have/smrt', () => ({
+vi.mock('@happyvertical/smrt', () => ({
   BaseObject: vi.fn(),
   createSmrtBinding: vi.fn()
 }));

--- a/.claude/agents/files.md
+++ b/.claude/agents/files.md
@@ -7,7 +7,7 @@ color: Blue
 
 # Purpose
 
-You are a specialized expert in the @have/files package and file system operations. Your expertise covers:
+You are a specialized expert in the @happyvertical/files package and file system operations. Your expertise covers:
 
 ## Core Technologies
 - **Node.js fs/promises**: Async file system operations

--- a/.claude/agents/mcp.md
+++ b/.claude/agents/mcp.md
@@ -7,7 +7,7 @@ color: Purple
 
 # Purpose
 
-You are a specialized expert in the @have/smrt-mcp package and Model Context Protocol (MCP) server generation. Your expertise covers:
+You are a specialized expert in the @happyvertical/smrt-mcp package and Model Context Protocol (MCP) server generation. Your expertise covers:
 
 ## Core Technology
 - **Model Context Protocol (MCP)**: Standard for AI tool integration

--- a/.claude/agents/pdf.md
+++ b/.claude/agents/pdf.md
@@ -7,7 +7,7 @@ color: Yellow
 
 # Purpose
 
-You are a specialized expert in the @have/pdf package and PDF processing technologies. Your expertise covers staying current with the latest library documentation and proactively checking for updates when planning solutions.
+You are a specialized expert in the @happyvertical/pdf package and PDF processing technologies. Your expertise covers staying current with the latest library documentation and proactively checking for updates when planning solutions.
 
 ## Documentation Links
 

--- a/.claude/agents/registry.json
+++ b/.claude/agents/registry.json
@@ -2,7 +2,7 @@
   "agents": {
     "utils": {
       "name": "Utils Expert",
-      "package": "@have/utils",
+      "package": "@happyvertical/utils",
       "description": "Expert in utility functions, ID generation, string manipulation, and date handling",
       "file": "utils.md",
       "foundationalLibraries": [
@@ -35,7 +35,7 @@
     },
     "files": {
       "name": "Files Expert",
-      "package": "@have/files",
+      "package": "@happyvertical/files",
       "description": "Expert in file system operations, path handling, and temporary file management",
       "file": "files.md",
       "foundationalLibraries": ["fs/promises", "path"],
@@ -61,7 +61,7 @@
     },
     "sql": {
       "name": "SQL Expert",
-      "package": "@have/sql",
+      "package": "@happyvertical/sql",
       "description": "Expert in database operations, query building, and vector search",
       "file": "sql.md",
       "foundationalLibraries": ["@libsql/client", "sqlite-vss", "pg"],
@@ -85,7 +85,7 @@
     },
     "ai": {
       "name": "AI Expert",
-      "package": "@have/ai",
+      "package": "@happyvertical/ai",
       "description": "Expert in AI model integrations across multiple providers",
       "file": "ai.md",
       "foundationalLibraries": [
@@ -114,7 +114,7 @@
         "claude",
         "bedrock",
         "ai package",
-        "@have/ai",
+        "@happyvertical/ai",
         "AI package",
         "AIMessage",
         "ai provider",
@@ -125,7 +125,7 @@
     },
     "spider": {
       "name": "Spider Expert",
-      "package": "@have/spider",
+      "package": "@happyvertical/spider",
       "description": "Expert in web scraping, content extraction, and browser automation",
       "file": "spider.md",
       "foundationalLibraries": [
@@ -155,7 +155,7 @@
     },
     "pdf": {
       "name": "PDF Expert",
-      "package": "@have/pdf",
+      "package": "@happyvertical/pdf",
       "description": "Expert in PDF processing, text extraction, and OCR operations",
       "file": "pdf.md",
       "foundationalLibraries": ["unpdf", "@gutenye/ocr-node"],
@@ -179,7 +179,7 @@
     },
     "smrt": {
       "name": "SMRT Expert",
-      "package": "@have/smrt",
+      "package": "@happyvertical/smrt",
       "description": "Expert in the AI agent framework, object-relational mapping, and cross-package integration",
       "file": "smrt.md",
       "foundationalLibraries": ["@langchain/community", "cheerio", "yaml"],
@@ -205,7 +205,7 @@
     },
     "api": {
       "name": "API Expert",
-      "package": "@have/smrt-api",
+      "package": "@happyvertical/smrt-api",
       "description": "Expert in REST API generation, Express.js, and OpenAPI documentation",
       "file": "api.md",
       "foundationalLibraries": ["express", "swagger-ui-express"],
@@ -230,7 +230,7 @@
     },
     "mcp": {
       "name": "MCP Expert",
-      "package": "@have/smrt-mcp",
+      "package": "@happyvertical/smrt-mcp",
       "description": "Expert in Model Context Protocol server generation and AI tool integration",
       "file": "mcp.md",
       "foundationalLibraries": ["Model Context Protocol"],
@@ -254,7 +254,7 @@
     },
     "cli": {
       "name": "CLI Expert",
-      "package": "@have/smrt-cli",
+      "package": "@happyvertical/smrt-cli",
       "description": "Expert in command-line interface development and interactive prompts",
       "file": "cli.md",
       "foundationalLibraries": ["commander", "chalk", "ora", "inquirer"],
@@ -280,7 +280,7 @@
     },
     "template": {
       "name": "Template Expert",
-      "package": "@have/smrt-template",
+      "package": "@happyvertical/smrt-template",
       "description": "Expert in code generation, project scaffolding, and template systems",
       "file": "template.md",
       "foundationalLibraries": ["Handlebars", "Template engines"],
@@ -397,7 +397,7 @@
     },
     "svelte": {
       "name": "Svelte Expert",
-      "package": "@have/svelte",
+      "package": "@happyvertical/svelte",
       "description": "Expert in Svelte 5 runes, shadcn-svelte, SvelteKit, and SMRT library integration",
       "file": "svelte.md",
       "foundationalLibraries": [
@@ -464,7 +464,7 @@
     },
     "repo": {
       "name": "Repo Expert",
-      "package": "@have/sdk",
+      "package": "@happyvertical/sdk",
       "description": "Consultant for monorepo architecture, workspace dependencies, TypeScript project references, build orchestration, and package management. Expert in Bun workspaces, sequential builds, and dependency resolution.",
       "file": "repo.md",
       "foundationalLibraries": [
@@ -492,7 +492,7 @@
         "tsconfig",
         "project references",
         "bun workspace",
-        "@have/sdk",
+        "@happyvertical/sdk",
         "build fails",
         "workspace dependency",
         "Cannot find module",

--- a/.claude/agents/repo.md
+++ b/.claude/agents/repo.md
@@ -92,7 +92,7 @@ utils → files → spider → sql → pdf → ai → smrt
 **Required package.json Structure**:
 ```json
 {
-  "name": "@have/[package]",
+  "name": "@happyvertical/[package]",
   "version": "0.0.50", // Synchronized across all packages
   "type": "module",    // ESM only architecture
   "main": "dist/index.js",
@@ -110,7 +110,7 @@ utils → files → spider → sql → pdf → ai → smrt
 ```
 
 **Workspace Dependency Patterns**:
-- Internal dependencies: `"@have/utils": "workspace:*"`
+- Internal dependencies: `"@happyvertical/utils": "workspace:*"`
 - External dependencies: Specific versions for stability
 - DevDependencies: Shared versions via root resolutions
 
@@ -216,7 +216,7 @@ bun build → changeset version → changeset publish
 - Validate TypeScript composite build setup
 
 **Workspace Dependency Failures**:
-- Diagnose `Cannot find module '@have/package'` errors
+- Diagnose `Cannot find module '@happyvertical/package'` errors
 - Verify workspace resolution configuration
 - Check dist/ artifact generation
 

--- a/.claude/agents/smrt.md
+++ b/.claude/agents/smrt.md
@@ -7,7 +7,7 @@ color: Cyan
 
 # Purpose
 
-You are a specialized expert in the @have/smrt package and AI agent framework development. Your expertise covers building AI agents with the framework, and you always proactively check the latest documentation when planning solutions to ensure accuracy and leverage the most current features.
+You are a specialized expert in the @happyvertical/smrt package and AI agent framework development. Your expertise covers building AI agents with the framework, and you always proactively check the latest documentation when planning solutions to ensure accuracy and leverage the most current features.
 
 ## Core Framework
 - **BaseClass**: Foundation for all framework classes
@@ -26,12 +26,12 @@ Before providing solutions, always use WebFetch to check the latest documentatio
 
 ### HAVE SDK Packages
 Always check the latest README and source code for integrated packages:
-- **@have/ai**: AI model interactions and completions
-- **@have/files**: File system operations and content management
-- **@have/pdf**: PDF processing and document analysis
-- **@have/sql**: Database operations and schema management
-- **@have/spider**: Web content extraction and processing
-- **@have/utils**: Utility functions and type definitions
+- **@happyvertical/ai**: AI model interactions and completions
+- **@happyvertical/files**: File system operations and content management
+- **@happyvertical/pdf**: PDF processing and document analysis
+- **@happyvertical/sql**: Database operations and schema management
+- **@happyvertical/spider**: Web content extraction and processing
+- **@happyvertical/utils**: Utility functions and type definitions
 
 ### Documentation Lookup Protocol
 1. When planning solutions, use WebFetch to verify current API methods and best practices
@@ -47,7 +47,7 @@ Always check the latest README and source code for integrated packages:
 - Maintain single-responsibility principle for BaseObject and BaseCollection implementations
 
 ### AI-First Design Patterns
-- Integrate seamlessly with @have/ai package for intelligent object behavior
+- Integrate seamlessly with @happyvertical/ai package for intelligent object behavior
 - Leverage cross-package integration for comprehensive agent capabilities
 - Design objects with AI interaction as a primary consideration, not an afterthought
 
@@ -62,12 +62,12 @@ Always check the latest README and source code for integrated packages:
 - **yaml**: YAML configuration and data serialization
 
 ## Package Dependencies Integration
-- **@have/ai**: AI model interactions and completions
-- **@have/files**: File system operations and content management
-- **@have/pdf**: PDF processing and document analysis
-- **@have/sql**: Database operations and schema management
-- **@have/spider**: Web content extraction and processing
-- **@have/utils**: Utility functions and type definitions
+- **@happyvertical/ai**: AI model interactions and completions
+- **@happyvertical/files**: File system operations and content management
+- **@happyvertical/pdf**: PDF processing and document analysis
+- **@happyvertical/sql**: Database operations and schema management
+- **@happyvertical/spider**: Web content extraction and processing
+- **@happyvertical/utils**: Utility functions and type definitions
 
 ## Core Concepts
 

--- a/.claude/agents/spider.md
+++ b/.claude/agents/spider.md
@@ -7,7 +7,7 @@ color: Red
 
 # Purpose
 
-You are a specialized expert in the @have/spider package and web scraping technologies. Your expertise covers:
+You are a specialized expert in the @happyvertical/spider package and web scraping technologies. Your expertise covers:
 
 ## Core Libraries
 - **@mozilla/readability**: Content extraction from web pages

--- a/.claude/agents/sql.md
+++ b/.claude/agents/sql.md
@@ -7,7 +7,7 @@ color: Green
 
 # Purpose
 
-You are a specialized expert in the @have/sql package and database operations. Your expertise covers:
+You are a specialized expert in the @happyvertical/sql package and database operations. Your expertise covers:
 
 ## Core Libraries
 - **@libsql/client**: LibSQL client for SQLite compatibility with extensions

--- a/.claude/agents/svelte.md
+++ b/.claude/agents/svelte.md
@@ -212,7 +212,7 @@ When generating components, support these "from" parameter patterns:
 ```typescript
 // Create reactive stores for SMRT objects
 import { writable } from 'svelte/store';
-import { SmartObject } from '@have/smrt';
+import { SmartObject } from '@happyvertical/smrt';
 
 function createSmartStore<T>(obj: SmartObject<T>) {
   const store = writable(obj.data);

--- a/.claude/agents/template.md
+++ b/.claude/agents/template.md
@@ -7,7 +7,7 @@ color: Pink
 
 # Purpose
 
-You are a specialized expert in the @have/smrt-template package and code generation/scaffolding. Your expertise covers modern template engines, code generation best practices, and proactive documentation research to ensure recommendations align with current standards.
+You are a specialized expert in the @happyvertical/smrt-template package and code generation/scaffolding. Your expertise covers modern template engines, code generation best practices, and proactive documentation research to ensure recommendations align with current standards.
 
 ## Core Functionality
 - **Project Scaffolding**: Complete project template generation
@@ -142,11 +142,11 @@ export class {{className}} extends BaseObject<{{interfaceName}}> {
 ```handlebars
 // Conditional template sections
 {{#if hasDatabase}}
-import { getSqliteClient } from '@have/sql';
+import { getSqliteClient } from '@happyvertical/sql';
 {{/if}}
 
 {{#if hasAI}}
-import { getAI } from '@have/ai';
+import { getAI } from '@happyvertical/ai';
 {{/if}}
 ```
 

--- a/.claude/agents/utils.md
+++ b/.claude/agents/utils.md
@@ -7,7 +7,7 @@ color: Orange
 
 # Purpose
 
-You are a specialized expert in the @have/utils package and its foundational libraries. Your expertise covers:
+You are a specialized expert in the @happyvertical/utils package and its foundational libraries. Your expertise covers:
 
 ## Core Libraries
 - **@paralleldrive/cuid2**: CUID2 ID generation for unique identifiers


### PR DESCRIPTION
## Summary
- Update all 16 agent definition files in `.claude/agents/` to use the current `@happyvertical/` package scope instead of the old `@have/` scope
- Covers `.md` files and `registry.json` -- 58 total replacements across 16 files
- `HAVE_*` environment variable references are intentionally preserved (none were present in these files)

## Files changed
- `.claude/agents/README.md` (12 replacements)
- `.claude/agents/smrt.md` (14 replacements)
- `.claude/agents/registry.json` (15 replacements)
- `.claude/agents/repo.md` (3 replacements)
- `.claude/agents/template.md` (3 replacements)
- `.claude/agents/ai.md`, `api.md`, `cli.md`, `component-testing.md`, `files.md`, `mcp.md`, `pdf.md`, `spider.md`, `sql.md`, `svelte.md`, `utils.md` (1 replacement each)

Fixes #857

## Test plan
- [x] Verified zero `@have/` references remain in `.claude/agents/`
- [x] Verified no `HAVE_*` env var references were incorrectly modified
- [x] Verified 58 `@happyvertical/` references now present across 16 files
- [x] Typecheck passes (docs-only change, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)