### PR TITLE
fix(ci): use mounted pnpm store on ARC runners

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -50,9 +50,9 @@ runs:
     - name: Configure pnpm store directory
       shell: bash
       run: |
-        store_root="${PNPM_STORE_DIR:-/home/runner/.local/share/pnpm/store}"
+        store_root="${PNPM_STORE_DIR:-$HOME/.local/share/pnpm/store}"
         mkdir -p "$store_root"
-        pnpm config set store-dir "$store_root" --location=user
+        pnpm config set store-dir "$store_root" --location=global
 
     - name: Get pnpm store directory
       id: pnpm-store

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,9 +70,9 @@ jobs:
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"
         shell: bash
         run: |
-          store_root="${PNPM_STORE_DIR:-/home/runner/.local/share/pnpm/store}"
+          store_root="${PNPM_STORE_DIR:-$HOME/.local/share/pnpm/store}"
           mkdir -p "$store_root"
-          pnpm config set store-dir "$store_root" --location=user
+          pnpm config set store-dir "$store_root" --location=global
 
       - name: Install dependencies
         if: "github.event.action == 'labeled' && github.event.label.name == 'agent: claude'"

--- a/.github/workflows/on-pr-main-dependabot.yml
+++ b/.github/workflows/on-pr-main-dependabot.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Configure pnpm store directory
         shell: bash
         run: |
-          store_root="${PNPM_STORE_DIR:-/home/runner/.local/share/pnpm/store}"
+          store_root="${PNPM_STORE_DIR:-$HOME/.local/share/pnpm/store}"
           mkdir -p "$store_root"
-          pnpm config set store-dir "$store_root" --location=user
+          pnpm config set store-dir "$store_root" --location=global
 
       - name: Install dependencies for security audit
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,9 +65,9 @@ jobs:
       - name: Configure pnpm store directory
         shell: bash
         run: |
-          store_root="${PNPM_STORE_DIR:-/home/runner/.local/share/pnpm/store}"
+          store_root="${PNPM_STORE_DIR:-$HOME/.local/share/pnpm/store}"
           mkdir -p "$store_root"
-          pnpm config set store-dir "$store_root" --location=user
+          pnpm config set store-dir "$store_root" --location=global
 
       - name: Get pnpm store directory
         id: pnpm-store


### PR DESCRIPTION
## Summary
- configure pnpm to use the mounted ARC tmpfs store before resolving the cache path
- apply the same fix to sdk workflows that bypass the shared setup action
- keep installs on the shared RAM-backed cache instead of the default per-runner store path

## Why
Live arc-happyvertical runners expose the persistent pnpm cache at `/home/runner/.local/share/pnpm/store`, but pnpm defaults to `/home/runner/.pnpm-store/v10` unless `store-dir` is set explicitly. That means workflow installs miss the shared tmpfs cache and rebuild more work than necessary.