### PR TITLE
fix(ci): remove release sync PR fallback

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -19,8 +19,7 @@ jobs:
     name: Check for Changeset
     runs-on: arc-happyvertical
     if: |
-      !startsWith(github.event.pull_request.head.ref, 'renovate/') &&
-      !startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      !startsWith(github.event.pull_request.head.ref, 'renovate/')
 
     steps:
       - name: Checkout
@@ -62,19 +61,8 @@ jobs:
           fi
 
           PR_BRANCH="${{ github.event.pull_request.head.ref }}"
-          if echo "$PR_BRANCH" | grep -q '^changeset-release/'; then
-            echo "✅ Skipping changeset check (changesets release PR from $PR_BRANCH)"
-            exit 0
-          fi
-
           if echo "$PR_BRANCH" | grep -q '^renovate/'; then
             echo "✅ Skipping changeset check (Renovate dependency update PR from $PR_BRANCH)"
-            exit 0
-          fi
-
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          if echo "$PR_TITLE" | grep -qi '^chore: version packages'; then
-            echo "✅ Skipping changeset check (version packages PR)"
             exit 0
           fi
 
@@ -202,12 +190,9 @@ jobs:
             1. Tests run on main branch
             2. Packages are built
             3. Versions are bumped automatically
-            4. Packages are published to GitHub Packages
-            5. Git tags are created
-
-            If branch rules block the final version-sync push, the release
-            workflow may open a short-lived sync PR for the generated
-            changelog and version files.`;
+            4. The release commit is pushed back to \`main\`
+            5. Packages are published to GitHub Packages
+            6. Git tags are created`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,7 @@
 # when code is merged to the main branch, after tests and build pass.
 #
 # Uses the shared direct publish workflow from SDK to version and publish
-# packages. When protected-branch rules reject the final sync push to main,
-# the workflow falls back to a short-lived release sync PR.
+# packages directly from main.
 # =============================================================================
 
 name: Publish
@@ -41,7 +40,6 @@ on:
 permissions:
   contents: write
   packages: write
-  pull-requests: write
   id-token: write
   pages: write
 

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -62,7 +62,6 @@ on:
 permissions:
   contents: write
   packages: write
-  pull-requests: write
   id-token: write
 
 jobs:
@@ -179,24 +178,6 @@ jobs:
             fi
           }
 
-          RELEASE_SYNC_BRANCH="changeset-release/main"
-          RELEASE_SYNC_PR_TITLE="chore: version packages"
-
-          EXISTING_SYNC_PR=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --state open \
-            --head "$RELEASE_SYNC_BRANCH" \
-            --json number \
-            --jq '.[0].number // empty')
-
-          if [ -n "$EXISTING_SYNC_PR" ]; then
-            echo "ℹ️  Release sync PR #$EXISTING_SYNC_PR is still open"
-            echo "Skipping direct publish until that PR merges."
-            echo "published=false" >> $GITHUB_OUTPUT
-            echo "reason=awaiting_release_sync_pr" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
           # Store current version before release
           BEFORE_VERSION=$(node -p "require('./package.json').version")
           echo "Version before release: $BEFORE_VERSION"
@@ -229,54 +210,15 @@ jobs:
             # Commit version changes
             git add .
             git commit -m "chore(release): v$AFTER_VERSION"
-            RELEASE_COMMIT_SHA=$(git rev-parse HEAD)
-
-            publish_release_artifacts "$AFTER_VERSION" "$BEFORE_VERSION"
-
-            if git push origin main; then
+            if git push origin HEAD:main; then
               echo "✅ Synced release commit to main"
             else
-              echo "⚠️  Direct push to protected main was rejected"
-              echo "Creating or updating a release sync PR instead..."
-
-              git push --force origin \
-                "$RELEASE_COMMIT_SHA:refs/heads/$RELEASE_SYNC_BRANCH"
-
-              SYNC_PR_BODY=$(printf '%s\n' \
-                "## Version Sync" \
-                "" \
-                "This PR syncs the already-published release commit for \`v$AFTER_VERSION\` back to \`main\`." \
-                "" \
-                "- Published packages: \`v$AFTER_VERSION\`" \
-                "- Release tag: \`v$AFTER_VERSION\`" \
-                "- Source workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-                "" \
-                "Merge this PR to bring package versions and changelogs back onto \`main\`." \
-              )
-
-              EXISTING_SYNC_PR=$(gh pr list \
-                --repo "$GITHUB_REPOSITORY" \
-                --state open \
-                --head "$RELEASE_SYNC_BRANCH" \
-                --json number \
-                --jq '.[0].number // empty')
-
-              if [ -n "$EXISTING_SYNC_PR" ]; then
-                gh pr edit "$EXISTING_SYNC_PR" \
-                  --repo "$GITHUB_REPOSITORY" \
-                  --title "$RELEASE_SYNC_PR_TITLE" \
-                  --body "$SYNC_PR_BODY"
-                echo "✅ Updated release sync PR #$EXISTING_SYNC_PR"
-              else
-                gh pr create \
-                  --repo "$GITHUB_REPOSITORY" \
-                  --base main \
-                  --head "$RELEASE_SYNC_BRANCH" \
-                  --title "$RELEASE_SYNC_PR_TITLE" \
-                  --body "$SYNC_PR_BODY"
-                echo "✅ Created release sync PR from $RELEASE_SYNC_BRANCH"
-              fi
+              echo "::error::Failed to push the release commit directly to main."
+              echo "::error::Direct-on-main publishing requires the release bot to bypass the main ruleset."
+              exit 1
             fi
+
+            publish_release_artifacts "$AFTER_VERSION" "$BEFORE_VERSION"
 
             echo "published=true" >> $GITHUB_OUTPUT
             echo "version=$AFTER_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- remove the `changeset-release/main` sync PR fallback from direct publish
- require the release commit to land on `main` before publishing packages
- remove obsolete PR workflow exceptions and messaging that referenced version-packages PRs

## Validation
- yamllint -c .github/.yamllint.yml .github/workflows/shared-direct-publish.yml .github/workflows/on-pull-request.yml .github/workflows/publish.yml
- git diff --check
- pre-commit workflow validation
- pre-push typecheck