### PR TITLE
fix(ci): harden squash-merge release detection

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           configFile: .commitlintrc.json
 
+      - name: Validate PR title for squash merge
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          echo "Validating PR title: $title"
+          node scripts/validate-conventional-commits.js --message "$title"
+
       - name: Determine version bump
         id: version
         run: |

--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -25,6 +25,8 @@ interface ParsedCommit {
   hash: string;
 }
 
+const CONVENTIONAL_COMMIT_REGEX = /^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
+
 function exec(command: string): string {
   try {
     return execSync(command, { encoding: 'utf-8' }).trim();
@@ -52,25 +54,20 @@ function getCommitsSinceLastRelease(): string[] {
   if (!commits) return [];
 
   // Split on null byte (not newline) to handle multi-line commit bodies
-  return commits.split('\x00').map((s) => s.trim()).filter(Boolean);
+  return commits
+    .split('\x00')
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
-function parseConventionalCommit(commitLine: string): ParsedCommit | null {
-  const [hash, subject, body] = commitLine.split('|||');
-
-  // Skip if subject is undefined or empty
-  if (!subject) {
-    console.log(
-      `Skipping commit with empty subject: ${hash?.substring(0, 7) || 'unknown'}`,
-    );
-    return null;
-  }
-
-  // Match conventional commit format: type(scope)!: message
-  const match = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
+function parseConventionalSubject(
+  subject: string,
+  body: string | undefined,
+  hash: string,
+): ParsedCommit | null {
+  const match = subject.match(CONVENTIONAL_COMMIT_REGEX);
 
   if (!match) {
-    console.log(`Skipping non-conventional commit: ${subject}`);
     return null;
   }
 
@@ -89,6 +86,54 @@ function parseConventionalCommit(commitLine: string): ParsedCommit | null {
   };
 }
 
+function parseConventionalCommitsFromBody(
+  hash: string,
+  body: string | undefined,
+): ParsedCommit[] {
+  if (!body) {
+    return [];
+  }
+
+  const parsedCommits = body
+    .split('\n')
+    .map((line) => line.replaceAll(String.fromCharCode(0), '').trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s+/, ''))
+    .map((line, index) =>
+      parseConventionalSubject(line, undefined, `${hash}-${index}`),
+    )
+    .filter((commit): commit is ParsedCommit => commit !== null);
+
+  if (parsedCommits.length > 0) {
+    console.log(
+      `Using ${parsedCommits.length} conventional commit(s) from squash body: ${hash.substring(0, 7)}`,
+    );
+  }
+
+  return parsedCommits;
+}
+
+function parseConventionalCommit(commitLine: string): ParsedCommit[] {
+  const [hash, subject, body] = commitLine.split('|||');
+
+  // Skip if subject is undefined or empty
+  if (!subject) {
+    console.log(
+      `Skipping commit with empty subject: ${hash?.substring(0, 7) || 'unknown'}`,
+    );
+    return [];
+  }
+
+  const parsedSubject = parseConventionalSubject(subject, body, hash);
+
+  if (parsedSubject) {
+    return [parsedSubject];
+  }
+
+  console.log(`Skipping non-conventional commit subject: ${subject}`);
+  return parseConventionalCommitsFromBody(hash, body);
+}
+
 function determineVersionBump(
   commits: ParsedCommit[],
 ): 'major' | 'minor' | 'patch' | null {
@@ -101,9 +146,7 @@ function determineVersionBump(
 
   const hasFeature = commits.some((c) => c.type === 'feat');
   const hasFix = commits.some((c) => ['fix', 'perf'].includes(c.type));
-  const hasDeps = commits.some(
-    (c) => c.type === 'chore' && c.scope === 'deps',
-  );
+  const hasDeps = commits.some((c) => c.type === 'chore' && c.scope === 'deps');
 
   if (hasFeature || hasFix || hasDeps) return 'patch';
 
@@ -117,9 +160,7 @@ function generateChangesetContent(
   const features = commits.filter((c) => c.type === 'feat');
   const fixes = commits.filter((c) => c.type === 'fix');
   const breaking = commits.filter((c) => c.breaking);
-  const deps = commits.filter(
-    (c) => c.type === 'chore' && c.scope === 'deps',
-  );
+  const deps = commits.filter((c) => c.type === 'chore' && c.scope === 'deps');
 
   let content = `---\n`;
   // Use @happyvertical/utils as representative package (all packages in fixed group will bump together)
@@ -157,7 +198,7 @@ function generateChangesetContent(
     });
   }
 
-  return content.trim() + '\n';
+  return `${content.trim()}\n`;
 }
 
 function hasExistingChangesets(): boolean {
@@ -188,9 +229,7 @@ function main() {
 
   console.log(`📝 Analyzing ${commitLines.length} commits...`);
 
-  const parsedCommits = commitLines
-    .map(parseConventionalCommit)
-    .filter((c): c is ParsedCommit => c !== null);
+  const parsedCommits = commitLines.flatMap(parseConventionalCommit);
 
   if (parsedCommits.length === 0) {
     console.log('ℹ️  No conventional commits found');
@@ -235,4 +274,12 @@ function main() {
   console.log('---');
 }
 
-main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export {
+  determineVersionBump,
+  generateChangesetContent,
+  parseConventionalCommit,
+};

--- a/scripts/validate-conventional-commits.js
+++ b/scripts/validate-conventional-commits.js
@@ -7,40 +7,26 @@
  * and can be used in pre-commit hooks or CI/CD pipelines.
  */
 
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 
 const CONVENTIONAL_COMMIT_TYPES = [
-  'feat',     // New feature
-  'fix',      // Bug fix
-  'docs',     // Documentation changes
-  'style',    // Code style changes (formatting, missing semi-colons, etc)
+  'feat', // New feature
+  'fix', // Bug fix
+  'docs', // Documentation changes
+  'style', // Code style changes (formatting, missing semi-colons, etc)
   'refactor', // Code refactoring
-  'perf',     // Performance improvements
-  'test',     // Adding or modifying tests
-  'build',    // Changes to build system or external dependencies
-  'ci',       // Changes to CI configuration files and scripts
-  'chore',    // Other changes that don't modify src or test files
-  'revert',   // Reverts a previous commit
+  'perf', // Performance improvements
+  'test', // Adding or modifying tests
+  'build', // Changes to build system or external dependencies
+  'ci', // Changes to CI configuration files and scripts
+  'chore', // Other changes that don't modify src or test files
+  'revert', // Reverts a previous commit
 ];
 
-const CONVENTIONAL_COMMIT_REGEX = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?(!)?: .{1,50}/;
+const CONVENTIONAL_COMMIT_REGEX =
+  /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?(!)?: .{1,50}/;
 
-function getCommits(range = 'HEAD~1..HEAD') {
-  try {
-    const output = execSync(`git log --pretty=format:"%H|%s" ${range}`, { encoding: 'utf8' });
-    return output.trim().split('\n').map(line => {
-      const [hash, message] = line.split('|');
-      return { hash, message };
-    }).filter(commit => commit.hash && commit.message);
-  } catch (error) {
-    console.error('Error getting commits:', error.message);
-    return [];
-  }
-}
-
-function validateCommit(commit) {
-  const { hash, message } = commit;
-
+function validateMessage(message) {
   // Skip merge commits
   if (message.startsWith('Merge ')) {
     return { valid: true, type: 'merge', message: 'Merge commit (skipped)' };
@@ -53,23 +39,68 @@ function validateCommit(commit) {
     return {
       valid: false,
       type: 'invalid',
-      message: `Invalid conventional commit format: "${message}"`
+      message: `Invalid conventional commit format: "${message}"`,
     };
   }
 
   const [, type, scope, breaking] = match;
+  const normalizedScope = scope ? scope.slice(1, -1) : null;
 
   return {
     valid: true,
     type,
-    scope: scope ? scope.slice(1, -1) : null, // Remove parentheses
+    scope: normalizedScope,
     breaking: !!breaking,
-    message: `Valid ${type} commit${scope ? ` (${scope})` : ''}${breaking ? ' [BREAKING]' : ''}`
+    message: `Valid ${type} commit${normalizedScope ? ` (${normalizedScope})` : ''}${breaking ? ' [BREAKING]' : ''}`,
   };
+}
+
+function getCommits(range = 'HEAD~1..HEAD') {
+  try {
+    const output = execSync(`git log --pretty=format:"%H|%s" ${range}`, {
+      encoding: 'utf8',
+    });
+    return output
+      .trim()
+      .split('\n')
+      .map((line) => {
+        const [hash, message] = line.split('|');
+        return { hash, message };
+      })
+      .filter((commit) => commit.hash && commit.message);
+  } catch (error) {
+    console.error('Error getting commits:', error.message);
+    return [];
+  }
+}
+
+function validateCommit(commit) {
+  return validateMessage(commit.message);
 }
 
 function main() {
   const args = process.argv.slice(2);
+  const messageFlagIndex = args.indexOf('--message');
+
+  if (messageFlagIndex !== -1) {
+    const message = args[messageFlagIndex + 1];
+
+    if (!message) {
+      console.error('Missing value for --message');
+      process.exit(1);
+    }
+
+    const validation = validateMessage(message);
+
+    if (!validation.valid) {
+      console.error(`❌ ${validation.message}`);
+      process.exit(1);
+    }
+
+    console.log(`✅ ${validation.message}`);
+    return;
+  }
+
   const range = args[0] || 'HEAD~1..HEAD';
 
   console.log(`Validating commits in range: ${range}`);
@@ -89,7 +120,9 @@ function main() {
     const validation = validateCommit(commit);
 
     const status = validation.valid ? '✅' : '❌';
-    console.log(`${status} ${commit.hash.substring(0, 8)}: ${validation.message}`);
+    console.log(
+      `${status} ${commit.hash.substring(0, 8)}: ${validation.message}`,
+    );
 
     if (!validation.valid) {
       invalidCommits++;
@@ -100,7 +133,9 @@ function main() {
   }
 
   console.log('='.repeat(50));
-  console.log(`Summary: ${validCommits} valid, ${invalidCommits} invalid commits`);
+  console.log(
+    `Summary: ${validCommits} valid, ${invalidCommits} invalid commits`,
+  );
 
   if (invalidCommits > 0) {
     console.log('\nConventional Commit Format:');


### PR DESCRIPTION
## Summary
- validate PR titles as conventional commits so the default squash-merge commit title cannot drift out of release automation expectations
- teach `changeset:auto` to recover conventional commits from GitHub squash-merge bodies when the squash subject itself is non-conventional
- reuse the local conventional-commit validator for both commit-range checks and PR-title checks

## Why
- `#904` merged with a non-conventional squash title, so the publish workflow skipped auto-generating a changeset and no version was released
- this hardens both the front door (PR validation) and the backstop (release detection)

## Testing
- `node scripts/validate-conventional-commits.js --message "Fix GA4 property discovery and align SOPS config (#904)"` returns non-zero
- `node scripts/validate-conventional-commits.js --message "fix(analytics): repair GA4 property discovery"` succeeds
- `node -e "import(\"./scripts/auto-changeset.ts\").then((mod) => { const { execSync } = require(\"node:child_process\"); const commit = execSync(\"git log origin/main~1..origin/main --pretty=format:'%H|||%s|||%b%x00' --no-merges\", { encoding: \"utf8\" }).trim(); console.log(JSON.stringify(mod.parseConventionalCommit(commit), null, 2)); });"` parses the squash body from `#904` into conventional commits
- `pnpm typecheck`
