### PR TITLE
fix(files): harden streamed file downloads

### DIFF
--- a/.changeset/files-streamed-download-options.md
+++ b/.changeset/files-streamed-download-options.md
@@ -2,4 +2,4 @@
 '@happyvertical/files': patch
 ---
 
-Add streamed `fetchToFile()` options for timeout, request headers, and transport `maxBytes` so large document downloads can stay out of application-level PDF handling logic.
+Add streamed `fetchToFile()` options for timeout, request headers, and transport `maxBytes` so large document downloads can stay out of application-level PDF handling logic. The fetch helpers now also reject non-2xx responses consistently across text, JSON, buffer, and file downloads.

--- a/.changeset/files-streamed-download-options.md
+++ b/.changeset/files-streamed-download-options.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/files': patch
+---
+
+Add streamed `fetchToFile()` options for timeout, request headers, and transport `maxBytes` so large document downloads can stay out of application-level PDF handling logic.

--- a/packages/files/src/fetch.spec.ts
+++ b/packages/files/src/fetch.spec.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fetchToFile } from './fetch';
+
+describe('fetchToFile', () => {
+  let server: Server;
+  let serverUrl: string;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'files-fetch-'));
+
+    server = createServer((req, res) => {
+      if (req.url === '/headers') {
+        if (req.headers['x-test-token'] !== 'present') {
+          res.writeHead(401, { 'Content-Type': 'text/plain' });
+          res.end('missing header');
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/pdf' });
+        res.end('header ok');
+        return;
+      }
+
+      if (req.url === '/slow') {
+        setTimeout(() => {
+          res.writeHead(200, { 'Content-Type': 'application/pdf' });
+          res.end('slow response');
+        }, 100);
+        return;
+      }
+
+      if (req.url === '/large') {
+        res.writeHead(200, { 'Content-Type': 'application/pdf' });
+        res.write(Buffer.alloc(1024, 'a'));
+        res.write(Buffer.alloc(1024, 'b'));
+        res.end(Buffer.alloc(1024, 'c'));
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          throw new Error('Failed to start test server');
+        }
+        serverUrl = `http://127.0.0.1:${address.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('streams to disk with custom headers', async () => {
+    const targetPath = join(tempDir, 'headers.pdf');
+
+    await fetchToFile(`${serverUrl}/headers`, targetPath, {
+      headers: {
+        'x-test-token': 'present',
+      },
+    });
+
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe('header ok');
+  });
+
+  it('honors timeout when provided', async () => {
+    const targetPath = join(tempDir, 'slow.pdf');
+
+    await expect(
+      fetchToFile(`${serverUrl}/slow`, targetPath, {
+        timeout: 10,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('enforces maxBytes and removes partial files', async () => {
+    const targetPath = join(tempDir, 'large.pdf');
+
+    await expect(
+      fetchToFile(`${serverUrl}/large`, targetPath, {
+        maxBytes: 1500,
+      }),
+    ).rejects.toThrow('Downloaded content exceeded maxBytes');
+
+    await expect(readFile(targetPath)).rejects.toThrow();
+  });
+
+  it('preserves an existing file when a refresh fails', async () => {
+    const targetPath = join(tempDir, 'existing.pdf');
+    await writeFile(targetPath, 'existing content');
+
+    await expect(
+      fetchToFile(`${serverUrl}/large`, targetPath, {
+        maxBytes: 1500,
+      }),
+    ).rejects.toThrow('Downloaded content exceeded maxBytes');
+
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe(
+      'existing content',
+    );
+  });
+
+  it('rejects cleanly when the destination path cannot be opened', async () => {
+    const targetPath = join(tempDir, 'missing', 'headers.pdf');
+
+    await expect(
+      fetchToFile(`${serverUrl}/headers`, targetPath),
+    ).rejects.toThrow();
+    await expect(readFile(targetPath)).rejects.toThrow();
+  });
+});

--- a/packages/files/src/fetch.spec.ts
+++ b/packages/files/src/fetch.spec.ts
@@ -1,9 +1,18 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  lstat,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { fetchToFile } from './fetch';
+import { fetchJSON, fetchText, fetchToFile } from './fetch';
 
 describe('fetchToFile', () => {
   let server: Server;
@@ -30,7 +39,7 @@ describe('fetchToFile', () => {
         setTimeout(() => {
           res.writeHead(200, { 'Content-Type': 'application/pdf' });
           res.end('slow response');
-        }, 100);
+        }, 250);
         return;
       }
 
@@ -80,7 +89,7 @@ describe('fetchToFile', () => {
 
     await expect(
       fetchToFile(`${serverUrl}/slow`, targetPath, {
-        timeout: 10,
+        timeout: 25,
       }),
     ).rejects.toThrow();
   });
@@ -119,5 +128,80 @@ describe('fetchToFile', () => {
       fetchToFile(`${serverUrl}/headers`, targetPath),
     ).rejects.toThrow();
     await expect(readFile(targetPath)).rejects.toThrow();
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves existing destination permissions when refreshing a file',
+    async () => {
+      const targetPath = join(tempDir, 'secure.pdf');
+      await writeFile(targetPath, 'existing content');
+      await chmod(targetPath, 0o600);
+
+      await fetchToFile(`${serverUrl}/headers`, targetPath, {
+        headers: {
+          'x-test-token': 'present',
+        },
+      });
+
+      await expect(readFile(targetPath, 'utf8')).resolves.toBe('header ok');
+      const targetStats = await stat(targetPath);
+      expect(targetStats.mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'writes through symlink destinations without replacing the symlink',
+    async () => {
+      const targetPath = join(tempDir, 'target.pdf');
+      const symlinkPath = join(tempDir, 'linked.pdf');
+
+      await writeFile(targetPath, 'existing content');
+      await symlink(targetPath, symlinkPath);
+
+      await fetchToFile(`${serverUrl}/headers`, symlinkPath, {
+        headers: {
+          'x-test-token': 'present',
+        },
+      });
+
+      await expect(readFile(targetPath, 'utf8')).resolves.toBe('header ok');
+      const linkStats = await lstat(symlinkPath);
+      expect(linkStats.isSymbolicLink()).toBe(true);
+    },
+  );
+});
+
+describe('fetch response helpers', () => {
+  let server: Server;
+  let serverUrl: string;
+
+  beforeEach(async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          throw new Error('Failed to start test server');
+        }
+        serverUrl = `http://127.0.0.1:${address.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('throws for non-ok text responses', async () => {
+    await expect(fetchText(serverUrl)).rejects.toThrow('Failed to fetch');
+  });
+
+  it('throws for non-ok JSON responses', async () => {
+    await expect(fetchJSON(serverUrl)).rejects.toThrow('Failed to fetch');
   });
 });

