### PR TITLE
feat(files): add shared response streaming helper

### DIFF
--- a/.changeset/quiet-paws-share.md
+++ b/.changeset/quiet-paws-share.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/files': patch
+---
+
+Add a shared `writeResponseToFile()` helper for streaming an existing fetch `Response` to disk with the same temp-file, metadata-preserving, and `maxBytes` safeguards used by `fetchToFile()`.

--- a/packages/files/src/fetch.spec.ts
+++ b/packages/files/src/fetch.spec.ts
@@ -19,10 +19,18 @@ import {
   writeResponseToFile,
 } from './fetch';
 
+function requireString(value: string | undefined, label: string): string {
+  if (!value) {
+    throw new Error(`${label} was not initialized`);
+  }
+
+  return value;
+}
+
 describe('fetchToFile', () => {
-  let server: Server;
+  let server: Server | undefined;
   let serverUrl: string;
-  let tempDir: string;
+  let tempDir: string | undefined;
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'files-fetch-'));
@@ -73,8 +81,13 @@ describe('fetchToFile', () => {
   });
 
   afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+    if (server) {
+      const activeServer = server;
+      await new Promise<void>((resolve) => activeServer.close(() => resolve()));
+    }
   });
 
   it('streams to disk with custom headers', async () => {
@@ -174,6 +187,35 @@ describe('fetchToFile', () => {
       expect(linkStats.isSymbolicLink()).toBe(true);
     },
   );
+
+  it.skipIf(process.platform === 'win32')(
+    'resolves the destination symlink before the network fetch begins',
+    async () => {
+      const activeTempDir = requireString(tempDir, 'tempDir');
+      const originalTargetPath = join(activeTempDir, 'original.pdf');
+      const alternateTargetPath = join(activeTempDir, 'alternate.pdf');
+      const symlinkPath = join(activeTempDir, 'linked.pdf');
+
+      await writeFile(originalTargetPath, 'original content');
+      await writeFile(alternateTargetPath, 'alternate content');
+      await symlink(originalTargetPath, symlinkPath);
+
+      const downloadPromise = fetchToFile(`${serverUrl}/slow`, symlinkPath);
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await rm(symlinkPath);
+      await symlink(alternateTargetPath, symlinkPath);
+
+      await downloadPromise;
+
+      await expect(readFile(originalTargetPath, 'utf8')).resolves.toBe(
+        'slow response',
+      );
+      await expect(readFile(alternateTargetPath, 'utf8')).resolves.toBe(
+        'alternate content',
+      );
+    },
+  );
 });
 
 describe('fetch response helpers', () => {
@@ -212,9 +254,9 @@ describe('fetch response helpers', () => {
 });
 
 describe('writeResponseToFile', () => {
-  let server: Server;
+  let server: Server | undefined;
   let serverUrl: string;
-  let tempDir: string;
+  let tempDir: string | undefined;
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'files-response-'));
@@ -245,13 +287,18 @@ describe('writeResponseToFile', () => {
   });
 
   afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+    if (server) {
+      const activeServer = server;
+      await new Promise<void>((resolve) => activeServer.close(() => resolve()));
+    }
   });
 
   it('writes an existing streamed response to disk', async () => {
     const response = await fetch(`${serverUrl}/large`);
-    const targetPath = join(tempDir, 'response.pdf');
+    const targetPath = join(requireString(tempDir, 'tempDir'), 'response.pdf');
 
     await writeResponseToFile(response, targetPath);
 
@@ -261,7 +308,7 @@ describe('writeResponseToFile', () => {
 
   it('preserves an existing file when response streaming exceeds maxBytes', async () => {
     const response = await fetch(`${serverUrl}/large`);
-    const targetPath = join(tempDir, 'existing.pdf');
+    const targetPath = join(requireString(tempDir, 'tempDir'), 'existing.pdf');
     await writeFile(targetPath, 'existing content');
 
     await expect(
@@ -277,7 +324,7 @@ describe('writeResponseToFile', () => {
     'preserves existing destination permissions when writing a response directly',
     async () => {
       const response = await fetch(`${serverUrl}/large`);
-      const targetPath = join(tempDir, 'secure.pdf');
+      const targetPath = join(requireString(tempDir, 'tempDir'), 'secure.pdf');
       await writeFile(targetPath, 'existing content');
       await chmod(targetPath, 0o600);
 
@@ -292,8 +339,9 @@ describe('writeResponseToFile', () => {
     'writes through symlink destinations without replacing the symlink',
     async () => {
       const response = await fetch(`${serverUrl}/large`);
-      const targetPath = join(tempDir, 'target.pdf');
-      const symlinkPath = join(tempDir, 'linked.pdf');
+      const activeTempDir = requireString(tempDir, 'tempDir');
+      const targetPath = join(activeTempDir, 'target.pdf');
+      const symlinkPath = join(activeTempDir, 'linked.pdf');
 
       await writeFile(targetPath, 'existing content');
       await symlink(targetPath, symlinkPath);

--- a/packages/files/src/fetch.spec.ts
+++ b/packages/files/src/fetch.spec.ts
@@ -272,4 +272,37 @@ describe('writeResponseToFile', () => {
       'existing content',
     );
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves existing destination permissions when writing a response directly',
+    async () => {
+      const response = await fetch(`${serverUrl}/large`);
+      const targetPath = join(tempDir, 'secure.pdf');
+      await writeFile(targetPath, 'existing content');
+      await chmod(targetPath, 0o600);
+
+      await writeResponseToFile(response, targetPath);
+
+      const targetStats = await stat(targetPath);
+      expect(targetStats.mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'writes through symlink destinations without replacing the symlink',
+    async () => {
+      const response = await fetch(`${serverUrl}/large`);
+      const targetPath = join(tempDir, 'target.pdf');
+      const symlinkPath = join(tempDir, 'linked.pdf');
+
+      await writeFile(targetPath, 'existing content');
+      await symlink(targetPath, symlinkPath);
+
+      await writeResponseToFile(response, symlinkPath);
+
+      await expect(readFile(targetPath)).resolves.toHaveLength(3072);
+      const linkStats = await lstat(symlinkPath);
+      expect(linkStats.isSymbolicLink()).toBe(true);
+    },
+  );
 });

--- a/packages/files/src/fetch.spec.ts
+++ b/packages/files/src/fetch.spec.ts
@@ -12,7 +12,12 @@ import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { fetchJSON, fetchText, fetchToFile } from './fetch';
+import {
+  fetchJSON,
+  fetchText,
+  fetchToFile,
+  writeResponseToFile,
+} from './fetch';
 
 describe('fetchToFile', () => {
   let server: Server;
@@ -203,5 +208,68 @@ describe('fetch response helpers', () => {
 
   it('throws for non-ok JSON responses', async () => {
     await expect(fetchJSON(serverUrl)).rejects.toThrow('Failed to fetch');
+  });
+});
+
+describe('writeResponseToFile', () => {
+  let server: Server;
+  let serverUrl: string;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'files-response-'));
+
+    server = createServer((req, res) => {
+      if (req.url === '/large') {
+        res.writeHead(200, { 'Content-Type': 'application/pdf' });
+        res.write(Buffer.alloc(1024, 'a'));
+        res.write(Buffer.alloc(1024, 'b'));
+        res.end(Buffer.alloc(1024, 'c'));
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'application/pdf' });
+      res.end('response body');
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          throw new Error('Failed to start test server');
+        }
+        serverUrl = `http://127.0.0.1:${address.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('writes an existing streamed response to disk', async () => {
+    const response = await fetch(`${serverUrl}/large`);
+    const targetPath = join(tempDir, 'response.pdf');
+
+    await writeResponseToFile(response, targetPath);
+
+    const buffer = await readFile(targetPath);
+    expect(buffer.byteLength).toBe(3072);
+  });
+
+  it('preserves an existing file when response streaming exceeds maxBytes', async () => {
+    const response = await fetch(`${serverUrl}/large`);
+    const targetPath = join(tempDir, 'existing.pdf');
+    await writeFile(targetPath, 'existing content');
+
+    await expect(
+      writeResponseToFile(response, targetPath, { maxBytes: 1500 }),
+    ).rejects.toThrow('Downloaded content exceeded maxBytes');
+
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe(
+      'existing content',
+    );
   });
 });

--- a/packages/files/src/fetch.ts
+++ b/packages/files/src/fetch.ts
@@ -144,6 +144,15 @@ class RateLimiter {
    */
   private defaultInterval = 500;
 
+  private getDefaultDomainConfig() {
+    const config = this.domains.get('default');
+    if (!config) {
+      throw new Error('Default domain rate limit configuration is missing');
+    }
+
+    return config;
+  }
+
   /**
    * Creates a new RateLimiter with default settings
    * Initializes with a 'default' domain configuration used as fallback
@@ -190,7 +199,7 @@ class RateLimiter {
     const now = Date.now();
 
     const domainConfig =
-      this.domains.get(domain) || this.domains.get('default')!;
+      this.domains.get(domain) || this.getDefaultDomainConfig();
 
     // Wait if we're over the limit
     if (domainConfig.queue >= domainConfig.limit) {
@@ -231,7 +240,7 @@ class RateLimiter {
    * @returns Rate limit configuration
    */
   getDomainLimit(domain: string) {
-    return this.domains.get(domain) || this.domains.get('default')!;
+    return this.domains.get(domain) || this.getDefaultDomainConfig();
   }
 }
 
@@ -435,6 +444,7 @@ export async function fetchToFile(
   options: FetchToFileOptions = {},
 ): Promise<void> {
   const { timeout, maxBytes, signal, ...requestInit } = options;
+  const destinationPath = await resolveDestinationPath(filepath);
   const response = await rateLimitedFetch(url, {
     ...requestInit,
     signal: buildFetchSignal(timeout, signal),
@@ -442,7 +452,7 @@ export async function fetchToFile(
 
   assertOkResponse(response, url);
 
-  await writeResponseToFile(response, filepath, { maxBytes });
+  await writeResponseToResolvedPath(response, destinationPath, { maxBytes });
 }
 
 async function writeResponseBodyToTempFile(
@@ -477,19 +487,11 @@ async function writeResponseBodyToTempFile(
   }
 }
 
-/**
- * Streams an existing fetch `Response` to disk using the same temp-file and
- * metadata-preserving semantics as {@link fetchToFile}.
- *
- * This helper is transport-only: callers are responsible for validating the
- * response status, headers, and content before persisting it.
- */
-export async function writeResponseToFile(
+async function writeResponseToResolvedPath(
   response: Response,
-  filepath: string,
+  destinationPath: string,
   options: WriteResponseToFileOptions = {},
 ): Promise<void> {
-  const destinationPath = await resolveDestinationPath(filepath);
   const tempFilepath = createTempFilePath(destinationPath);
 
   try {
@@ -500,4 +502,24 @@ export async function writeResponseToFile(
     await rm(tempFilepath, { force: true }).catch(() => {});
     throw error;
   }
+}
+
+/**
+ * Streams an existing fetch `Response` to disk.
+ *
+ * The response body is written to a temp file in the destination directory,
+ * optional `maxBytes` enforcement is applied while streaming, existing file
+ * permissions/ownership are preserved when possible, and the temp file is then
+ * atomically renamed into place on success.
+ *
+ * This helper is transport-only: callers are responsible for validating
+ * `response.ok`, headers, and content before persisting it.
+ */
+export async function writeResponseToFile(
+  response: Response,
+  filepath: string,
+  options: WriteResponseToFileOptions = {},
+): Promise<void> {
+  const destinationPath = await resolveDestinationPath(filepath);
+  await writeResponseToResolvedPath(response, destinationPath, options);
 }

--- a/packages/files/src/fetch.ts
+++ b/packages/files/src/fetch.ts
@@ -22,6 +22,11 @@ export interface FetchToFileOptions extends RequestInit {
   maxBytes?: number;
 }
 
+export interface WriteResponseToFileOptions {
+  /** Optional transport ceiling in bytes */
+  maxBytes?: number;
+}
+
 function createTempFilePath(filepath: string): string {
   return join(
     dirname(filepath),
@@ -430,8 +435,6 @@ export async function fetchToFile(
   options: FetchToFileOptions = {},
 ): Promise<void> {
   const { timeout, maxBytes, signal, ...requestInit } = options;
-  const destinationPath = await resolveDestinationPath(filepath);
-  const tempFilepath = createTempFilePath(destinationPath);
   const response = await rateLimitedFetch(url, {
     ...requestInit,
     signal: buildFetchSignal(timeout, signal),
@@ -439,30 +442,51 @@ export async function fetchToFile(
 
   assertOkResponse(response, url);
 
-  try {
-    if (!response.body) {
-      const buffer = Buffer.from(await response.arrayBuffer());
+  await writeResponseToFile(response, filepath, { maxBytes });
+}
 
-      if (maxBytes != null && buffer.byteLength > maxBytes) {
-        throw new Error(
-          `Downloaded content exceeded maxBytes (${buffer.byteLength} > ${maxBytes})`,
-        );
-      }
+async function writeResponseBodyToTempFile(
+  response: Response,
+  tempFilepath: string,
+  options: WriteResponseToFileOptions = {},
+): Promise<void> {
+  const { maxBytes } = options;
 
-      await writeFile(tempFilepath, buffer);
-    } else {
-      const source = Readable.fromWeb(
-        response.body as unknown as NodeReadableStream<Uint8Array>,
+  if (!response.body) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    if (maxBytes != null && buffer.byteLength > maxBytes) {
+      throw new Error(
+        `Downloaded content exceeded maxBytes (${buffer.byteLength} > ${maxBytes})`,
       );
-      const destination = createWriteStream(tempFilepath);
-
-      if (maxBytes != null) {
-        await pipeline(source, new MaxBytesTransform(maxBytes), destination);
-      } else {
-        await pipeline(source, destination);
-      }
     }
 
+    await writeFile(tempFilepath, buffer);
+    return;
+  }
+
+  const source = Readable.fromWeb(
+    response.body as unknown as NodeReadableStream<Uint8Array>,
+  );
+  const destination = createWriteStream(tempFilepath);
+
+  if (maxBytes != null) {
+    await pipeline(source, new MaxBytesTransform(maxBytes), destination);
+  } else {
+    await pipeline(source, destination);
+  }
+}
+
+export async function writeResponseToFile(
+  response: Response,
+  filepath: string,
+  options: WriteResponseToFileOptions = {},
+): Promise<void> {
+  const destinationPath = await resolveDestinationPath(filepath);
+  const tempFilepath = createTempFilePath(destinationPath);
+
+  try {
+    await writeResponseBodyToTempFile(response, tempFilepath, options);
     await preserveExistingDestinationMetadata(destinationPath, tempFilepath);
     await rename(tempFilepath, destinationPath);
   } catch (error) {

--- a/packages/files/src/fetch.ts
+++ b/packages/files/src/fetch.ts
@@ -477,6 +477,13 @@ async function writeResponseBodyToTempFile(
   }
 }
 
+/**
+ * Streams an existing fetch `Response` to disk using the same temp-file and
+ * metadata-preserving semantics as {@link fetchToFile}.
+ *
+ * This helper is transport-only: callers are responsible for validating the
+ * response status, headers, and content before persisting it.
+ */
 export async function writeResponseToFile(
   response: Response,
   filepath: string,

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -32,6 +32,7 @@ export {
   fetchText,
   fetchToFile,
   getRateLimit,
+  writeResponseToFile,
 } from './fetch';
 // Re-export existing filesystem adapter classes for compatibility
 export * from './filesystem';

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -24,6 +24,10 @@
  * @packageDocumentation
  */
 
+export type {
+  FetchToFileOptions,
+  WriteResponseToFileOptions,
+} from './fetch';
 // Re-export fetch utilities with rate limiting
 export {
   addRateLimit,


### PR DESCRIPTION
## Summary
- add `writeResponseToFile()` as a shared helper for streaming an existing `Response` to disk
- reuse the same temp-file, metadata-preserving, and `maxBytes` safeguards from `fetchToFile()`
- cover direct response streaming and max-bytes preservation in `packages/files` tests

## Verification
- pnpm --filter @happyvertical/files exec vitest run src/fetch.spec.ts
- pnpm --filter @happyvertical/files exec tsc --noEmit
- pnpm --filter @happyvertical/files build
- git push pre-push hook: turbo run typecheck