### PR TITLE
fix(ci): restore release sync PR fallback

### DIFF
--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -140,6 +140,24 @@ jobs:
 
           echo "🚀 Running Changesets release..."
 
+          RELEASE_SYNC_BRANCH="changeset-release/main"
+          RELEASE_SYNC_PR_TITLE="chore: version packages"
+
+          EXISTING_SYNC_PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --head "$RELEASE_SYNC_BRANCH" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_SYNC_PR" ]; then
+            echo "ℹ️  Release sync PR #$EXISTING_SYNC_PR is still open"
+            echo "Skipping direct publish until that PR merges."
+            echo "published=false" >> $GITHUB_OUTPUT
+            echo "reason=awaiting_release_sync_pr" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Store current version before release
           BEFORE_VERSION=$(node -p "require('./package.json').version")
           echo "Version before release: $BEFORE_VERSION"
@@ -172,52 +190,13 @@ jobs:
             # Commit version changes
             git add .
             git commit -m "chore(release): v$AFTER_VERSION [skip ci]"
+            RELEASE_COMMIT_SHA=$(git rev-parse HEAD)
 
             # Build packages
             pnpm run build
 
             # Validate publishable artifacts before pushing packages
             pnpm run validate-build
-
-            sync_target="HEAD:main"
-            sync_rebuild_required=0
-
-            sync_release_commit() {
-              local attempt=1
-              while [ "$attempt" -le 3 ]; do
-                if git push origin "$sync_target"; then
-                  echo "✅ Synced release commit to main"
-                  return 0
-                fi
-
-                echo "⚠️  Main sync failed (attempt $attempt/3)"
-
-                git fetch origin main --quiet || true
-                if git rebase origin/main; then
-                  sync_rebuild_required=1
-                  echo "🔁 Rebased release commit onto latest main"
-                else
-                  echo "❌ Release commit could not be rebased onto latest main"
-                  exit 1
-                fi
-
-                sleep $((attempt * 5))
-                attempt=$((attempt + 1))
-              done
-
-              echo "❌ Failed to sync release commit to main before publish"
-              exit 1
-            }
-
-            # Sync the release commit before publishing so main stays aligned
-            # with the version/changelog state we are about to publish.
-            sync_release_commit
-
-            if [ "$sync_rebuild_required" -eq 1 ]; then
-              echo "🔁 Rebuilding release artifacts after rebasing onto latest main"
-              pnpm run build
-              pnpm run validate-build
-            fi
 
             # Publish packages
             pnpm run changeset:publish
@@ -240,6 +219,51 @@ jobs:
                 --title "v$AFTER_VERSION" \
                 --notes "$RELEASE_NOTES" \
                 --latest
