### PR TITLE
fix(ci): skip release commit retriggers

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
 
 concurrency:
-  group: on-merge-main
+  # Keep release-generated pushes from cancelling the original merge-to-main run
+  # that created them. Those follow-up runs are intentionally skipped below.
+  group: "${{ startsWith(github.event.head_commit.message, 'chore(release): v') && format('on-merge-main-release-{0}', github.sha) || 'on-merge-main' }}"
   cancel-in-progress: true
 
 permissions:
@@ -17,6 +19,8 @@ permissions:
 
 jobs:
   orchestrate:
+    # Skip the release commit that the publish workflow pushes back to main.
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore(release): v') }}"
     uses: ./.github/workflows/shared-merge-orchestrator.yml
     with:
       repo_owner: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary

Skip `on-merge-main` orchestration for release commits like `chore(release): v...`.

## Why

After `#1000` merged, `on-merge-main` correctly created and pushed `chore(release): v0.71.26` back to `main`, but that release commit immediately triggered a second `On Merge to Main` run. Because both runs shared the same concurrency key, the follow-up run could cancel the tail of the original release run.

## What Changed

- give release-generated pushes their own concurrency group in `on-merge-main`
- skip the `orchestrate` job entirely when the pushed commit message starts with `chore(release): v`

## Impact

- the real merge-to-main release run is allowed to finish cleanly
- release commits no longer recurse back into publish/test orchestration
- the follow-up run becomes a harmless no-op instead of competing with the original run

## Validation

- `yamllint -c .github/.yamllint.yml .github/workflows/on-merge-main.yml`
- `git diff --check`
- repo git hooks validated the workflow during commit
- pre-push hook ran `pnpm turbo run typecheck` successfully
