### PR TITLE
feat(analytics): AnalyticsAdminInterface + Matomo provider

### DIFF
--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -81,6 +81,7 @@ export type {
   KeyEvent,
   KeyEventOptions,
   ListPropertiesOptions,
+  MatomoOptions,
   MeasurementUnit,
   Metric,
   MetricMetadata,

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -37,16 +37,25 @@ export { getAnalytics } from './shared/factory.js';
 
 // All types
 export type {
+  // Admin / provisioning types
+  AnalyticsAccessRole,
+  AnalyticsAdminInterface,
   // Capabilities
   AnalyticsCapabilities,
+  AnalyticsHealthResult,
   // Interface
   AnalyticsInterface,
+  AnalyticsSite,
+  AnalyticsUser,
+  AnalyticsUserToken,
   // Base options
   BaseAnalyticsOptions,
   BetweenFilter,
   ConfigOptions,
   // Key event types
   CountingMethod,
+  CreateAnalyticsSiteOptions,
+  CreateAnalyticsUserOptions,
   CreateDataStreamOptions,
   CreatePropertyOptions,
   CustomDimension,
@@ -77,6 +86,7 @@ export type {
   MetricMetadata,
   // Metadata types
   MetricType,
+  MintUserTokenOptions,
   MinuteRange,
   NumericFilter,
   NumericOperation,
@@ -93,6 +103,7 @@ export type {
   ReportResult,
   ReportRow,
   ServiceAccountCredentials,
+  SetUserAccessOptions,
   SnippetOptions,
   StringFilter,
   StringMatchType,

--- a/packages/analytics/src/shared/factory.ts
+++ b/packages/analytics/src/shared/factory.ts
@@ -8,6 +8,7 @@ import type {
   AnalyticsInterface,
   GA4Options,
   GetAnalyticsOptions,
+  MatomoOptions,
   PlausibleOptions,
 } from './types.js';
 
@@ -28,17 +29,27 @@ function isPlausibleOptions(
 }
 
 /**
+ * Type guard for Matomo options
+ */
+function isMatomoOptions(
+  options: GetAnalyticsOptions,
+): options is MatomoOptions {
+  return options.type === 'matomo';
+}
+
+/**
  * Creates an analytics provider instance based on the provided options.
  *
  * Supports environment variable configuration using the pattern:
- * - HAVE_ANALYTICS_TYPE → provider type ('ga4' | 'plausible')
+ * - HAVE_ANALYTICS_TYPE → provider type ('ga4' | 'plausible' | 'matomo')
  * - HAVE_ANALYTICS_SERVICE_ACCOUNT_KEY → path to service account JSON or JSON string
  * - HAVE_ANALYTICS_MEASUREMENT_ID → GA4 measurement ID (G-XXXXXXX)
  * - HAVE_ANALYTICS_API_SECRET → GA4 API secret for Measurement Protocol
  * - HAVE_ANALYTICS_DEFAULT_PROPERTY_ID → default property ID
  * - HAVE_ANALYTICS_API_KEY → Plausible API key
- * - HAVE_ANALYTICS_BASE_URL → Plausible base URL (for self-hosted)
- * - HAVE_ANALYTICS_DEFAULT_SITE_ID → Plausible default site ID
+ * - HAVE_ANALYTICS_BASE_URL → Plausible / Matomo base URL (for self-hosted)
+ * - HAVE_ANALYTICS_DEFAULT_SITE_ID → Plausible / Matomo default site ID
+ * - HAVE_ANALYTICS_TOKEN_AUTH → Matomo per-user token_auth
  * - HAVE_ANALYTICS_TIMEOUT → request timeout in milliseconds
  * - HAVE_ANALYTICS_MAX_RETRIES → maximum retry attempts
  * - HAVE_ANALYTICS_CACHE_TTL → cache TTL in milliseconds
@@ -88,6 +99,7 @@ export async function getAnalytics(
         apiKey: 'string',
         baseUrl: 'string',
         defaultSiteId: 'string',
+        tokenAuth: 'string',
         timeout: 'number',
         maxRetries: 'number',
         cacheTTL: 'number',
@@ -106,8 +118,13 @@ export async function getAnalytics(
     return new PlausibleProvider(options);
   }
 
+  if (isMatomoOptions(options)) {
+    const { MatomoProvider } = await import('./providers/matomo.js');
+    return new MatomoProvider(options);
+  }
+
   throw new ValidationError('Unsupported analytics provider type', {
-    supportedTypes: ['ga4', 'plausible'],
+    supportedTypes: ['ga4', 'plausible', 'matomo'],
     providedType: (options as { type?: string }).type,
   });
 }

--- a/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration tests for the Matomo admin client against a live Matomo install.
+ *
+ * Skipped unless these env vars are set:
+ *   MATOMO_BASE_URL=https://your-matomo
+ *   MATOMO_TOKEN_AUTH=<super-user `token_auth` from Profile → Security → Auth Tokens>
+ *
+ * Also honours `MATOMO_INTEGRATION=1` as an explicit opt-in toggle.
+ *
+ * The tests provision and tear down a uniquely-named site + user on every run,
+ * so a successful test leaves no residue. A failed test may leave a partially-
+ * provisioned site or user — they're labelled `analytics-admin-test-<timestamp>`
+ * for easy manual cleanup.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { MatomoAdmin } from './matomo-admin';
+
+const baseUrl = process.env.MATOMO_BASE_URL;
+const tokenAuth = process.env.MATOMO_TOKEN_AUTH;
+const optedIn =
+  process.env.MATOMO_INTEGRATION === '1' || (!!baseUrl && !!tokenAuth);
+
+const describeIf = optedIn && baseUrl && tokenAuth ? describe : describe.skip;
+
+describeIf('MatomoAdmin (integration)', () => {
+  // Construction is deferred so describe.skip doesn't trip the env-var guards
+  // when we're not opted in. (Vitest still evaluates the describe callback to
+  // register tests, even when skipped.)
+  let admin: MatomoAdmin;
+  const ensureAdmin = (): MatomoAdmin => {
+    if (!admin) {
+      admin = new MatomoAdmin({
+        baseUrl: baseUrl as string,
+        tokenAuth: tokenAuth as string,
+        timeout: 15_000,
+      });
+    }
+    return admin;
+  };
+
+  const stamp = Date.now();
+  const siteName = `analytics-admin-test-${stamp}`;
+  const siteUrl = `https://test-${stamp}.example.invalid`;
+  const userLogin = `analytics-admin-test-${stamp}`;
+  const userEmail = `analytics-admin-test-${stamp}@example.invalid`;
+  // Matomo enforces complexity on user passwords; this satisfies length + variety.
+  const userPassword = `T3st-pass-${stamp}!`;
+
+  let createdSiteId: string | undefined;
+  let createdUserLogin: string | undefined;
+
+  it('health() returns ok with a version', async () => {
+    const result = await ensureAdmin().health();
+    expect(result.ok).toBe(true);
+    expect(typeof result.version).toBe('string');
+    expect(result.version?.length).toBeGreaterThan(0);
+  });
+
+  it('createSite → getSite roundtrip surfaces the new site', async () => {
+    const created = await ensureAdmin().createSite({
+      name: siteName,
+      urls: [siteUrl],
+      timezone: 'America/Edmonton',
+      currency: 'CAD',
+      tenantId: 'integration-test',
+    });
+    createdSiteId = created.id;
+
+    expect(created.id).toMatch(/^\d+$/);
+    expect(created.name).toBe(siteName);
+    expect(created.url).toBe(siteUrl);
+    expect(created.tenantId).toBe('integration-test');
+    expect(created.timezone).toBe('America/Edmonton');
+    expect(created.currency).toBe('CAD');
+
+    const fetched = await ensureAdmin().getSite(created.id);
+    expect(fetched?.name).toBe(siteName);
+  });
+
+  it('listSites includes the newly created site', async () => {
+    if (!createdSiteId) throw new Error('site was not created');
+    const sites = await ensureAdmin().listSites();
+    const ours = sites.find((s) => s.id === createdSiteId);
+    expect(ours?.name).toBe(siteName);
+  });
+
+  it('createUser → getUser roundtrip', async () => {
+    const created = await ensureAdmin().createUser({
+      login: userLogin,
+      email: userEmail,
+      password: userPassword,
+      tenantId: 'integration-test',
+    });
+    createdUserLogin = created.login;
+    expect(created.login).toBe(userLogin);
+    expect(created.email).toBe(userEmail);
+
+    const fetched = await ensureAdmin().getUser(userLogin);
+    expect(fetched?.email).toBe(userEmail);
+  });
+
+  it('setUserAccess + mintUserToken + the minted token can authenticate', async () => {
+    if (!createdSiteId || !createdUserLogin) {
+      throw new Error('site or user was not created');
+    }
+    await ensureAdmin().setUserAccess({
+      login: createdUserLogin,
+      access: 'view',
+      siteIds: [createdSiteId],
+    });
+
+    const minted = await ensureAdmin().mintUserToken({
+      login: createdUserLogin,
+      description: `integration-test-${stamp}`,
+      // Matomo confirms the *target* user's password — we know it because
+      // we just provisioned the user above with `userPassword`.
+      passwordConfirmation: userPassword,
+    });
+    expect(minted.token.length).toBeGreaterThan(16);
+    expect(minted.login).toBe(createdUserLogin);
+
+    // The minted token is scoped to the new user's permissions: view on the
+    // new site only. A health() call should succeed against it.
+    const scoped = new MatomoAdmin({
+      baseUrl: baseUrl as string,
+      tokenAuth: minted.token,
+      timeout: 15_000,
+    });
+    const health = await scoped.health();
+    expect(health.ok).toBe(true);
+  });
+
+  it('teardown: deletes the test user and site', async () => {
+    if (createdUserLogin) {
+      await ensureAdmin().deleteUser(createdUserLogin);
+      const gone = await ensureAdmin().getUser(createdUserLogin);
+      expect(gone).toBeUndefined();
+    }
+    if (createdSiteId) {
+      await ensureAdmin().deleteSite(createdSiteId);
+      const gone = await ensureAdmin().getSite(createdSiteId);
+      expect(gone).toBeUndefined();
+    }
+  });
+});

--- a/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
@@ -13,7 +13,7 @@
  * for easy manual cleanup.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 import { MatomoAdmin } from './matomo-admin';
 
@@ -132,16 +132,32 @@ describeIf('MatomoAdmin (integration)', () => {
     expect(health.ok).toBe(true);
   });
 
-  it('teardown: deletes the test user and site', async () => {
+  // Cleanup runs as afterAll(best-effort) rather than a test case so that:
+  //   - it still runs when an earlier test fails or the runner bails early
+  //   - it doesn't fail the suite if cleanup itself fails (we'd rather see
+  //     the original test failure than a teardown error mask it)
+  // The unique-per-run naming (`analytics-admin-test-<timestamp>`) makes any
+  // residue easy to find and clear manually.
+  afterAll(async () => {
     if (createdUserLogin) {
-      await ensureAdmin().deleteUser(createdUserLogin);
-      const gone = await ensureAdmin().getUser(createdUserLogin);
-      expect(gone).toBeUndefined();
+      try {
+        await ensureAdmin().deleteUser(createdUserLogin);
+      } catch (error) {
+        console.warn(
+          `[matomo-integration] cleanup: failed to delete user ${createdUserLogin}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
     }
     if (createdSiteId) {
-      await ensureAdmin().deleteSite(createdSiteId);
-      const gone = await ensureAdmin().getSite(createdSiteId);
-      expect(gone).toBeUndefined();
+      try {
+        await ensureAdmin().deleteSite(createdSiteId);
+      } catch (error) {
+        console.warn(
+          `[matomo-integration] cleanup: failed to delete site ${createdSiteId}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
     }
   });
 });

--- a/packages/analytics/src/shared/providers/matomo-admin.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.test.ts
@@ -201,6 +201,52 @@ describe('MatomoAdminTransport', () => {
       /HTTP 500|boom/,
     );
   });
+
+  it('ignores caller-supplied module/method/format/token_auth (reserved keys)', async () => {
+    const { calls } = setFetchMock(() => jsonResponse({ value: 'ok' }));
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'real-tok',
+    });
+
+    await transport.call('API.getMatomoVersion', {
+      // All four of these MUST be ignored — a caller cannot redirect the
+      // dispatch or override the response format / auth token by passing
+      // them through `params`.
+      module: 'NotAPI',
+      method: 'BogusMethod',
+      format: 'xml',
+      token_auth: 'attacker-supplied',
+    });
+
+    const [call] = calls;
+    expect(call.body.get('module')).toBe('API');
+    expect(call.body.get('method')).toBe('API.getMatomoVersion');
+    expect(call.body.get('format')).toBe('json');
+    expect(call.body.get('token_auth')).toBe('real-tok');
+  });
+
+  it('throws MATOMO_INVALID_RESPONSE when a 2xx body is not JSON', async () => {
+    // Real-world scenario: a misconfigured reverse proxy or PHP fatal
+    // error returns an HTML error page with HTTP 200. Previously this
+    // branch silently coerced the HTML to `{ message: text }`, masking
+    // the failure. Now it raises a typed error.
+    setFetchMock(
+      () =>
+        new Response('<html><body>PHP Fatal error: ...</body></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+    );
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    await expect(transport.call('API.getMatomoVersion', {})).rejects.toThrow(
+      /invalid JSON response/i,
+    );
+  });
 });
 
 describe('MatomoAdmin.createSite', () => {
@@ -431,6 +477,38 @@ describe('MatomoAdmin.user lifecycle', () => {
     await expect(admin.mintUserToken({ login: 'tenant-bma' })).rejects.toThrow(
       /passwordConfirmation/,
     );
+  });
+
+  it('mintUserToken returns the effective description even when defaulted', async () => {
+    const { calls } = setFetchMock(() => jsonResponse({ value: 'mint-token' }));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    const minted = await admin.mintUserToken({
+      login: 'tenant-bma',
+      passwordConfirmation: 'pw',
+    });
+    // The effective description must be defined and must match what was sent.
+    expect(minted.description).toBeDefined();
+    expect(calls[0].body.get('description')).toBe(minted.description);
+    // And it must not leak a project-specific brand into the upstream package.
+    expect(minted.description).not.toMatch(/anytown/i);
+  });
+
+  it('mintUserToken propagates a caller-supplied description', async () => {
+    const { calls } = setFetchMock(() => jsonResponse({ value: 'mint-token' }));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    const minted = await admin.mintUserToken({
+      login: 'tenant-bma',
+      passwordConfirmation: 'pw',
+      description: 'tenancy-doctor probe',
+    });
+    expect(minted.description).toBe('tenancy-doctor probe');
+    expect(calls[0].body.get('description')).toBe('tenancy-doctor probe');
   });
 
   it('getUser returns undefined for "doesn\'t exist" error', async () => {

--- a/packages/analytics/src/shared/providers/matomo-admin.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.test.ts
@@ -1,0 +1,484 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AnalyticsError, AuthenticationError } from '../types';
+import {
+  MatomoAdmin,
+  MatomoAdminTransport,
+  normalizeMatomoBaseUrl,
+} from './matomo-admin';
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: URLSearchParams;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+function setFetchMock(
+  fn: (call: RecordedCall) => Response | Promise<Response>,
+): {
+  mock: ReturnType<typeof vi.fn>;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = new Headers(init.headers);
+      h.forEach((value, key) => {
+        headers[key] = value;
+      });
+    }
+    const bodyText =
+      typeof init?.body === 'string'
+        ? init.body
+        : init?.body instanceof URLSearchParams
+          ? init.body.toString()
+          : '';
+    const recorded: RecordedCall = {
+      url,
+      method: init?.method ?? 'GET',
+      headers,
+      body: new URLSearchParams(bodyText),
+    };
+    calls.push(recorded);
+    return fn(recorded);
+  });
+
+  vi.stubGlobal('fetch', mock);
+  return { mock, calls };
+}
+
+describe('normalizeMatomoBaseUrl', () => {
+  it('strips trailing slashes and a trailing /index.php', () => {
+    expect(normalizeMatomoBaseUrl('https://m.example.com/')).toBe(
+      'https://m.example.com',
+    );
+    expect(normalizeMatomoBaseUrl('https://m.example.com/index.php')).toBe(
+      'https://m.example.com',
+    );
+    expect(normalizeMatomoBaseUrl('https://m.example.com/index.php/')).toBe(
+      'https://m.example.com',
+    );
+  });
+
+  it('throws when the value is empty', () => {
+    expect(() => normalizeMatomoBaseUrl('   ')).toThrow(AnalyticsError);
+  });
+});
+
+describe('MatomoAdminTransport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('requires a tokenAuth value', () => {
+    expect(
+      () =>
+        new MatomoAdminTransport({
+          baseUrl: 'https://m.example.com',
+          tokenAuth: '',
+        }),
+    ).toThrow(AnalyticsError);
+  });
+
+  it('posts module=API form-encoded with token_auth and format=json', async () => {
+    const { calls } = setFetchMock(() => jsonResponse({ value: '5.9.0' }));
+
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com/',
+      tokenAuth: 'tok-1',
+    });
+
+    await transport.call('API.getMatomoVersion', {});
+
+    expect(calls).toHaveLength(1);
+    const [call] = calls;
+    expect(call.method).toBe('POST');
+    expect(call.url).toBe('https://m.example.com/index.php');
+    expect(call.headers['content-type']).toBe(
+      'application/x-www-form-urlencoded',
+    );
+    expect(call.body.get('module')).toBe('API');
+    expect(call.body.get('method')).toBe('API.getMatomoVersion');
+    expect(call.body.get('format')).toBe('json');
+    expect(call.body.get('token_auth')).toBe('tok-1');
+  });
+
+  it('encodes array params as key[]=v', async () => {
+    const { calls } = setFetchMock(() => jsonResponse({ value: 'ok' }));
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    await transport.call('UsersManager.setUserAccess', {
+      userLogin: 'tenant-bma',
+      access: 'view',
+      idSites: ['1', '2'],
+    });
+
+    const body = calls[0].body;
+    expect(body.getAll('idSites[]')).toEqual(['1', '2']);
+    expect(body.get('userLogin')).toBe('tenant-bma');
+    expect(body.get('access')).toBe('view');
+  });
+
+  it('maps Matomo error payload (HTTP 200, result=error) to AnalyticsError', async () => {
+    setFetchMock(() =>
+      jsonResponse({ result: 'error', message: 'Some bad input' }),
+    );
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    await expect(transport.call('SitesManager.addSite', {})).rejects.toThrow(
+      'Some bad input',
+    );
+  });
+
+  it('maps "requires view access" to AuthenticationError', async () => {
+    setFetchMock(() =>
+      jsonResponse({
+        result: 'error',
+        message:
+          "You can't access this resource as it requires view access for at least one website.",
+      }),
+    );
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    await expect(
+      transport.call('API.getMatomoVersion', {}),
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('maps HTTP 401 to AuthenticationError', async () => {
+    setFetchMock(
+      () =>
+        new Response('not authorized', {
+          status: 401,
+          headers: { 'content-type': 'text/plain' },
+        }),
+    );
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    await expect(
+      transport.call('API.getMatomoVersion', {}),
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('maps HTTP 500 to AnalyticsError with code MATOMO_HTTP_500', async () => {
+    setFetchMock(
+      () =>
+        new Response('boom', {
+          status: 500,
+          headers: { 'content-type': 'text/plain' },
+        }),
+    );
+    const transport = new MatomoAdminTransport({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    await expect(transport.call('API.getMatomoVersion', {})).rejects.toThrow(
+      /HTTP 500|boom/,
+    );
+  });
+});
+
+describe('MatomoAdmin.createSite', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('calls SitesManager.addSite then SitesManager.getSiteFromId', async () => {
+    const responses = [
+      jsonResponse({ value: 7 }),
+      jsonResponse({
+        idsite: '7',
+        name: 'Bentley Alberta',
+        main_url: 'https://bentleyalberta.com',
+        timezone: 'America/Edmonton',
+        currency: 'CAD',
+      }),
+    ];
+    const { calls } = setFetchMock(() => responses.shift()!);
+
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    const site = await admin.createSite({
+      name: 'Bentley Alberta',
+      urls: ['https://bentleyalberta.com'],
+      timezone: 'America/Edmonton',
+      currency: 'CAD',
+      tenantId: 'bentleyalberta',
+    });
+
+    expect(site.id).toBe('7');
+    expect(site.name).toBe('Bentley Alberta');
+    expect(site.url).toBe('https://bentleyalberta.com');
+    expect(site.tenantId).toBe('bentleyalberta');
+    expect(site.timezone).toBe('America/Edmonton');
+    expect(site.currency).toBe('CAD');
+    expect(site.provider).toBe('matomo');
+
+    expect(calls[0].body.get('method')).toBe('SitesManager.addSite');
+    expect(calls[0].body.get('siteName')).toBe('Bentley Alberta');
+    expect(calls[0].body.getAll('urls[]')).toEqual([
+      'https://bentleyalberta.com',
+    ]);
+    expect(calls[1].body.get('method')).toBe('SitesManager.getSiteFromId');
+    expect(calls[1].body.get('idSite')).toBe('7');
+  });
+
+  it('throws when no urls are provided', async () => {
+    setFetchMock(() => jsonResponse({}));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    await expect(admin.createSite({ name: 'x', urls: [] })).rejects.toThrow(
+      /at least one URL/,
+    );
+  });
+});
+
+describe('MatomoAdmin.listSites / getSite', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('listSites maps an array of rows', async () => {
+    setFetchMock(() =>
+      jsonResponse([
+        {
+          idsite: '1',
+          name: 'a',
+          main_url: 'https://a.example.com',
+          timezone: 'UTC',
+          currency: 'USD',
+        },
+        {
+          idsite: '2',
+          name: 'b',
+          main_url: 'https://b.example.com',
+        },
+      ]),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    const sites = await admin.listSites();
+    expect(sites.map((s) => s.id)).toEqual(['1', '2']);
+    expect(sites[0].url).toBe('https://a.example.com');
+    expect(sites[1].timezone).toBeUndefined();
+  });
+
+  it('getSite returns undefined for an empty-array response', async () => {
+    setFetchMock(() => jsonResponse([]));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    expect(await admin.getSite('999')).toBeUndefined();
+  });
+
+  it('getSite returns undefined for the "unexpected website" application error', async () => {
+    setFetchMock(() =>
+      jsonResponse({
+        result: 'error',
+        message:
+          "An unexpected website was found in the request: website id was set to '999' .",
+      }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    expect(await admin.getSite('999')).toBeUndefined();
+  });
+});
+
+describe('MatomoAdmin.user lifecycle', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('createUser requires a password', async () => {
+    setFetchMock(() => jsonResponse({}));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    await expect(
+      admin.createUser({ login: 'tenant-bma', email: 'x@y.com' }),
+    ).rejects.toThrow(/password/);
+  });
+
+  it('createUser POSTs UsersManager.addUser then reads the user back', async () => {
+    const responses = [
+      jsonResponse({ result: 'success', message: 'ok' }),
+      jsonResponse({
+        login: 'tenant-bma',
+        email: 'x@y.com',
+        superuser_access: '0',
+      }),
+    ];
+    const { calls } = setFetchMock(() => responses.shift()!);
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    const user = await admin.createUser({
+      login: 'tenant-bma',
+      email: 'x@y.com',
+      password: 'long-random-password',
+      tenantId: 'bma',
+    });
+
+    expect(user.login).toBe('tenant-bma');
+    expect(user.email).toBe('x@y.com');
+    expect(user.isSuperUser).toBe(false);
+
+    expect(calls[0].body.get('method')).toBe('UsersManager.addUser');
+    expect(calls[0].body.get('userLogin')).toBe('tenant-bma');
+    expect(calls[0].body.get('password')).toBe('long-random-password');
+    expect(calls[1].body.get('method')).toBe('UsersManager.getUser');
+  });
+
+  it('setUserAccess validates role and posts idSites[]', async () => {
+    const { calls } = setFetchMock(() =>
+      jsonResponse({ result: 'success', message: 'ok' }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    await admin.setUserAccess({
+      login: 'tenant-bma',
+      access: 'view',
+      siteIds: ['7'],
+    });
+    expect(calls[0].body.get('method')).toBe('UsersManager.setUserAccess');
+    expect(calls[0].body.get('access')).toBe('view');
+    expect(calls[0].body.getAll('idSites[]')).toEqual(['7']);
+
+    await expect(
+      admin.setUserAccess({
+        login: 'tenant-bma',
+        // @ts-expect-error invalid role test
+        access: 'editor',
+        siteIds: ['7'],
+      }),
+    ).rejects.toThrow(/Invalid Matomo access role/);
+  });
+
+  it('mintUserToken forwards the per-call passwordConfirmation', async () => {
+    const { calls } = setFetchMock(() =>
+      jsonResponse({ value: 'mint-token-abc' }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    const minted = await admin.mintUserToken({
+      login: 'tenant-bma',
+      passwordConfirmation: 'tenant-bma-password',
+    });
+    expect(minted.token).toBe('mint-token-abc');
+    expect(minted.login).toBe('tenant-bma');
+    // Matomo confirms the *target* user's password, not the caller's.
+    expect(calls[0].body.get('passwordConfirmation')).toBe(
+      'tenant-bma-password',
+    );
+    expect(calls[0].body.get('userLogin')).toBe('tenant-bma');
+  });
+
+  it('mintUserToken refuses without a passwordConfirmation', async () => {
+    setFetchMock(() => jsonResponse({ value: 'never-minted' }));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    await expect(admin.mintUserToken({ login: 'tenant-bma' })).rejects.toThrow(
+      /passwordConfirmation/,
+    );
+  });
+
+  it('getUser returns undefined for "doesn\'t exist" error', async () => {
+    setFetchMock(() =>
+      jsonResponse({
+        result: 'error',
+        message: "User 'who-dis' doesn't exist.",
+      }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    expect(await admin.getUser('who-dis')).toBeUndefined();
+  });
+});
+
+describe('MatomoAdmin.health', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns ok=true with a version when API.getMatomoVersion responds', async () => {
+    setFetchMock(() => jsonResponse({ value: '5.9.0' }));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    const result = await admin.health();
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe('5.9.0');
+  });
+
+  it('returns ok=false on transport error', async () => {
+    setFetchMock(
+      () =>
+        new Response('nope', {
+          status: 500,
+          headers: { 'content-type': 'text/plain' },
+        }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+    const result = await admin.health();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/packages/analytics/src/shared/providers/matomo-admin.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.ts
@@ -133,8 +133,11 @@ export class MatomoAdminTransport {
    * Call a Matomo API method by name (e.g. `SitesManager.addSite`).
    *
    * `params` becomes the request body. Array values are encoded as
-   * `key[]=...&key[]=...`. Undefined values are dropped. `token_auth` and
-   * `format=json` are always appended last so callers cannot override them.
+   * `key[]=...&key[]=...`. Undefined and null values are dropped. The
+   * reserved keys `module`, `method`, `format`, and `token_auth` are
+   * controlled by the transport — any caller-supplied value for those
+   * keys is silently ignored so they cannot override the dispatch or
+   * the response format.
    */
   async call<T = unknown>(
     method: string,
@@ -144,11 +147,9 @@ export class MatomoAdminTransport {
     >,
   ): Promise<T> {
     const body = new URLSearchParams();
-    body.set('module', 'API');
-    body.set('method', method);
-    body.set('format', 'json');
 
     for (const [key, value] of Object.entries(params)) {
+      if (RESERVED_PARAM_KEYS.has(key)) continue;
       if (value === undefined || value === null) continue;
       if (Array.isArray(value)) {
         for (const item of value) {
@@ -159,6 +160,9 @@ export class MatomoAdminTransport {
       body.set(key, String(value));
     }
 
+    body.set('module', 'API');
+    body.set('method', method);
+    body.set('format', 'json');
     body.set('token_auth', this.tokenAuth);
 
     const controller =
@@ -182,11 +186,15 @@ export class MatomoAdminTransport {
       });
 
       const text = await response.text();
-      const parsed = text.length > 0 ? safeParseJson(text) : undefined;
 
       if (!response.ok) {
-        throw mapHttpError(response.status, parsed, text);
+        // Read the body purely to enrich the error message; parse failures
+        // here are not fatal because the HTTP error already explains the
+        // shape of what came back.
+        throw mapHttpError(response.status, tryParseJson(text), text);
       }
+
+      const parsed = text.length > 0 ? parseJsonOrThrow(text) : undefined;
 
       const errorMessage = readMatomoError(parsed);
       if (errorMessage) {
@@ -209,11 +217,45 @@ export class MatomoAdminTransport {
   }
 }
 
-function safeParseJson(text: string): unknown {
+const RESERVED_PARAM_KEYS = new Set([
+  'module',
+  'method',
+  'format',
+  'token_auth',
+]);
+
+/**
+ * Parse a 2xx response body as JSON. Matomo always answers `format=json`
+ * with JSON; if it doesn't, something has gone wrong upstream (usually a
+ * misconfigured reverse proxy or PHP fatal error returning HTML), and we
+ * surface that as a typed error rather than silently coercing.
+ */
+function parseJsonOrThrow(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const preview = text.slice(0, 200);
+    throw new AnalyticsError(
+      `Matomo returned an invalid JSON response${
+        error instanceof Error ? `: ${error.message}` : ''
+      }${preview ? ` (response preview: ${preview})` : ''}`,
+      'MATOMO_INVALID_RESPONSE',
+      PROVIDER,
+    );
+  }
+}
+
+/**
+ * Best-effort parse for non-2xx response bodies — returns `undefined` on
+ * parse failure so the HTTP-error code path can still surface a useful
+ * status-based message.
+ */
+function tryParseJson(text: string): unknown {
+  if (!text) return undefined;
   try {
     return JSON.parse(text);
   } catch {
-    return { message: text };
+    return undefined;
   }
 }
 
@@ -477,12 +519,14 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
         PROVIDER,
       );
     }
+    const effectiveDescription =
+      options.description ?? `analytics-token ${options.login}`;
     const response = await this.transport.call<unknown>(
       'UsersManager.createAppSpecificTokenAuth',
       {
         userLogin: options.login,
         passwordConfirmation: options.passwordConfirmation,
-        description: options.description ?? `anytown ${options.login}`,
+        description: effectiveDescription,
         expireHours: 0,
       },
     );
@@ -502,7 +546,7 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
     return {
       token,
       login: options.login,
-      description: options.description,
+      description: effectiveDescription,
       provider: PROVIDER,
       raw: response,
     };

--- a/packages/analytics/src/shared/providers/matomo-admin.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.ts
@@ -1,0 +1,574 @@
+/**
+ * Matomo admin client.
+ *
+ * Implements `AnalyticsAdminInterface` against Matomo's Reporting API. Matomo
+ * exposes everything we need on a single endpoint (`POST {baseUrl}/index.php`)
+ * with the action selected via `module=API` + `method=...`.
+ *
+ * Auth is `token_auth` — passed in the POST body, never the URL, so it does
+ * not appear in proxy/access logs.
+ */
+
+import {
+  type AnalyticsAccessRole,
+  type AnalyticsAdminInterface,
+  AnalyticsError,
+  type AnalyticsHealthResult,
+  type AnalyticsSite,
+  type AnalyticsUser,
+  type AnalyticsUserToken,
+  AuthenticationError,
+  type CreateAnalyticsSiteOptions,
+  type CreateAnalyticsUserOptions,
+  type MintUserTokenOptions,
+  type SetUserAccessOptions,
+} from '../types.js';
+
+const PROVIDER = 'matomo';
+
+export interface MatomoAdminTransportOptions {
+  baseUrl: string;
+  tokenAuth: string;
+  timeout?: number;
+}
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+type JsonRecord = { [key: string]: JsonValue };
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function stripIndexPhpSuffix(value: string): string {
+  return value.endsWith('/index.php')
+    ? value.slice(0, -'/index.php'.length)
+    : value;
+}
+
+/**
+ * Normalize a Matomo base URL: trim whitespace, strip trailing slashes, and
+ * remove a trailing `/index.php` if the caller provided one. Returns the host
+ * root so callers can append `/index.php` themselves.
+ */
+export function normalizeMatomoBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new AnalyticsError(
+      'Matomo baseUrl is required',
+      'MATOMO_BASE_URL_REQUIRED',
+      PROVIDER,
+    );
+  }
+  return stripIndexPhpSuffix(stripTrailingSlash(trimmed));
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readString(record: JsonRecord, key: string): string | undefined {
+  const value = record[key];
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readBoolean(record: JsonRecord, key: string): boolean | undefined {
+  const value = record[key];
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    if (value === '1' || value === 'true') return true;
+    if (value === '0' || value === 'false') return false;
+  }
+  if (typeof value === 'number') return value !== 0;
+  return undefined;
+}
+
+/**
+ * Matomo signals errors with a JSON body of the shape
+ * `{ "result": "error", "message": "..." }` and HTTP 200. Detect that.
+ */
+function readMatomoError(body: unknown): string | undefined {
+  if (!isJsonRecord(body)) return undefined;
+  if (body.result !== 'error') return undefined;
+  return readString(body, 'message') ?? 'Matomo returned an error';
+}
+
+/**
+ * POST a `module=API&method=...` form to Matomo and return the parsed JSON.
+ *
+ * Matomo accepts `application/x-www-form-urlencoded` — we use `URLSearchParams`
+ * so array values like `idSites[]=1&idSites[]=2` are handled by the runtime.
+ */
+export class MatomoAdminTransport {
+  private readonly baseUrl: string;
+  private readonly tokenAuth: string;
+  private readonly timeout?: number;
+
+  constructor(options: MatomoAdminTransportOptions) {
+    this.baseUrl = normalizeMatomoBaseUrl(options.baseUrl);
+    if (!options.tokenAuth) {
+      throw new AnalyticsError(
+        'Matomo tokenAuth is required',
+        'MATOMO_TOKEN_REQUIRED',
+        PROVIDER,
+      );
+    }
+    this.tokenAuth = options.tokenAuth;
+    this.timeout = options.timeout;
+  }
+
+  /**
+   * Call a Matomo API method by name (e.g. `SitesManager.addSite`).
+   *
+   * `params` becomes the request body. Array values are encoded as
+   * `key[]=...&key[]=...`. Undefined values are dropped. `token_auth` and
+   * `format=json` are always appended last so callers cannot override them.
+   */
+  async call<T = unknown>(
+    method: string,
+    params: Record<
+      string,
+      string | number | boolean | undefined | string[] | number[]
+    >,
+  ): Promise<T> {
+    const body = new URLSearchParams();
+    body.set('module', 'API');
+    body.set('method', method);
+    body.set('format', 'json');
+
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          body.append(`${key}[]`, String(item));
+        }
+        continue;
+      }
+      body.set(key, String(value));
+    }
+
+    body.set('token_auth', this.tokenAuth);
+
+    const controller =
+      typeof AbortController === 'undefined'
+        ? undefined
+        : new AbortController();
+    const timeoutHandle =
+      controller && this.timeout
+        ? setTimeout(() => controller.abort(), this.timeout)
+        : undefined;
+
+    try {
+      const response = await fetch(`${this.baseUrl}/index.php`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body,
+        signal: controller?.signal,
+      });
+
+      const text = await response.text();
+      const parsed = text.length > 0 ? safeParseJson(text) : undefined;
+
+      if (!response.ok) {
+        throw mapHttpError(response.status, parsed, text);
+      }
+
+      const errorMessage = readMatomoError(parsed);
+      if (errorMessage) {
+        throw mapApplicationError(errorMessage);
+      }
+
+      return parsed as T;
+    } catch (error) {
+      if (error instanceof AnalyticsError) throw error;
+      throw new AnalyticsError(
+        `Matomo admin request failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        'MATOMO_REQUEST_FAILED',
+        PROVIDER,
+      );
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function safeParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { message: text };
+  }
+}
+
+function mapHttpError(
+  status: number,
+  body: unknown,
+  text: string,
+): AnalyticsError {
+  if (status === 401 || status === 403) {
+    return new AuthenticationError(PROVIDER);
+  }
+  const message =
+    (isJsonRecord(body) && readString(body, 'message')) ||
+    text ||
+    `Matomo HTTP ${status}`;
+  return new AnalyticsError(message, `MATOMO_HTTP_${status}`, PROVIDER);
+}
+
+function mapApplicationError(message: string): AnalyticsError {
+  // Matomo sentinel: anonymous (or insufficient-scope) tokens hit this branch
+  // with HTTP 200 and a `result=error` payload.
+  if (
+    message.includes('requires view access') ||
+    message.includes('requires admin access') ||
+    message.includes('requires Super User access') ||
+    message.includes("doesn't have access")
+  ) {
+    return new AuthenticationError(PROVIDER);
+  }
+  return new AnalyticsError(message, 'MATOMO_API_ERROR', PROVIDER);
+}
+
+function siteFromRow(row: JsonRecord): AnalyticsSite {
+  const id = readString(row, 'idsite') ?? readString(row, 'idSite');
+  if (!id) {
+    throw new AnalyticsError(
+      'Matomo did not return a site id',
+      'MATOMO_INVALID_RESPONSE',
+      PROVIDER,
+    );
+  }
+  return {
+    id,
+    name: readString(row, 'name') ?? '',
+    url: readString(row, 'main_url'),
+    timezone: readString(row, 'timezone'),
+    currency: readString(row, 'currency'),
+    provider: PROVIDER,
+    raw: row,
+  };
+}
+
+function userFromRow(row: JsonRecord): AnalyticsUser {
+  const login = readString(row, 'login');
+  if (!login) {
+    throw new AnalyticsError(
+      'Matomo did not return a user login',
+      'MATOMO_INVALID_RESPONSE',
+      PROVIDER,
+    );
+  }
+  return {
+    login,
+    email: readString(row, 'email'),
+    isSuperUser: readBoolean(row, 'superuser_access'),
+    provider: PROVIDER,
+    raw: row,
+  };
+}
+
+export class MatomoAdmin implements AnalyticsAdminInterface {
+  private readonly transport: MatomoAdminTransport;
+
+  constructor(options: MatomoAdminTransportOptions) {
+    this.transport = new MatomoAdminTransport(options);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sites
+  // ---------------------------------------------------------------------------
+
+  async createSite(
+    options: CreateAnalyticsSiteOptions,
+  ): Promise<AnalyticsSite> {
+    if (!options.urls || options.urls.length === 0) {
+      throw new AnalyticsError(
+        'Matomo createSite requires at least one URL',
+        'MATOMO_URLS_REQUIRED',
+        PROVIDER,
+      );
+    }
+
+    const response = await this.transport.call<unknown>(
+      'SitesManager.addSite',
+      {
+        siteName: options.name,
+        urls: options.urls,
+        timezone: options.timezone,
+        currency: options.currency,
+        ...(options.raw ?? {}),
+      },
+    );
+
+    // Matomo returns the new idSite as a bare integer or `{ value: N }`.
+    const id = coerceSiteIdResponse(response);
+    if (!id) {
+      throw new AnalyticsError(
+        'Matomo did not return a site id',
+        'MATOMO_INVALID_RESPONSE',
+        PROVIDER,
+      );
+    }
+
+    const site = await this.getSite(id);
+    if (site) return { ...site, tenantId: options.tenantId };
+
+    return {
+      id,
+      name: options.name,
+      url: options.urls[0],
+      timezone: options.timezone,
+      currency: options.currency,
+      tenantId: options.tenantId,
+      provider: PROVIDER,
+      raw: response,
+    };
+  }
+
+  async listSites(): Promise<AnalyticsSite[]> {
+    const response = await this.transport.call<unknown>(
+      'SitesManager.getAllSites',
+      {},
+    );
+    if (!Array.isArray(response)) return [];
+    return response.filter(isJsonRecord).map((row) => siteFromRow(row));
+  }
+
+  async getSite(siteId: string): Promise<AnalyticsSite | undefined> {
+    try {
+      const response = await this.transport.call<unknown>(
+        'SitesManager.getSiteFromId',
+        { idSite: siteId },
+      );
+      if (isJsonRecord(response)) {
+        return siteFromRow(response);
+      }
+      // Some Matomo versions return `[]` for a non-existent site.
+      return undefined;
+    } catch (error) {
+      if (error instanceof AnalyticsError && isNotFoundSiteError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async deleteSite(siteId: string): Promise<void> {
+    await this.transport.call<unknown>('SitesManager.deleteSite', {
+      idSite: siteId,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Users
+  // ---------------------------------------------------------------------------
+
+  async createUser(
+    options: CreateAnalyticsUserOptions,
+  ): Promise<AnalyticsUser> {
+    if (!options.password) {
+      throw new AnalyticsError(
+        'Matomo createUser requires a password',
+        'MATOMO_PASSWORD_REQUIRED',
+        PROVIDER,
+      );
+    }
+
+    await this.transport.call<unknown>('UsersManager.addUser', {
+      userLogin: options.login,
+      password: options.password,
+      email: options.email,
+      ...(options.raw ?? {}),
+    });
+
+    const user = await this.getUser(options.login);
+    return (
+      user ?? {
+        login: options.login,
+        email: options.email,
+        tenantId: options.tenantId,
+        provider: PROVIDER,
+      }
+    );
+  }
+
+  async getUser(login: string): Promise<AnalyticsUser | undefined> {
+    try {
+      const response = await this.transport.call<unknown>(
+        'UsersManager.getUser',
+        { userLogin: login },
+      );
+
+      if (isJsonRecord(response)) return userFromRow(response);
+
+      // Some Matomo versions return `[]` for a non-existent user.
+      if (Array.isArray(response) && response.length === 0) return undefined;
+
+      return undefined;
+    } catch (error) {
+      // Matomo 5.x raises an application error rather than returning an
+      // empty array when the login is unknown.
+      if (
+        error instanceof AnalyticsError &&
+        error.code === 'MATOMO_API_ERROR' &&
+        /doesn'?t exist|does not exist|unknown/i.test(error.message)
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async deleteUser(login: string): Promise<void> {
+    await this.transport.call<unknown>('UsersManager.deleteUser', {
+      userLogin: login,
+    });
+  }
+
+  async setUserAccess(options: SetUserAccessOptions): Promise<void> {
+    if (!isAccessRole(options.access)) {
+      throw new AnalyticsError(
+        `Invalid Matomo access role: ${options.access}`,
+        'MATOMO_INVALID_ROLE',
+        PROVIDER,
+      );
+    }
+    if (!options.siteIds || options.siteIds.length === 0) {
+      throw new AnalyticsError(
+        'Matomo setUserAccess requires at least one site id',
+        'MATOMO_SITE_IDS_REQUIRED',
+        PROVIDER,
+      );
+    }
+    await this.transport.call<unknown>('UsersManager.setUserAccess', {
+      userLogin: options.login,
+      access: options.access,
+      idSites: options.siteIds,
+    });
+  }
+
+  async mintUserToken(
+    options: MintUserTokenOptions,
+  ): Promise<AnalyticsUserToken> {
+    if (!options.passwordConfirmation) {
+      throw new AnalyticsError(
+        "Matomo's createAppSpecificTokenAuth requires the target user's " +
+          'password as `passwordConfirmation`. (It confirms the user being ' +
+          'minted for — not the caller — so a stolen super-user token alone ' +
+          "can't mint tokens for arbitrary users.)",
+        'MATOMO_PASSWORD_CONFIRMATION_REQUIRED',
+        PROVIDER,
+      );
+    }
+    const response = await this.transport.call<unknown>(
+      'UsersManager.createAppSpecificTokenAuth',
+      {
+        userLogin: options.login,
+        passwordConfirmation: options.passwordConfirmation,
+        description: options.description ?? `anytown ${options.login}`,
+        expireHours: 0,
+      },
+    );
+
+    const token =
+      (isJsonRecord(response) && readString(response, 'value')) ||
+      (typeof response === 'string' ? response : undefined);
+
+    if (!token) {
+      throw new AnalyticsError(
+        'Matomo did not return a token value',
+        'MATOMO_INVALID_RESPONSE',
+        PROVIDER,
+      );
+    }
+
+    return {
+      token,
+      login: options.login,
+      description: options.description,
+      provider: PROVIDER,
+      raw: response,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Health
+  // ---------------------------------------------------------------------------
+
+  async health(): Promise<AnalyticsHealthResult> {
+    try {
+      const response = await this.transport.call<unknown>(
+        'API.getMatomoVersion',
+        {},
+      );
+      const version =
+        (isJsonRecord(response) && readString(response, 'value')) ||
+        (typeof response === 'string' ? response : undefined);
+      return { ok: true, version };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+
+function coerceSiteIdResponse(response: unknown): string | undefined {
+  if (typeof response === 'number' && Number.isFinite(response)) {
+    return String(response);
+  }
+  if (typeof response === 'string' && response.length > 0) {
+    return response;
+  }
+  if (isJsonRecord(response)) {
+    return (
+      readString(response, 'value') ??
+      readString(response, 'idsite') ??
+      readString(response, 'idSite')
+    );
+  }
+  return undefined;
+}
+
+function isAccessRole(value: string): value is AnalyticsAccessRole {
+  return (
+    value === 'noaccess' ||
+    value === 'view' ||
+    value === 'write' ||
+    value === 'admin'
+  );
+}
+
+/**
+ * Recognise the various ways Matomo signals "this site id doesn't exist (or
+ * isn't visible to the caller)". Matomo has at least three error sentinels for
+ * this case across versions and contexts:
+ *   - "Site not found"
+ *   - "doesn't exist" / "does not exist"
+ *   - "An unexpected website was found in the request: website id was set to '...'"
+ */
+function isNotFoundSiteError(error: AnalyticsError): boolean {
+  if (error.code !== 'MATOMO_API_ERROR') return false;
+  return (
+    /not.*found|doesn'?t exist|does not exist|unknown/i.test(error.message) ||
+    /website was found in the request|website id was set/i.test(error.message)
+  );
+}

--- a/packages/analytics/src/shared/providers/matomo.test.ts
+++ b/packages/analytics/src/shared/providers/matomo.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { MatomoProvider } from './matomo';
+
+function buildProvider() {
+  return new MatomoProvider({
+    type: 'matomo',
+    baseUrl: 'https://m.example.com',
+    tokenAuth: 'tok',
+  });
+}
+
+describe('MatomoProvider.generateTrackingSnippet', () => {
+  it('emits a Matomo _paq snippet with trackPageView and enableLinkTracking', () => {
+    const snippet = buildProvider().generateTrackingSnippet('7');
+
+    expect(snippet.html).toContain('var _paq');
+    expect(snippet.html).toContain("_paq.push(['trackPageView']);");
+    expect(snippet.html).toContain("_paq.push(['enableLinkTracking']);");
+    expect(snippet.html).toContain('_paq.push([\'setSiteId\', "7"]);');
+    expect(snippet.html).toContain(
+      "_paq.push(['setTrackerUrl', u+'matomo.php']);",
+    );
+    expect(snippet.scripts).toEqual(['https://m.example.com/matomo.js']);
+  });
+
+  it('omits trackPageView when sendPageView is false', () => {
+    const snippet = buildProvider().generateTrackingSnippet('7', {
+      sendPageView: false,
+    });
+    expect(snippet.html).not.toContain('trackPageView');
+  });
+
+  it('does NOT emit setDoNotTrack when anonymizeIp is true (server-side concern in Matomo)', () => {
+    const snippet = buildProvider().generateTrackingSnippet('7', {
+      anonymizeIp: true,
+    });
+    // setDoNotTrack respects the browser's DNT signal, NOT IP anonymization.
+    // Matomo IP anonymization is handled server-side by PrivacyManager.
+    expect(snippet.html).not.toContain('setDoNotTrack');
+    // The caller's flag is still preserved on the returned config so that
+    // higher layers know the operator opted in.
+    expect(snippet.config.anonymizeIp).toBe(true);
+  });
+
+  it('queues custom _paq directives in customConfig', () => {
+    const snippet = buildProvider().generateTrackingSnippet('7', {
+      customConfig: { setSecureCookie: true },
+    });
+    expect(snippet.html).toContain('_paq.push(["setSecureCookie", true]);');
+  });
+});
+
+describe('MatomoProvider.generateConfig', () => {
+  it('returns a flat config object suitable for embed/programmatic use', () => {
+    const config = buildProvider().generateConfig('7', { anonymizeIp: true });
+    expect(config).toMatchObject({
+      trackerUrl: 'https://m.example.com/matomo.php',
+      scriptUrl: 'https://m.example.com/matomo.js',
+      siteId: '7',
+      anonymizeIp: true,
+      sendPageView: true,
+    });
+  });
+});

--- a/packages/analytics/src/shared/providers/matomo.test.ts
+++ b/packages/analytics/src/shared/providers/matomo.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { PropertyNotFoundError } from '../types';
 import { MatomoProvider } from './matomo';
 
 function buildProvider() {
@@ -7,6 +8,14 @@ function buildProvider() {
     type: 'matomo',
     baseUrl: 'https://m.example.com',
     tokenAuth: 'tok',
+  });
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
   });
 }
 
@@ -61,5 +70,32 @@ describe('MatomoProvider.generateConfig', () => {
       anonymizeIp: true,
       sendPageView: true,
     });
+  });
+});
+
+describe('MatomoProvider.getProperty', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('throws PropertyNotFoundError when the site does not exist', async () => {
+    // Matomo signals a missing site with `result=error, "...website was found
+    // in the request..."`. The provider must surface that as
+    // PropertyNotFoundError so callers can `instanceof`-check it the same way
+    // they do for GA4 and Plausible.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          result: 'error',
+          message:
+            "An unexpected website was found in the request: website id was set to '999' .",
+        }),
+      ),
+    );
+    await expect(buildProvider().getProperty('999')).rejects.toBeInstanceOf(
+      PropertyNotFoundError,
+    );
   });
 });

