### PR TITLE
fix(ci): fallback to release sync PR on protected main

### DIFF
--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # Use GitHub App token to allow pushing to protected main branch
+          # Use the release app token for tags, releases, and sync PRs
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Environment
@@ -132,7 +132,26 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           echo "🚀 Running Changesets release..."
+
+          RELEASE_SYNC_BRANCH="changeset-release/main"
+          RELEASE_SYNC_PR_TITLE="chore: version packages"
+
+          EXISTING_SYNC_PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --head "$RELEASE_SYNC_BRANCH" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_SYNC_PR" ]; then
+            echo "ℹ️  Release sync PR #$EXISTING_SYNC_PR is still open"
+            echo "Skipping direct publish until that PR merges."
+            echo "published=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           # Store current version before release
           BEFORE_VERSION=$(node -p "require('./package.json').version")
@@ -166,6 +185,7 @@ jobs:
             # Commit version changes
             git add .
             git commit -m "chore(release): v$AFTER_VERSION [skip ci]"
+            RELEASE_COMMIT_SHA=$(git rev-parse HEAD)
 
             # Build packages
             pnpm run build
@@ -180,7 +200,6 @@ jobs:
               git tag "v$AFTER_VERSION"
               git push origin "v$AFTER_VERSION"
             fi
-            git push origin main
 
             # Create GitHub Release (idempotent - skip if release already exists)
             if gh release view "v$AFTER_VERSION" >/dev/null 2>&1; then
@@ -192,6 +211,51 @@ jobs:
                 --title "v$AFTER_VERSION" \
                 --notes "$RELEASE_NOTES" \
                 --latest
+            fi
+
+            if git push origin main; then
+              echo "✅ Synced release commit to main"
+            else
+              echo "⚠️  Direct push to protected main was rejected"
+              echo "Creating or updating a release sync PR instead..."
+
+              git push --force origin \
+                "$RELEASE_COMMIT_SHA:refs/heads/$RELEASE_SYNC_BRANCH"
+
+              SYNC_PR_BODY=$(printf '%s\n' \
+                "## Version Sync" \
+                "" \
+                "This PR syncs the already-published release commit for \`v$AFTER_VERSION\` back to \`main\`." \
+                "" \
+                "- Published packages: \`v$AFTER_VERSION\`" \
+                "- Release tag: \`v$AFTER_VERSION\`" \
+                "- Source workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+                "" \
+                "Merge this PR to bring package versions and changelogs back onto \`main\`." \
+              )
+
+              EXISTING_SYNC_PR=$(gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --state open \
+                --head "$RELEASE_SYNC_BRANCH" \
+                --json number \
+                --jq '.[0].number // empty')
+
+              if [ -n "$EXISTING_SYNC_PR" ]; then
+                gh pr edit "$EXISTING_SYNC_PR" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --title "$RELEASE_SYNC_PR_TITLE" \
+                  --body "$SYNC_PR_BODY"
+                echo "✅ Updated release sync PR #$EXISTING_SYNC_PR"
+              else
+                gh pr create \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base main \
+                  --head "$RELEASE_SYNC_BRANCH" \
+                  --title "$RELEASE_SYNC_PR_TITLE" \
+                  --body "$SYNC_PR_BODY"
+                echo "✅ Created release sync PR from $RELEASE_SYNC_BRANCH"
+              fi
             fi
 
             echo "published=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- create the GitHub release before trying to sync the release commit back to main
- fall back to updating `changeset-release/main` and opening/editing a `chore: version packages` PR when protected branch rules reject `git push origin main`
- skip direct publish runs while that sync PR is still open to avoid duplicate publishes from an out-of-date main version

## Validation
- `yamllint -c .github/.yamllint.yml .github/workflows/shared-direct-publish.yml`
- `act --list`
- local pre-commit/pre-push hooks (`validate-workflows`, `typecheck`)

## Context
Run 23075928397 published/tagged `v0.71.17` but then failed on `git push origin main` with `GH006: Protected branch update failed`, so this preserves the publish and routes the version sync through PRs instead.