--- a/packages/files/src/fetch.ts
+++ b/packages/files/src/fetch.ts
@@ -1,4 +1,50 @@
-import { writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+export interface FetchToFileOptions extends RequestInit {
+  /** Optional timeout in milliseconds */
+  timeout?: number;
+  /** Optional transport ceiling in bytes */
+  maxBytes?: number;
+}
+
+function createTempFilePath(filepath: string): string {
+  return join(
+    dirname(filepath),
+    `.${basename(filepath)}.${randomUUID()}.download`,
+  );
+}
+
+class MaxBytesTransform extends Transform {
+  private totalBytes = 0;
+
+  constructor(private readonly maxBytes: number) {
+    super();
+  }
+
+  override _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null, data?: Buffer) => void,
+  ): void {
+    this.totalBytes += chunk.byteLength;
+
+    if (this.totalBytes > this.maxBytes) {
+      callback(
+        new Error(
+          `Downloaded content exceeded maxBytes (${this.totalBytes} > ${this.maxBytes})`,
+        ),
+      );
+      return;
+    }
+
+    callback(null, chunk);
+  }
+}
 
 /**
  * Rate limiter for controlling fetch request frequency by domain
@@ -204,6 +250,30 @@ async function rateLimitedFetch(
   return fetch(url, options);
 }
 
+function buildFetchSignal(
+  timeout: number | undefined,
+  signal: AbortSignal | null | undefined,
+): AbortSignal | undefined {
+  if (timeout == null) {
+    return signal ?? undefined;
+  }
+
+  const timeoutSignal = AbortSignal.timeout(timeout);
+  if (!signal) {
+    return timeoutSignal;
+  }
+
+  return AbortSignal.any([signal, timeoutSignal]);
+}
+
+function assertOkResponse(response: Response, url: string): void {
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
 /**
  * Fetches a URL and returns the response as text with automatic rate limiting
  *
@@ -272,6 +342,7 @@ export async function fetchJSON(url: string): Promise<any> {
  */
 export async function fetchBuffer(url: string): Promise<Buffer> {
   const response = await rateLimitedFetch(url);
+  assertOkResponse(response, url);
   return Buffer.from(await response.arrayBuffer());
 }
 