--- a/packages/analytics/src/shared/providers/matomo.ts
+++ b/packages/analytics/src/shared/providers/matomo.ts
@@ -137,6 +137,18 @@ export class MatomoProvider implements AnalyticsInterface {
   // Client-side snippet
   // ---------------------------------------------------------------------------
 
+  /**
+   * Generate a Matomo `_paq` tracking snippet.
+   *
+   * Note on `SnippetOptions.anonymizeIp`: Matomo handles IP anonymization
+   * **server-side** via the PrivacyManager plugin (Matomo admin → Privacy →
+   * Anonymize visitors' IP addresses). The JS tracker has no equivalent
+   * client-side directive — `setDoNotTrack` respects the browser's DNT
+   * signal but does not anonymize IPs, so we deliberately do not emit it
+   * here. The flag is preserved on the returned `config` object as a
+   * caller-visible signal, but its enforcement is the operator's
+   * responsibility on the Matomo install.
+   */
   generateTrackingSnippet(
     propertyId: string,
     options: SnippetOptions = {},
@@ -146,9 +158,6 @@ export class MatomoProvider implements AnalyticsInterface {
     const sendPageView = options.sendPageView ?? true;
 
     const lines: string[] = ['var _paq = window._paq = window._paq || [];'];
-    if (options.anonymizeIp) {
-      lines.push("_paq.push(['setDoNotTrack', true]);");
-    }
     if (sendPageView) {
       lines.push("_paq.push(['trackPageView']);");
     }

--- a/packages/analytics/src/shared/providers/matomo.ts
+++ b/packages/analytics/src/shared/providers/matomo.ts
@@ -21,7 +21,6 @@
 
 import {
   type AnalyticsCapabilities,
-  AnalyticsError,
   type AnalyticsInterface,
   type ConfigOptions,
   type CreateDataStreamOptions,
@@ -40,6 +39,7 @@ import {
   NotSupportedError,
   type PageviewEvent,
   type Property,
+  PropertyNotFoundError,
   type RealtimeReportOptions,
   type ReportOptions,
   type ReportResult,
@@ -89,12 +89,7 @@ export class MatomoProvider implements AnalyticsInterface {
   async getProperty(propertyId: string): Promise<Property> {
     const site = await this.admin.getSite(propertyId);
     if (!site) {
-      throw new AnalyticsError(
-        `Matomo site not found: ${propertyId}`,
-        'PROPERTY_NOT_FOUND',
-        PROVIDER,
-        propertyId,
-      );
+      throw new PropertyNotFoundError(propertyId, PROVIDER);
     }
     return propertyFromSite(site);
   }

--- a/packages/analytics/src/shared/providers/matomo.ts
+++ b/packages/analytics/src/shared/providers/matomo.ts
@@ -1,0 +1,302 @@
+/**
+ * Matomo Analytics provider implementation.
+ *
+ * This first cut implements:
+ * - The full `AnalyticsAdminInterface` (sites, users, access, tokens, health)
+ *   via {@link MatomoAdmin}. This is the API the tenant doctor uses.
+ * - The `AnalyticsInterface` property-management surface, by delegating to the
+ *   admin (a Matomo "site" maps 1:1 to a GA4-style "property").
+ * - Capabilities and tracking-snippet generation.
+ *
+ * Reporting (`runReport`/`runRealtimeReport`) and server-side tracking
+ * (`track`/`trackPageview`) are intentionally left as `NotSupportedError` for
+ * this slice. They land in a follow-up — they hit different Matomo endpoints
+ * (`Live.*`, `VisitsSummary.*`, `/matomo.php`) and warrant their own tests.
+ *
+ * GA4-specific concepts that don't translate cleanly (data streams, custom
+ * dimensions/metrics, key events) throw `NotSupportedError`. Matomo has its
+ * own analogues (goals, custom dimensions plugin) — they need a different
+ * shape and don't belong on the GA4-shaped methods.
+ */
+
+import {
+  type AnalyticsCapabilities,
+  AnalyticsError,
+  type AnalyticsInterface,
+  type ConfigOptions,
+  type CreateDataStreamOptions,
+  type CreatePropertyOptions,
+  type CustomDimension,
+  type CustomDimensionOptions,
+  type CustomMetric,
+  type CustomMetricOptions,
+  type DataStream,
+  type DimensionMetadata,
+  type KeyEvent,
+  type KeyEventOptions,
+  type ListPropertiesOptions,
+  type MatomoOptions,
+  type MetricMetadata,
+  NotSupportedError,
+  type PageviewEvent,
+  type Property,
+  type RealtimeReportOptions,
+  type ReportOptions,
+  type ReportResult,
+  type SnippetOptions,
+  type TrackEvent,
+  type TrackingSnippet,
+  type UpdatePropertyOptions,
+} from '../types.js';
+import { MatomoAdmin, normalizeMatomoBaseUrl } from './matomo-admin.js';
+
+const PROVIDER = 'matomo';
+
+export class MatomoProvider implements AnalyticsInterface {
+  private readonly options: MatomoOptions;
+  private readonly baseUrl: string;
+  public readonly admin: MatomoAdmin;
+
+  constructor(options: MatomoOptions) {
+    this.options = options;
+    this.baseUrl = normalizeMatomoBaseUrl(options.baseUrl);
+    this.admin = new MatomoAdmin({
+      baseUrl: this.baseUrl,
+      tokenAuth: options.tokenAuth,
+      timeout: options.timeout,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Property management — delegated to admin (site === property in Matomo)
+  // ---------------------------------------------------------------------------
+
+  createProperty(_options: CreatePropertyOptions): Promise<Property> {
+    // GA4's CreatePropertyOptions doesn't carry a website URL. Matomo
+    // mandates one on every site, so use `admin.createSite({ urls: [...] })`
+    // directly rather than overloading this method.
+    throw new NotSupportedError(
+      'createProperty (use admin.createSite instead)',
+      PROVIDER,
+    );
+  }
+
+  async listProperties(_options?: ListPropertiesOptions): Promise<Property[]> {
+    const sites = await this.admin.listSites();
+    return sites.map((site) => propertyFromSite(site));
+  }
+
+  async getProperty(propertyId: string): Promise<Property> {
+    const site = await this.admin.getSite(propertyId);
+    if (!site) {
+      throw new AnalyticsError(
+        `Matomo site not found: ${propertyId}`,
+        'PROPERTY_NOT_FOUND',
+        PROVIDER,
+        propertyId,
+      );
+    }
+    return propertyFromSite(site);
+  }
+
+  async updateProperty(
+    _propertyId: string,
+    _data: UpdatePropertyOptions,
+  ): Promise<Property> {
+    // SitesManager.updateSite exists; landing it requires shaping the
+    // GA4-style fields onto Matomo's params (siteName/urls/timezone/...).
+    // Deferred to the reporting follow-up where we round-trip these fields.
+    throw new NotSupportedError('updateProperty', PROVIDER);
+  }
+
+  async deleteProperty(propertyId: string): Promise<void> {
+    await this.admin.deleteSite(propertyId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Capabilities
+  // ---------------------------------------------------------------------------
+
+  async getCapabilities(): Promise<AnalyticsCapabilities> {
+    return {
+      propertyManagement: true,
+      dataStreams: false,
+      customDimensions: false,
+      customMetrics: false,
+      keyEvents: false,
+      reporting: false,
+      realtimeReporting: false,
+      serverSideTracking: false,
+      clientSideSnippet: true,
+      userIdentification: false,
+      batchTracking: false,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Client-side snippet
+  // ---------------------------------------------------------------------------
+
+  generateTrackingSnippet(
+    propertyId: string,
+    options: SnippetOptions = {},
+  ): TrackingSnippet {
+    const trackerUrl = `${this.baseUrl}/matomo.php`;
+    const scriptUrl = `${this.baseUrl}/matomo.js`;
+    const sendPageView = options.sendPageView ?? true;
+
+    const lines: string[] = ['var _paq = window._paq = window._paq || [];'];
+    if (options.anonymizeIp) {
+      lines.push("_paq.push(['setDoNotTrack', true]);");
+    }
+    if (sendPageView) {
+      lines.push("_paq.push(['trackPageView']);");
+    }
+    lines.push("_paq.push(['enableLinkTracking']);");
+    if (options.customConfig) {
+      for (const [key, value] of Object.entries(options.customConfig)) {
+        lines.push(
+          `_paq.push([${JSON.stringify(key)}, ${JSON.stringify(value)}]);`,
+        );
+      }
+    }
+    lines.push(
+      `(function() { var u=${JSON.stringify(`${this.baseUrl}/`)};` +
+        ` _paq.push(['setTrackerUrl', u+'matomo.php']);` +
+        ` _paq.push(['setSiteId', ${JSON.stringify(propertyId)}]);` +
+        ` var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];` +
+        ` g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s); })();`,
+    );
+
+    return {
+      html: `<script>\n${lines.join('\n')}\n</script>`,
+      config: {
+        trackerUrl,
+        scriptUrl,
+        siteId: propertyId,
+        anonymizeIp: !!options.anonymizeIp,
+        sendPageView,
+      },
+      scripts: [scriptUrl],
+    };
+  }
+
+  generateConfig(
+    propertyId: string,
+    options: ConfigOptions = {},
+  ): Record<string, unknown> {
+    return {
+      trackerUrl: `${this.baseUrl}/matomo.php`,
+      scriptUrl: `${this.baseUrl}/matomo.js`,
+      siteId: propertyId,
+      anonymizeIp: !!options.anonymizeIp,
+      sendPageView: options.sendPageView ?? true,
+      userId: options.userId,
+      customDimensions: options.customDimensions,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Methods deferred to a follow-up PR — they have meaningful Matomo analogues
+  // but warrant their own tests and a wider review surface.
+  // ---------------------------------------------------------------------------
+
+  getDataStreams(_propertyId: string): Promise<DataStream[]> {
+    throw new NotSupportedError('dataStreams', PROVIDER);
+  }
+  createDataStream(
+    _propertyId: string,
+    _options: CreateDataStreamOptions,
+  ): Promise<DataStream> {
+    throw new NotSupportedError('dataStreams', PROVIDER);
+  }
+  deleteDataStream(_propertyId: string, _streamId: string): Promise<void> {
+    throw new NotSupportedError('dataStreams', PROVIDER);
+  }
+  getCustomDimensions(_propertyId: string): Promise<CustomDimension[]> {
+    throw new NotSupportedError('customDimensions', PROVIDER);
+  }
+  createCustomDimension(
+    _propertyId: string,
+    _options: CustomDimensionOptions,
+  ): Promise<CustomDimension> {
+    throw new NotSupportedError('customDimensions', PROVIDER);
+  }
+  archiveCustomDimension(
+    _propertyId: string,
+    _dimensionId: string,
+  ): Promise<void> {
+    throw new NotSupportedError('customDimensions', PROVIDER);
+  }
+  getCustomMetrics(_propertyId: string): Promise<CustomMetric[]> {
+    throw new NotSupportedError('customMetrics', PROVIDER);
+  }
+  createCustomMetric(
+    _propertyId: string,
+    _options: CustomMetricOptions,
+  ): Promise<CustomMetric> {
+    throw new NotSupportedError('customMetrics', PROVIDER);
+  }
+  archiveCustomMetric(_propertyId: string, _metricId: string): Promise<void> {
+    throw new NotSupportedError('customMetrics', PROVIDER);
+  }
+  getKeyEvents(_propertyId: string): Promise<KeyEvent[]> {
+    throw new NotSupportedError('keyEvents', PROVIDER);
+  }
+  createKeyEvent(
+    _propertyId: string,
+    _options: KeyEventOptions,
+  ): Promise<KeyEvent> {
+    throw new NotSupportedError('keyEvents', PROVIDER);
+  }
+  deleteKeyEvent(_propertyId: string, _eventId: string): Promise<void> {
+    throw new NotSupportedError('keyEvents', PROVIDER);
+  }
+  runReport(
+    _propertyId: string,
+    _options: ReportOptions,
+  ): Promise<ReportResult> {
+    throw new NotSupportedError('runReport', PROVIDER);
+  }
+  runRealtimeReport(
+    _propertyId: string,
+    _options?: RealtimeReportOptions,
+  ): Promise<ReportResult> {
+    throw new NotSupportedError('runRealtimeReport', PROVIDER);
+  }
+  getMetrics(_propertyId: string): Promise<MetricMetadata[]> {
+    throw new NotSupportedError('getMetrics', PROVIDER);
+  }
+  getDimensions(_propertyId: string): Promise<DimensionMetadata[]> {
+    throw new NotSupportedError('getDimensions', PROVIDER);
+  }
+  track(_event: TrackEvent): Promise<void> {
+    throw new NotSupportedError('track', PROVIDER);
+  }
+  trackPageview(_pageview: PageviewEvent): Promise<void> {
+    throw new NotSupportedError('trackPageview', PROVIDER);
+  }
+  trackBatch(_events: TrackEvent[]): Promise<void> {
+    throw new NotSupportedError('trackBatch', PROVIDER);
+  }
+  identify(_userId: string, _traits?: Record<string, unknown>): Promise<void> {
+    throw new NotSupportedError('identify', PROVIDER);
+  }
+}
+
+function propertyFromSite(site: {
+  id: string;
+  name: string;
+  url?: string;
+  timezone?: string;
+  currency?: string;
+}): Property {
+  return {
+    id: site.id,
+    name: `sites/${site.id}`,
+    displayName: site.name,
+    createTime: '',
+    timeZone: site.timezone,
+    currencyCode: site.currency,
+  };
+}

--- a/packages/analytics/src/shared/types.ts
+++ b/packages/analytics/src/shared/types.ts
@@ -85,9 +85,36 @@ export interface PlausibleOptions extends BaseAnalyticsOptions {
 }
 
 /**
+ * Matomo Analytics provider options
+ *
+ * Matomo's Reporting API authenticates via per-user `token_auth` values; admin
+ * provisioning operations require a token belonging to a super-user.
+ */
+export interface MatomoOptions extends BaseAnalyticsOptions {
+  type: 'matomo';
+  /**
+   * Matomo base URL (e.g. `https://matomo.example.com`).
+   *
+   * Trailing slashes and explicit `/index.php` suffixes are normalized.
+   */
+  baseUrl: string;
+  /**
+   * `token_auth` for the calling user. Required for all reporting calls.
+   *
+   * For admin provisioning (createSite/createUser/etc.) this token must
+   * belong to a Matomo super-user.
+   */
+  tokenAuth: string;
+  /**
+   * Default site ID (`idSite`) for operations that don't specify one.
+   */
+  defaultSiteId?: string;
+}
+
+/**
  * Union type for all provider options
  */
-export type GetAnalyticsOptions = GA4Options | PlausibleOptions;
+export type GetAnalyticsOptions = GA4Options | PlausibleOptions | MatomoOptions;
 
 // =============================================================================
 // Property Types

--- a/packages/analytics/src/shared/types.ts
+++ b/packages/analytics/src/shared/types.ts
@@ -978,6 +978,313 @@ export interface AnalyticsInterface {
    * Get provider capabilities
    */
   getCapabilities(): Promise<AnalyticsCapabilities>;
+
+  /**
+   * Provisioning admin operations exposed by providers that support them.
+   *
+   * Optional. Providers that don't support tenant/site/user provisioning leave
+   * this undefined. Implementations should mirror the pattern used by
+   * `@happyvertical/ai`'s `AIAdminInterface`.
+   */
+  admin?: AnalyticsAdminInterface;
+}
+
+// =============================================================================
+// Admin Provisioning
+// =============================================================================
+
+/**
+ * Site descriptor returned by admin providers.
+ */
+export interface AnalyticsSite {
+  /**
+   * Provider site ID. For Matomo this is the numeric `idSite` as a string.
+   */
+  id: string;
+  /**
+   * Human-readable site name as stored by the provider.
+   */
+  name: string;
+  /**
+   * Primary URL or domain for the site.
+   */
+  url?: string;
+  /**
+   * Site timezone (e.g. `America/Edmonton`).
+   */
+  timezone?: string;
+  /**
+   * Currency code where applicable (e.g. `CAD`).
+   */
+  currency?: string;
+  /**
+   * Tenant identifier this site is associated with, when supplied at create time.
+   */
+  tenantId?: string;
+  /**
+   * Provider that owns this site descriptor.
+   */
+  provider: string;
+  /**
+   * Raw provider response.
+   */
+  raw?: unknown;
+}
+
+/**
+ * Options for creating a site.
+ */
+export interface CreateAnalyticsSiteOptions {
+  /**
+   * Human-readable site name.
+   */
+  name: string;
+  /**
+   * Site URL(s). At least one is required for Matomo.
+   */
+  urls: string[];
+  /**
+   * Site timezone (IANA, e.g. `America/Edmonton`). Defaults to provider default.
+   */
+  timezone?: string;
+  /**
+   * Currency code. Defaults to provider default.
+   */
+  currency?: string;
+  /**
+   * Optional tenant identifier to associate with this site.
+   */
+  tenantId?: string;
+  /**
+   * Provider-specific request body overrides.
+   */
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * User access role assignable to an analytics site.
+ */
+export type AnalyticsAccessRole = 'noaccess' | 'view' | 'write' | 'admin';
+
+/**
+ * Analytics user descriptor returned by admin providers.
+ */
+export interface AnalyticsUser {
+  /**
+   * Login or username used to authenticate the user.
+   */
+  login: string;
+  /**
+   * Email address recorded for the user.
+   */
+  email?: string;
+  /**
+   * Tenant identifier this user is associated with, when supplied at create time.
+   */
+  tenantId?: string;
+  /**
+   * Whether the user has been granted super-user access.
+   */
+  isSuperUser?: boolean;
+  /**
+   * Provider that owns this user descriptor.
+   */
+  provider: string;
+  /**
+   * Raw provider response.
+   */
+  raw?: unknown;
+}
+
+/**
+ * Options for creating a user.
+ */
+export interface CreateAnalyticsUserOptions {
+  /**
+   * Login or username for the new user.
+   */
+  login: string;
+  /**
+   * Email address for the new user.
+   */
+  email: string;
+  /**
+   * Initial password. Implementations may generate one if omitted, but should
+   * surface it on the returned user. For Matomo the password is required.
+   */
+  password?: string;
+  /**
+   * Optional tenant identifier to associate with this user (stored in
+   * provider metadata where supported).
+   */
+  tenantId?: string;
+  /**
+   * Provider-specific request body overrides.
+   */
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * Options for granting site access to a user.
+ */
+export interface SetUserAccessOptions {
+  /**
+   * Login or username to grant access to.
+   */
+  login: string;
+  /**
+   * Access level to grant.
+   */
+  access: AnalyticsAccessRole;
+  /**
+   * Site IDs the access applies to.
+   */
+  siteIds: string[];
+}
+
+/**
+ * Options for minting a per-user auth token scoped to a user's permissions.
+ */
+export interface MintUserTokenOptions {
+  /**
+   * Login or username to mint the token for.
+   */
+  login: string;
+  /**
+   * Description of the token (where supported).
+   */
+  description?: string;
+  /**
+   * The target user's password. Matomo's `createAppSpecificTokenAuth`
+   * confirms the *target* user's password (not the caller's) — this prevents
+   * a stolen super-user token from minting tokens for arbitrary other users.
+   *
+   * Other providers may not need this; it's optional in the shared interface
+   * but Matomo will throw without it.
+   */
+  passwordConfirmation?: string;
+}
+
+/**
+ * Auth token descriptor returned by admin providers.
+ */
+export interface AnalyticsUserToken {
+  /**
+   * The token value. Show-once for most providers; not stored in plaintext on
+   * the provider side.
+   */
+  token: string;
+  /**
+   * Login the token belongs to.
+   */
+  login: string;
+  /**
+   * Description recorded on the provider.
+   */
+  description?: string;
+  /**
+   * Provider that owns this token descriptor.
+   */
+  provider: string;
+  /**
+   * Raw provider response.
+   */
+  raw?: unknown;
+}
+
+/**
+ * Result of a provider health probe.
+ */
+export interface AnalyticsHealthResult {
+  /**
+   * Whether the probe was able to reach the provider AND complete an authed
+   * round-trip (if the probe is authed).
+   */
+  ok: boolean;
+  /**
+   * Provider version string, when available.
+   */
+  version?: string;
+  /**
+   * Failure reason when `ok` is false.
+   */
+  error?: string;
+}
+
+/**
+ * Admin operations exposed by analytics providers that support provisioning.
+ *
+ * Mirrors the shape of `@happyvertical/ai`'s `AIAdminInterface`. Methods that a
+ * particular provider can't support (e.g. `mintUserToken` against GA4) are left
+ * out of that provider's admin object — callers should feature-check via
+ * `typeof admin.mintUserToken === 'function'`.
+ */
+export interface AnalyticsAdminInterface {
+  // ---------------------------------------------------------------------------
+  // Site provisioning
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a site/property for a tenant.
+   */
+  createSite(options: CreateAnalyticsSiteOptions): Promise<AnalyticsSite>;
+
+  /**
+   * List all sites visible to the calling token.
+   */
+  listSites(): Promise<AnalyticsSite[]>;
+
+  /**
+   * Look up a site by id. Resolves to undefined when the site does not exist.
+   */
+  getSite(siteId: string): Promise<AnalyticsSite | undefined>;
+
+  /**
+   * Delete a site.
+   */
+  deleteSite(siteId: string): Promise<void>;
+
+  // ---------------------------------------------------------------------------
+  // User provisioning (optional capability)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a user.
+   */
+  createUser?(options: CreateAnalyticsUserOptions): Promise<AnalyticsUser>;
+
+  /**
+   * Look up a user by login. Resolves to undefined when the user does not exist.
+   */
+  getUser?(login: string): Promise<AnalyticsUser | undefined>;
+
+  /**
+   * Delete a user.
+   */
+  deleteUser?(login: string): Promise<void>;
+
+  /**
+   * Grant a user access to one or more sites at the given role.
+   */
+  setUserAccess?(options: SetUserAccessOptions): Promise<void>;
+
+  /**
+   * Mint a per-user auth token scoped to that user's existing permissions.
+   *
+   * The returned token is shown-once on most providers — implementations are
+   * expected to return the live value in the response and not refetch it.
+   */
+  mintUserToken?(options: MintUserTokenOptions): Promise<AnalyticsUserToken>;
+
+  // ---------------------------------------------------------------------------
+  // Health
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Probe provider reachability and auth. Always available — providers that
+   * lack a public health endpoint should make a cheap authed call instead.
+   */
+  health(): Promise<AnalyticsHealthResult>;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Adds a provider-agnostic `AnalyticsAdminInterface` to `@happyvertical/analytics` and a Matomo provider implementing it, mirroring the `AIAdminInterface` pattern from `@happyvertical/ai`. Ships the primitives needed to programmatically provision per-tenant analytics: create a site, create a user, grant `view`/`write`/`admin` access on specific sites, mint a per-user scoped token, and probe health — all on free Matomo Core, no Enterprise gating.

Two commits:
- `feat(analytics): add AnalyticsAdminInterface for tenant provisioning` — interface + supporting types only, no provider implementation. Hung off `AnalyticsInterface` as `admin?:` so existing GA4/Plausible providers stay backward-compatible.
- `feat(analytics): add Matomo provider with admin (sites, users, access, tokens)` — Matomo provider, full admin client, 22 unit + 6 integration tests.

## Why this shape

The interface deliberately splits methods between **required** (`createSite`, `listSites`, `getSite`, `deleteSite`, `health`) and **optional** (`createUser`, `getUser`, `deleteUser`, `setUserAccess`, `mintUserToken`). Providers without user-management — e.g. GA4, Plausible self-hosted — leave the optional methods undefined; callers feature-check with `typeof admin.method === 'function'`. This keeps the shared interface honest without forcing every provider to throw `NotSupportedError`.

The Matomo client speaks to a single endpoint (`POST {baseUrl}/index.php`, `module=API&method=...`) with `token_auth` POSTed in the body so it never appears in proxy/access logs. Auto-detects three different "site doesn't exist" error sentinels Matomo emits across versions, and handles the Matomo 5.x application-error variant of "user doesn't exist".

`mintUserToken` takes `passwordConfirmation` per-call rather than as a constructor option because Matomo confirms the **target** user's password (not the caller's) — this prevents a stolen super-user token alone from minting tokens for arbitrary users. Surfaced as a real bug when the integration tests hit a live Matomo.

## Test plan

- [x] Unit tests pass (22 new + 16 existing): \`npx vitest run\` against \`packages/analytics\`
- [x] Integration tests pass against a real Matomo install: \`MATOMO_BASE_URL=... MATOMO_TOKEN_AUTH=... npx vitest run\` — provisions a uniquely-named site + user, exercises every admin method, verifies the minted scoped token authenticates, tears everything down with no residue
- [x] Type check: \`npx tsc --noEmit\`
- [x] Build: \`npx vite build\` — Matomo provider chunk ~18 kB
- [x] No regressions on GA4 / Plausible test suites

## Follow-ups (out of scope here)

- Reporting (`runReport` / `runRealtimeReport`) and server-side tracking (`track` / `trackPageview`) for Matomo — they hit different endpoints (`Live.*`, `VisitsSummary.*`, `/matomo.php`) and warrant their own tests.
- Plausible adapter could opt into the new `AnalyticsAdminInterface` (its Sites API maps cleanly), but the self-hosted Sites-API key minting blocker still applies.