### PR TITLE
fix(ci): standardize direct release automation

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -96,10 +96,10 @@ jobs:
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           # Check for releaseable conventional commits
-          # (feat, fix, perf, breaking changes)
+          # (feat, fix, perf, chore(deps), breaking changes)
           RELEASEABLE_COMMITS=$(git log \
             $BASE_SHA..$HEAD_SHA --pretty=format:"%s" --no-merges | \
-            grep -E '^(feat|fix|perf)(\(.+\))?!?:|BREAKING CHANGE' \
+            grep -E '^(feat|fix|perf)(\(.+\))?!?:|^chore\(deps\)!?:|BREAKING CHANGE' \
             || true)
 
           if [ -n "$RELEASEABLE_COMMITS" ]; then
@@ -130,7 +130,7 @@ jobs:
           fi
 
           echo "ℹ️  No releaseable conventional commits found"
-          echo "(feat, fix, perf, or breaking changes)"
+          echo "(feat, fix, perf, chore(deps), or breaking changes)"
           echo ""
 
           # Check if explicit changeset files exist (excluding README.md)
@@ -140,8 +140,9 @@ jobs:
           if [ "$changeset_count" -eq 0 ]; then
             echo "✅ No explicit changeset required for this PR"
             echo ""
-            echo "This PR will merge without a version bump unless the" \
-              "final merge commit triggers the on-main auto changeset rules."
+            echo "This PR will merge without a version bump unless" \
+              "non-merge commits on main (including squash/rebase commits)" \
+              "match the on-main auto changeset rules."
             exit 0
           fi
 

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -133,21 +133,16 @@ jobs:
           echo "(feat, fix, perf, or breaking changes)"
           echo ""
 
-          # Check if changeset files exist (excluding README.md)
+          # Check if explicit changeset files exist (excluding README.md)
           changeset_count=$(find .changeset -name '*.md' \
             ! -name 'README.md' 2>/dev/null | wc -l)
 
           if [ "$changeset_count" -eq 0 ]; then
-            echo "❌ No changeset found"
+            echo "✅ No explicit changeset required for this PR"
             echo ""
-            echo "Please add a changeset by running:"
-            echo "  npx changeset"
-            echo ""
-            echo "Or add the 'skip-changeset' label if this PR" \
-              "doesn't require a version bump"
-            echo "(e.g., documentation changes, test updates," \
-              "workflow changes)"
-            exit 1
+            echo "This PR will merge without a version bump unless the" \
+              "final merge commit triggers the on-main auto changeset rules."
+            exit 0
           fi
 
           echo "✅ Found $changeset_count changeset(s)"

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # Use the release app token for tags, releases, and sync PRs
+          # Use the release app token for tags, releases, and main-branch sync
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Environment
@@ -140,24 +140,6 @@ jobs:
 
           echo "🚀 Running Changesets release..."
 
-          RELEASE_SYNC_BRANCH="changeset-release/main"
-          RELEASE_SYNC_PR_TITLE="chore: version packages"
-
-          EXISTING_SYNC_PR=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --state open \
-            --head "$RELEASE_SYNC_BRANCH" \
-            --json number \
-            --jq '.[0].number // empty')
-
-          if [ -n "$EXISTING_SYNC_PR" ]; then
-            echo "ℹ️  Release sync PR #$EXISTING_SYNC_PR is still open"
-            echo "Skipping direct publish until that PR merges."
-            echo "published=false" >> $GITHUB_OUTPUT
-            echo "reason=release_sync_pr_open:$EXISTING_SYNC_PR" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
           # Store current version before release
           BEFORE_VERSION=$(node -p "require('./package.json').version")
           echo "Version before release: $BEFORE_VERSION"
@@ -190,7 +172,6 @@ jobs:
             # Commit version changes
             git add .
             git commit -m "chore(release): v$AFTER_VERSION [skip ci]"
-            RELEASE_COMMIT_SHA=$(git rev-parse HEAD)
 
             # Build packages
             pnpm run build
@@ -221,50 +202,10 @@ jobs:
                 --latest
             fi
 
