### PR TITLE
fix(sql): preserve postgres raw query operators

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -79,12 +79,13 @@ Interpolated values are always passed as parameterized values (never string-conc
 // Raw queries use each adapter's native placeholder syntax.
 await pgDb.query('SELECT * FROM posts WHERE id = $1', postId);
 await pgDb.query('SELECT * FROM posts WHERE id = $1', [postId]);
+await pgDb.query('SELECT * FROM posts WHERE id = ANY($1)', postIds);
 
 // PostgreSQL SQL is passed through unchanged, so native operators are safe.
 await pgDb.query(`SELECT ('{"db":true}'::jsonb ? 'db') AS has_db`);
 ```
 
-Transaction handles follow the same raw query behavior as the root database handle.
+For PostgreSQL, a single array argument is treated as a values list unless the SQL shows a single array-typed placeholder, such as `$1::text[]`, `CAST($1 AS text[])`, or `ANY($1)`. Transaction handles follow the same raw query behavior as the root database handle.
 
 ### CRUD Helpers
 

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -73,6 +73,19 @@ Shorthand aliases: `oo` (many), `oO` (single), `ox` (pluck), `xx` (execute).
 
 Interpolated values are always passed as parameterized values (never string-concatenated), with placeholder format handled per adapter (`?` for SQLite/DuckDB, `$1`/`$2` for PostgreSQL).
 
+### Raw Queries
+
+```typescript
+// Raw queries use each adapter's native placeholder syntax.
+await pgDb.query('SELECT * FROM posts WHERE id = $1', postId);
+await pgDb.query('SELECT * FROM posts WHERE id = $1', [postId]);
+
+// PostgreSQL SQL is passed through unchanged, so native operators are safe.
+await pgDb.query(`SELECT ('{"db":true}'::jsonb ? 'db') AS has_db`);
+```
+
+Transaction handles follow the same raw query behavior as the root database handle.
+
 ### CRUD Helpers
 
 ```typescript

--- a/packages/sql/src/postgres.spec.ts
+++ b/packages/sql/src/postgres.spec.ts
@@ -208,6 +208,73 @@ describe('postgres tests', () => {
     const result = await db.get('contents', { id });
     expect(result).toBeNull();
   });
+
+  it('should preserve PostgreSQL JSONB existence operators in raw queries', async () => {
+    if (!postgresAvailable) return;
+
+    const hasKey = await db.query(
+      `SELECT ('{"db":true}'::jsonb ? 'db') AS has_key`,
+    );
+    const hasAny = await db.query(
+      `SELECT ('{"db":true,"cache":false}'::jsonb ?| ARRAY['db', 'missing']) AS has_any`,
+    );
+    const hasAll = await db.query(
+      `SELECT ('{"db":true,"cache":false}'::jsonb ?& ARRAY['db', 'cache']) AS has_all`,
+    );
+
+    expect(hasKey.rows[0].has_key).toBe(true);
+    expect(hasAny.rows[0].has_any).toBe(true);
+    expect(hasAll.rows[0].has_all).toBe(true);
+  });
+
+  it('should support PostgreSQL-native placeholders in raw queries', async () => {
+    if (!postgresAvailable) return;
+
+    const restArgs = await db.query(
+      'SELECT $1::text AS name, $2::int AS count',
+      'native',
+      2,
+    );
+    const valuesArray = await db.query(
+      'SELECT $1::text AS name, $2::int AS count',
+      ['array', 3],
+    );
+    const singleArrayParam = await db.query('SELECT $1::text[] AS items', [
+      'first',
+      'second',
+    ]);
+
+    expect(restArgs.rows[0]).toEqual({ name: 'native', count: 2 });
+    expect(valuesArray.rows[0]).toEqual({ name: 'array', count: 3 });
+    expect(singleArrayParam.rows[0].items).toEqual(['first', 'second']);
+  });
+
+  it('should use the same raw query behavior in transaction handles', async () => {
+    if (!postgresAvailable || !db.transaction || !db.beginTransaction) return;
+
+    await db.transaction(async (tx) => {
+      const result = await tx.query(
+        `SELECT ('{"tx":true}'::jsonb ? 'tx') AS "hasTx", $1::text AS value`,
+        ['callback'],
+      );
+
+      expect(result.rows[0]).toEqual({ hasTx: true, value: 'callback' });
+    });
+
+    const tx = await db.beginTransaction();
+    try {
+      const result = await tx.query(
+        `SELECT ('{"tx":true,"manual":true}'::jsonb ?& ARRAY['tx', 'manual']) AS "hasAll", $1::text AS value`,
+        ['manual'],
+      );
+
+      expect(result.rows[0]).toEqual({ hasAll: true, value: 'manual' });
+    } finally {
+      if (tx.isActive()) {
+        await tx.rollback();
+      }
+    }
+  });
 });
 
 describe('postgres JSON serialization', () => {

--- a/packages/sql/src/postgres.spec.ts
+++ b/packages/sql/src/postgres.spec.ts
@@ -243,10 +243,14 @@ describe('postgres tests', () => {
       'first',
       'second',
     ]);
+    const singleItemArrayParam = await db.query('SELECT $1::text[] AS items', [
+      'only',
+    ]);
 
     expect(restArgs.rows[0]).toEqual({ name: 'native', count: 2 });
     expect(valuesArray.rows[0]).toEqual({ name: 'array', count: 3 });
     expect(singleArrayParam.rows[0].items).toEqual(['first', 'second']);
+    expect(singleItemArrayParam.rows[0].items).toEqual(['only']);
   });
 
   it('should use the same raw query behavior in transaction handles', async () => {

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -128,6 +128,21 @@ function getMaxPostgresParameterIndex(sql: string): number {
   return maxIndex;
 }
 
+function usesSingleArrayParameter(sql: string): boolean {
+  const identifier = String.raw`(?:"[^"]+"|[a-z_][\w$]*)`;
+  const qualifiedIdentifier = String.raw`${identifier}(?:\s*\.\s*${identifier})?`;
+  const arrayType = String.raw`${qualifiedIdentifier}(?:\s*\([^)]*\))?\s*\[\]`;
+
+  return (
+    new RegExp(String.raw`\$1\s*::\s*${arrayType}`, 'i').test(sql) ||
+    new RegExp(
+      String.raw`\bCAST\s*\(\s*\$1\s+AS\s+${arrayType}\s*\)`,
+      'i',
+    ).test(sql) ||
+    /\b(?:ANY|ALL|SOME)\s*\(\s*\$1\s*\)/i.test(sql)
+  );
+}
+
 function normalizeRawQueryValues(sql: string, values: any[]): any[] {
   if (values.length !== 1 || !Array.isArray(values[0])) {
     return values;
@@ -135,6 +150,10 @@ function normalizeRawQueryValues(sql: string, values: any[]): any[] {
 
   const valuesArray = values[0];
   const maxParameterIndex = getMaxPostgresParameterIndex(sql);
+
+  if (maxParameterIndex === 1 && usesSingleArrayParameter(sql)) {
+    return values;
+  }
 
   if (maxParameterIndex === 0 || maxParameterIndex === valuesArray.length) {
     return valuesArray;

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -117,6 +117,32 @@ function vectorOperator(metric: 'cosine' | 'l2' | 'ip'): string {
   }
 }
 
+function getMaxPostgresParameterIndex(sql: string): number {
+  let maxIndex = 0;
+  for (const match of sql.matchAll(/\$(\d+)/g)) {
+    const index = Number(match[1]);
+    if (Number.isSafeInteger(index) && index > maxIndex) {
+      maxIndex = index;
+    }
+  }
+  return maxIndex;
+}
+
+function normalizeRawQueryValues(sql: string, values: any[]): any[] {
+  if (values.length !== 1 || !Array.isArray(values[0])) {
+    return values;
+  }
+
+  const valuesArray = values[0];
+  const maxParameterIndex = getMaxPostgresParameterIndex(sql);
+
+  if (maxParameterIndex === 0 || maxParameterIndex === valuesArray.length) {
+    return valuesArray;
+  }
+
+  return values;
+}
+
 /**
  * pgvector index operator class for CREATE INDEX
  */
@@ -954,6 +980,9 @@ async function createDatabase(
   /**
    * Executes a raw SQL query with parameterized values
    *
+   * Uses PostgreSQL-native placeholders ($1, $2, ...). SQL is passed through
+   * unchanged so Postgres operators such as JSONB ? remain intact.
+   *
    * @param sql - SQL query string
    * @param values - Variables to use as parameters
    * @returns Promise resolving to query result with rows and count
@@ -962,12 +991,9 @@ async function createDatabase(
     sql: string,
     ...values: any[]
   ): Promise<{ rows: Record<string, any>[]; rowCount: number }> => {
+    const queryValues = normalizeRawQueryValues(sql, values);
     try {
-      // Convert ? placeholders to $1, $2, etc for PostgreSQL compatibility
-      let paramIndex = 0;
-      const pgSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
-
-      const result = await client.query(pgSql, values);
+      const result = await client.query(sql, queryValues);
       return {
         rows: result.rows,
         rowCount: result.rowCount ?? 0,
@@ -975,7 +1001,7 @@ async function createDatabase(
     } catch (e) {
       throw new DatabaseError('Failed to execute raw query', {
         sql,
-        values,
+        values: queryValues,
         originalError: formatDbError(e),
       });
     }
@@ -1316,7 +1342,8 @@ async function createDatabase(
           await txClient.query(sql, values);
         },
         query: async (sql, ...values) => {
-          const result = await txClient.query(sql, values);
+          const queryValues = normalizeRawQueryValues(sql, values);
+          const result = await txClient.query(sql, queryValues);
           return {
             rows: result.rows,
             rowCount: result.rowCount ?? 0,
@@ -1540,7 +1567,8 @@ async function createDatabase(
         await txClient.query(sql, values);
       },
       query: async (sql, ...values) => {
-        const result = await txClient.query(sql, values);
+        const queryValues = normalizeRawQueryValues(sql, values);
+        const result = await txClient.query(sql, queryValues);
         return {
           rows: result.rows,
           rowCount: result.rowCount ?? 0,

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -790,6 +790,7 @@ export interface DatabaseInterface {
    *
    * Raw queries use the adapter's native placeholder syntax.
    * Parameters may be passed as rest arguments or as one values array.
+   * For adapter-specific array parameter caveats, see the package docs.
    *
    * @param str - SQL query string
    * @param vars - Variables to use as parameters

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -788,6 +788,9 @@ export interface DatabaseInterface {
   /**
    * Executes a raw SQL query with parameterized values
    *
+   * Raw queries use the adapter's native placeholder syntax.
+   * Parameters may be passed as rest arguments or as one values array.
+   *
    * @param str - SQL query string
    * @param vars - Variables to use as parameters
    * @returns Promise resolving to query result with rows and count


### PR DESCRIPTION
## Summary

- Stop blindly rewriting `?` characters in Postgres raw `query()` SQL so JSONB operators like `?`, `?|`, and `?&` reach Postgres intact.
- Keep raw queries on PostgreSQL-native `$1`, `$2`, ... placeholders and normalize either rest params or a single values array.
- Document raw query behavior and add Postgres regression coverage for JSONB operators, native placeholders, transaction handles, and array-valued parameters.

## Root cause

The Postgres adapter converted every `?` in raw SQL into numbered placeholders, which also rewrote valid Postgres operators and could alter string/comment/operator contexts before the query reached the database.

Fixes #1017.

## Validation

- `pnpm --filter @happyvertical/sql test:postgres`
- `pnpm --filter @happyvertical/sql build`
- `pnpm exec biome check packages/sql/src/postgres.ts packages/sql/src/postgres.spec.ts packages/sql/src/shared/types.ts` (passes with existing warnings in `postgres.spec.ts`)
- pre-push `pnpm run typecheck`