### PR TITLE
feat(geo): add findPoisNear for POI discovery

### DIFF
--- a/packages/geo/README.md
+++ b/packages/geo/README.md
@@ -49,6 +49,40 @@ const adapter = await getGeoAdapter({
 const results = await adapter.lookup('Big Ben, London');
 ```
 
+### POI (Point-of-Interest) search
+
+Both providers implement `findPoisNear(lat, lon, radiusMeters, options?)`
+for discovering businesses, landmarks, and amenities around a coordinate.
+It's an optional method on the adapter — feature-detect before calling:
+
+```typescript
+if (typeof adapter.findPoisNear === 'function') {
+  const cafes = await adapter.findPoisNear(48.8566, 2.3522, 300, {
+    types: ['cafe'],
+    limit: 10,
+  });
+  for (const cafe of cafes) {
+    console.log(cafe.name, '@', cafe.latitude, cafe.longitude);
+  }
+}
+```
+
+**Google** routes the request through the Places API (Nearby Search) so the
+API key needs the Places API enabled in Google Cloud in addition to
+Geocoding. The first entry of `options.types` becomes the request's `type`
+filter; additional entries fan out across separate requests and the results
+are deduped by `place_id`. Max radius 50 000 m per Places API.
+
+**OpenStreetMap** uses the public [Overpass API][overpass]. No key, but
+the same community use-policy as Nominatim applies — cache aggressively
+and reuse a `rateLimitDelay` that matches your traffic. When `types` is
+omitted, the query looks across `amenity`, `shop`, `tourism`, `leisure`,
+`office`, `historic`, and `craft` tag keys. When supplied, values are
+matched against each of those keys so you can pass `['cafe']` or
+`['supermarket']` without knowing the exact tag.
+
+[overpass]: https://wiki.openstreetmap.org/wiki/Overpass_API
+
 ### Environment Variable Configuration
 
 Set `HAVE_GEO_PROVIDER`, `HAVE_GEO_TIMEOUT`, `HAVE_GEO_MAX_RESULTS`, `HAVE_GEO_RATE_LIMIT_DELAY`, `HAVE_GEO_USER_AGENT`, and `GOOGLE_MAPS_API_KEY` to configure without passing options:

--- a/packages/geo/src/google.integration.test.ts
+++ b/packages/geo/src/google.integration.test.ts
@@ -195,4 +195,57 @@ describe('Google Maps Provider Integration', () => {
       ]).toContain(location.type);
     }, 10000);
   });
+
+  describe('findPoisNear (Places Nearby)', () => {
+    it('should return POIs near downtown Edmonton', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'google',
+        apiKey: apiKey!,
+      });
+      expect(typeof adapter.findPoisNear).toBe('function');
+
+      const results = await adapter.findPoisNear!(53.5461, -113.4938, 200, {
+        limit: 10,
+      });
+      expect(results.length).toBeGreaterThan(0);
+
+      const poi = results[0];
+      expect(poi.type).toBe('point_of_interest');
+      expect(typeof poi.id).toBe('string');
+      expect(typeof poi.name).toBe('string');
+      expect(poi.latitude).toBeGreaterThan(53);
+      expect(poi.latitude).toBeLessThan(54);
+      expect(poi.longitude).toBeGreaterThan(-114);
+      expect(poi.longitude).toBeLessThan(-113);
+    }, 15000);
+
+    it('should narrow results with a type filter', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'google',
+        apiKey: apiKey!,
+      });
+
+      const results = await adapter.findPoisNear!(48.8566, 2.3522, 500, {
+        types: ['cafe'],
+        limit: 5,
+      });
+      // Google returns POIs whose `types` include the requested category,
+      // though the specific category string isn't always first.
+      for (const result of results) {
+        const types = (result.raw as { types?: string[] })?.types ?? [];
+        expect(types.includes('cafe') || types.includes('food')).toBe(true);
+      }
+    }, 15000);
+
+    it('should reject out-of-range radius', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'google',
+        apiKey: apiKey!,
+      });
+
+      await expect(
+        adapter.findPoisNear!(48.8566, 2.3522, 100_000),
+      ).rejects.toThrow(InvalidQueryError);
+    });
+  });
 });

--- a/packages/geo/src/google.integration.test.ts
+++ b/packages/geo/src/google.integration.test.ts
@@ -247,5 +247,40 @@ describe('Google Maps Provider Integration', () => {
         adapter.findPoisNear!(48.8566, 2.3522, 100_000),
       ).rejects.toThrow(InvalidQueryError);
     });
+
+    it('should reject non-positive limits', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'google',
+        apiKey: apiKey!,
+      });
+
+      await expect(
+        adapter.findPoisNear!(48.8566, 2.3522, 200, { limit: 0 }),
+      ).rejects.toThrow(InvalidQueryError);
+      await expect(
+        adapter.findPoisNear!(48.8566, 2.3522, 200, { limit: -5 }),
+      ).rejects.toThrow(InvalidQueryError);
+    });
+
+    it('should paginate beyond 20 results when limit exceeds one page', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'google',
+        apiKey: apiKey!,
+      });
+
+      // Central Paris is dense enough that a 300m bar/restaurant query
+      // easily exceeds 20 POIs. Ask for 35 — the only way to satisfy
+      // this is to follow `next_page_token` past the first page.
+      const results = await adapter.findPoisNear!(48.8566, 2.3522, 300, {
+        types: ['restaurant'],
+        limit: 35,
+      });
+      expect(results.length).toBeGreaterThan(20);
+      expect(results.length).toBeLessThanOrEqual(35);
+      // Unique ids — the merge should dedupe by place_id even across
+      // overlapping pages.
+      const ids = new Set(results.map((result) => result.id));
+      expect(ids.size).toBe(results.length);
+    }, 30000);
   });
 });

--- a/packages/geo/src/openstreetmap.integration.test.ts
+++ b/packages/geo/src/openstreetmap.integration.test.ts
@@ -191,4 +191,64 @@ describe.skipIf(SKIP_INTEGRATION)('OpenStreetMap Provider Integration', () => {
       expect(duration).toBeGreaterThanOrEqual(1000);
     }, 20000);
   });
+
+  describe('findPoisNear (Overpass)', () => {
+    it('should return POIs near downtown Edmonton', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'openstreetmap',
+        rateLimitDelay: 1000,
+      });
+      expect(typeof adapter.findPoisNear).toBe('function');
+
+      const results = await adapter.findPoisNear!(53.5461, -113.4938, 250, {
+        limit: 10,
+      });
+      expect(results).toBeDefined();
+      expect(results.length).toBeGreaterThan(0);
+
+      const poi = results[0];
+      expect(poi.type).toBe('point_of_interest');
+      expect(typeof poi.name).toBe('string');
+      expect(poi.latitude).toBeGreaterThan(53);
+      expect(poi.latitude).toBeLessThan(54);
+      expect(poi.longitude).toBeGreaterThan(-114);
+      expect(poi.longitude).toBeLessThan(-113);
+      // Overpass ids are stable enough to assert the prefix shape.
+      expect(poi.id.startsWith('osm-')).toBe(true);
+    }, 30000);
+
+    it('should filter by type when provided', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'openstreetmap',
+        rateLimitDelay: 1000,
+      });
+
+      // Query specifically for cafes; expect at least one result in Paris.
+      const results = await adapter.findPoisNear!(48.8566, 2.3522, 500, {
+        types: ['cafe'],
+        limit: 5,
+      });
+      expect(results.length).toBeGreaterThan(0);
+      // Every returned element's raw tags should mention "cafe" somewhere in
+      // the amenity/shop/tourism/craft space — we just check that our
+      // filter was respected, not that Overpass categorizes perfectly.
+      for (const result of results) {
+        const tags =
+          (result.raw as { tags?: Record<string, string> })?.tags ?? {};
+        const values = Object.values(tags).join('|').toLowerCase();
+        expect(values.includes('cafe')).toBe(true);
+      }
+    }, 30000);
+
+    it('should reject invalid coordinates', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'openstreetmap',
+        rateLimitDelay: 1000,
+      });
+
+      await expect(adapter.findPoisNear!(999, 0, 100)).rejects.toThrow(
+        InvalidQueryError,
+      );
+    });
+  });
 });

--- a/packages/geo/src/openstreetmap.integration.test.ts
+++ b/packages/geo/src/openstreetmap.integration.test.ts
@@ -250,5 +250,37 @@ describe.skipIf(SKIP_INTEGRATION)('OpenStreetMap Provider Integration', () => {
         InvalidQueryError,
       );
     });
+
+    it('should reject non-positive limits', async () => {
+      const adapter = await getGeoAdapter({
+        provider: 'openstreetmap',
+        rateLimitDelay: 1000,
+      });
+
+      await expect(
+        adapter.findPoisNear!(53.5461, -113.4938, 100, { limit: 0 }),
+      ).rejects.toThrow(InvalidQueryError);
+      await expect(
+        adapter.findPoisNear!(53.5461, -113.4938, 100, { limit: -5 }),
+      ).rejects.toThrow(InvalidQueryError);
+    });
+
+    it('should treat keyword metacharacters literally, not as regex', async () => {
+      // Keyword with characters that are regex-meaningful in Overpass ERE.
+      // Pre-fix this blew up the query; post-fix the escape helper treats
+      // them as literals and the query returns cleanly (0 or more results
+      // — we just assert it doesn't throw).
+      const adapter = await getGeoAdapter({
+        provider: 'openstreetmap',
+        rateLimitDelay: 1000,
+      });
+
+      await expect(
+        adapter.findPoisNear!(53.5461, -113.4938, 200, {
+          keyword: 'C++ [coffee] (bar).',
+          limit: 3,
+        }),
+      ).resolves.toBeDefined();
+    }, 30000);
   });
 });

--- a/packages/geo/src/providers/google.ts
+++ b/packages/geo/src/providers/google.ts
@@ -250,6 +250,12 @@ export class GoogleMapsProvider implements GeoProvider {
     }
 
     const limit = options.limit ?? this.maxResults;
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new InvalidQueryError(
+        `limit ${limit} must be a positive integer`,
+        'google',
+      );
+    }
     const types =
       options.types && options.types.length > 0 ? options.types : [undefined];
 
@@ -271,40 +277,75 @@ export class GoogleMapsProvider implements GeoProvider {
     try {
       const merged = new Map<string, Location>();
       for (const type of types) {
-        const response = await this.client.placesNearby({
-          params: {
-            location: { lat: latitude, lng: longitude },
-            radius: radiusMeters,
-            ...(type ? { type } : {}),
-            ...(options.keyword ? { keyword: options.keyword } : {}),
-            ...(options.language ? { language: options.language as any } : {}),
-            key: this.apiKey,
-          },
-          timeout: this.timeout,
-        });
+        // Places Nearby returns up to 20 results per call and up to 60 total
+        // via `next_page_token`, with Google requiring a short activation
+        // delay after each token is issued. Keep paging per-type until we
+        // either satisfy the caller's `limit`, hit the 3-page ceiling, or
+        // run out of tokens.
+        let pageToken: string | undefined;
+        let pagesFetched = 0;
+        const maxPagesPerType = 3;
 
-        if (response.data.status === 'ZERO_RESULTS') continue;
-        if (response.data.status === 'REQUEST_DENIED') {
-          throw new AuthenticationError('google');
-        }
-        if (response.data.status === 'OVER_QUERY_LIMIT') {
-          throw new RateLimitError('google');
-        }
-        if (response.data.status !== 'OK') {
-          throw new GeoError(
-            `Google Places API error: ${response.data.status}`,
-            'API_ERROR',
-            'google',
-          );
-        }
+        while (pagesFetched < maxPagesPerType) {
+          const params = pageToken
+            ? { pagetoken: pageToken, key: this.apiKey }
+            : {
+                location: { lat: latitude, lng: longitude },
+                radius: radiusMeters,
+                ...(type ? { type } : {}),
+                ...(options.keyword ? { keyword: options.keyword } : {}),
+                ...(options.language
+                  ? { language: options.language as any }
+                  : {}),
+                key: this.apiKey,
+              };
 
-        for (const result of response.data.results) {
-          const location = this.mapGooglePoiToLocation(result);
-          if (!merged.has(location.id)) {
-            merged.set(location.id, location);
+          const response = await this.client.placesNearby({
+            params,
+            timeout: this.timeout,
+          });
+
+          if (response.data.status === 'ZERO_RESULTS') break;
+          if (response.data.status === 'REQUEST_DENIED') {
+            throw new AuthenticationError('google');
           }
+          if (response.data.status === 'OVER_QUERY_LIMIT') {
+            throw new RateLimitError('google');
+          }
+          if (response.data.status === 'INVALID_REQUEST' && pageToken) {
+            // Google returns INVALID_REQUEST if the page token is polled
+            // before it has activated (typically ≤2s). Back off and retry
+            // one more time rather than aborting the whole call.
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            continue;
+          }
+          if (response.data.status !== 'OK') {
+            throw new GeoError(
+              `Google Places API error: ${response.data.status}`,
+              'API_ERROR',
+              'google',
+            );
+          }
+
+          for (const result of response.data.results) {
+            const location = this.mapGooglePoiToLocation(result);
+            if (!merged.has(location.id)) {
+              merged.set(location.id, location);
+            }
+            if (merged.size >= limit) break;
+          }
+
+          pagesFetched += 1;
           if (merged.size >= limit) break;
+
+          pageToken = response.data.next_page_token;
+          if (!pageToken) break;
+          // `pagetoken` isn't activated instantly; Google's docs say to
+          // wait a short moment before using it. 2s is the commonly-cited
+          // activation window.
+          await new Promise((resolve) => setTimeout(resolve, 2000));
         }
+
         if (merged.size >= limit) break;
       }
 

--- a/packages/geo/src/providers/google.ts
+++ b/packages/geo/src/providers/google.ts
@@ -5,7 +5,12 @@
 import { Client } from '@googlemaps/google-maps-services-js';
 import type { CacheAdapter } from '@happyvertical/cache';
 import { getCache } from '@happyvertical/cache';
-import type { GeoProvider, GoogleMapsOptions, Location } from '../shared/types';
+import type {
+  GeoProvider,
+  GoogleMapsOptions,
+  Location,
+  PoiSearchOptions,
+} from '../shared/types';
 import {
   AuthenticationError,
   GeoError,
@@ -214,6 +219,134 @@ export class GoogleMapsProvider implements GeoProvider {
         'google',
       );
     }
+  }
+
+  /**
+   * Find POIs near a coordinate using the Places API Nearby Search endpoint.
+   *
+   * Maps to `placesNearby` on the Google Maps Services SDK. Note that Places
+   * Nearby Search is a separate product line from Geocoding: it requires the
+   * Places API to be enabled for the supplied API key and is billed per
+   * request. Results are deduped across multi-type requests by `place_id`.
+   */
+  async findPoisNear(
+    latitude: number,
+    longitude: number,
+    radiusMeters: number,
+    options: PoiSearchOptions = {},
+  ): Promise<Location[]> {
+    const validation = validateCoordinates(latitude, longitude);
+    if (!validation.valid) {
+      throw new InvalidQueryError(
+        `${latitude}, ${longitude}: ${validation.error}`,
+        'google',
+      );
+    }
+    if (!(radiusMeters > 0) || radiusMeters > 50_000) {
+      throw new InvalidQueryError(
+        `radius ${radiusMeters}m must be in (0, 50000]`,
+        'google',
+      );
+    }
+
+    const limit = options.limit ?? this.maxResults;
+    const types =
+      options.types && options.types.length > 0 ? options.types : [undefined];
+
+    const cacheKey = this.getCacheKey(
+      'pois',
+      String(latitude),
+      String(longitude),
+      String(radiusMeters),
+      (options.types ?? []).join(','),
+      options.keyword ?? '',
+      options.language ?? '',
+      String(limit),
+    );
+    if (this.cache) {
+      const cached = await this.cache.get<Location[]>(cacheKey);
+      if (cached) return cached;
+    }
+
+    try {
+      const merged = new Map<string, Location>();
+      for (const type of types) {
+        const response = await this.client.placesNearby({
+          params: {
+            location: { lat: latitude, lng: longitude },
+            radius: radiusMeters,
+            ...(type ? { type } : {}),
+            ...(options.keyword ? { keyword: options.keyword } : {}),
+            ...(options.language ? { language: options.language as any } : {}),
+            key: this.apiKey,
+          },
+          timeout: this.timeout,
+        });
+
+        if (response.data.status === 'ZERO_RESULTS') continue;
+        if (response.data.status === 'REQUEST_DENIED') {
+          throw new AuthenticationError('google');
+        }
+        if (response.data.status === 'OVER_QUERY_LIMIT') {
+          throw new RateLimitError('google');
+        }
+        if (response.data.status !== 'OK') {
+          throw new GeoError(
+            `Google Places API error: ${response.data.status}`,
+            'API_ERROR',
+            'google',
+          );
+        }
+
+        for (const result of response.data.results) {
+          const location = this.mapGooglePoiToLocation(result);
+          if (!merged.has(location.id)) {
+            merged.set(location.id, location);
+          }
+          if (merged.size >= limit) break;
+        }
+        if (merged.size >= limit) break;
+      }
+
+      const locations = [...merged.values()];
+      if (this.cache) await this.cache.set(cacheKey, locations);
+      return locations;
+    } catch (error) {
+      if (error instanceof GeoError) throw error;
+      throw new GeoError(
+        `Failed to find POIs: ${(error as Error).message}`,
+        'POI_SEARCH_FAILED',
+        'google',
+      );
+    }
+  }
+
+  /**
+   * Map Google Places Nearby Search result to standardized Location. The
+   * Places schema is a superset of Geocoding (adds `name`, `vicinity`,
+   * `types[]` semantics slightly different from geocoding `types`) so this
+   * is a separate mapper from `mapGoogleResultToLocation`.
+   */
+  private mapGooglePoiToLocation(result: any): Location {
+    const loc = result.geometry?.location;
+    const latitude = loc?.lat ?? 0;
+    const longitude = loc?.lng ?? 0;
+    const name = result.name
+      ? result.vicinity
+        ? `${result.name}, ${result.vicinity}`
+        : result.name
+      : result.vicinity || 'Unknown place';
+
+    return {
+      id: result.place_id,
+      type: 'point_of_interest',
+      name,
+      latitude,
+      longitude,
+      addressComponents: {},
+      countryCode: 'XX',
+      raw: result,
+    };
   }
 
   /**

--- a/packages/geo/src/providers/openstreetmap.ts
+++ b/packages/geo/src/providers/openstreetmap.ts
@@ -8,6 +8,7 @@ import type {
   GeoProvider,
   Location,
   OpenStreetMapOptions,
+  PoiSearchOptions,
 } from '../shared/types';
 import { GeoError, InvalidQueryError, RateLimitError } from '../shared/types';
 import {
@@ -45,10 +46,43 @@ interface NominatimResult {
 }
 
 /**
+ * Overpass API response element (node or way within the result set).
+ */
+interface OverpassElement {
+  type: 'node' | 'way' | 'relation';
+  id: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat: number; lon: number };
+  tags?: Record<string, string>;
+}
+
+/**
+ * Tag keys Overpass treats as POI-like. Used when the caller doesn't
+ * specify `types` — broad enough to cover businesses, landmarks, and
+ * amenities without pulling back every single residential address.
+ */
+const POI_TAG_KEYS = [
+  'amenity',
+  'shop',
+  'tourism',
+  'leisure',
+  'office',
+  'historic',
+  'craft',
+];
+
+/**
  * OpenStreetMap provider using Nominatim API with in-memory caching
  */
 export class OpenStreetMapProvider implements GeoProvider {
   private baseUrl = 'https://nominatim.openstreetmap.org';
+  /**
+   * Overpass endpoint for POI search. The public instance has a community
+   * use-policy similar to Nominatim's — be polite, cache aggressively, and
+   * consider a self-hosted instance if you'd hit it hard.
+   */
+  private overpassUrl = 'https://overpass-api.de/api/interpreter';
   private userAgent: string;
   private rateLimitDelay: number;
   private lastRequestTime = 0;
@@ -275,6 +309,210 @@ export class OpenStreetMapProvider implements GeoProvider {
         'openstreetmap',
       );
     }
+  }
+
+  /**
+   * Find POIs near a coordinate using the public Overpass API. Nominatim
+   * only does address-level reverse geocoding — Overpass is the right tool
+   * when you want "every café within 200m" kind of queries.
+   */
+  async findPoisNear(
+    latitude: number,
+    longitude: number,
+    radiusMeters: number,
+    options: PoiSearchOptions = {},
+  ): Promise<Location[]> {
+    const validation = validateCoordinates(latitude, longitude);
+    if (!validation.valid) {
+      throw new InvalidQueryError(
+        `${latitude}, ${longitude}: ${validation.error}`,
+        'openstreetmap',
+      );
+    }
+    if (!(radiusMeters > 0)) {
+      throw new InvalidQueryError(
+        `radius ${radiusMeters}m must be > 0`,
+        'openstreetmap',
+      );
+    }
+
+    const limit = options.limit ?? this.maxResults;
+    const cacheKey = this.getCacheKey(
+      'pois',
+      String(latitude),
+      String(longitude),
+      String(radiusMeters),
+      (options.types ?? []).join(','),
+      options.keyword ?? '',
+      String(limit),
+    );
+    if (this.cache) {
+      const cached = await this.cache.get<Location[]>(cacheKey);
+      if (cached) return cached;
+    }
+
+    await this.enforceRateLimit();
+
+    const query = this.buildOverpassQuery(
+      latitude,
+      longitude,
+      radiusMeters,
+      options,
+    );
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(this.overpassUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': this.userAgent,
+          Accept: 'application/json',
+        },
+        body: `data=${encodeURIComponent(query)}`,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (response.status === 429) {
+        throw new RateLimitError('openstreetmap');
+      }
+      if (!response.ok) {
+        throw new GeoError(
+          `Overpass API error: ${response.status} ${response.statusText}`,
+          'API_ERROR',
+          'openstreetmap',
+        );
+      }
+
+      const data = (await response.json()) as { elements?: OverpassElement[] };
+      const elements = Array.isArray(data.elements) ? data.elements : [];
+
+      // Overpass returns each POI once per matched tag key, but when we
+      // union multiple keys in the query elements can repeat — dedupe by
+      // `(type, id)` so "node/42" only appears once regardless of how many
+      // tag clauses matched.
+      const seen = new Set<string>();
+      const locations: Location[] = [];
+      for (const element of elements) {
+        const key = `${element.type}/${element.id}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const location = this.mapOverpassElementToLocation(element);
+        if (!location) continue;
+        locations.push(location);
+        if (locations.length >= limit) break;
+      }
+
+      if (this.cache) await this.cache.set(cacheKey, locations);
+      return locations;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof GeoError) throw error;
+      if ((error as Error).name === 'AbortError') {
+        throw new GeoError('Request timeout', 'TIMEOUT', 'openstreetmap');
+      }
+      throw new GeoError(
+        `Failed to find POIs: ${(error as Error).message}`,
+        'POI_SEARCH_FAILED',
+        'openstreetmap',
+      );
+    }
+  }
+
+  /**
+   * Build an Overpass QL query that collects nodes + ways with POI-shaped
+   * tags within `radiusMeters` of the center point. `out center tags`
+   * coerces ways/relations into point geometries so downstream mapping
+   * doesn't have to deal with geometry types.
+   */
+  private buildOverpassQuery(
+    latitude: number,
+    longitude: number,
+    radiusMeters: number,
+    options: PoiSearchOptions,
+  ): string {
+    const around = `around:${radiusMeters},${latitude},${longitude}`;
+    const keywordFilter = options.keyword
+      ? `[name~"${options.keyword.replace(/"/g, '\\"')}",i]`
+      : '';
+    const clauses: string[] = [];
+
+    if (options.types && options.types.length > 0) {
+      // Types filter: try each value against each POI tag key. We don't know
+      // which key the caller intends (e.g. 'cafe' is an amenity; 'bakery'
+      // could be either amenity or shop) so we fan out conservatively.
+      for (const value of options.types) {
+        const safe = value.replace(/"/g, '\\"');
+        for (const key of POI_TAG_KEYS) {
+          clauses.push(
+            `  node(${around})["${key}"="${safe}"]${keywordFilter};`,
+          );
+          clauses.push(`  way(${around})["${key}"="${safe}"]${keywordFilter};`);
+        }
+      }
+    } else {
+      for (const key of POI_TAG_KEYS) {
+        clauses.push(`  node(${around})["${key}"]${keywordFilter};`);
+        clauses.push(`  way(${around})["${key}"]${keywordFilter};`);
+      }
+    }
+
+    return `[out:json][timeout:25];\n(\n${clauses.join('\n')}\n);\nout center tags;`;
+  }
+
+  /**
+   * Map an Overpass element to a standardized Location. Returns null for
+   * tagless elements or ways without a `center` (which can happen when the
+   * server falls back to geometry-less output under load).
+   */
+  private mapOverpassElementToLocation(
+    element: OverpassElement,
+  ): Location | null {
+    const lat = element.lat ?? element.center?.lat;
+    const lon = element.lon ?? element.center?.lon;
+    if (lat == null || lon == null) return null;
+
+    const tags = element.tags ?? {};
+    const name =
+      tags.name ||
+      tags['name:en'] ||
+      tags.brand ||
+      tags.operator ||
+      this.derivePoiLabelFromTags(tags) ||
+      'Unnamed place';
+
+    return {
+      id: `osm-${element.type}-${element.id}`,
+      type: 'point_of_interest',
+      name,
+      latitude: lat,
+      longitude: lon,
+      addressComponents: {
+        streetNumber: tags['addr:housenumber'],
+        streetName: tags['addr:street'],
+        city: tags['addr:city'],
+        region: tags['addr:state'] || tags['addr:province'],
+        country: tags['addr:country'],
+        postalCode: tags['addr:postcode'],
+      },
+      countryCode: normalizeCountryCode(tags['addr:country']),
+      raw: element,
+    };
+  }
+
+  /**
+   * Produce a readable label from a tag-only element (e.g. a shop with no
+   * `name`). Picks the first POI-shaped tag value as a fallback so the
+   * caller still gets something meaningful to show operators.
+   */
+  private derivePoiLabelFromTags(tags: Record<string, string>): string | null {
+    for (const key of POI_TAG_KEYS) {
+      const value = tags[key];
+      if (value) return value.replace(/_/g, ' ');
+    }
+    return null;
   }
 
   /**

--- a/packages/geo/src/providers/openstreetmap.ts
+++ b/packages/geo/src/providers/openstreetmap.ts
@@ -58,6 +58,18 @@ interface OverpassElement {
 }
 
 /**
+ * Escape a literal string for safe interpolation into an Overpass
+ * `name~"..."` regex match. Overpass uses POSIX extended regular
+ * expressions; we escape the ERE metacharacters plus the enclosing
+ * double-quote and backslash so callers can pass arbitrary user-entered
+ * keywords without worrying about regex injection or accidental pattern
+ * matching.
+ */
+function escapeOverpassRegex(value: string): string {
+  return value.replace(/["\\.*+?^${}()|[\]]/g, '\\$&');
+}
+
+/**
  * Tag keys Overpass treats as POI-like. Used when the caller doesn't
  * specify `types` — broad enough to cover businesses, landmarks, and
  * amenities without pulling back every single residential address.
@@ -337,6 +349,12 @@ export class OpenStreetMapProvider implements GeoProvider {
     }
 
     const limit = options.limit ?? this.maxResults;
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new InvalidQueryError(
+        `limit ${limit} must be a positive integer`,
+        'openstreetmap',
+      );
+    }
     const cacheKey = this.getCacheKey(
       'pois',
       String(latitude),
@@ -434,8 +452,13 @@ export class OpenStreetMapProvider implements GeoProvider {
     options: PoiSearchOptions,
   ): string {
     const around = `around:${radiusMeters},${latitude},${longitude}`;
+    // `keyword` is documented as a free-text substring filter, but Overpass
+    // interprets the right-hand side of `name~"..."` as a POSIX ERE. Escape
+    // regex metacharacters so inputs like `C++`, `A.*`, or `Joes [Bar]`
+    // match literally instead of silently changing the regex semantics or
+    // producing an invalid query.
     const keywordFilter = options.keyword
-      ? `[name~"${options.keyword.replace(/"/g, '\\"')}",i]`
+      ? `[name~"${escapeOverpassRegex(options.keyword)}",i]`
       : '';
     const clauses: string[] = [];
 

--- a/packages/geo/src/shared/types.ts
+++ b/packages/geo/src/shared/types.ts
@@ -66,7 +66,41 @@ export interface Location {
 }
 
 /**
- * Geo provider interface - all providers must implement this
+ * Options for POI (point-of-interest) searches.
+ *
+ * `types` and `keyword` are both forwarded to the backing provider but each
+ * provider interprets them slightly differently:
+ *
+ * - **Google**: `types[0]` becomes the request's `type` filter (Places API
+ *   accepts a single type per request; additional entries are ignored).
+ *   `keyword` is a free-text match across name/type/address/reviews.
+ * - **OpenStreetMap (Overpass)**: `types` are matched against
+ *   `amenity`, `shop`, and `tourism` tag values (e.g. `'cafe'`,
+ *   `'supermarket'`, `'museum'`). When omitted, the provider searches across
+ *   a broad set of POI-ish tag keys (`amenity`, `shop`, `tourism`,
+ *   `leisure`, `office`, `historic`). `keyword` is appended as a substring
+ *   filter on the `name` tag.
+ */
+export interface PoiSearchOptions {
+  /** Filter results to POIs matching these category values. See notes above. */
+  types?: string[];
+  /** Free-text keyword to narrow the search. */
+  keyword?: string;
+  /** Max results to return. Default 20. */
+  limit?: number;
+  /** Preferred language for place names (Google only). */
+  language?: string;
+}
+
+/**
+ * Geo provider interface - all providers must implement lookup and
+ * reverseGeocode. `findPoisNear` is optional — providers implement it when
+ * they support POI discovery beyond reverse geocoding. Callers that need to
+ * know whether a given instance supports POI search should feature-detect:
+ *
+ * ```ts
+ * if (typeof adapter.findPoisNear === 'function') { ... }
+ * ```
  */
 export interface GeoProvider {
   /**
@@ -83,6 +117,25 @@ export interface GeoProvider {
    * @returns Promise resolving to array of matching Location objects
    */
   reverseGeocode(latitude: number, longitude: number): Promise<Location[]>;
+
+  /**
+   * Find POIs (point-of-interest places — businesses, landmarks, amenities)
+   * within a radius of a coordinate. Returns locations with
+   * `type: 'point_of_interest'` whose coords lie inside the requested
+   * radius, sorted by the provider's relevance ranking.
+   *
+   * @param latitude - Center latitude
+   * @param longitude - Center longitude
+   * @param radiusMeters - Search radius in meters
+   * @param options - Optional filters
+   * @returns Promise resolving to array of matching Location objects
+   */
+  findPoisNear?(
+    latitude: number,
+    longitude: number,
+    radiusMeters: number,
+    options?: PoiSearchOptions,
+  ): Promise<Location[]>;
 }
 
 /**
@@ -103,6 +156,16 @@ export interface GeoAdapter {
    * @returns Promise resolving to array of matching Location objects
    */
   reverseGeocode(latitude: number, longitude: number): Promise<Location[]>;
+
+  /**
+   * Find POIs near a coordinate. Optional — see `GeoProvider.findPoisNear`.
+   */
+  findPoisNear?(
+    latitude: number,
+    longitude: number,
+    radiusMeters: number,
+    options?: PoiSearchOptions,
+  ): Promise<Location[]>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `findPoisNear(latitude, longitude, radiusMeters, options?)` method to the `GeoAdapter` / `GeoProvider` interfaces, implemented for both bundled providers. Gives `@happyvertical/geo` consumers a first-class way to ask "what POIs are near this coordinate" without reaching past the library to Places API / Overpass directly.

- **Google** routes through the Places API (Nearby Search) via the existing `@googlemaps/google-maps-services-js` `Client.placesNearby`. Uses the first entry of `options.types` as the request `type` filter (Places Nearby only accepts one per call); additional entries fan out across separate requests and results are deduped by `place_id`. Enforces the 50 000 m Places API max radius.

- **OpenStreetMap** uses the public Overpass API. When `options.types` is omitted the query scans the standard POI tag keys (`amenity`, `shop`, `tourism`, `leisure`, `office`, `historic`, `craft`). When supplied, values are matched against each of those keys so callers can pass `['cafe']` or `['supermarket']` without having to know which OSM tag to target. Both `node` and `way` elements are accepted — ways coerced via `out center` so consumers get a point geometry. Respects `rateLimitDelay` for polite community-instance use.

The method is **optional on the adapter surface** (`findPoisNear?`) so existing providers keep working unchanged; callers feature-detect:

```ts
if (typeof adapter.findPoisNear === 'function') {
  const cafes = await adapter.findPoisNear(48.8566, 2.3522, 300, {
    types: ['cafe'],
    limit: 10,
  });
}
```

## What's in the PR

| File | Change |
|---|---|
| `shared/types.ts` | New `PoiSearchOptions` interface + optional `findPoisNear` on `GeoProvider` and `GeoAdapter`. |
| `providers/google.ts` | `findPoisNear` implementation via `placesNearby`; dedicated `mapGooglePoiToLocation` mapper (Places results have a different schema from Geocoding); reuses the existing memory cache with a `pois:…` cache key. |
| `providers/openstreetmap.ts` | `findPoisNear` via Overpass at `https://overpass-api.de/api/interpreter`; `POI_TAG_KEYS` broad-default list; Overpass-QL query builder; element→Location mapper. Reuses the existing Nominatim cache layer. |
| `openstreetmap.integration.test.ts` | Three new tests: downtown Edmonton returns POIs, type-filter narrows to `cafe` tags, invalid input rejected. Gated behind `RUN_INTEGRATION_TESTS=true` alongside the existing suite. |
| `google.integration.test.ts` | Parallel three new tests; gated behind `GOOGLE_MAPS_API_KEY`. |
| `README.md` | New "POI (Point-of-Interest) search" section with per-provider notes. |

## Verified

- `pnpm --filter @happyvertical/geo build` clean.
- `RUN_INTEGRATION_TESTS=true npx vitest run src/openstreetmap.integration.test.ts` → 3/3 new Overpass tests green live (~30s end-to-end).
- Downstream consumer (`willgriffin/ergot.io` POI discovery branch) uses the new surface via `smrt-places.discoverNearby`/`resolveTrackPlaces` to resolve real POIs along GPS tracks; validates the adapter shape against both providers.

## Notes

- Google's Places API (New) uses a POST-style interface and field masks that the current SDK doesn't support cleanly. This PR stays on the legacy Places Nearby endpoint to keep the change focused. A follow-up can migrate once the SDK catches up to the New API.
- Overpass's public instance has a community use-policy similar to Nominatim's. Consumers hitting it heavily should configure a longer `rateLimitDelay` or point at a self-hosted tileserver.

## Test plan

- [x] Unit / integration: `RUN_INTEGRATION_TESTS=true npx vitest run src/openstreetmap.integration.test.ts`
- [ ] Google variant: `GOOGLE_MAPS_API_KEY=… npx vitest run src/google.integration.test.ts -t findPoisNear` (billable; haven't run here)
- [x] Build clean: `pnpm --filter @happyvertical/geo build`
- [x] Downstream consumer smoke (ergot.io resolveTrackPlaces → real POIs persisted)