### PR TITLE
fix(release): republish analytics with GA4 fix

### DIFF
--- a/.changeset/ga4-republish-908.md
+++ b/.changeset/ga4-republish-908.md
@@ -1,0 +1,10 @@
+---
+"@happyvertical/analytics": patch
+---
+
+Cut a fresh `@happyvertical/analytics` release so downstream installs pick up the
+GA4 property discovery and bounded hydration fixes from `#904`.
+
+The published `0.71.17` artifact still contains the pre-`#904` GA4
+implementation, so this changeset forces a distinct version with the corrected
+build output.


### PR DESCRIPTION
## Summary
- add a manual changeset to force a fresh @happyvertical/analytics release
- document that the published 0.71.17 artifact still contains the pre-#904 GA4 implementation
- ensure downstream apps can install a distinct version with the corrected GA4 build output

## Testing
- pre-push hook: `pnpm typecheck`

Closes #908