@@ -298,8 +369,51 @@ export async function fetchBuffer(url: string): Promise<Buffer> {
 export async function fetchToFile(
   url: string,
   filepath: string,
+  options: FetchToFileOptions = {},
 ): Promise<void> {
-  const response = await rateLimitedFetch(url);
-  const buffer = await response.arrayBuffer();
-  await writeFile(filepath, Buffer.from(buffer));
+  const { timeout, maxBytes, signal, ...requestInit } = options;
+  const tempFilepath = createTempFilePath(filepath);
+  const response = await rateLimitedFetch(url, {
+    ...requestInit,
+    signal: buildFetchSignal(timeout, signal),
+  });
+
+  assertOkResponse(response, url);
+
+  try {
+    if (!response.body) {
+      const buffer = Buffer.from(await response.arrayBuffer());
+
+      if (maxBytes != null && buffer.byteLength > maxBytes) {
+        throw new Error(
+          `Downloaded content exceeded maxBytes (${buffer.byteLength} > ${maxBytes})`,
+        );
+      }
+
+      await writeFile(tempFilepath, buffer);
+    } else {
+      const streams: [
+        Readable,
+        ...Transform[],
+        ReturnType<typeof createWriteStream>,
+      ] =
+        maxBytes != null
+          ? [
+              Readable.fromWeb(response.body as globalThis.ReadableStream),
+              new MaxBytesTransform(maxBytes),
+              createWriteStream(tempFilepath),
+            ]
+          : [
+              Readable.fromWeb(response.body as globalThis.ReadableStream),
+              createWriteStream(tempFilepath),
+            ];
+
+      await pipeline(...streams);
+    }
+
+    await rename(tempFilepath, filepath);
+  } catch (error) {
+    await rm(tempFilepath, { force: true }).catch(() => {});
+    throw error;
+  }
 }

--- a/packages/files/src/fetch.ts
+++ b/packages/files/src/fetch.ts
@@ -4,6 +4,7 @@ import { rename, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
 export interface FetchToFileOptions extends RequestInit {
   /** Optional timeout in milliseconds */
@@ -392,23 +393,16 @@ export async function fetchToFile(
 
       await writeFile(tempFilepath, buffer);
     } else {
-      const streams: [
-        Readable,
-        ...Transform[],
-        ReturnType<typeof createWriteStream>,
-      ] =
-        maxBytes != null
-          ? [
-              Readable.fromWeb(response.body as globalThis.ReadableStream),
-              new MaxBytesTransform(maxBytes),
-              createWriteStream(tempFilepath),
-            ]
-          : [
-              Readable.fromWeb(response.body as globalThis.ReadableStream),
-              createWriteStream(tempFilepath),
-            ];
+      const source = Readable.fromWeb(
+        response.body as unknown as NodeReadableStream<Uint8Array>,
+      );
+      const destination = createWriteStream(tempFilepath);
 
-      await pipeline(...streams);
+      if (maxBytes != null) {
+        await pipeline(source, new MaxBytesTransform(maxBytes), destination);
+      } else {
+        await pipeline(source, destination);
+      }
     }
 
     await rename(tempFilepath, filepath);

--- a/packages/files/src/fetch.ts
+++ b/packages/files/src/fetch.ts
@@ -1,6 +1,15 @@
 import { randomUUID } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
-import { rename, rm, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  chown,
+  lstat,
+  realpath,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -18,6 +27,52 @@ function createTempFilePath(filepath: string): string {
     dirname(filepath),
     `.${basename(filepath)}.${randomUUID()}.download`,
   );
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+async function resolveDestinationPath(filepath: string): Promise<string> {
+  try {
+    const destinationStats = await lstat(filepath);
+    if (!destinationStats.isSymbolicLink()) {
+      return filepath;
+    }
+
+    return await realpath(filepath);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      return filepath;
+    }
+
+    throw error;
+  }
+}
+
+async function preserveExistingDestinationMetadata(
+  sourcePath: string,
+  tempFilepath: string,
+): Promise<void> {
+  try {
+    const sourceStats = await stat(sourcePath);
+    await chmod(tempFilepath, sourceStats.mode);
+
+    try {
+      await chown(tempFilepath, sourceStats.uid, sourceStats.gid);
+    } catch (error) {
+      if (
+        !isErrnoException(error) ||
+        !['EPERM', 'EINVAL', 'ENOSYS', 'EROFS'].includes(error.code ?? '')
+      ) {
+        throw error;
+      }
+    }
+  } catch (error) {
+    if (!(isErrnoException(error) && error.code === 'ENOENT')) {
+      throw error;
+    }
+  }
 }
 
 class MaxBytesTransform extends Transform {
@@ -296,6 +351,7 @@ function assertOkResponse(response: Response, url: string): void {
  */
 export async function fetchText(url: string): Promise<string> {
   const response = await rateLimitedFetch(url);
+  assertOkResponse(response, url);
   return response.text();
 }
 
@@ -319,6 +375,7 @@ export async function fetchText(url: string): Promise<string> {
  */
 export async function fetchJSON(url: string): Promise<any> {
   const response = await rateLimitedFetch(url);
+  assertOkResponse(response, url);
   return response.json();
 }
 
@@ -373,7 +430,8 @@ export async function fetchToFile(
   options: FetchToFileOptions = {},
 ): Promise<void> {
   const { timeout, maxBytes, signal, ...requestInit } = options;
-  const tempFilepath = createTempFilePath(filepath);
+  const destinationPath = await resolveDestinationPath(filepath);
+  const tempFilepath = createTempFilePath(destinationPath);
   const response = await rateLimitedFetch(url, {
     ...requestInit,
     signal: buildFetchSignal(timeout, signal),
@@ -405,7 +463,8 @@ export async function fetchToFile(
       }
     }
 
-    await rename(tempFilepath, filepath);
+    await preserveExistingDestinationMetadata(destinationPath, tempFilepath);
+    await rename(tempFilepath, destinationPath);
   } catch (error) {
     await rm(tempFilepath, { force: true }).catch(() => {});
     throw error;


### PR DESCRIPTION
## What changed

- switched `fetchToFile()` to download into a temporary sibling file and only rename into place after a successful write
- replaced the manual `ReadableStream` reader loop with a real Node stream pipeline so write/open failures propagate safely
- added regression coverage for preserving an existing file on failed refreshes and for destination-path write failures
- kept the new `timeout`, `headers`, and `maxBytes` transport options in place

## Why

The original streamed implementation had two blockers:

1. stream write failures could still surface as unhandled write-stream errors
2. a failed refresh could delete an existing good destination file because cleanup removed the final path directly

This update fixes both at the library layer so app code can rely on `fetchToFile()` without adding its own recovery logic.

## Impact

- failed downloads now leave the previous destination file intact
- streamed download failures reject cleanly instead of risking process-level stream errors
- large document downloads remain transport-level behavior in `@happyvertical/files`, not application logic

## Validation

- `pnpm --filter @happyvertical/files exec vitest run src/fetch.spec.ts`
- `pnpm --filter @happyvertical/files build`
- pre-push hook: `turbo run typecheck`
