### PR TITLE
fix(sql): pass scalar params to secrets key version lookup

### DIFF
--- a/.changeset/fix-secrets-list-key-versions.md
+++ b/.changeset/fix-secrets-list-key-versions.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/secrets': patch
+---
+
+Pass tenant key version queries through the raw SQL adapter with scalar parameters so PostgreSQL resolves tenant key versions correctly.

--- a/packages/secrets/src/__tests__/database-store.test.ts
+++ b/packages/secrets/src/__tests__/database-store.test.ts
@@ -1,5 +1,5 @@
 import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DatabaseSecretStore } from '../adapters/database.js';
 import { EnvelopeEncryption } from '../shared/envelope.js';
 import {
@@ -260,6 +260,17 @@ describe('DatabaseSecretStore', () => {
     it('returns empty array for non-existent tenant', async () => {
       const versions = await store.listKeyVersions('non-existent');
       expect(versions).toEqual([]);
+    });
+
+    it('passes the tenant id directly to the raw query adapter', async () => {
+      const querySpy = vi.spyOn(db, 'query');
+
+      await store.listKeyVersions(testTenantId);
+
+      expect(querySpy).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE tenant_id = ? ORDER BY version DESC'),
+        testTenantId,
+      );
     });
   });
 

--- a/packages/secrets/src/adapters/database.ts
+++ b/packages/secrets/src/adapters/database.ts
@@ -516,10 +516,10 @@ export class DatabaseSecretStore implements SecretStore {
 
     const { rows } = await this.db.query(
       `SELECT * FROM "${this.keysTable}" WHERE tenant_id = ? ORDER BY version DESC`,
-      [tenantId],
+      tenantId,
     );
 
-    return rows.map((row) => this.parseKeyRow(row as Record<string, unknown>));
+    return rows.map((row: Record<string, unknown>) => this.parseKeyRow(row));
   }
 
   /**


### PR DESCRIPTION
## Summary
- pass `tenantId` directly to the raw SQL adapter in `DatabaseSecretStore.listKeyVersions()`
- add a regression test that asserts the raw query receives a scalar tenant id
- add a changeset so `@happyvertical/secrets` can be republished without a repo-local patch downstream

## Verification
- `pnpm --filter @happyvertical/utils build`
- `pnpm --filter @happyvertical/sql build`
- `pnpm --filter @happyvertical/secrets build`
- `pnpm --filter @happyvertical/secrets test`

## Notes
- `happyvertical/sdk#938` is still open, so the publish workflow may need that release-sync PR merged before it can publish the next package version.