### PR TITLE
feat(ai): add gateway admin provisioning

### DIFF
--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -99,7 +99,7 @@
         "index": 2,
         "count": 29
       },
-      "description": "Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
+      "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
       "commands": {
         "build": "pnpm --filter @happyvertical/ai build",
         "test": "pnpm --filter @happyvertical/ai test",
@@ -111,7 +111,7 @@
         "If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands."
       ],
       "provides": [
-        "Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS"
+        "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS"
       ],
       "implements": [],
       "requires": {
@@ -1452,7 +1452,7 @@
     {
       "type": "provides",
       "from": "@happyvertical/ai",
-      "to": "Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS"
+      "to": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS"
     },
     {
       "type": "requires",

--- a/packages/ai/AGENT.md
+++ b/packages/ai/AGENT.md
@@ -2,7 +2,7 @@
 
 <!-- BEGIN AGENT:GENERATED -->
 ## Purpose
-Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS
+Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS
 
 ## Package Map
 - Package: `@happyvertical/ai`
@@ -25,7 +25,7 @@ pnpm --filter @happyvertical/ai clean
 - If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands.
 
 ## Ecosystem Relationships
-- Provides: Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS
+- Provides: Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS
 - Implements: none
 - Requires: @happyvertical/utils, @anthropic-ai/sdk, @aws-sdk/client-bedrock-runtime, @google/genai, openai
 - Stability: stable (Primary package surface is described as implemented and production-oriented.)

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,6 +1,6 @@
 # @happyvertical/ai
 
-Unified interface for AI model interactions across multiple providers. Supports OpenAI, LiteLLM, Ollama, Anthropic Claude, Google Gemini, AWS Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS with a consistent API for chat, completions, embeddings, streaming, function calling, image operations, and text-to-speech.
+Unified interface for AI model interactions across multiple providers. Supports OpenAI, LiteLLM, Bifrost, Ollama, Anthropic Claude, Google Gemini, AWS Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS with a consistent API for chat, completions, embeddings, streaming, function calling, image operations, text-to-speech, and gateway admin provisioning where available.
 
 ## Installation
 
@@ -53,6 +53,17 @@ const litellm = await getAI({
   defaultModel: process.env.LITELLM_MODEL, // Use a model id returned by /v1/models
 });
 
+// Bifrost (OpenAI-compatible gateway with governance admin APIs)
+const bifrost = await getAI({
+  type: 'bifrost',
+  apiKey: process.env.BIFROST_API_KEY!,
+  adminUser: process.env.BIFROST_ADMIN_USER,
+  adminPassword: process.env.BIFROST_ADMIN_PASSWORD,
+  adminUrl: process.env.BIFROST_ADMIN_URL,
+  baseUrl: process.env.BIFROST_BASE_URL || 'http://localhost:8080',
+  defaultModel: process.env.BIFROST_MODEL,
+});
+
 // Ollama (local by default)
 const ollama = await getAI({
   type: 'ollama',
@@ -89,6 +100,51 @@ const cli = await getAI({ type: 'claude-cli', defaultModel: 'sonnet' });
 // Qwen3-TTS (text-to-speech only)
 const tts = await getAI({ type: 'qwen3-tts', endpoint: 'http://localhost:8880' });
 ```
+
+## Gateway Admin
+
+Gateway providers that support provisioning expose `ai.admin`.
+
+```typescript
+const ai = await getAI({
+  type: 'bifrost',
+  apiKey: process.env.BIFROST_API_KEY!,
+  adminUrl: process.env.BIFROST_ADMIN_URL || 'http://localhost:8080',
+  adminUser: process.env.BIFROST_ADMIN_USER!,
+  adminPassword: process.env.BIFROST_ADMIN_PASSWORD!,
+  baseUrl: 'http://localhost:8080',
+});
+
+const project = await ai.admin!.createProject({
+  name: 'Tenant A Production',
+  tenantId: 'customer-tenant-a',
+  budget: { maxLimit: 100, resetDuration: '1M' },
+});
+
+const key = await ai.admin!.createVirtualKey({
+  name: 'Tenant A API Key',
+  projectId: project.id,
+  providerConfigs: [
+    {
+      provider: 'openai',
+      weight: 1,
+      allowedModels: ['gpt-4o-mini'],
+    },
+  ],
+  keyIds: ['*'],
+  budget: { maxLimit: 25, resetDuration: '1M' },
+  rateLimit: {
+    tokenMaxLimit: 10000,
+    tokenResetDuration: '1h',
+    requestMaxLimit: 100,
+    requestResetDuration: '1m',
+  },
+});
+
+console.log(key.key);
+```
+
+LiteLLM uses the same SDK surface, mapping projects to LiteLLM teams and virtual keys to `/key/generate`.
 
 ## Opt-In Rate-Limit Pacing
 

--- a/packages/ai/metadata.json
+++ b/packages/ai/metadata.json
@@ -5,9 +5,9 @@
     "index": 2,
     "count": 29
   },
-  "description": "Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
+  "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
   "provides": [
-    "Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS"
+    "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS"
   ],
   "implements": [],
   "requires": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@happyvertical/ai",
   "version": "0.71.32",
-  "description": "Standardized AI interface supporting OpenAI, LiteLLM, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
+  "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ai/src/index.spec.ts
+++ b/packages/ai/src/index.spec.ts
@@ -3,6 +3,7 @@ import { AIClient } from './shared/client';
 import type {
   AnthropicOptions,
   BedrockOptions,
+  BifrostOptions,
   GeminiOptions,
   HuggingFaceOptions,
   OllamaOptions,
@@ -62,6 +63,17 @@ it('should support creating Ollama client via AIClient.create', async () => {
   expect(client.options.type).toBe('ollama');
 });
 
+it('should support creating Bifrost client via AIClient.create', async () => {
+  const options: BifrostOptions = {
+    type: 'bifrost',
+    apiKey: 'test-key',
+    baseUrl: 'https://bifrost.example.com/openai',
+  };
+  const client = await AIClient.create(options);
+  expect(client).toBeDefined();
+  expect(client.options.type).toBe('bifrost');
+});
+
 it('should throw helpful error for unsupported provider type', async () => {
   await expect(
     // @ts-expect-error - Testing invalid provider type
@@ -85,6 +97,7 @@ it('should list all supported providers in error message', async () => {
     const err = error as { context: { supportedTypes: string[] } };
     expect(err.context.supportedTypes).toContain('openai');
     expect(err.context.supportedTypes).toContain('litellm');
+    expect(err.context.supportedTypes).toContain('bifrost');
     expect(err.context.supportedTypes).toContain('ollama');
     expect(err.context.supportedTypes).toContain('anthropic');
     expect(err.context.supportedTypes).toContain('gemini');

--- a/packages/ai/src/node/factory.ts
+++ b/packages/ai/src/node/factory.ts
@@ -84,23 +84,34 @@ export async function getAIAuto(
     adminPassword?: string;
   };
 
+  // Caller options always win over env: collapse alias pairs (adminUrl/adminBaseUrl
+  // and adminUser/adminUsername) on the caller side first, so that an env override
+  // for one alias cannot mask an explicit caller value supplied via the other.
+  const callerAdminUrl = adminConfig.adminUrl || adminConfig.adminBaseUrl;
+  const callerAdminUser = adminConfig.adminUser || adminConfig.adminUsername;
+
   // If type is specified (either from options or env vars), use getAI directly
   if (config.type) {
     if (config.type === 'bifrost') {
+      const resolvedAdminUrl =
+        callerAdminUrl ||
+        process.env.BIFROST_ADMIN_URL ||
+        process.env.BIFROST_ADMIN_BASE_URL;
+      const resolvedAdminUser =
+        callerAdminUser ||
+        process.env.BIFROST_ADMIN_USER ||
+        process.env.BIFROST_ADMIN_USERNAME;
+
       return getAIUniversal({
         ...config,
         baseUrl: config.baseUrl || process.env.BIFROST_BASE_URL,
         apiKey: config.apiKey || process.env.BIFROST_API_KEY,
         adminApiKey:
           adminConfig.adminApiKey || process.env.BIFROST_ADMIN_API_KEY,
-        adminBaseUrl:
-          adminConfig.adminBaseUrl || process.env.BIFROST_ADMIN_BASE_URL,
-        adminUrl: adminConfig.adminUrl || process.env.BIFROST_ADMIN_URL,
-        adminUser:
-          adminConfig.adminUser ||
-          adminConfig.adminUsername ||
-          process.env.BIFROST_ADMIN_USER ||
-          process.env.BIFROST_ADMIN_USERNAME,
+        adminBaseUrl: resolvedAdminUrl,
+        adminUrl: resolvedAdminUrl,
+        adminUser: resolvedAdminUser,
+        adminUsername: resolvedAdminUser,
         adminPassword:
           adminConfig.adminPassword || process.env.BIFROST_ADMIN_PASSWORD,
       } as BifrostOptions);

--- a/packages/ai/src/node/factory.ts
+++ b/packages/ai/src/node/factory.ts
@@ -11,6 +11,7 @@ import type {
   AIProviderType,
   AnthropicOptions,
   BedrockOptions,
+  BifrostOptions,
   GeminiOptions,
   GetAIOptions,
   HuggingFaceOptions,
@@ -32,7 +33,8 @@ export { getAI } from '../shared/factory';
  * Supports both HAVE_AI_* environment variables and provider-specific variables:
  * - HAVE_AI_PROVIDER / HAVE_AI_TYPE → provider type
  * - HAVE_AI_API_KEY → fallback API key
- * - LITELLM_BASE_URL / LITELLM_API_KEY → LiteLLM-specific gateway config
+ * - LITELLM_BASE_URL / LITELLM_API_KEY / LITELLM_ADMIN_API_KEY → LiteLLM-specific gateway config
+ * - BIFROST_BASE_URL / BIFROST_API_KEY / BIFROST_ADMIN_URL / BIFROST_ADMIN_USER / BIFROST_ADMIN_PASSWORD → Bifrost gateway config
  * - OLLAMA_HOST / OLLAMA_BASE_URL / OLLAMA_API_KEY → Ollama host/auth config
  * - OPENAI_API_KEY → OpenAI-specific key
  * - ANTHROPIC_API_KEY → Anthropic-specific key
@@ -59,6 +61,12 @@ export async function getAIAuto(
       maxRetries: 'number',
       apiKey: 'string',
       baseUrl: 'string',
+      adminApiKey: 'string',
+      adminBaseUrl: 'string',
+      adminUrl: 'string',
+      adminUser: 'string',
+      adminUsername: 'string',
+      adminPassword: 'string',
     },
   }) as GetAIOptions;
 
@@ -67,8 +75,37 @@ export async function getAIAuto(
     (config as any).type = (config as any).provider;
   }
 
+  const adminConfig = config as {
+    adminApiKey?: string;
+    adminBaseUrl?: string;
+    adminUrl?: string;
+    adminUser?: string;
+    adminUsername?: string;
+    adminPassword?: string;
+  };
+
   // If type is specified (either from options or env vars), use getAI directly
   if (config.type) {
+    if (config.type === 'bifrost') {
+      return getAIUniversal({
+        ...config,
+        baseUrl: config.baseUrl || process.env.BIFROST_BASE_URL,
+        apiKey: config.apiKey || process.env.BIFROST_API_KEY,
+        adminApiKey:
+          adminConfig.adminApiKey || process.env.BIFROST_ADMIN_API_KEY,
+        adminBaseUrl:
+          adminConfig.adminBaseUrl || process.env.BIFROST_ADMIN_BASE_URL,
+        adminUrl: adminConfig.adminUrl || process.env.BIFROST_ADMIN_URL,
+        adminUser:
+          adminConfig.adminUser ||
+          adminConfig.adminUsername ||
+          process.env.BIFROST_ADMIN_USER ||
+          process.env.BIFROST_ADMIN_USERNAME,
+        adminPassword:
+          adminConfig.adminPassword || process.env.BIFROST_ADMIN_PASSWORD,
+      } as BifrostOptions);
+    }
+
     return getAIUniversal(config);
   }
 
@@ -85,6 +122,27 @@ export async function getAIAuto(
   const hasLiteLLMSignal = Boolean(
     process.env.LITELLM_BASE_URL || process.env.LITELLM_API_KEY,
   );
+  const hasBifrostSignal = Boolean(process.env.BIFROST_BASE_URL);
+
+  if (hasBifrostSignal && !config.type) {
+    return getAIUniversal({
+      ...config,
+      type: 'bifrost',
+      baseUrl: config.baseUrl || process.env.BIFROST_BASE_URL,
+      apiKey: config.apiKey || process.env.BIFROST_API_KEY,
+      adminApiKey: adminConfig.adminApiKey || process.env.BIFROST_ADMIN_API_KEY,
+      adminBaseUrl:
+        adminConfig.adminBaseUrl || process.env.BIFROST_ADMIN_BASE_URL,
+      adminUrl: adminConfig.adminUrl || process.env.BIFROST_ADMIN_URL,
+      adminUser:
+        adminConfig.adminUser ||
+        adminConfig.adminUsername ||
+        process.env.BIFROST_ADMIN_USER ||
+        process.env.BIFROST_ADMIN_USERNAME,
+      adminPassword:
+        adminConfig.adminPassword || process.env.BIFROST_ADMIN_PASSWORD,
+    } as BifrostOptions);
+  }
 
   if (hasLiteLLMSignal && !config.type) {
     return getAIUniversal({
@@ -92,6 +150,10 @@ export async function getAIAuto(
       type: 'litellm',
       baseUrl: config.baseUrl || process.env.LITELLM_BASE_URL,
       apiKey: config.apiKey || process.env.LITELLM_API_KEY,
+      adminApiKey: adminConfig.adminApiKey || process.env.LITELLM_ADMIN_API_KEY,
+      adminBaseUrl:
+        adminConfig.adminBaseUrl || process.env.LITELLM_ADMIN_BASE_URL,
+      adminUrl: adminConfig.adminUrl || process.env.LITELLM_ADMIN_URL,
     } as LiteLLMOptions);
   }
 

--- a/packages/ai/src/providers.test.ts
+++ b/packages/ai/src/providers.test.ts
@@ -7,6 +7,7 @@ import { ValidationError } from '@happyvertical/utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AnthropicProvider } from './shared/providers/anthropic';
 import { BedrockProvider } from './shared/providers/bedrock';
+import { BifrostProvider } from './shared/providers/bifrost';
 import { ClaudeCliProvider } from './shared/providers/claude-cli';
 import { GeminiProvider } from './shared/providers/gemini';
 import { HuggingFaceProvider } from './shared/providers/huggingface';
@@ -318,6 +319,329 @@ describe('LiteLLM Provider', () => {
     expect(generateImage).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'gpt-image-1' }),
     );
+  });
+
+  it('should create projects and virtual keys through the LiteLLM admin API', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const headers = new Headers(init?.headers);
+        const body = JSON.parse(String(init?.body || '{}'));
+
+        expect(headers.get('Authorization')).toBe('Bearer admin-key');
+
+        if (url === 'https://llm.example.com/team/new') {
+          expect(body).toEqual({
+            team_id: 'tenant-a-project-one',
+            team_alias: 'Project One',
+            models: ['gpt-4o'],
+            max_budget: 100,
+            budget_duration: '30d',
+            tpm_limit: 10000,
+            rpm_limit: 100,
+            metadata: {
+              tenant_id: 'tenant-a',
+              environment: 'test',
+            },
+          });
+
+          return jsonResponse({
+            team_id: 'tenant-a-project-one',
+            team_alias: 'Project One',
+          });
+        }
+
+        if (url === 'https://llm.example.com/key/generate') {
+          expect(body).toEqual({
+            key_alias: 'Project One Production',
+            team_id: 'tenant-a-project-one',
+            models: ['gpt-4o'],
+            duration: '30d',
+            max_budget: 25,
+            tpm_limit: 1000,
+            rpm_limit: 20,
+            metadata: {
+              tenant_id: 'tenant-a',
+              description: 'Production tenant key',
+            },
+          });
+
+          return jsonResponse({
+            key: 'sk-litellm-generated',
+            key_alias: 'Project One Production',
+            key_name: 'sk-...rated',
+            token_id: 'token-123',
+            team_id: 'tenant-a-project-one',
+            expires: '2026-05-25T00:00:00Z',
+          });
+        }
+
+        throw new Error(`Unexpected fetch call: ${url}`);
+      },
+    );
+
+    global.fetch = fetchMock as any;
+
+    try {
+      const provider = new LiteLLMProvider({
+        type: 'litellm',
+        apiKey: 'runtime-key',
+        adminApiKey: 'admin-key',
+        baseUrl: 'https://llm.example.com/v1',
+      });
+
+      const project = await provider.admin.createProject({
+        name: 'Project One',
+        tenantId: 'tenant-a',
+        models: ['gpt-4o'],
+        budget: { maxLimit: 100, resetDuration: '30d' },
+        rateLimit: { tokenMaxLimit: 10000, requestMaxLimit: 100 },
+        metadata: { environment: 'test' },
+      });
+
+      const key = await provider.admin.createVirtualKey({
+        name: 'Project One Production',
+        description: 'Production tenant key',
+        tenantId: 'tenant-a',
+        projectId: project.id,
+        models: ['gpt-4o'],
+        duration: '30d',
+        budget: { maxLimit: 25 },
+        rateLimit: { tpmLimit: 1000, rpmLimit: 20 },
+      });
+
+      expect(project).toEqual(
+        expect.objectContaining({
+          id: 'tenant-a-project-one',
+          name: 'Project One',
+          tenantId: 'tenant-a',
+          provider: 'litellm',
+        }),
+      );
+      expect(key).toEqual(
+        expect.objectContaining({
+          id: 'token-123',
+          key: 'sk-litellm-generated',
+          projectId: 'tenant-a-project-one',
+          tenantId: 'tenant-a',
+          provider: 'litellm',
+        }),
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});
+
+describe('Bifrost Provider', () => {
+  it('should initialize with valid options', () => {
+    const provider = new BifrostProvider({
+      type: 'bifrost',
+      apiKey: 'runtime-key',
+      adminApiKey: 'admin-key',
+      baseUrl: 'http://localhost:8080/openai',
+      defaultModel: 'openai/gpt-4o-mini',
+    });
+
+    expect(provider).toBeInstanceOf(BifrostProvider);
+    expect((provider as any).options.baseUrl).toBe(
+      'http://localhost:8080/openai',
+    );
+    expect((provider as any).options.defaultModel).toBe('openai/gpt-4o-mini');
+    expect(provider.admin).toBeDefined();
+  });
+
+  it('should normalize a bare Bifrost gateway root to the OpenAI-compatible endpoint', () => {
+    const provider = new BifrostProvider({
+      type: 'bifrost',
+      apiKey: 'runtime-key',
+      baseUrl: 'http://localhost:8080/',
+    });
+
+    expect((provider as any).options.baseUrl).toBe(
+      'http://localhost:8080/openai',
+    );
+    expect((provider as any).options.headers).toEqual({
+      'x-bf-vk': 'runtime-key',
+      'x-api-key': 'runtime-key',
+    });
+  });
+
+  it('should require a baseUrl', () => {
+    expect(
+      () =>
+        new BifrostProvider({
+          type: 'bifrost',
+          apiKey: 'test-key',
+        }),
+    ).toThrow(ValidationError);
+  });
+
+  it('should return Bifrost-specific capabilities', async () => {
+    const provider = new BifrostProvider({
+      type: 'bifrost',
+      apiKey: 'test-key',
+      baseUrl: 'http://localhost:8080/openai',
+    });
+
+    const capabilities = await provider.getCapabilities();
+
+    expect(capabilities).toEqual({
+      chat: true,
+      completion: true,
+      embeddings: true,
+      streaming: true,
+      functions: true,
+      vision: true,
+      fineTuning: false,
+      imageEmbeddings: true,
+      imageGeneration: true,
+      tts: false,
+      voiceCloning: false,
+      voiceDesign: false,
+      maxContextLength: 128000,
+      supportedOperations: [
+        'chat',
+        'completion',
+        'embedding',
+        'streaming',
+        'functions',
+        'vision',
+        'image_embedding',
+        'image_generation',
+      ],
+    });
+  });
+
+  it('should create projects and virtual keys through the Bifrost governance API', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const headers = new Headers(init?.headers);
+        const body = JSON.parse(String(init?.body || '{}'));
+
+        expect(headers.get('Authorization')).toBe('Basic YWRtaW46c2VjcmV0');
+
+        if (url === 'http://bifrost.local/api/governance/teams') {
+          expect(body).toEqual({
+            name: 'Project One',
+            customer_id: 'tenant-a',
+            budget: {
+              max_limit: 100,
+              reset_duration: '1M',
+            },
+          });
+
+          return jsonResponse({
+            id: 'team-project-one',
+            name: 'Project One',
+            customer_id: 'tenant-a',
+            budget_id: 'budget-team-project-one',
+          });
+        }
+
+        if (url === 'http://bifrost.local/api/governance/virtual-keys') {
+          expect(body).toEqual({
+            name: 'Project One Production',
+            description: 'Production tenant key',
+            provider_configs: [
+              {
+                provider: 'openai',
+                weight: 1,
+                allowed_models: ['gpt-4o-mini'],
+              },
+            ],
+            team_id: 'team-project-one',
+            budget: {
+              max_limit: 25,
+              reset_duration: '1M',
+            },
+            rate_limit: {
+              token_max_limit: 1000,
+              token_reset_duration: '1h',
+              request_max_limit: 20,
+              request_reset_duration: '1m',
+            },
+            key_ids: ['*'],
+            is_active: true,
+          });
+
+          return jsonResponse({
+            virtual_key: {
+              id: 'vk-project-one',
+              name: 'Project One Production',
+              value: 'sk-bf-generated',
+              team_id: 'team-project-one',
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch call: ${url}`);
+      },
+    );
+
+    global.fetch = fetchMock as any;
+
+    try {
+      const provider = new BifrostProvider({
+        type: 'bifrost',
+        apiKey: 'runtime-key',
+        adminUser: 'admin',
+        adminPassword: 'secret',
+        baseUrl: 'http://bifrost.local/openai',
+      });
+
+      const project = await provider.admin.createProject({
+        name: 'Project One',
+        tenantId: 'tenant-a',
+        budget: { maxLimit: 100, resetDuration: '1M' },
+      });
+
+      const key = await provider.admin.createVirtualKey({
+        name: 'Project One Production',
+        description: 'Production tenant key',
+        projectId: project.id,
+        providerConfigs: [
+          {
+            provider: 'openai',
+            weight: 1,
+            allowedModels: ['gpt-4o-mini'],
+          },
+        ],
+        budget: { maxLimit: 25, resetDuration: '1M' },
+        rateLimit: {
+          tokenMaxLimit: 1000,
+          tokenResetDuration: '1h',
+          requestMaxLimit: 20,
+          requestResetDuration: '1m',
+        },
+        keyIds: ['*'],
+      });
+
+      expect(project).toEqual(
+        expect.objectContaining({
+          id: 'team-project-one',
+          name: 'Project One',
+          tenantId: 'tenant-a',
+          budgetId: 'budget-team-project-one',
+          provider: 'bifrost',
+        }),
+      );
+      expect(key).toEqual(
+        expect.objectContaining({
+          id: 'vk-project-one',
+          key: 'sk-bf-generated',
+          projectId: 'team-project-one',
+          provider: 'bifrost',
+        }),
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 });
 
@@ -1266,6 +1590,13 @@ describe('Provider Implementations', () => {
     });
     expect(litellmProvider).toBeInstanceOf(LiteLLMProvider);
 
+    const bifrostProvider = new BifrostProvider({
+      type: 'bifrost',
+      apiKey: 'test-token',
+      baseUrl: 'https://bifrost.example.com/openai',
+    });
+    expect(bifrostProvider).toBeInstanceOf(BifrostProvider);
+
     // HuggingFace should work
     const hfProvider = new HuggingFaceProvider({
       type: 'huggingface',
@@ -1315,6 +1646,14 @@ describe('Provider Implementations', () => {
           type: 'litellm',
           apiKey: 'test-token',
           baseUrl: 'https://llm.example.com/v1',
+        }),
+    ).not.toThrow();
+    expect(
+      () =>
+        new BifrostProvider({
+          type: 'bifrost',
+          apiKey: 'test-token',
+          baseUrl: 'https://bifrost.example.com/openai',
         }),
     ).not.toThrow();
     expect(
@@ -1460,6 +1799,22 @@ describe('Environment Variable Configuration', () => {
     expect((client as any).options.baseUrl).toBe('https://llm.example.com/v1');
   });
 
+  it('should load Bifrost provider from HAVE_AI_TYPE', async () => {
+    process.env.HAVE_AI_TYPE = 'bifrost';
+    process.env.HAVE_AI_API_KEY = 'runtime-key';
+    process.env.HAVE_AI_ADMIN_API_KEY = 'admin-key';
+    process.env.HAVE_AI_BASE_URL = 'https://bifrost.example.com/openai';
+
+    const { getAI } = await import('./shared/factory');
+    const client = await getAI({});
+
+    expect(client).toBeInstanceOf(BifrostProvider);
+    expect((client as any).options.baseUrl).toBe(
+      'https://bifrost.example.com/openai',
+    );
+    expect((client as any).options.adminApiKey).toBe('admin-key');
+  });
+
   it('should load Ollama provider from HAVE_AI_TYPE', async () => {
     process.env.HAVE_AI_TYPE = 'ollama';
     delete process.env.HAVE_AI_BASE_URL;
@@ -1510,6 +1865,9 @@ describe('Environment Variable Configuration', () => {
   });
 
   it('should auto-detect LiteLLM from LITELLM_BASE_URL', async () => {
+    delete process.env.BIFROST_BASE_URL;
+    delete process.env.BIFROST_API_KEY;
+    delete process.env.BIFROST_ADMIN_API_KEY;
     process.env.LITELLM_BASE_URL = 'https://llm.example.com/v1';
     process.env.LITELLM_API_KEY = 'litellm-key';
 
@@ -1521,9 +1879,38 @@ describe('Environment Variable Configuration', () => {
     expect((client as any).options.apiKey).toBe('litellm-key');
   });
 
+  it('should auto-detect Bifrost from BIFROST_BASE_URL', async () => {
+    delete process.env.LITELLM_BASE_URL;
+    delete process.env.LITELLM_API_KEY;
+    process.env.BIFROST_BASE_URL = 'https://bifrost.example.com/openai';
+    process.env.BIFROST_API_KEY = 'runtime-key';
+    process.env.BIFROST_ADMIN_API_KEY = 'admin-key';
+    process.env.BIFROST_ADMIN_URL = 'https://bifrost-admin.example.com';
+    process.env.BIFROST_ADMIN_USER = 'admin';
+    process.env.BIFROST_ADMIN_PASSWORD = 'secret';
+
+    const { getAIAuto } = await import('./node/factory');
+    const client = await getAIAuto({});
+
+    expect(client).toBeInstanceOf(BifrostProvider);
+    expect((client as any).options.baseUrl).toBe(
+      'https://bifrost.example.com/openai',
+    );
+    expect((client as any).options.apiKey).toBe('runtime-key');
+    expect((client as any).options.adminApiKey).toBe('admin-key');
+    expect((client as any).options.adminUrl).toBe(
+      'https://bifrost-admin.example.com',
+    );
+    expect((client as any).options.adminUser).toBe('admin');
+    expect((client as any).options.adminPassword).toBe('secret');
+  });
+
   it('should auto-detect Ollama from OLLAMA_HOST', async () => {
     delete process.env.LITELLM_BASE_URL;
     delete process.env.LITELLM_API_KEY;
+    delete process.env.BIFROST_BASE_URL;
+    delete process.env.BIFROST_API_KEY;
+    delete process.env.BIFROST_ADMIN_API_KEY;
     delete process.env.OPENAI_API_KEY;
     process.env.OLLAMA_HOST = 'https://ollama.example.com/api';
     process.env.OLLAMA_API_KEY = 'ollama-key';
@@ -1539,6 +1926,9 @@ describe('Environment Variable Configuration', () => {
   it('should not treat a custom baseUrl as LiteLLM when Ollama env signals are present', async () => {
     delete process.env.LITELLM_BASE_URL;
     delete process.env.LITELLM_API_KEY;
+    delete process.env.BIFROST_BASE_URL;
+    delete process.env.BIFROST_API_KEY;
+    delete process.env.BIFROST_ADMIN_API_KEY;
     delete process.env.OPENAI_API_KEY;
     process.env.OLLAMA_API_KEY = 'ollama-key';
 
@@ -1555,6 +1945,9 @@ describe('Environment Variable Configuration', () => {
   it('should auto-detect Anthropic from ANTHROPIC_API_KEY', async () => {
     delete process.env.LITELLM_BASE_URL;
     delete process.env.LITELLM_API_KEY;
+    delete process.env.BIFROST_BASE_URL;
+    delete process.env.BIFROST_API_KEY;
+    delete process.env.BIFROST_ADMIN_API_KEY;
     delete process.env.OLLAMA_HOST;
     delete process.env.OLLAMA_BASE_URL;
     delete process.env.OLLAMA_API_KEY;
@@ -1570,6 +1963,9 @@ describe('Environment Variable Configuration', () => {
   it('should auto-detect Gemini from GEMINI_API_KEY', async () => {
     delete process.env.LITELLM_BASE_URL;
     delete process.env.LITELLM_API_KEY;
+    delete process.env.BIFROST_BASE_URL;
+    delete process.env.BIFROST_API_KEY;
+    delete process.env.BIFROST_ADMIN_API_KEY;
     delete process.env.OLLAMA_HOST;
     delete process.env.OLLAMA_BASE_URL;
     delete process.env.OLLAMA_API_KEY;

--- a/packages/ai/src/providers.test.ts
+++ b/packages/ai/src/providers.test.ts
@@ -643,6 +643,25 @@ describe('Bifrost Provider', () => {
       global.fetch = originalFetch;
     }
   });
+
+  it('should derive the gateway admin root from a baseUrl with stacked inference suffixes', async () => {
+    const { deriveGatewayAdminBaseUrl } = await import(
+      './shared/providers/gateway-admin'
+    );
+
+    expect(
+      deriveGatewayAdminBaseUrl('https://gateway.example.com/openai'),
+    ).toBe('https://gateway.example.com');
+    expect(
+      deriveGatewayAdminBaseUrl('https://gateway.example.com/openai/v1'),
+    ).toBe('https://gateway.example.com');
+    expect(deriveGatewayAdminBaseUrl('https://gateway.example.com/v1')).toBe(
+      'https://gateway.example.com',
+    );
+    expect(
+      deriveGatewayAdminBaseUrl('https://gateway.example.com/pydanticai/v1'),
+    ).toBe('https://gateway.example.com');
+  });
 });
 
 describe('Ollama Provider', () => {
@@ -1903,6 +1922,31 @@ describe('Environment Variable Configuration', () => {
     );
     expect((client as any).options.adminUser).toBe('admin');
     expect((client as any).options.adminPassword).toBe('secret');
+  });
+
+  it('should let caller-provided adminBaseUrl win over BIFROST_ADMIN_URL env', async () => {
+    delete process.env.LITELLM_BASE_URL;
+    delete process.env.LITELLM_API_KEY;
+    process.env.BIFROST_BASE_URL = 'https://bifrost.example.com/openai';
+    process.env.BIFROST_API_KEY = 'runtime-key';
+    process.env.BIFROST_ADMIN_URL = 'https://env-admin.example.com';
+
+    const { getAIAuto } = await import('./node/factory');
+    const client = await getAIAuto({
+      type: 'bifrost',
+      adminBaseUrl: 'https://caller-admin.example.com',
+    });
+
+    expect(client).toBeInstanceOf(BifrostProvider);
+    expect((client as any).options.adminBaseUrl).toBe(
+      'https://caller-admin.example.com',
+    );
+    expect((client as any).options.adminUrl).toBe(
+      'https://caller-admin.example.com',
+    );
+    expect((client.admin as any).transport.baseUrl).toBe(
+      'https://caller-admin.example.com',
+    );
   });
 
   it('should auto-detect Ollama from OLLAMA_HOST', async () => {

--- a/packages/ai/src/shared/client.ts
+++ b/packages/ai/src/shared/client.ts
@@ -30,6 +30,41 @@ export interface AIClientOptions {
   baseUrl?: string;
 
   /**
+   * Admin API key for gateway providers that support provisioning.
+   */
+  adminApiKey?: string;
+
+  /**
+   * Admin base URL for gateway providers when it differs from `baseUrl`.
+   */
+  adminBaseUrl?: string;
+
+  /**
+   * Alias for adminBaseUrl.
+   */
+  adminUrl?: string;
+
+  /**
+   * Admin username for providers that use HTTP Basic auth.
+   */
+  adminUser?: string;
+
+  /**
+   * Admin username for providers that use HTTP Basic auth.
+   */
+  adminUsername?: string;
+
+  /**
+   * Admin password for providers that use HTTP Basic auth.
+   */
+  adminPassword?: string;
+
+  /**
+   * Custom admin headers for gateway providers.
+   */
+  adminHeaders?: Record<string, string>;
+
+  /**
    * Optional shared pacing / retry configuration for getAI().
    */
   rateLimit?: AIRateLimitOptions;

--- a/packages/ai/src/shared/factory.ts
+++ b/packages/ai/src/shared/factory.ts
@@ -12,6 +12,7 @@ import type {
   AIProviderType,
   AnthropicOptions,
   BedrockOptions,
+  BifrostOptions,
   ClaudeCliOptions,
   GeminiOptions,
   GetAIOptions,
@@ -47,6 +48,17 @@ function isLiteLLMOptions(
   options: GetAIOptions | AIClientOptions,
 ): options is LiteLLMOptions {
   return options.type === 'litellm';
+}
+
+/**
+ * Checks if the options are for Bifrost provider
+ * @param options - The AI provider options to check
+ * @returns True if options are for Bifrost provider
+ */
+function isBifrostOptions(
+  options: GetAIOptions | AIClientOptions,
+): options is BifrostOptions {
+  return options.type === 'bifrost';
 }
 
 /**
@@ -187,6 +199,12 @@ export async function getAI(
       maxRetries: 'number',
       apiKey: 'string',
       baseUrl: 'string',
+      adminApiKey: 'string',
+      adminBaseUrl: 'string',
+      adminUrl: 'string',
+      adminUser: 'string',
+      adminUsername: 'string',
+      adminPassword: 'string',
     },
   }) as GetAIOptions;
 
@@ -208,6 +226,9 @@ export async function getAI(
   } else if (isLiteLLMOptions(options)) {
     const { LiteLLMProvider } = await import('./providers/litellm.js');
     client = new LiteLLMProvider(options);
+  } else if (isBifrostOptions(options)) {
+    const { BifrostProvider } = await import('./providers/bifrost.js');
+    client = new BifrostProvider(options);
   } else if (isOllamaOptions(options)) {
     const { OllamaProvider } = await import('./providers/ollama.js');
     client = new OllamaProvider(options);

--- a/packages/ai/src/shared/providers/bifrost.ts
+++ b/packages/ai/src/shared/providers/bifrost.ts
@@ -5,6 +5,7 @@ import type {
   AIMessage,
   AIModel,
   AIResponse,
+  BifrostOptions,
   ChatOptions,
   EmbeddingOptions,
   EmbeddingResponse,
@@ -12,12 +13,15 @@ import type {
   ImageEmbeddingOptions,
   ImageGenerationOptions,
   ImageGenerationResponse,
-  LiteLLMOptions,
 } from '../types';
-import { LiteLLMAdmin, resolveGatewayAdminBaseUrl } from './gateway-admin';
+import {
+  BifrostAdmin,
+  normalizeGatewayBaseUrl,
+  resolveGatewayAdminBaseUrl,
+} from './gateway-admin';
 import { type OpenAICompatibleProfile, OpenAIProvider } from './openai';
 
-const LITELLM_CAPABILITIES: AICapabilities = {
+const BIFROST_CAPABILITIES: AICapabilities = {
   chat: true,
   completion: true,
   embeddings: true,
@@ -59,11 +63,11 @@ function isImageGenerationModel(modelId: string): boolean {
   );
 }
 
-function isFilteredLiteLLMModel(modelId: string): boolean {
+function isFilteredBifrostModel(modelId: string): boolean {
   return /moderation|transcrib|whisper|speech|tts|rerank/i.test(modelId);
 }
 
-function inferLiteLLMContextLength(modelId: string): number {
+function inferBifrostContextLength(modelId: string): number {
   if (isEmbeddingModel(modelId)) return 8192;
   if (/gemini-1\.5|gemini-2\.0|gemini-2\.5|gemini-3/i.test(modelId)) {
     return 1000000;
@@ -75,20 +79,20 @@ function inferLiteLLMContextLength(modelId: string): number {
   return 32768;
 }
 
-function inferLiteLLMFunctions(modelId: string): boolean {
+function inferBifrostFunctions(modelId: string): boolean {
   if (isEmbeddingModel(modelId)) return false;
   return /gpt|claude|gemini|command|llama|mistral|qwen|deepseek|o1|o3|o4/i.test(
     modelId,
   );
 }
 
-function inferLiteLLMVision(modelId: string): boolean {
+function inferBifrostVision(modelId: string): boolean {
   return /gpt-4o|gpt-4\.1|vision|claude-3|gemini|pixtral|llava|qwen.*vl|vl-/i.test(
     modelId,
   );
 }
 
-function inferLiteLLMCapabilities(modelId: string): string[] {
+function inferBifrostCapabilities(modelId: string): string[] {
   if (isImageGenerationModel(modelId)) {
     return ['image_generation'];
   }
@@ -103,49 +107,58 @@ function inferLiteLLMCapabilities(modelId: string): string[] {
 
   const capabilities = ['text', 'chat'];
 
-  if (inferLiteLLMFunctions(modelId)) {
+  if (inferBifrostFunctions(modelId)) {
     capabilities.push('functions');
   }
 
-  if (inferLiteLLMVision(modelId)) {
+  if (inferBifrostVision(modelId)) {
     capabilities.push('vision');
   }
 
   return capabilities;
 }
 
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-}
-
-function ensureLiteLLMOptions(options: LiteLLMOptions): LiteLLMOptions {
+function ensureBifrostOptions(options: BifrostOptions): BifrostOptions {
   if (!options.baseUrl?.trim()) {
-    throw new ValidationError('LiteLLM baseUrl is required', {
-      provider: 'litellm',
-      hint: 'Pass baseUrl like https://llm.happyvertical.com/v1 or set HAVE_AI_BASE_URL / LITELLM_BASE_URL',
+    throw new ValidationError('Bifrost baseUrl is required', {
+      provider: 'bifrost',
+      hint: 'Pass baseUrl like http://localhost:8080, http://localhost:8080/openai, or http://localhost:8080/v1 and optionally adminBaseUrl for governance endpoints',
     });
   }
 
+  const baseUrl = normalizeGatewayBaseUrl(options.baseUrl);
+  const inferenceBaseUrl = /\/(?:openai|v1|pydanticai\/v1)$/.test(baseUrl)
+    ? baseUrl
+    : `${baseUrl}/openai`;
+  const headers = options.apiKey
+    ? {
+        'x-bf-vk': options.apiKey,
+        'x-api-key': options.apiKey,
+        ...options.headers,
+      }
+    : options.headers;
+
   return {
     ...options,
-    baseUrl: normalizeBaseUrl(options.baseUrl.trim()),
+    baseUrl: inferenceBaseUrl,
+    headers,
   };
 }
 
-const LITELLM_PROFILE: OpenAICompatibleProfile = {
-  providerLabel: 'LiteLLM',
-  providerName: 'litellm',
-  defaultModel: 'gpt-4',
-  capabilities: LITELLM_CAPABILITIES,
-  describeModel: (modelId) => `LiteLLM model: ${modelId}`,
-  getContextLength: inferLiteLLMContextLength,
-  getModelCapabilities: inferLiteLLMCapabilities,
-  shouldIncludeModel: (modelId) => !isFilteredLiteLLMModel(modelId),
-  supportsFunctions: inferLiteLLMFunctions,
-  supportsVision: inferLiteLLMVision,
+const BIFROST_PROFILE: OpenAICompatibleProfile = {
+  providerLabel: 'Bifrost',
+  providerName: 'bifrost',
+  defaultModel: 'openai/gpt-4o-mini',
+  capabilities: BIFROST_CAPABILITIES,
+  describeModel: (modelId) => `Bifrost model: ${modelId}`,
+  getContextLength: inferBifrostContextLength,
+  getModelCapabilities: inferBifrostCapabilities,
+  shouldIncludeModel: (modelId) => !isFilteredBifrostModel(modelId),
+  supportsFunctions: inferBifrostFunctions,
+  supportsVision: inferBifrostVision,
 };
 
-type LiteLLMResolvedCapability =
+type BifrostResolvedCapability =
   | 'chat'
   | 'vision'
   | 'embeddings'
@@ -153,7 +166,7 @@ type LiteLLMResolvedCapability =
 
 function supportsCapability(
   model: AIModel,
-  capability: LiteLLMResolvedCapability,
+  capability: BifrostResolvedCapability,
 ): boolean {
   if (capability === 'vision') {
     return (
@@ -173,39 +186,50 @@ function supportsCapability(
 }
 
 /**
- * LiteLLM provider implementation.
+ * Bifrost provider implementation.
  *
- * LiteLLM exposes an OpenAI-compatible API surface, so this provider reuses the
- * OpenAI transport while customizing provider identity, model discovery, and
- * capability heuristics for gateway-backed deployments.
+ * Bifrost exposes OpenAI-compatible inference and governance admin APIs. This
+ * provider reuses the OpenAI-compatible transport for inference and exposes
+ * `admin` for tenant project and virtual-key provisioning.
  */
-export class LiteLLMProvider extends OpenAIProvider {
-  readonly admin: LiteLLMAdmin;
+export class BifrostProvider extends OpenAIProvider {
+  readonly admin: BifrostAdmin;
   private readonly configuredDefaultModel?: string;
   private readonly resolvedModelCache = new Map<
-    LiteLLMResolvedCapability,
+    BifrostResolvedCapability,
     Promise<string>
   >();
 
-  constructor(options: LiteLLMOptions) {
-    const normalized = ensureLiteLLMOptions(options);
-    super(normalized, LITELLM_PROFILE);
-    this.admin = new LiteLLMAdmin({
-      provider: 'litellm',
+  constructor(options: BifrostOptions) {
+    const normalized = ensureBifrostOptions(options);
+    super(normalized, BIFROST_PROFILE);
+    const adminKey = normalized.adminApiKey || normalized.apiKey;
+    const adminUsername = normalized.adminUser || normalized.adminUsername;
+    this.admin = new BifrostAdmin({
+      provider: 'bifrost',
       baseUrl: resolveGatewayAdminBaseUrl(
         normalized.baseUrl,
         normalized.adminUrl || normalized.adminBaseUrl,
-        'litellm',
+        'bifrost',
       ),
-      apiKey: normalized.adminApiKey || normalized.apiKey,
-      headers: normalized.adminHeaders,
+      apiKey: adminKey,
+      username: adminUsername,
+      password: normalized.adminPassword,
+      headers:
+        adminKey && !(adminUsername && normalized.adminPassword)
+          ? {
+              'x-bf-vk': adminKey,
+              'x-api-key': adminKey,
+              ...normalized.adminHeaders,
+            }
+          : normalized.adminHeaders,
       timeout: normalized.timeout,
     });
     this.configuredDefaultModel = normalized.defaultModel;
   }
 
   private async resolveModel(
-    capability: LiteLLMResolvedCapability,
+    capability: BifrostResolvedCapability,
     explicitModel?: string,
   ): Promise<string> {
     if (explicitModel) {
@@ -233,7 +257,7 @@ export class LiteLLMProvider extends OpenAIProvider {
   }
 
   private async selectModel(
-    capability: LiteLLMResolvedCapability,
+    capability: BifrostResolvedCapability,
   ): Promise<string> {
     const models = await super.getModels();
     const model = models.find((candidate) =>
@@ -242,11 +266,11 @@ export class LiteLLMProvider extends OpenAIProvider {
 
     if (!model) {
       throw new ValidationError(
-        `No ${capability} model is available from the LiteLLM gateway`,
+        `No ${capability} model is available from the Bifrost gateway`,
         {
-          provider: 'litellm',
+          provider: 'bifrost',
           capability,
-          hint: 'Pass defaultModel explicitly or ensure /models returns a compatible model for this key',
+          hint: 'Pass defaultModel explicitly or ensure the gateway returns a compatible model for this key',
         },
       );
     }

--- a/packages/ai/src/shared/providers/bifrost.ts
+++ b/packages/ai/src/shared/providers/bifrost.ts
@@ -132,9 +132,9 @@ function ensureBifrostOptions(options: BifrostOptions): BifrostOptions {
     : `${baseUrl}/openai`;
   const headers = options.apiKey
     ? {
+        ...options.headers,
         'x-bf-vk': options.apiKey,
         'x-api-key': options.apiKey,
-        ...options.headers,
       }
     : options.headers;
 
@@ -218,9 +218,9 @@ export class BifrostProvider extends OpenAIProvider {
       headers:
         adminKey && !(adminUsername && normalized.adminPassword)
           ? {
+              ...normalized.adminHeaders,
               'x-bf-vk': adminKey,
               'x-api-key': adminKey,
-              ...normalized.adminHeaders,
             }
           : normalized.adminHeaders,
       timeout: normalized.timeout,

--- a/packages/ai/src/shared/providers/gateway-admin.ts
+++ b/packages/ai/src/shared/providers/gateway-admin.ts
@@ -1,0 +1,495 @@
+import type {
+  AIAdminBudget,
+  AIAdminInterface,
+  AIAdminProject,
+  AIAdminProviderConfig,
+  AIAdminRateLimit,
+  AIVirtualKey,
+  CreateAIProjectOptions,
+  CreateAIVirtualKeyOptions,
+} from '../types';
+import { AIError } from '../types';
+
+interface GatewayAdminTransportOptions {
+  provider: string;
+  baseUrl: string;
+  apiKey?: string;
+  username?: string;
+  password?: string;
+  headers?: Record<string, string>;
+  timeout?: number;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+export function normalizeGatewayBaseUrl(baseUrl: string): string {
+  return stripTrailingSlash(baseUrl.trim());
+}
+
+/**
+ * Derive the gateway root URL for admin APIs from an OpenAI-compatible base URL.
+ */
+export function deriveGatewayAdminBaseUrl(baseUrl: string): string {
+  let normalized = normalizeGatewayBaseUrl(baseUrl);
+
+  for (const suffix of ['/pydanticai/v1', '/openai', '/v1']) {
+    if (normalized.endsWith(suffix)) {
+      normalized = normalized.slice(0, -suffix.length);
+      break;
+    }
+  }
+
+  return normalized || normalizeGatewayBaseUrl(baseUrl);
+}
+
+export function resolveGatewayAdminBaseUrl(
+  baseUrl: string | undefined,
+  adminBaseUrl: string | undefined,
+  provider: string,
+): string {
+  const configuredBaseUrl = adminBaseUrl || baseUrl;
+  if (!configuredBaseUrl?.trim()) {
+    throw new AIError(
+      `${provider} baseUrl is required for admin operations`,
+      'ADMIN_BASE_URL_REQUIRED',
+      provider,
+    );
+  }
+
+  return adminBaseUrl
+    ? normalizeGatewayBaseUrl(adminBaseUrl)
+    : deriveGatewayAdminBaseUrl(configuredBaseUrl);
+}
+
+export function slugifyProjectId(name: string, tenantId?: string): string {
+  const value = [tenantId, name].filter(Boolean).join('-');
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return slug || 'ai-project';
+}
+
+function toJsonRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function encodeBasicCredentials(username: string, password: string): string {
+  const value = `${username}:${password}`;
+
+  if (typeof btoa === 'function') {
+    return btoa(value);
+  }
+
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function removeUndefinedValues<T extends JsonRecord>(value: T): T {
+  for (const key of Object.keys(value)) {
+    if (value[key] === undefined) {
+      delete value[key];
+    }
+  }
+
+  return value;
+}
+
+function createMetadata(
+  options: {
+    tenantId?: string;
+    description?: string;
+    metadata?: Record<string, unknown>;
+  },
+  tenantField = 'tenant_id',
+): Record<string, unknown> | undefined {
+  const metadata = {
+    ...options.metadata,
+  };
+
+  if (options.tenantId) {
+    metadata[tenantField] = options.tenantId;
+  }
+
+  if (options.description) {
+    metadata.description = options.description;
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function responseMessage(body: unknown, fallback: string): string {
+  const record = toJsonRecord(body);
+  const error = toJsonRecord(record.error);
+
+  return (
+    stringValue(error.message) ||
+    stringValue(record.message) ||
+    stringValue(record.detail) ||
+    fallback
+  );
+}
+
+class GatewayAdminTransport {
+  private readonly baseUrl: string;
+  private readonly provider: string;
+  private readonly apiKey?: string;
+  private readonly username?: string;
+  private readonly password?: string;
+  private readonly headers?: Record<string, string>;
+  private readonly timeout?: number;
+
+  constructor(options: GatewayAdminTransportOptions) {
+    this.provider = options.provider;
+    this.baseUrl = normalizeGatewayBaseUrl(options.baseUrl);
+    this.apiKey = options.apiKey;
+    this.username = options.username;
+    this.password = options.password;
+    this.headers = options.headers;
+    this.timeout = options.timeout;
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    query?: Record<string, string | undefined>,
+  ): Promise<T> {
+    const url = new URL(
+      `${this.baseUrl}${path.startsWith('/') ? path : `/${path}`}`,
+    );
+
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, value);
+        }
+      }
+    }
+
+    const controller =
+      typeof AbortController === 'undefined'
+        ? undefined
+        : new AbortController();
+    const timeoutHandle =
+      controller && this.timeout
+        ? setTimeout(() => controller.abort(), this.timeout)
+        : undefined;
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          Accept: 'application/json',
+          ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+          ...this.createAuthHeaders(),
+          ...this.headers,
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller?.signal,
+      });
+
+      const text = await response.text();
+      const parsed = text ? this.parseJson(text) : undefined;
+
+      if (!response.ok) {
+        throw this.mapResponseError(response, parsed);
+      }
+
+      return parsed as T;
+    } catch (error) {
+      if (error instanceof AIError) {
+        throw error;
+      }
+
+      throw new AIError(
+        `${this.provider} admin request failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        'ADMIN_REQUEST_FAILED',
+        this.provider,
+      );
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  private createAuthHeaders(): Record<string, string> {
+    if (this.username && this.password) {
+      return {
+        Authorization: `Basic ${encodeBasicCredentials(
+          this.username,
+          this.password,
+        )}`,
+      };
+    }
+
+    return this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {};
+  }
+
+  private parseJson(text: string): unknown {
+    try {
+      return JSON.parse(text);
+    } catch (_error) {
+      return { message: text };
+    }
+  }
+
+  private mapResponseError(response: Response, body: unknown): AIError {
+    const message = responseMessage(
+      body,
+      `${this.provider} admin request failed with ${response.status}`,
+    );
+
+    if (response.status === 401 || response.status === 403) {
+      return new AIError(message, 'AUTH_ERROR', this.provider);
+    }
+
+    if (response.status === 429) {
+      return new AIError(message, 'RATE_LIMIT', this.provider, undefined, true);
+    }
+
+    return new AIError(
+      message,
+      `ADMIN_HTTP_${response.status}`,
+      this.provider,
+      undefined,
+      response.status >= 500,
+    );
+  }
+}
+
+function mapBifrostBudget(budget?: AIAdminBudget): JsonRecord | undefined {
+  if (!budget) return undefined;
+
+  return removeUndefinedValues({
+    max_limit: budget.maxLimit,
+    reset_duration: budget.resetDuration,
+    calendar_aligned: budget.calendarAligned,
+  });
+}
+
+function mapBifrostRateLimit(
+  rateLimit?: AIAdminRateLimit,
+): JsonRecord | undefined {
+  if (!rateLimit) return undefined;
+
+  return removeUndefinedValues({
+    token_max_limit: rateLimit.tokenMaxLimit ?? rateLimit.tpmLimit,
+    token_reset_duration: rateLimit.tokenResetDuration,
+    request_max_limit: rateLimit.requestMaxLimit ?? rateLimit.rpmLimit,
+    request_reset_duration: rateLimit.requestResetDuration,
+  });
+}
+
+function mapBifrostProviderConfigs(
+  configs?: AIAdminProviderConfig[],
+): JsonRecord[] | undefined {
+  if (!configs) return undefined;
+
+  return configs.map((config) =>
+    removeUndefinedValues({
+      provider: config.provider,
+      weight: config.weight,
+      allowed_models: config.allowedModels,
+      key_ids: config.keyIds,
+    }),
+  );
+}
+
+function mapLiteLLMBudget(
+  budget?: AIAdminBudget,
+): Pick<JsonRecord, 'max_budget' | 'budget_duration'> {
+  return removeUndefinedValues({
+    max_budget: budget?.maxLimit,
+    budget_duration: budget?.resetDuration,
+  });
+}
+
+function mapLiteLLMRateLimit(
+  rateLimit?: AIAdminRateLimit,
+): Pick<JsonRecord, 'tpm_limit' | 'rpm_limit'> {
+  return removeUndefinedValues({
+    tpm_limit: rateLimit?.tpmLimit ?? rateLimit?.tokenMaxLimit,
+    rpm_limit: rateLimit?.rpmLimit ?? rateLimit?.requestMaxLimit,
+  });
+}
+
+export class BifrostAdmin implements AIAdminInterface {
+  private readonly transport: GatewayAdminTransport;
+
+  constructor(options: GatewayAdminTransportOptions) {
+    this.transport = new GatewayAdminTransport(options);
+  }
+
+  async createProject(
+    options: CreateAIProjectOptions,
+  ): Promise<AIAdminProject> {
+    const body = removeUndefinedValues({
+      name: options.name,
+      customer_id: options.tenantId,
+      budget: mapBifrostBudget(options.budget),
+      ...options.raw,
+    });
+
+    const response = await this.transport.request<JsonRecord>(
+      'POST',
+      '/api/governance/teams',
+      body,
+    );
+    const team = toJsonRecord(response.team ?? response);
+    const id = stringValue(team.id) || stringValue(team.team_id);
+
+    if (!id) {
+      throw new AIError(
+        'Bifrost did not return a project id',
+        'ADMIN_INVALID_RESPONSE',
+        'bifrost',
+      );
+    }
+
+    return {
+      id,
+      name:
+        stringValue(team.name) || stringValue(team.team_alias) || options.name,
+      tenantId: stringValue(team.customer_id) || options.tenantId,
+      budgetId: stringValue(team.budget_id),
+      provider: 'bifrost',
+      raw: response,
+    };
+  }
+
+  async createVirtualKey(
+    options: CreateAIVirtualKeyOptions,
+  ): Promise<AIVirtualKey> {
+    const body = removeUndefinedValues({
+      name: options.name,
+      description: options.description,
+      provider_configs: mapBifrostProviderConfigs(options.providerConfigs),
+      team_id: options.projectId,
+      customer_id: options.projectId ? undefined : options.tenantId,
+      budget: mapBifrostBudget(options.budget),
+      rate_limit: mapBifrostRateLimit(options.rateLimit),
+      key_ids: options.keyIds,
+      is_active: options.isActive ?? true,
+      ...options.raw,
+    });
+
+    const response = await this.transport.request<JsonRecord>(
+      'POST',
+      '/api/governance/virtual-keys',
+      body,
+    );
+    const virtualKey = toJsonRecord(
+      response.virtual_key ?? response.virtualKey ?? response,
+    );
+
+    return {
+      id: stringValue(virtualKey.id) || stringValue(virtualKey.key_id),
+      name: stringValue(virtualKey.name) || options.name,
+      key: stringValue(virtualKey.value) || stringValue(virtualKey.key),
+      maskedKey:
+        stringValue(virtualKey.key_name) || stringValue(virtualKey.masked_key),
+      projectId: stringValue(virtualKey.team_id) || options.projectId,
+      tenantId: stringValue(virtualKey.customer_id) || options.tenantId,
+      expiresAt:
+        stringValue(virtualKey.expires) || stringValue(virtualKey.expires_at),
+      provider: 'bifrost',
+      raw: response,
+    };
+  }
+}
+
+export class LiteLLMAdmin implements AIAdminInterface {
+  private readonly transport: GatewayAdminTransport;
+
+  constructor(options: GatewayAdminTransportOptions) {
+    this.transport = new GatewayAdminTransport(options);
+  }
+
+  async createProject(
+    options: CreateAIProjectOptions,
+  ): Promise<AIAdminProject> {
+    const projectId =
+      options.id || slugifyProjectId(options.name, options.tenantId);
+    const body = removeUndefinedValues({
+      team_id: projectId,
+      team_alias: options.name,
+      models: options.models,
+      ...mapLiteLLMBudget(options.budget),
+      ...mapLiteLLMRateLimit(options.rateLimit),
+      metadata: createMetadata(options),
+      blocked: options.isBlocked,
+      ...options.raw,
+    });
+
+    const response = await this.transport.request<JsonRecord>(
+      'POST',
+      '/team/new',
+      body,
+    );
+    const team = toJsonRecord(response.team ?? response);
+
+    return {
+      id: stringValue(team.team_id) || projectId,
+      name:
+        stringValue(team.team_alias) || stringValue(team.name) || options.name,
+      tenantId: options.tenantId,
+      provider: 'litellm',
+      raw: response,
+    };
+  }
+
+  async createVirtualKey(
+    options: CreateAIVirtualKeyOptions,
+  ): Promise<AIVirtualKey> {
+    const body = removeUndefinedValues({
+      key_alias: options.name,
+      team_id: options.projectId,
+      user_id: options.userId,
+      models: options.models,
+      duration: options.duration,
+      ...mapLiteLLMBudget(options.budget),
+      ...mapLiteLLMRateLimit(options.rateLimit),
+      metadata: createMetadata(options),
+      aliases: options.aliases,
+      config: options.config,
+      permissions: options.permissions,
+      blocked: options.isActive === undefined ? undefined : !options.isActive,
+      ...options.raw,
+    });
+
+    const response = await this.transport.request<JsonRecord>(
+      'POST',
+      '/key/generate',
+      body,
+    );
+
+    return {
+      id: stringValue(response.token_id) || stringValue(response.key_id),
+      name:
+        stringValue(response.key_alias) ||
+        stringValue(response.key_name) ||
+        options.name,
+      key: stringValue(response.key),
+      maskedKey: stringValue(response.key_name),
+      projectId: stringValue(response.team_id) || options.projectId,
+      tenantId: options.tenantId,
+      expiresAt: stringValue(response.expires),
+      provider: 'litellm',
+      raw: response,
+    };
+  }
+}

--- a/packages/ai/src/shared/providers/gateway-admin.ts
+++ b/packages/ai/src/shared/providers/gateway-admin.ts
@@ -32,14 +32,24 @@ export function normalizeGatewayBaseUrl(baseUrl: string): string {
 
 /**
  * Derive the gateway root URL for admin APIs from an OpenAI-compatible base URL.
+ *
+ * Strips known inference path suffixes iteratively so that a baseUrl such as
+ * `http://host/openai/v1` collapses to the gateway root rather than to the
+ * partial `http://host/openai`.
  */
 export function deriveGatewayAdminBaseUrl(baseUrl: string): string {
   let normalized = normalizeGatewayBaseUrl(baseUrl);
+  const suffixes = ['/pydanticai/v1', '/openai', '/v1'];
+  let stripped = true;
 
-  for (const suffix of ['/pydanticai/v1', '/openai', '/v1']) {
-    if (normalized.endsWith(suffix)) {
-      normalized = normalized.slice(0, -suffix.length);
-      break;
+  while (stripped) {
+    stripped = false;
+    for (const suffix of suffixes) {
+      if (normalized.endsWith(suffix)) {
+        normalized = normalized.slice(0, -suffix.length);
+        stripped = true;
+        break;
+      }
     }
   }
 
@@ -192,8 +202,8 @@ class GatewayAdminTransport {
         headers: {
           Accept: 'application/json',
           ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
-          ...this.createAuthHeaders(),
           ...this.headers,
+          ...this.createAuthHeaders(),
         },
         body: body === undefined ? undefined : JSON.stringify(body),
         signal: controller?.signal,

--- a/packages/ai/src/shared/types.ts
+++ b/packages/ai/src/shared/types.ts
@@ -14,6 +14,7 @@ export type GeminiThinkingLevel = 'minimal' | 'low' | 'medium' | 'high';
 export const AI_PROVIDER_TYPES = [
   'openai',
   'litellm',
+  'bifrost',
   'ollama',
   'gemini',
   'anthropic',
@@ -620,6 +621,346 @@ export interface AIModel {
 }
 
 /**
+ * Budget configuration for AI gateway admin operations.
+ *
+ * Providers translate this to their native field names:
+ * - Bifrost: `budget.max_limit` / `budget.reset_duration`
+ * - LiteLLM: `max_budget` / `budget_duration`
+ */
+export interface AIAdminBudget {
+  /**
+   * Maximum spend in USD.
+   */
+  maxLimit?: number;
+
+  /**
+   * Reset duration such as `1h`, `1d`, `30d`, or `1M`.
+   */
+  resetDuration?: string;
+
+  /**
+   * Bifrost only: reset at calendar boundaries for day/week/month/year periods.
+   */
+  calendarAligned?: boolean;
+}
+
+/**
+ * Rate-limit configuration for AI gateway admin operations.
+ */
+export interface AIAdminRateLimit {
+  /**
+   * Provider-agnostic token limit.
+   *
+   * Bifrost maps this to `token_max_limit`; LiteLLM maps it to `tpm_limit`.
+   */
+  tokenMaxLimit?: number;
+
+  /**
+   * Bifrost token reset duration such as `1h`.
+   */
+  tokenResetDuration?: string;
+
+  /**
+   * Provider-agnostic request limit.
+   *
+   * Bifrost maps this to `request_max_limit`; LiteLLM maps it to `rpm_limit`.
+   */
+  requestMaxLimit?: number;
+
+  /**
+   * Bifrost request reset duration such as `1m`.
+   */
+  requestResetDuration?: string;
+
+  /**
+   * LiteLLM tokens-per-minute limit. Overrides `tokenMaxLimit` for LiteLLM.
+   */
+  tpmLimit?: number;
+
+  /**
+   * LiteLLM requests-per-minute limit. Overrides `requestMaxLimit` for LiteLLM.
+   */
+  rpmLimit?: number;
+}
+
+/**
+ * Bifrost virtual-key routing configuration.
+ */
+export interface AIAdminProviderConfig {
+  /**
+   * Provider identifier such as `openai` or `anthropic`.
+   */
+  provider: string;
+
+  /**
+   * Routing weight for this provider.
+   */
+  weight?: number;
+
+  /**
+   * Models this virtual key may use for the provider.
+   */
+  allowedModels?: string[];
+
+  /**
+   * Bifrost provider key IDs that this virtual key may use.
+   */
+  keyIds?: string[];
+}
+
+/**
+ * Options for creating a gateway-scoped project.
+ *
+ * In Bifrost, projects are implemented as governance teams, optionally attached
+ * to a customer via `tenantId`. In LiteLLM, projects are implemented as teams.
+ */
+export interface CreateAIProjectOptions {
+  /**
+   * Stable project ID. LiteLLM requires one; if omitted, a slug is derived from
+   * the tenant and project name. Bifrost generates its own team ID.
+   */
+  id?: string;
+
+  /**
+   * Human-readable project name.
+   */
+  name: string;
+
+  /**
+   * Tenant/customer identifier to attach the project to where supported.
+   */
+  tenantId?: string;
+
+  /**
+   * Human-readable description. Stored in metadata for providers that support it.
+   */
+  description?: string;
+
+  /**
+   * Models the project may access.
+   */
+  models?: string[];
+
+  /**
+   * Shared project budget.
+   */
+  budget?: AIAdminBudget;
+
+  /**
+   * Shared project rate limits.
+   */
+  rateLimit?: AIAdminRateLimit;
+
+  /**
+   * Provider-specific metadata.
+   */
+  metadata?: Record<string, unknown>;
+
+  /**
+   * Whether the project should be blocked on creation where supported.
+   */
+  isBlocked?: boolean;
+
+  /**
+   * Provider-specific request body overrides.
+   */
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * Gateway project descriptor returned by admin providers.
+ */
+export interface AIAdminProject {
+  /**
+   * Provider project ID.
+   */
+  id: string;
+
+  /**
+   * Human-readable project name.
+   */
+  name: string;
+
+  /**
+   * Tenant/customer identifier where available.
+   */
+  tenantId?: string;
+
+  /**
+   * Provider budget ID where available.
+   */
+  budgetId?: string;
+
+  /**
+   * Admin provider that created this project.
+   */
+  provider: string;
+
+  /**
+   * Raw provider response.
+   */
+  raw?: unknown;
+}
+
+/**
+ * Options for creating a gateway virtual key.
+ */
+export interface CreateAIVirtualKeyOptions {
+  /**
+   * Human-readable key name or alias.
+   */
+  name: string;
+
+  /**
+   * Human-readable key description.
+   */
+  description?: string;
+
+  /**
+   * Project/team ID to attach the key to.
+   */
+  projectId?: string;
+
+  /**
+   * Tenant/customer ID to attach the key to when no project is supplied, or to
+   * record in LiteLLM metadata.
+   */
+  tenantId?: string;
+
+  /**
+   * Optional end-user ID associated with the key.
+   */
+  userId?: string;
+
+  /**
+   * Models this key may access.
+   */
+  models?: string[];
+
+  /**
+   * Bifrost provider routing configuration.
+   */
+  providerConfigs?: AIAdminProviderConfig[];
+
+  /**
+   * Key-level budget.
+   */
+  budget?: AIAdminBudget;
+
+  /**
+   * Key-level rate limits.
+   */
+  rateLimit?: AIAdminRateLimit;
+
+  /**
+   * Key duration such as `30d`, `1h`, or `permanent` where supported.
+   */
+  duration?: string;
+
+  /**
+   * Provider-specific metadata.
+   */
+  metadata?: Record<string, unknown>;
+
+  /**
+   * Bifrost provider API key IDs this virtual key may use. Use `["*"]` to allow
+   * all configured provider keys.
+   */
+  keyIds?: string[];
+
+  /**
+   * Whether the key should be active on creation.
+   */
+  isActive?: boolean;
+
+  /**
+   * LiteLLM model aliases for this key.
+   */
+  aliases?: Record<string, string>;
+
+  /**
+   * LiteLLM key-specific config.
+   */
+  config?: Record<string, unknown>;
+
+  /**
+   * LiteLLM key-specific permissions.
+   */
+  permissions?: Record<string, unknown>;
+
+  /**
+   * Provider-specific request body overrides.
+   */
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * Gateway virtual key descriptor returned by admin providers.
+ */
+export interface AIVirtualKey {
+  /**
+   * Provider key ID, when returned separately from the key value.
+   */
+  id?: string;
+
+  /**
+   * Human-readable key name or alias.
+   */
+  name?: string;
+
+  /**
+   * Newly generated key value. Some provider list/detail responses may only
+   * expose a masked value.
+   */
+  key?: string;
+
+  /**
+   * Masked key value or key name, when provided.
+   */
+  maskedKey?: string;
+
+  /**
+   * Attached project/team ID.
+   */
+  projectId?: string;
+
+  /**
+   * Attached tenant/customer ID.
+   */
+  tenantId?: string;
+
+  /**
+   * Expiration timestamp where supported.
+   */
+  expiresAt?: string;
+
+  /**
+   * Admin provider that created this key.
+   */
+  provider: string;
+
+  /**
+   * Raw provider response.
+   */
+  raw?: unknown;
+}
+
+/**
+ * Admin operations exposed by gateway providers that support provisioning.
+ */
+export interface AIAdminInterface {
+  /**
+   * Create a project/team for a tenant.
+   */
+  createProject(options: CreateAIProjectOptions): Promise<AIAdminProject>;
+
+  /**
+   * Create a virtual key, optionally attached to a project or tenant.
+   */
+  createVirtualKey(options: CreateAIVirtualKeyOptions): Promise<AIVirtualKey>;
+}
+
+/**
  * AI provider capabilities
  */
 export interface AICapabilities {
@@ -821,6 +1162,11 @@ export interface EmbeddingResponse {
  * Core AI interface that all providers must implement
  */
 export interface AIInterface {
+  /**
+   * Optional admin surface for gateway providers that support provisioning.
+   */
+  admin?: AIAdminInterface;
+
   /**
    * Generate a chat completion from a sequence of messages.
    *
@@ -1254,6 +1600,51 @@ export interface LiteLLMOptions extends BaseAIOptions {
   apiKey?: string;
   baseUrl?: string;
   organization?: string;
+  adminApiKey?: string;
+  adminBaseUrl?: string;
+  adminUrl?: string;
+  adminHeaders?: Record<string, string>;
+}
+
+/**
+ * Bifrost provider options.
+ *
+ * Bifrost exposes OpenAI-compatible inference through endpoints such as
+ * `/openai` and `/v1`, plus governance admin endpoints at `/api/governance/*`.
+ */
+export interface BifrostOptions extends BaseAIOptions {
+  type: 'bifrost';
+  apiKey?: string;
+  baseUrl?: string;
+  organization?: string;
+  /**
+   * Optional virtual key for admin routes. Bifrost OSS admin APIs typically use
+   * username/password Basic auth instead; use `adminUser` / `adminPassword`
+   * when governance auth is enabled without enterprise bearer-token support.
+   */
+  adminApiKey?: string;
+  /**
+   * Admin API root. Alias: `adminUrl`.
+   */
+  adminBaseUrl?: string;
+  /**
+   * Admin API root. Kept as a friendly alias for env vars such as
+   * `BIFROST_ADMIN_URL`.
+   */
+  adminUrl?: string;
+  /**
+   * Bifrost admin username for HTTP Basic auth.
+   */
+  adminUser?: string;
+  /**
+   * Bifrost admin username for HTTP Basic auth.
+   */
+  adminUsername?: string;
+  /**
+   * Bifrost admin password for HTTP Basic auth.
+   */
+  adminPassword?: string;
+  adminHeaders?: Record<string, string>;
 }
 
 /**
@@ -1389,6 +1780,7 @@ export interface Qwen3TTSOptions extends BaseAIOptions {
 export type GetAIOptions =
   | OpenAIOptions
   | LiteLLMOptions
+  | BifrostOptions
   | OllamaOptions
   | GeminiOptions
   | AnthropicOptions


### PR DESCRIPTION
## Summary
- add a Bifrost provider that reuses the OpenAI-compatible transport for inference
- add a shared `ai.admin` provisioning surface for gateway projects and virtual keys
- implement Bifrost governance admin mappings and LiteLLM team/key parity
- support Bifrost root URL normalization, virtual-key headers, and OSS Basic auth via `BIFROST_ADMIN_URL`, `BIFROST_ADMIN_USER`, and `BIFROST_ADMIN_PASSWORD`

## Why
Tenant provisioning needs to create Bifrost projects and virtual keys from the SDK, with LiteLLM kept close enough that callers can use the same admin shape where possible.

## Notes
- Bifrost `BIFROST_BASE_URL=https://llm.happyvertical.com/` normalizes to `/openai` for inference.
- Bifrost OSS governance admin uses Basic auth, so admin calls use `BIFROST_ADMIN_URL` plus username/password when present.
- For keyless/internal Bifrost providers, omit `keyIds`; provider/model scoping works with provider configs and wildcard models.

## Validation
- `pnpm --filter @happyvertical/ai test`
- `pnpm --filter @happyvertical/ai build`
- pre-push `pnpm typecheck`
- live Bifrost governance smoke test created a project and virtual key using Basic auth; generated key value was not logged