+            fi
+
+            if git push origin main; then
+              echo "✅ Synced release commit to main"
+            else
+              echo "⚠️  Direct push to protected main was rejected"
+              echo "Creating or updating a release sync PR instead..."
+
+              git push --force origin \
+                "$RELEASE_COMMIT_SHA:refs/heads/$RELEASE_SYNC_BRANCH"
+
+              SYNC_PR_BODY=$(printf '%s\n' \
+                "## Version Sync" \
+                "" \
+                "This PR syncs the already-published release commit for \`v$AFTER_VERSION\` back to \`main\`." \
+                "" \
+                "- Published packages: \`v$AFTER_VERSION\`" \
+                "- Release tag: \`v$AFTER_VERSION\`" \
+                "- Source workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+                "" \
+                "Merge this PR to bring package versions and changelogs back onto \`main\`." \
+              )
+
+              EXISTING_SYNC_PR=$(gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --state open \
+                --head "$RELEASE_SYNC_BRANCH" \
+                --json number \
+                --jq '.[0].number // empty')
+
+              if [ -n "$EXISTING_SYNC_PR" ]; then
+                gh pr edit "$EXISTING_SYNC_PR" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --title "$RELEASE_SYNC_PR_TITLE" \
+                  --body "$SYNC_PR_BODY"
+                echo "✅ Updated release sync PR #$EXISTING_SYNC_PR"
+              else
+                gh pr create \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base main \
+                  --head "$RELEASE_SYNC_BRANCH" \
+                  --title "$RELEASE_SYNC_PR_TITLE" \
+                  --body "$SYNC_PR_BODY"
+                echo "✅ Created release sync PR from $RELEASE_SYNC_BRANCH"
+              fi
             fi
 
             echo "published=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- restore the protected-main fallback for direct Changesets releases
- create or update a release sync PR on changeset-release/main when direct push to main is blocked
- preserve the newer validate-build and output handling around publish

## Why
The main-branch release workflow for #987 failed because repo rules now block direct pushes to main. This restores the earlier supported behavior for protected repositories so releases can publish packages and then sync version/changelog commits back through a PR.

## Testing
- pre-commit workflow validation (Stage  Job ID              Job name                            Workflow name              Workflow file                  Events                                                              
0      build               Build ${{ matrix.package-suffix }}  Build JSON Native          build-json-native.yml          workflow_call,workflow_dispatch                                     
0      build               build                               Build                      build.yml                      workflow_dispatch,workflow_call                                     
0      check               Check for Changeset                 Changeset Check            changeset-check.yml            pull_request                                                        
0      claude              claude                              Claude Code                claude.yml                     issue_comment,pull_request_review_comment,issues,pull_request_review
0      check-naming        Check for stale @have/ references   Documentation Review       doc-review.yml                 pull_request                                                        
0      doc-coverage        Check documentation coverage        Documentation Review       doc-review.yml                 pull_request                                                        
0      auto-fix            auto-fix                            CI Failure Auto-Fix        on-ci-failure.yml              workflow_run                                                        
0      checkup             checkup                             Issue Checkup              on-issue-checkup.yml           schedule,workflow_dispatch                                          
0      triage              triage                              Issue Opened               on-issue-opened.yml            issues                                                              
0      label-handler       label-handler                       Label Changed              on-label-changed.yml           issues                                                              
0      orchestrate         orchestrate                         On Merge to Main           on-merge-main.yml              push                                                                
0      test                Validate Dependency Updates         Dependabot Automation      on-pr-main-dependabot.yml      pull_request                                                        
0      validate-commits    Validate Conventional Commits       Pull Request Validation    on-pull-request.yml            pull_request                                                        
0      validate-workflows  Validate Workflow Files             Pull Request Validation    on-pull-request.yml            pull_request                                                        
0      test                Validate Changes                    Pull Request Validation    on-pull-request.yml            pull_request                                                        
0      docs-build          Validate Documentation Build        Pull Request Validation    on-pull-request.yml            pull_request                                                        
0      analyze             analyze                             Test Failure Analysis      on-test-failure.yml            workflow_run                                                        
0      planning            planning                            Planning Workflow          planning.yml                   workflow_dispatch                                                   
0      release             Version and Publish                 Publish                    publish.yml                    workflow_call,workflow_dispatch                                     
0      orchestrate         orchestrate                         Shared Agent Orchestrator  shared-agent-orchestrator.yml  workflow_call                                                       
0      release             Version and Publish                 Shared Direct Publish      shared-direct-publish.yml      workflow_call                                                       
0      cleanup             cleanup                             Shared Issue Closer        shared-issue-closer.yml        workflow_call                                                       
0      handle-label        handle-label                        Shared Label Handler       shared-label-handler.yml       workflow_call                                                       
0      test                test                                Shared Merge Orchestrator  shared-merge-orchestrator.yml  workflow_call                                                       
0      handle-pr           handle-pr                           Shared PR Handler          shared-pr-handler.yml          workflow_call                                                       
0      triage              triage                              Shared Triage Workflow     shared-triage.yml              workflow_call                                                       
0      test                Run Tests                           Test Suite                 test-suite.yml                 workflow_call                                                       
0      test                Run Tests                           Test                       test.yml                       workflow_call,workflow_dispatch                                     
1      publish             Publish platform packages           Build JSON Native          build-json-native.yml          workflow_dispatch,workflow_call                                     
1      dependabot          dependabot                          Dependabot Automation      on-pr-main-dependabot.yml      pull_request                                                        
1      deploy-docs         Deploy Documentation                Publish                    publish.yml                    workflow_call,workflow_dispatch                                     
1      publish             publish                             Shared Merge Orchestrator  shared-merge-orchestrator.yml  workflow_call                                                       
2      summary             summary                             Shared Merge Orchestrator  shared-merge-orchestrator.yml  workflow_call                                                       

Detected multiple jobs with the same job name, use `-W` to specify the path to the specific workflow. via lefthook)
- repo pre-push typecheck
- 
