### PR TITLE
chore(release): republish context installer bins

### DIFF
--- a/.changeset/republish-context-bins.md
+++ b/.changeset/republish-context-bins.md
@@ -1,0 +1,7 @@
+---
+'@happyvertical/encryption': patch
+'@happyvertical/weather': patch
+---
+
+Republish the context installer bins so `have-encryption-context` and
+`have-weather-context` point at built CLI files in published packages.


### PR DESCRIPTION
## Summary
- add a changeset to republish the context installer bin fix wave
- ensure published packages stop shipping missing `dist/cli/claude-context.js` entries
- specifically unblock downstream warnings from `@happyvertical/weather` and `@happyvertical/encryption`

## Why
The source-side fix for publishing context bins is already on `main`, but the broken published artifacts are still what downstream consumers see today. This changeset nudges a fresh release so the built context installer bins actually make it out to GitHub Packages.

## Verification
- `pnpm --dir packages/weather build`
- `pnpm --dir packages/encryption build`
- `pnpm changeset status`
- `git push` pre-push `turbo run typecheck`

## Notes
Changesets will cascade patch bumps through dependent SDK packages, so this PR is intentionally framed as a republish wave rather than a two-package-only release.