### PR TITLE
chore: align pnpm with smrt

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,5 @@
     "node": ">=24",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,13 +243,6 @@ importers:
       jose:
         specifier: ^6.2.2
         version: 6.2.2
-    optionalDependencies:
-      '@aws-sdk/client-cognito-identity-provider':
-        specifier: ^3.1034.0
-        version: 3.1034.0
-      nostr-tools:
-        specifier: ^2.23.3
-        version: 2.23.3(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -266,6 +259,13 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.9.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+    optionalDependencies:
+      '@aws-sdk/client-cognito-identity-provider':
+        specifier: ^3.1034.0
+        version: 3.1034.0
+      nostr-tools:
+        specifier: ^2.23.3
+        version: 2.23.3(typescript@5.9.3)
 
   packages/cache:
     dependencies:


### PR DESCRIPTION
## Summary
- bump the SDK repo package manager from `pnpm@9.15.9` to `pnpm@10.33.0`
- refresh the lockfile with pnpm 10 so the repo is clean on the newer client
- bring SDK package-manager parity in line with SMRT

## Validation
- `NODE_AUTH_TOKEN=$(gh auth token) corepack pnpm --version`
- `NODE_AUTH_TOKEN=$(gh auth token) corepack pnpm install --lockfile-only`
- `NODE_AUTH_TOKEN=$(gh auth token) corepack pnpm install --frozen-lockfile`
- `NODE_AUTH_TOKEN=$(gh auth token) corepack pnpm typecheck`
- `git diff --check`