-            if git push origin main; then
-              echo "✅ Synced release commit to main"
-            else
-              echo "⚠️  Direct push to protected main was rejected"
-              echo "Creating or updating a release sync PR instead..."
-
-              git push --force origin \
-                "$RELEASE_COMMIT_SHA:refs/heads/$RELEASE_SYNC_BRANCH"
-
-              SYNC_PR_BODY=$(printf '%s\n' \
-                "## Version Sync" \
-                "" \
-                "This PR syncs the already-published release commit for \`v$AFTER_VERSION\` back to \`main\`." \
-                "" \
-                "- Published packages: \`v$AFTER_VERSION\`" \
-                "- Release tag: \`v$AFTER_VERSION\`" \
-                "- Source workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-                "" \
-                "Merge this PR to bring package versions and changelogs back onto \`main\`." \
-              )
-
-              EXISTING_SYNC_PR=$(gh pr list \
-                --repo "$GITHUB_REPOSITORY" \
-                --state open \
-                --head "$RELEASE_SYNC_BRANCH" \
-                --json number \
-                --jq '.[0].number // empty')
-
-              if [ -n "$EXISTING_SYNC_PR" ]; then
-                gh pr edit "$EXISTING_SYNC_PR" \
-                  --repo "$GITHUB_REPOSITORY" \
-                  --title "$RELEASE_SYNC_PR_TITLE" \
-                  --body "$SYNC_PR_BODY"
-                echo "✅ Updated release sync PR #$EXISTING_SYNC_PR"
-              else
-                gh pr create \
-                  --repo "$GITHUB_REPOSITORY" \
-                  --base main \
-                  --head "$RELEASE_SYNC_BRANCH" \
-                  --title "$RELEASE_SYNC_PR_TITLE" \
-                  --body "$SYNC_PR_BODY"
-                echo "✅ Created release sync PR from $RELEASE_SYNC_BRANCH"
-              fi
-            fi
+            # Direct publish depends on branch rules allowing the release app
+            # to bypass pull-request-only enforcement on main.
+            git push origin main
+            echo "✅ Synced release commit to main"
 
             echo "published=true" >> $GITHUB_OUTPUT
             echo "version=$AFTER_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -179,6 +179,46 @@ jobs:
             # Validate publishable artifacts before pushing packages
             pnpm run validate-build
 
+            sync_target="HEAD:main"
+            sync_rebuild_required=0
+
+            sync_release_commit() {
+              local attempt=1
+              while [ "$attempt" -le 3 ]; do
+                if git push origin "$sync_target"; then
+                  echo "✅ Synced release commit to main"
+                  return 0
+                fi
+
+                echo "⚠️  Main sync failed (attempt $attempt/3)"
+
+                git fetch origin main --quiet || true
+                if git rebase origin/main; then
+                  sync_rebuild_required=1
+                  echo "🔁 Rebased release commit onto latest main"
+                else
+                  echo "❌ Release commit could not be rebased onto latest main"
+                  exit 1
+                fi
+
+                sleep $((attempt * 5))
+                attempt=$((attempt + 1))
+              done
+
+              echo "❌ Failed to sync release commit to main before publish"
+              exit 1
+            }
+
+            # Sync the release commit before publishing so main stays aligned
+            # with the version/changelog state we are about to publish.
+            sync_release_commit
+
+            if [ "$sync_rebuild_required" -eq 1 ]; then
+              echo "🔁 Rebuilding release artifacts after rebasing onto latest main"
+              pnpm run build
+              pnpm run validate-build
+            fi
+
             # Publish packages
             pnpm run changeset:publish
 
@@ -201,11 +241,6 @@ jobs:
                 --notes "$RELEASE_NOTES" \
                 --latest
             fi
-
-            # Direct publish depends on branch rules allowing the release app
-            # to bypass pull-request-only enforcement on main.
-            git push origin main
-            echo "✅ Synced release commit to main"
 
             echo "published=true" >> $GITHUB_OUTPUT
             echo "version=$AFTER_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -64,9 +64,6 @@ jobs:
             echo "- **Build + Publish**: $publish_result" >> $GITHUB_STEP_SUMMARY
           elif [ -n "$publish_version" ]; then
             echo "- **Build + Publish**: success (published v$publish_version)" >> $GITHUB_STEP_SUMMARY
-          elif [ "${publish_reason#release_sync_pr_open:}" != "$publish_reason" ]; then
-            sync_pr_number="${publish_reason#release_sync_pr_open:}"
-            echo "- **Build + Publish**: success (publish skipped: release sync PR #$sync_pr_number is still open)" >> $GITHUB_STEP_SUMMARY
           elif [ "$publish_reason" = "no_version_changes" ]; then
             echo "- **Build + Publish**: success (no version changes detected)" >> $GITHUB_STEP_SUMMARY
           else

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>happyvertical/renovate-config:sdk"]
+  "extends": ["local>happyvertical/renovate-config:sdk"],
+  "packageRules": [
+    {
+      "description": "Automerge minor and patch updates on green branches",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,10 @@
   "extends": ["local>happyvertical/renovate-config:sdk"],
   "packageRules": [
     {
-      "description": "Automerge minor and patch updates on green branches",
+      "description": "Automerge minor and patch updates on green PRs",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## What changed

This standardizes the SDK repo around direct publish-on-merge behavior instead of the fragile release sync PR fallback.

It:
- removes the `changeset-release/main` fallback flow from the shared direct publish workflow
- simplifies the PR changeset check so manual changesets are optional when no releasable conventional commits are present
- removes the obsolete release-sync summary path
- makes Renovate minor/patch branch automerge explicit in repo config

## Why

The old fallback could leave published versions and changelogs waiting in a separate sync PR for days, which made the release state fragile and drift-prone.

## Impact

Merges to `main` continue to test, version, publish, tag, and release, but now the workflow expects direct main-branch sync via the release app.

Note: matching GitHub branch rules were updated directly on the repository so `main` is enforced via rulesets with required checks plus release-bot bypass. That settings change is intentionally not part of this code diff.

## Validation

- `yamllint -c .github/.yamllint.yml .github/workflows/shared-direct-publish.yml .github/workflows/shared-merge-orchestrator.yml .github/workflows/changeset-check.yml`
- `jq . renovate.json >/dev/null && jq . .changeset/config.json >/dev/null`
- local pre-commit workflow validation hook
- local pre-push `pnpm run typecheck`
