### PR TITLE
feat(analytics): add Matomo access verification

### DIFF
--- a/.changeset/matomo-access-verification.md
+++ b/.changeset/matomo-access-verification.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/analytics": minor
+---
+
+Add public Matomo admin verification helpers for user site access and tenant token site access.

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -39,6 +39,7 @@ export { getAnalytics } from './shared/factory.js';
 export type {
   // Admin / provisioning types
   AnalyticsAccessRole,
+  AnalyticsAccessVerificationResult,
   AnalyticsAdminInterface,
   // Capabilities
   AnalyticsCapabilities,
@@ -113,6 +114,8 @@ export type {
   // Snippet types
   TrackingSnippet,
   UpdatePropertyOptions,
+  VerifyTokenSiteAccessOptions,
+  VerifyUserSiteAccessOptions,
 } from './shared/types.js';
 
 // Error classes

--- a/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
@@ -101,7 +101,7 @@ describeIf('MatomoAdmin (integration)', () => {
     expect(fetched?.email).toBe(userEmail);
   });
 
-  it('setUserAccess + mintUserToken + the minted token can authenticate', async () => {
+  it('setUserAccess + mintUserToken + verify access for the minted token', async () => {
     if (!createdSiteId || !createdUserLogin) {
       throw new Error('site or user was not created');
     }

--- a/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.integration.test.ts
@@ -110,6 +110,12 @@ describeIf('MatomoAdmin (integration)', () => {
       access: 'view',
       siteIds: [createdSiteId],
     });
+    const accessCheck = await ensureAdmin().verifyUserSiteAccess({
+      login: createdUserLogin,
+      siteId: createdSiteId,
+    });
+    expect(accessCheck.ok).toBe(true);
+    expect(accessCheck.access).toBe('view');
 
     const minted = await ensureAdmin().mintUserToken({
       login: createdUserLogin,
@@ -130,6 +136,12 @@ describeIf('MatomoAdmin (integration)', () => {
     });
     const health = await scoped.health();
     expect(health.ok).toBe(true);
+
+    const tokenCheck = await ensureAdmin().verifyTokenSiteAccess({
+      tokenAuth: minted.token,
+      siteId: createdSiteId,
+    });
+    expect(tokenCheck.ok).toBe(true);
   });
 
   // Cleanup runs as afterAll(best-effort) rather than a test case so that:

--- a/packages/analytics/src/shared/providers/matomo-admin.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.test.ts
@@ -447,6 +447,120 @@ describe('MatomoAdmin.user lifecycle', () => {
     ).rejects.toThrow(/Invalid Matomo access role/);
   });
 
+  it('verifyUserSiteAccess reads user site access and enforces minimum role', async () => {
+    const { calls } = setFetchMock(() =>
+      jsonResponse([
+        { site: '7', access: 'view' },
+        { site: '8', access: 'admin' },
+      ]),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    const viewResult = await admin.verifyUserSiteAccess({
+      login: 'tenant-bma',
+      siteId: '7',
+    });
+    expect(viewResult.ok).toBe(true);
+    expect(viewResult.access).toBe('view');
+    expect(viewResult.requiredAccess).toBe('view');
+
+    const adminResult = await admin.verifyUserSiteAccess({
+      login: 'tenant-bma',
+      siteId: '7',
+      minimumAccess: 'admin',
+    });
+    expect(adminResult.ok).toBe(false);
+    expect(adminResult.access).toBe('view');
+    expect(adminResult.error).toMatch(/admin is required/);
+
+    expect(calls[0].body.get('method')).toBe(
+      'UsersManager.getSitesAccessFromUser',
+    );
+    expect(calls[0].body.get('userLogin')).toBe('tenant-bma');
+  });
+
+  it('verifyUserSiteAccess accepts object-shaped Matomo access maps', async () => {
+    setFetchMock(() => jsonResponse({ '7': 'write', '8': 'view' }));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    const result = await admin.verifyUserSiteAccess({
+      login: 'tenant-bma',
+      siteId: '7',
+      minimumAccess: 'write',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.access).toBe('write');
+  });
+
+  it('verifyUserSiteAccess reports noaccess when the user lacks the site', async () => {
+    setFetchMock(() => jsonResponse([{ site: '8', access: 'view' }]));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    const result = await admin.verifyUserSiteAccess({
+      login: 'tenant-bma',
+      siteId: '7',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.access).toBe('noaccess');
+    expect(result.error).toMatch(/noaccess access/);
+  });
+
+  it('verifyTokenSiteAccess probes the target token against getSiteFromId', async () => {
+    const { calls } = setFetchMock(() =>
+      jsonResponse({
+        idsite: '7',
+        name: 'Bentley Alberta',
+        main_url: 'https://bentleyalberta.com',
+      }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'admin-token',
+    });
+
+    const result = await admin.verifyTokenSiteAccess({
+      tokenAuth: 'tenant-token',
+      siteId: '7',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.access).toBe('view');
+    expect(result.requiredAccess).toBe('view');
+    expect(calls[0].body.get('method')).toBe('SitesManager.getSiteFromId');
+    expect(calls[0].body.get('idSite')).toBe('7');
+    expect(calls[0].body.get('token_auth')).toBe('tenant-token');
+  });
+
+  it('verifyTokenSiteAccess reports false when the token cannot see the site', async () => {
+    setFetchMock(() =>
+      jsonResponse({
+        result: 'error',
+        message:
+          "You can't access this resource as it requires view access for at least one website.",
+      }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'admin-token',
+    });
+
+    const result = await admin.verifyTokenSiteAccess({
+      tokenAuth: 'tenant-token',
+      siteId: '7',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.access).toBe('noaccess');
+    expect(result.error).toMatch(/Authentication failed/i);
+  });
+
   it('mintUserToken forwards the per-call passwordConfirmation', async () => {
     const { calls } = setFetchMock(() =>
       jsonResponse({ value: 'mint-token-abc' }),

--- a/packages/analytics/src/shared/providers/matomo-admin.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.test.ts
@@ -651,7 +651,7 @@ describe('MatomoAdmin.user lifecycle', () => {
     expect(result.error).toMatch(/Authentication failed/i);
   });
 
-  it('verifyTokenSiteAccess reports noaccess for empty-array site responses', async () => {
+  it('verifyTokenSiteAccess reports site-not-found for empty-array site responses', async () => {
     setFetchMock(() => jsonResponse([]));
     const admin = new MatomoAdmin({
       baseUrl: 'https://m.example.com',
@@ -664,8 +664,8 @@ describe('MatomoAdmin.user lifecycle', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.access).toBe('noaccess');
-    expect(result.errorCode).toBe('MATOMO_ACCESS_DENIED');
-    expect(result.error).toMatch(/Token cannot read site 7/);
+    expect(result.errorCode).toBe('MATOMO_SITE_NOT_FOUND');
+    expect(result.error).toMatch(/Site 7 was not found/);
   });
 
   it('mintUserToken forwards the per-call passwordConfirmation', async () => {

--- a/packages/analytics/src/shared/providers/matomo-admin.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.test.ts
@@ -58,6 +58,14 @@ function setFetchMock(
   return { mock, calls };
 }
 
+function nextResponse(responses: Response[]): Response {
+  const response = responses.shift();
+  if (!response) {
+    throw new Error('No mocked response left');
+  }
+  return response;
+}
+
 describe('normalizeMatomoBaseUrl', () => {
   it('strips trailing slashes and a trailing /index.php', () => {
     expect(normalizeMatomoBaseUrl('https://m.example.com/')).toBe(
@@ -161,9 +169,13 @@ describe('MatomoAdminTransport', () => {
       tokenAuth: 'tok',
     });
 
-    await expect(
-      transport.call('API.getMatomoVersion', {}),
-    ).rejects.toBeInstanceOf(AuthenticationError);
+    const request = transport.call('API.getMatomoVersion', {});
+    await expect(request).rejects.toMatchObject({
+      code: 'MATOMO_ACCESS_DENIED',
+      message:
+        "You can't access this resource as it requires view access for at least one website.",
+    });
+    await expect(request).rejects.toBeInstanceOf(AuthenticationError);
   });
 
   it('maps HTTP 401 to AuthenticationError', async () => {
@@ -269,7 +281,7 @@ describe('MatomoAdmin.createSite', () => {
         currency: 'CAD',
       }),
     ];
-    const { calls } = setFetchMock(() => responses.shift()!);
+    const { calls } = setFetchMock(() => nextResponse(responses));
 
     const admin = new MatomoAdmin({
       baseUrl: 'https://m.example.com',
@@ -397,7 +409,7 @@ describe('MatomoAdmin.user lifecycle', () => {
         superuser_access: '0',
       }),
     ];
-    const { calls } = setFetchMock(() => responses.shift()!);
+    const { calls } = setFetchMock(() => nextResponse(responses));
     const admin = new MatomoAdmin({
       baseUrl: 'https://m.example.com',
       tokenAuth: 'tok',
@@ -498,8 +510,61 @@ describe('MatomoAdmin.user lifecycle', () => {
     expect(result.access).toBe('write');
   });
 
+  it('verifyUserSiteAccess rejects an invalid minimumAccess role', async () => {
+    setFetchMock(() => jsonResponse([]));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    await expect(
+      admin.verifyUserSiteAccess({
+        login: 'tenant-bma',
+        siteId: '7',
+        // @ts-expect-error invalid role test
+        minimumAccess: 'editor',
+      }),
+    ).rejects.toThrow(/Invalid Matomo access role/);
+  });
+
+  it('verifyUserSiteAccess treats super users as admin when site rows omit them', async () => {
+    const responses = [
+      jsonResponse([]),
+      jsonResponse({
+        login: 'root',
+        email: 'root@example.com',
+        superuser_access: '1',
+      }),
+    ];
+    const { calls } = setFetchMock(() => nextResponse(responses));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'tok',
+    });
+
+    const result = await admin.verifyUserSiteAccess({
+      login: 'root',
+      siteId: '7',
+      minimumAccess: 'admin',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.access).toBe('admin');
+    expect(calls[0].body.get('method')).toBe(
+      'UsersManager.getSitesAccessFromUser',
+    );
+    expect(calls[1].body.get('method')).toBe('UsersManager.getUser');
+  });
+
   it('verifyUserSiteAccess reports noaccess when the user lacks the site', async () => {
-    setFetchMock(() => jsonResponse([{ site: '8', access: 'view' }]));
+    const responses = [
+      jsonResponse([{ site: '8', access: 'view' }]),
+      jsonResponse({
+        login: 'tenant-bma',
+        email: 'tenant@example.com',
+        superuser_access: '0',
+      }),
+    ];
+    setFetchMock(() => nextResponse(responses));
     const admin = new MatomoAdmin({
       baseUrl: 'https://m.example.com',
       tokenAuth: 'tok',
@@ -511,6 +576,7 @@ describe('MatomoAdmin.user lifecycle', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.access).toBe('noaccess');
+    expect(result.errorCode).toBe('MATOMO_ACCESS_DENIED');
     expect(result.error).toMatch(/noaccess access/);
   });
 
@@ -558,7 +624,48 @@ describe('MatomoAdmin.user lifecycle', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.access).toBe('noaccess');
+    expect(result.errorCode).toBe('MATOMO_ACCESS_DENIED');
+    expect(result.error).toMatch(/no view grant/i);
+  });
+
+  it('verifyTokenSiteAccess distinguishes an invalid token from a missing site grant', async () => {
+    setFetchMock(
+      () =>
+        new Response('not authorized', {
+          status: 401,
+          headers: { 'content-type': 'text/plain' },
+        }),
+    );
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'admin-token',
+    });
+
+    const result = await admin.verifyTokenSiteAccess({
+      tokenAuth: 'bad-token',
+      siteId: '7',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.access).toBe('noaccess');
+    expect(result.errorCode).toBe('AUTH_ERROR');
     expect(result.error).toMatch(/Authentication failed/i);
+  });
+
+  it('verifyTokenSiteAccess reports noaccess for empty-array site responses', async () => {
+    setFetchMock(() => jsonResponse([]));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'admin-token',
+    });
+
+    const result = await admin.verifyTokenSiteAccess({
+      tokenAuth: 'tenant-token',
+      siteId: '7',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.access).toBe('noaccess');
+    expect(result.errorCode).toBe('MATOMO_ACCESS_DENIED');
+    expect(result.error).toMatch(/Token cannot read site 7/);
   });
 
   it('mintUserToken forwards the per-call passwordConfirmation', async () => {

--- a/packages/analytics/src/shared/providers/matomo-admin.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.ts
@@ -286,7 +286,7 @@ function mapApplicationError(message: string): AnalyticsError {
     message.includes('requires Super User access') ||
     message.includes("doesn't have access")
   ) {
-    return new AuthenticationError(PROVIDER);
+    return new AuthenticationError(PROVIDER, message, 'MATOMO_ACCESS_DENIED');
   }
   return new AnalyticsError(message, 'MATOMO_API_ERROR', PROVIDER);
 }
@@ -340,6 +340,14 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
     this.transport = new MatomoAdminTransport({
       ...options,
       baseUrl: this.baseUrl,
+    });
+  }
+
+  private cloneTransportWithToken(tokenAuth: string): MatomoAdminTransport {
+    return new MatomoAdminTransport({
+      baseUrl: this.baseUrl,
+      tokenAuth,
+      timeout: this.timeout,
     });
   }
 
@@ -535,7 +543,13 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
       );
       const entries = normalizeSiteAccessEntries(response);
       const match = entries.find((entry) => entry.siteId === options.siteId);
-      const access = match?.access ?? 'noaccess';
+      let access = match?.access ?? 'noaccess';
+      if (access === 'noaccess') {
+        const user = await this.getUser(options.login);
+        if (user?.isSuperUser) {
+          access = 'admin';
+        }
+      }
       const ok = hasMinimumAccess(access, requiredAccess);
 
       return {
@@ -545,6 +559,7 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
         siteId: options.siteId,
         access,
         requiredAccess,
+        errorCode: ok ? undefined : 'MATOMO_ACCESS_DENIED',
         error: ok
           ? undefined
           : `User "${options.login}" has ${access} access to site ${options.siteId}; ${requiredAccess} is required.`,
@@ -559,6 +574,7 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
         access: 'noaccess',
         requiredAccess,
         error: error instanceof Error ? error.message : String(error),
+        errorCode: error instanceof AnalyticsError ? error.code : undefined,
       };
     }
   }
@@ -567,17 +583,14 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
     options: VerifyTokenSiteAccessOptions,
   ): Promise<AnalyticsAccessVerificationResult> {
     try {
-      const transport = new MatomoAdminTransport({
-        baseUrl: this.baseUrl,
-        tokenAuth: options.tokenAuth,
-        timeout: this.timeout,
-      });
+      const transport = this.cloneTransportWithToken(options.tokenAuth);
       const response = await transport.call<unknown>(
         'SitesManager.getSiteFromId',
         { idSite: options.siteId },
       );
       const siteVisible = isJsonRecord(response);
       if (siteVisible) {
+        // Validate the response shape; siteFromRow throws on malformed rows.
         siteFromRow(response);
       }
       return {
@@ -586,19 +599,28 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
         siteId: options.siteId,
         access: siteVisible ? 'view' : 'noaccess',
         requiredAccess: 'view',
+        errorCode: siteVisible ? undefined : 'MATOMO_ACCESS_DENIED',
         error: siteVisible
           ? undefined
           : `Token cannot read site ${options.siteId}.`,
         raw: response,
       };
     } catch (error) {
+      const errorCode =
+        error instanceof AnalyticsError ? error.code : undefined;
       return {
         ok: false,
         provider: PROVIDER,
         siteId: options.siteId,
         access: 'noaccess',
         requiredAccess: 'view',
-        error: error instanceof Error ? error.message : String(error),
+        error:
+          errorCode === 'MATOMO_ACCESS_DENIED'
+            ? `Token cannot read site ${options.siteId} (no view grant).`
+            : error instanceof Error
+              ? error.message
+              : String(error),
+        errorCode,
       };
     }
   }
@@ -733,24 +755,18 @@ function normalizeSiteAccessEntries(response: unknown): SiteAccessEntry[] {
   return [];
 }
 
-function accessRank(access: AnalyticsAccessRole): number {
-  switch (access) {
-    case 'admin':
-      return 3;
-    case 'write':
-      return 2;
-    case 'view':
-      return 1;
-    case 'noaccess':
-      return 0;
-  }
-}
+const ACCESS_RANK: Record<AnalyticsAccessRole, number> = {
+  noaccess: 0,
+  view: 1,
+  write: 2,
+  admin: 3,
+};
 
 function hasMinimumAccess(
   access: AnalyticsAccessRole,
   minimumAccess: AnalyticsAccessRole,
 ): boolean {
-  return accessRank(access) >= accessRank(minimumAccess);
+  return ACCESS_RANK[access] >= ACCESS_RANK[minimumAccess];
 }
 
 /**

--- a/packages/analytics/src/shared/providers/matomo-admin.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.ts
@@ -588,6 +588,18 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
         'SitesManager.getSiteFromId',
         { idSite: options.siteId },
       );
+      if (Array.isArray(response) && response.length === 0) {
+        return {
+          ok: false,
+          provider: PROVIDER,
+          siteId: options.siteId,
+          access: 'noaccess',
+          requiredAccess: 'view',
+          errorCode: 'MATOMO_SITE_NOT_FOUND',
+          error: `Site ${options.siteId} was not found.`,
+          raw: response,
+        };
+      }
       const siteVisible = isJsonRecord(response);
       if (siteVisible) {
         // Validate the response shape; siteFromRow throws on malformed rows.

--- a/packages/analytics/src/shared/providers/matomo-admin.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.ts
@@ -11,6 +11,7 @@
 
 import {
   type AnalyticsAccessRole,
+  type AnalyticsAccessVerificationResult,
   type AnalyticsAdminInterface,
   AnalyticsError,
   type AnalyticsHealthResult,
@@ -22,6 +23,8 @@ import {
   type CreateAnalyticsUserOptions,
   type MintUserTokenOptions,
   type SetUserAccessOptions,
+  type VerifyTokenSiteAccessOptions,
+  type VerifyUserSiteAccessOptions,
 } from '../types.js';
 
 const PROVIDER = 'matomo';
@@ -327,10 +330,17 @@ function userFromRow(row: JsonRecord): AnalyticsUser {
 }
 
 export class MatomoAdmin implements AnalyticsAdminInterface {
+  private readonly baseUrl: string;
+  private readonly timeout?: number;
   private readonly transport: MatomoAdminTransport;
 
   constructor(options: MatomoAdminTransportOptions) {
-    this.transport = new MatomoAdminTransport(options);
+    this.baseUrl = normalizeMatomoBaseUrl(options.baseUrl);
+    this.timeout = options.timeout;
+    this.transport = new MatomoAdminTransport({
+      ...options,
+      baseUrl: this.baseUrl,
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -506,6 +516,93 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
     });
   }
 
+  async verifyUserSiteAccess(
+    options: VerifyUserSiteAccessOptions,
+  ): Promise<AnalyticsAccessVerificationResult> {
+    const requiredAccess = options.minimumAccess ?? 'view';
+    if (!isAccessRole(requiredAccess)) {
+      throw new AnalyticsError(
+        `Invalid Matomo access role: ${requiredAccess}`,
+        'MATOMO_INVALID_ROLE',
+        PROVIDER,
+      );
+    }
+
+    try {
+      const response = await this.transport.call<unknown>(
+        'UsersManager.getSitesAccessFromUser',
+        { userLogin: options.login },
+      );
+      const entries = normalizeSiteAccessEntries(response);
+      const match = entries.find((entry) => entry.siteId === options.siteId);
+      const access = match?.access ?? 'noaccess';
+      const ok = hasMinimumAccess(access, requiredAccess);
+
+      return {
+        ok,
+        provider: PROVIDER,
+        login: options.login,
+        siteId: options.siteId,
+        access,
+        requiredAccess,
+        error: ok
+          ? undefined
+          : `User "${options.login}" has ${access} access to site ${options.siteId}; ${requiredAccess} is required.`,
+        raw: response,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        provider: PROVIDER,
+        login: options.login,
+        siteId: options.siteId,
+        access: 'noaccess',
+        requiredAccess,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async verifyTokenSiteAccess(
+    options: VerifyTokenSiteAccessOptions,
+  ): Promise<AnalyticsAccessVerificationResult> {
+    try {
+      const transport = new MatomoAdminTransport({
+        baseUrl: this.baseUrl,
+        tokenAuth: options.tokenAuth,
+        timeout: this.timeout,
+      });
+      const response = await transport.call<unknown>(
+        'SitesManager.getSiteFromId',
+        { idSite: options.siteId },
+      );
+      const siteVisible = isJsonRecord(response);
+      if (siteVisible) {
+        siteFromRow(response);
+      }
+      return {
+        ok: siteVisible,
+        provider: PROVIDER,
+        siteId: options.siteId,
+        access: siteVisible ? 'view' : 'noaccess',
+        requiredAccess: 'view',
+        error: siteVisible
+          ? undefined
+          : `Token cannot read site ${options.siteId}.`,
+        raw: response,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        provider: PROVIDER,
+        siteId: options.siteId,
+        access: 'noaccess',
+        requiredAccess: 'view',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
   async mintUserToken(
     options: MintUserTokenOptions,
   ): Promise<AnalyticsUserToken> {
@@ -599,6 +696,61 @@ function isAccessRole(value: string): value is AnalyticsAccessRole {
     value === 'write' ||
     value === 'admin'
   );
+}
+
+interface SiteAccessEntry {
+  siteId: string;
+  access: AnalyticsAccessRole;
+}
+
+function normalizeSiteAccessEntries(response: unknown): SiteAccessEntry[] {
+  if (Array.isArray(response)) {
+    return response
+      .filter(isJsonRecord)
+      .map((row) => {
+        const siteId =
+          readString(row, 'site') ??
+          readString(row, 'idsite') ??
+          readString(row, 'idSite');
+        const access = readString(row, 'access');
+        return siteId && access && isAccessRole(access)
+          ? { siteId, access }
+          : undefined;
+      })
+      .filter((entry): entry is SiteAccessEntry => !!entry);
+  }
+
+  if (isJsonRecord(response)) {
+    const entries: SiteAccessEntry[] = [];
+    for (const [siteId, access] of Object.entries(response)) {
+      if (typeof access === 'string' && isAccessRole(access)) {
+        entries.push({ siteId, access });
+      }
+    }
+    return entries;
+  }
+
+  return [];
+}
+
+function accessRank(access: AnalyticsAccessRole): number {
+  switch (access) {
+    case 'admin':
+      return 3;
+    case 'write':
+      return 2;
+    case 'view':
+      return 1;
+    case 'noaccess':
+      return 0;
+  }
+}
+
+function hasMinimumAccess(
+  access: AnalyticsAccessRole,
+  minimumAccess: AnalyticsAccessRole,
+): boolean {
+  return accessRank(access) >= accessRank(minimumAccess);
 }
 
 /**

--- a/packages/analytics/src/shared/types.ts
+++ b/packages/analytics/src/shared/types.ts
@@ -1236,7 +1236,13 @@ export interface AnalyticsAccessVerificationResult {
    */
   error?: string;
   /**
-   * Raw provider response.
+   * Provider-specific failure code when `ok` is false.
+   */
+  errorCode?: string;
+  /**
+   * Raw provider response. This is intended for debugging and may include more
+   * provider data than the specific access check asked for; avoid logging it
+   * verbatim in application logs.
    */
   raw?: unknown;
 }
@@ -1423,8 +1429,12 @@ export class AnalyticsError extends Error {
  * Authentication failed
  */
 export class AuthenticationError extends AnalyticsError {
-  constructor(provider?: string) {
-    super('Authentication failed', 'AUTH_ERROR', provider);
+  constructor(
+    provider?: string,
+    message: string = 'Authentication failed',
+    code: string = 'AUTH_ERROR',
+  ) {
+    super(message, code, provider);
     this.name = 'AuthenticationError';
   }
 }

--- a/packages/analytics/src/shared/types.ts
+++ b/packages/analytics/src/shared/types.ts
@@ -1170,6 +1170,78 @@ export interface SetUserAccessOptions {
 }
 
 /**
+ * Options for verifying that a user has sufficient access to a site.
+ */
+export interface VerifyUserSiteAccessOptions {
+  /**
+   * Login or username to inspect.
+   */
+  login: string;
+  /**
+   * Site ID the user should be able to access.
+   */
+  siteId: string;
+  /**
+   * Minimum required access. Defaults to `view`.
+   */
+  minimumAccess?: AnalyticsAccessRole;
+}
+
+/**
+ * Options for verifying that a token can read a site.
+ */
+export interface VerifyTokenSiteAccessOptions {
+  /**
+   * Token to probe. This is the token under test, not necessarily the admin
+   * token used by the provider instance.
+   */
+  tokenAuth: string;
+  /**
+   * Site ID the token should be able to read.
+   */
+  siteId: string;
+}
+
+/**
+ * Result returned by access-verification helpers.
+ */
+export interface AnalyticsAccessVerificationResult {
+  /**
+   * Whether the requested access check passed.
+   */
+  ok: boolean;
+  /**
+   * Provider that performed the check.
+   */
+  provider: string;
+  /**
+   * Login that was inspected, when the check targets a user.
+   */
+  login?: string;
+  /**
+   * Site ID that was inspected.
+   */
+  siteId: string;
+  /**
+   * Observed access level. Token probes report `view` when the token can read
+   * the site and `noaccess` when it cannot.
+   */
+  access?: AnalyticsAccessRole;
+  /**
+   * Required access level used by the check.
+   */
+  requiredAccess?: AnalyticsAccessRole;
+  /**
+   * Failure reason when `ok` is false.
+   */
+  error?: string;
+  /**
+   * Raw provider response.
+   */
+  raw?: unknown;
+}
+
+/**
  * Options for minting a per-user auth token scoped to a user's permissions.
  */
 export interface MintUserTokenOptions {
@@ -1294,6 +1366,20 @@ export interface AnalyticsAdminInterface {
    * Grant a user access to one or more sites at the given role.
    */
   setUserAccess?(options: SetUserAccessOptions): Promise<void>;
+
+  /**
+   * Verify that a user has at least the requested access to a site.
+   */
+  verifyUserSiteAccess?(
+    options: VerifyUserSiteAccessOptions,
+  ): Promise<AnalyticsAccessVerificationResult>;
+
+  /**
+   * Verify that a token can read a site.
+   */
+  verifyTokenSiteAccess?(
+    options: VerifyTokenSiteAccessOptions,
+  ): Promise<AnalyticsAccessVerificationResult>;
 
   /**
    * Mint a per-user auth token scoped to that user's existing permissions.


### PR DESCRIPTION
## Summary
- add public Matomo admin verification helpers for user site access and tenant token site access
- verify user access with `UsersManager.getSitesAccessFromUser`
- verify tenant tokens by probing `SitesManager.getSiteFromId` with the token under test
- add unit and opt-in integration coverage for the new verification paths

## Release train context
This unblocks the Anytown Matomo doctor from proving that the tenant user and tenant token can actually read the provisioned Matomo site without private API reach-ins.

## Verification
- `pnpm --filter @happyvertical/analytics test -- matomo-admin.test.ts`
- `pnpm --filter @happyvertical/analytics build`
- pre-push `pnpm typecheck` hook passed
- `git diff --check`