### PR TITLE
ci: add Docusaurus build check on PRs

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -158,3 +158,37 @@ jobs:
   test:
     name: Validate Changes
     uses: ./.github/workflows/test.yml
+
+  docs-build:
+    name: Validate Documentation Build
+    runs-on: arc-happyvertical
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
+        with:
+          files: |
+            docs/**
+            packages/*/README.md
+            packages/*/CLAUDE.md
+
+      - name: Setup Environment
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24'
+
+      - name: Build documentation site
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          cd docs
+          npm run build
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+
+      - name: Documentation build summary
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: echo "Documentation site built successfully with no broken links."


### PR DESCRIPTION
## Summary
- Adds a `docs-build` job to the PR validation workflow that builds the Docusaurus site when docs or package README/CLAUDE.md files change
- Uses `tj-actions/changed-files` (same pattern as the existing `validate-workflows` job) to skip the build when no documentation files are modified
- Catches broken links and build errors before merge

## Test plan
- [ ] Open a PR that modifies a file under `docs/` and verify the `docs-build` job runs
- [ ] Open a PR that modifies a `packages/*/README.md` and verify the `docs-build` job runs
- [ ] Open a PR with no documentation changes and verify the `docs-build` job skips the build steps

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)