### PR TITLE
chore(release): trigger 0.71.21 publish

### DIFF
--- a/.changeset/release-secrets-0-71-21.md
+++ b/.changeset/release-secrets-0-71-21.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/secrets': patch
+---
+
+Republish the tenant key version lookup fix in a fresh package release now that the `0.71.20` release sync has landed on `main`.


### PR DESCRIPTION
## Summary
- add a release-only changeset so the next SDK publish bumps past the already-shipped `v0.71.20` release
- queue a fresh `@happyvertical/secrets` patch release now that the tenant key version lookup fix is on `main`
- keep the diff intentionally minimal: changeset only, no code changes

## Why
- `v0.71.20` was already published before the secrets fix landed on `main`
- merging the fix and the release sync PR brought the code onto `main`, but did not create a new package version
- this PR forces the next publish to become `v0.71.21`, which is the first release line that can actually carry the secrets fix downstream

## Verification
- `git diff --check`
- `pnpm install --frozen-lockfile`
- `git push -u origin codex/release-secrets-0-71-21` (pre-push `typecheck` hook passed)

## Notes
- because the repo uses a fixed-version workspace, this changeset will advance the shared `@happyvertical/*` release line, even though the user-facing intent here is to ship the secrets fix