### PR TITLE
fix(ci): use smrt package manager metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,16 +88,10 @@ jobs:
           node-version: '24'
           registry-url: 'https://npm.pkg.github.com'
 
-      - name: Determine SMRT pnpm version
-        id: smrt_pnpm
-        run: |
-          version=$(node -p "require('./smrt/package.json').packageManager.split('@')[1]")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
       - name: Setup pnpm
         uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
         with:
-          version: ${{ steps.smrt_pnpm.outputs.version }}
+          package_json_file: smrt/package.json
           run_install: false
 
       - name: Update SMRT SDK dependency pins


### PR DESCRIPTION
## Summary
- fix the SMRT sync job to read pnpm metadata from `smrt/package.json`
- avoid `pnpm/action-setup` picking up the SDK repo's root package manager config
- unblock the failed `Sync SMRT SDK Dependencies` step from run 24790330100

## Root cause
`pnpm/action-setup` was being passed an explicit SMRT pnpm version while also auto-reading the SDK root `package.json`, which declares a different pnpm version. The action aborts on that mismatch.

## Validation
- `yamllint -c .github/.yamllint.yml .github/workflows/publish.yml`
- `git diff --check`