### PR TITLE
feat(video): add extensible media bundle inspection

### DIFF
--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -745,7 +745,9 @@
           "sharp"
         ]
       },
-      "dependents": [],
+      "dependents": [
+        "@happyvertical/video"
+      ],
       "stability": {
         "level": "stable",
         "reason": "Primary package surface is described as implemented and production-oriented."
@@ -1362,7 +1364,7 @@
         "clean": "pnpm --filter @happyvertical/video clean"
       },
       "correctionLoops": [
-        "If module resolution or export errors mention a workspace dependency, build the dependency first (`pnpm --filter @happyvertical/logger build`, `pnpm --filter @happyvertical/utils build`) and then rerun `pnpm --filter @happyvertical/video build`.",
+        "If module resolution or export errors mention a workspace dependency, build the dependency first (`pnpm --filter @happyvertical/images build`, `pnpm --filter @happyvertical/logger build`, `pnpm --filter @happyvertical/utils build`) and then rerun `pnpm --filter @happyvertical/video build`.",
         "If tests or exports fail after API, type, or bundle changes, run `pnpm --filter @happyvertical/video clean` followed by `pnpm --filter @happyvertical/video build` and `pnpm --filter @happyvertical/video test`.",
         "If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands."
       ],
@@ -1372,6 +1374,7 @@
       "implements": [],
       "requires": {
         "workspace": [
+          "@happyvertical/images",
           "@happyvertical/logger",
           "@happyvertical/utils"
         ],
@@ -1758,6 +1761,11 @@
       "type": "provides",
       "from": "@happyvertical/utils",
       "to": "Foundation utilities for ID generation, date parsing, URL handling, string conversion, error handling, and logging"
+    },
+    {
+      "type": "requires",
+      "from": "@happyvertical/video",
+      "to": "@happyvertical/images"
     },
     {
       "type": "requires",

--- a/packages/images/AGENT.md
+++ b/packages/images/AGENT.md
@@ -9,7 +9,7 @@ Image processing utilities with adapter pattern for scaling from static to enter
 - Hierarchy path: `@happyvertical/sdk > packages > images`
 - Workspace position: `15 of 29` local packages
 - Internal dependencies: none
-- Internal dependents: none
+- Internal dependents: `@happyvertical/video`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`
 
 ## Build & Test

--- a/packages/images/metadata.json
+++ b/packages/images/metadata.json
@@ -20,7 +20,9 @@
       "sharp"
     ]
   },
-  "dependents": [],
+  "dependents": [
+    "@happyvertical/video"
+  ],
   "stability": {
     "level": "stable",
     "reason": "Primary package surface is described as implemented and production-oriented."

--- a/packages/video/AGENT.md
+++ b/packages/video/AGENT.md
@@ -8,7 +8,7 @@ Video processing utilities with adapter pattern for composition and transcoding
 - Package: `@happyvertical/video`
 - Hierarchy path: `@happyvertical/sdk > packages > video`
 - Workspace position: `28 of 29` local packages
-- Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
+- Internal dependencies: `@happyvertical/images`, `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`
 
@@ -20,14 +20,14 @@ pnpm --filter @happyvertical/video clean
 ```
 
 ## Agent Correction Loops
-- If module resolution or export errors mention a workspace dependency, build the dependency first (`pnpm --filter @happyvertical/logger build`, `pnpm --filter @happyvertical/utils build`) and then rerun `pnpm --filter @happyvertical/video build`.
+- If module resolution or export errors mention a workspace dependency, build the dependency first (`pnpm --filter @happyvertical/images build`, `pnpm --filter @happyvertical/logger build`, `pnpm --filter @happyvertical/utils build`) and then rerun `pnpm --filter @happyvertical/video build`.
 - If tests or exports fail after API, type, or bundle changes, run `pnpm --filter @happyvertical/video clean` followed by `pnpm --filter @happyvertical/video build` and `pnpm --filter @happyvertical/video test`.
 - If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands.
 
 ## Ecosystem Relationships
 - Provides: Video processing utilities with adapter pattern for composition and transcoding
 - Implements: none
-- Requires: @happyvertical/logger, @happyvertical/utils, sharp
+- Requires: @happyvertical/images, @happyvertical/logger, @happyvertical/utils, sharp
 - Stability: stable (Primary package surface is described as implemented and production-oriented.)
 <!-- END AGENT:GENERATED -->
 

--- a/packages/video/metadata.json
+++ b/packages/video/metadata.json
@@ -12,6 +12,7 @@
   "implements": [],
   "requires": {
     "workspace": [
+      "@happyvertical/images",
       "@happyvertical/logger",
       "@happyvertical/utils"
     ],

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -20,6 +20,7 @@
     "dev": "npm run build:watch & npm run test:watch"
   },
   "dependencies": {
+    "@happyvertical/images": "workspace:*",
     "@happyvertical/logger": "workspace:*",
     "@happyvertical/utils": "workspace:*",
     "sharp": "^0.34.5"

--- a/packages/video/src/index.ts
+++ b/packages/video/src/index.ts
@@ -71,6 +71,9 @@
 // Adapters
 export { FFmpegProcessor } from './adapters/ffmpeg.js';
 
+// Media bundle inspection
+export * from './media-bundles/index.js';
+
 // Types
 export type {
   AudioCodecOptions,

--- a/packages/video/src/index.ts
+++ b/packages/video/src/index.ts
@@ -70,9 +70,33 @@
 
 // Adapters
 export { FFmpegProcessor } from './adapters/ffmpeg.js';
-
+export type {
+  InspectMediaBundleOptions,
+  Insta360FileIdentity,
+  MediaBundleCapability,
+  MediaBundleFileRole,
+  MediaBundleHandler,
+  MediaBundleInspectContext,
+  MediaBundleInspection,
+  MediaBundleInspectTools,
+  MediaBundleSupportFile,
+  MediaFileDescriptor,
+  MediaFormatFamily,
+  MediaSupportFileVisibility,
+  NormalizedGpsTrackPoint,
+  NormalizedMediaDevice,
+  NormalizedMediaMetadata,
+  NormalizedMediaStream,
+} from './media-bundles/index.js';
 // Media bundle inspection
-export * from './media-bundles/index.js';
+export {
+  defaultMediaBundleHandlers,
+  genericImageBundleHandler,
+  genericVideoBundleHandler,
+  inspectMediaBundle,
+  insta360BundleHandler,
+  parseInsta360FileName,
+} from './media-bundles/index.js';
 
 // Types
 export type {

--- a/packages/video/src/media-bundles.spec.ts
+++ b/packages/video/src/media-bundles.spec.ts
@@ -7,6 +7,7 @@ import {
   type MediaBundleHandler,
   type MediaFileDescriptor,
 } from './media-bundles/index.js';
+import { parseExiftoolGpsRecord } from './media-bundles/utils.js';
 
 const file = (path: string, mimeType?: string): MediaFileDescriptor => ({
   path,
@@ -54,6 +55,33 @@ describe('media bundle inspection', () => {
       probe: false,
     });
     expect(tied.handlerId).toBe('first');
+  });
+
+  it('appends validate hook warnings to a matched inspection', async () => {
+    const result = await inspectMediaBundle([file('/tmp/a.bin')], {
+      handlers: [
+        {
+          id: 'validator',
+          version: '1.0.0',
+          priority: 1,
+          supports: () => true,
+          inspect: async (files) => ({
+            handlerId: 'validator',
+            handlerVersion: '1.0.0',
+            formatFamily: 'unknown',
+            primary: { ...files[0], role: 'primary' },
+            supportFiles: [],
+            metadata: {},
+            capabilities: [],
+            warnings: ['existing warning'],
+            errors: [],
+          }),
+          validate: () => ['validation warning'],
+        },
+      ],
+    });
+
+    expect(result.warnings).toEqual(['existing warning', 'validation warning']);
   });
 
   it('lets app-private handlers override or handle unknown formats explicitly', async () => {
@@ -152,6 +180,25 @@ describe('media bundle inspection', () => {
       '/tmp/VID_20260418_173449_00_004.insv',
       '/tmp/LRV_20260418_173449_01_004.lrv',
     ]);
+    expect(result.warnings).toEqual([
+      'ignored 2 file(s) outside Insta360 bundle 20260418_173449_004: VID_20260418_180000_00_005.insv, unrelated.mp4',
+      'probe disabled; returning file-level Insta360 bundle inspection',
+    ]);
+    expect(
+      (result.raw?.insta360 as { ignoredFiles: unknown[] }).ignoredFiles,
+    ).toHaveLength(2);
+  });
+
+  it('returns an unknown inspection when no handler matches', async () => {
+    const result = await inspectMediaBundle([file('/tmp/readme.txt')], {
+      handlers: [],
+    });
+
+    expect(result.handlerId).toBe('unknown');
+    expect(result.primary.role).toBe('primary');
+    expect(result.warnings).toEqual([
+      'no media bundle handler matched; returned unknown inspection',
+    ]);
   });
 
   it('falls back to generic video for ordinary video files', async () => {
@@ -165,5 +212,97 @@ describe('media bundle inspection', () => {
     expect(result.handlerId).toBe('generic-video');
     expect(result.formatFamily).toBe('generic-video');
     expect(result.primary.role).toBe('primary');
+  });
+});
+
+describe('parseExiftoolGpsRecord', () => {
+  it('normalizes Doc-grouped GPS samples into a deduped relative track', () => {
+    const points = parseExiftoolGpsRecord(
+      {
+        'Main:QuickTime:GPSLatitude': 1,
+        'Main:QuickTime:GPSLongitude': 2,
+        'Main:QuickTime:GPSDateTime': '2026:04:18 17:34:40Z',
+        'Doc2:QuickTime:GPSLatitude': 52.2,
+        'Doc2:QuickTime:GPSLongitude': -114.2,
+        'Doc2:QuickTime:GPSDateTime': '2026:04:18 17:34:51Z',
+        'Doc2:QuickTime:GPSAltitude': 940,
+        'Doc2:QuickTime:GPSTrack': 180,
+        'Doc2:QuickTime:GPSSpeed': 4.5,
+        'Doc1:QuickTime:GPSLatitude': 52.1,
+        'Doc1:QuickTime:GPSLongitude': -114.1,
+        'Doc1:QuickTime:GPSDateTime': '2026:04:18 17:34:50Z',
+        'Doc3:QuickTime:GPSLatitude': 52.2,
+        'Doc3:QuickTime:GPSLongitude': -114.2,
+        'Doc3:QuickTime:GPSDateTime': '2026:04:18 17:34:52Z',
+      },
+      '/tmp/LRV_20260418_173449_01_004.lrv',
+    );
+
+    expect(points).toEqual([
+      {
+        tSeconds: 0,
+        recordedAt: '2026-04-18T17:34:50.000Z',
+        latitude: 52.1,
+        longitude: -114.1,
+        altitude: null,
+        heading: null,
+        speedMps: null,
+        sourceFilePath: '/tmp/LRV_20260418_173449_01_004.lrv',
+      },
+      {
+        tSeconds: 1,
+        recordedAt: '2026-04-18T17:34:51.000Z',
+        latitude: 52.2,
+        longitude: -114.2,
+        altitude: 940,
+        heading: 180,
+        speedMps: 4.5,
+        sourceFilePath: '/tmp/LRV_20260418_173449_01_004.lrv',
+      },
+    ]);
+  });
+
+  it('falls back to a single Main or flat GPS fix when Doc groups are absent', () => {
+    expect(
+      parseExiftoolGpsRecord({
+        'Main:QuickTime:GPSLatitude': 52.468,
+        'Main:QuickTime:GPSLongitude': -114.043,
+        'Main:QuickTime:GPSDateTime': '2026:04:18 17:34:50Z',
+        'Main:QuickTime:GPSAltitude': 930,
+      }),
+    ).toEqual([
+      {
+        tSeconds: 0,
+        recordedAt: '2026-04-18T17:34:50.000Z',
+        latitude: 52.468,
+        longitude: -114.043,
+        altitude: 930,
+        heading: null,
+        speedMps: null,
+        sourceFilePath: undefined,
+      },
+    ]);
+
+    expect(
+      parseExiftoolGpsRecord(
+        Object.fromEntries([
+          ['GPSLatitude', 52.469],
+          ['GPSLongitude', -114.044],
+          ['GPSDateTime', '2026:04:18 17:34:51Z'],
+          ['GPSImgDirection', 45],
+        ]),
+      ),
+    ).toEqual([
+      {
+        tSeconds: 0,
+        recordedAt: '2026-04-18T17:34:51.000Z',
+        latitude: 52.469,
+        longitude: -114.044,
+        altitude: null,
+        heading: 45,
+        speedMps: null,
+        sourceFilePath: undefined,
+      },
+    ]);
   });
 });

--- a/packages/video/src/media-bundles.spec.ts
+++ b/packages/video/src/media-bundles.spec.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultMediaBundleHandlers,
+  genericVideoBundleHandler,
+  inspectMediaBundle,
+  insta360BundleHandler,
+  type MediaBundleHandler,
+  type MediaFileDescriptor,
+} from './media-bundles/index.js';
+
+const file = (path: string, mimeType?: string): MediaFileDescriptor => ({
+  path,
+  name: path.split('/').at(-1),
+  mimeType,
+});
+
+describe('media bundle inspection', () => {
+  it('chooses handlers by priority and keeps registration order for ties', async () => {
+    const calls: string[] = [];
+    const makeHandler = (id: string, priority: number): MediaBundleHandler => ({
+      id,
+      version: '1.0.0',
+      priority,
+      supports: () => {
+        calls.push(`${id}:supports`);
+        return true;
+      },
+      inspect: async (files) => ({
+        handlerId: id,
+        handlerVersion: '1.0.0',
+        formatFamily: 'unknown',
+        primary: files[0],
+        supportFiles: [],
+        metadata: {},
+        capabilities: [],
+        warnings: [],
+        errors: [],
+      }),
+    });
+
+    const high = makeHandler('high', 20);
+    const first = makeHandler('first', 10);
+    const second = makeHandler('second', 10);
+    const result = await inspectMediaBundle([file('/tmp/a.bin')], {
+      handlers: [first, second, high],
+      probe: false,
+    });
+
+    expect(result.handlerId).toBe('high');
+    expect(calls).toEqual(['high:supports']);
+
+    const tied = await inspectMediaBundle([file('/tmp/a.bin')], {
+      handlers: [first, second],
+      probe: false,
+    });
+    expect(tied.handlerId).toBe('first');
+  });
+
+  it('lets app-private handlers override or handle unknown formats explicitly', async () => {
+    const privateHandler: MediaBundleHandler = {
+      id: 'private-format',
+      version: '1.0.0',
+      priority: 1000,
+      capabilities: ['private:closed-format'],
+      supports: (files) =>
+        files.some((candidate) => candidate.path.endsWith('.private')),
+      inspect: async (files) => ({
+        handlerId: 'private-format',
+        handlerVersion: '1.0.0',
+        formatFamily: 'unknown',
+        primary: { ...files[0], role: 'primary' },
+        supportFiles: [],
+        metadata: {
+          private: {
+            'example.private': { inspected: true },
+          },
+        },
+        capabilities: ['private:closed-format'],
+        warnings: [],
+        errors: [],
+      }),
+    };
+
+    const result = await inspectMediaBundle([file('/tmp/camera.private')], {
+      handlers: [privateHandler, ...defaultMediaBundleHandlers],
+      probe: false,
+    });
+
+    expect(result.handlerId).toBe('private-format');
+    expect(result.metadata.private?.['example.private']).toEqual({
+      inspected: true,
+    });
+  });
+
+  it('groups default Insta360 INSV/LRV bundles into one visible primary and hidden support files', async () => {
+    const result = await inspectMediaBundle(
+      [
+        file('/tmp/VID_20260418_173449_00_004.insv', 'video/mp4'),
+        file('/tmp/VID_20260418_173449_10_004.insv', 'video/mp4'),
+        file('/tmp/LRV_20260418_173449_01_004.lrv', 'video/mp4'),
+      ],
+      {
+        handlers: [insta360BundleHandler, genericVideoBundleHandler],
+        probe: false,
+      },
+    );
+
+    expect(result.handlerId).toBe('insta360-insv-lrv');
+    expect(result.formatFamily).toBe('insta360');
+    expect(result.primary.name).toBe('VID_20260418_173449_00_004.insv');
+    expect(result.capabilities).toEqual(
+      expect.arrayContaining(['sidecar-binding', 'stitch-export']),
+    );
+    expect(result.supportFiles).toEqual([
+      expect.objectContaining({
+        relationship: 'paired-video-stream',
+        visibility: 'hidden-retained',
+      }),
+      expect.objectContaining({
+        relationship: 'proxy-video',
+        visibility: 'hidden-retained',
+      }),
+    ]);
+  });
+
+  it('does not retain unrelated files as Insta360 support files', async () => {
+    const result = await inspectMediaBundle(
+      [
+        file('/tmp/VID_20260418_173449_00_004.insv', 'video/mp4'),
+        file('/tmp/LRV_20260418_173449_01_004.lrv', 'video/mp4'),
+        file('/tmp/VID_20260418_180000_00_005.insv', 'video/mp4'),
+        file('/tmp/unrelated.mp4', 'video/mp4'),
+      ],
+      {
+        handlers: [insta360BundleHandler, genericVideoBundleHandler],
+        probe: false,
+      },
+    );
+
+    expect(result.primary.name).toBe('VID_20260418_173449_00_004.insv');
+    expect(
+      result.supportFiles.map((supportFile) => supportFile.file.name),
+    ).toEqual(['LRV_20260418_173449_01_004.lrv']);
+    expect(
+      Object.keys(result.raw?.insta360 as Record<string, unknown>),
+    ).toContain('files');
+    expect(
+      Object.keys(
+        (result.raw?.insta360 as { files: Record<string, unknown> }).files,
+      ),
+    ).toEqual([
+      '/tmp/VID_20260418_173449_00_004.insv',
+      '/tmp/LRV_20260418_173449_01_004.lrv',
+    ]);
+  });
+
+  it('falls back to generic video for ordinary video files', async () => {
+    const result = await inspectMediaBundle(
+      [file('/tmp/news-clip.mp4', 'video/mp4')],
+      {
+        probe: false,
+      },
+    );
+
+    expect(result.handlerId).toBe('generic-video');
+    expect(result.formatFamily).toBe('generic-video');
+    expect(result.primary.role).toBe('primary');
+  });
+});

--- a/packages/video/src/media-bundles/handlers/generic-image.ts
+++ b/packages/video/src/media-bundles/handlers/generic-image.ts
@@ -5,7 +5,7 @@ import type {
   MediaBundleInspection,
   NormalizedMediaMetadata,
 } from '../types.js';
-import { displayName, isImageFile } from '../utils.js';
+import { displayName, formatError, isImageFile } from '../utils.js';
 
 export const genericImageBundleHandler: MediaBundleHandler = {
   id: 'generic-image',
@@ -64,7 +64,3 @@ export const genericImageBundleHandler: MediaBundleHandler = {
     };
   },
 };
-
-function formatError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/packages/video/src/media-bundles/handlers/generic-image.ts
+++ b/packages/video/src/media-bundles/handlers/generic-image.ts
@@ -1,0 +1,70 @@
+import { getImageMetadata } from '@happyvertical/images';
+
+import type {
+  MediaBundleHandler,
+  MediaBundleInspection,
+  NormalizedMediaMetadata,
+} from '../types.js';
+import { displayName, isImageFile } from '../utils.js';
+
+export const genericImageBundleHandler: MediaBundleHandler = {
+  id: 'generic-image',
+  version: '1.0.0',
+  priority: 10,
+  capabilities: ['image-metadata'],
+
+  supports(files) {
+    return files.some(isImageFile);
+  },
+
+  async inspect(files, context): Promise<MediaBundleInspection> {
+    const primary = files.find(isImageFile) ?? files[0];
+    const warnings: string[] = [];
+    let metadata: NormalizedMediaMetadata = {
+      mimeType: primary.mimeType,
+    };
+
+    if (context.probe === false) {
+      warnings.push(
+        'probe disabled; returning file-level generic image inspection',
+      );
+    } else {
+      try {
+        const image = await getImageMetadata(primary.path);
+        metadata = {
+          width: image.width,
+          height: image.height,
+          mimeType: primary.mimeType,
+          raw: { image },
+        };
+      } catch (error) {
+        warnings.push(
+          `image metadata probe failed for ${displayName(primary)}: ${formatError(error)}`,
+        );
+      }
+    }
+
+    return {
+      handlerId: genericImageBundleHandler.id,
+      handlerVersion: genericImageBundleHandler.version,
+      formatFamily: 'generic-image',
+      primary: { ...primary, role: 'primary' },
+      supportFiles: files
+        .filter((file) => file !== primary)
+        .map((file) => ({
+          file: { ...file, role: file.role ?? 'support' },
+          role: 'support' as const,
+          relationship: 'co-located-file',
+          visibility: context.defaultSupportFileVisibility ?? 'hidden-retained',
+        })),
+      metadata,
+      capabilities: [...(genericImageBundleHandler.capabilities ?? [])],
+      warnings,
+      errors: [],
+    };
+  },
+};
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/video/src/media-bundles/handlers/generic-video.ts
+++ b/packages/video/src/media-bundles/handlers/generic-video.ts
@@ -6,6 +6,7 @@ import type {
 } from '../types.js';
 import {
   displayName,
+  formatError,
   isVideoFile,
   mergeMetadata,
   probeEmbeddedMetadata,
@@ -83,7 +84,3 @@ export const genericVideoBundleHandler: MediaBundleHandler = {
     };
   },
 };
-
-function formatError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/packages/video/src/media-bundles/handlers/generic-video.ts
+++ b/packages/video/src/media-bundles/handlers/generic-video.ts
@@ -1,0 +1,89 @@
+import type {
+  MediaBundleHandler,
+  MediaBundleInspection,
+  MediaBundleSupportFile,
+  NormalizedMediaMetadata,
+} from '../types.js';
+import {
+  displayName,
+  isVideoFile,
+  mergeMetadata,
+  probeEmbeddedMetadata,
+  probeVideoMetadata,
+} from '../utils.js';
+
+export const genericVideoBundleHandler: MediaBundleHandler = {
+  id: 'generic-video',
+  version: '1.0.0',
+  priority: 10,
+  capabilities: ['stream-info'],
+
+  supports(files) {
+    return files.some(isVideoFile);
+  },
+
+  async inspect(files, context): Promise<MediaBundleInspection> {
+    const primary = files.find(isVideoFile) ?? files[0];
+    const warnings: string[] = [];
+    const supportFiles: MediaBundleSupportFile[] = files
+      .filter((file) => file !== primary)
+      .map((file) => ({
+        file: { ...file, role: file.role ?? 'support' },
+        role: 'support',
+        relationship: 'co-located-file',
+        visibility: context.defaultSupportFileVisibility ?? 'hidden-retained',
+      }));
+
+    let metadata: NormalizedMediaMetadata = {
+      mimeType: primary.mimeType,
+    };
+
+    if (context.probe === false) {
+      warnings.push(
+        'probe disabled; returning file-level generic video inspection',
+      );
+    } else {
+      try {
+        metadata = mergeMetadata(
+          await probeVideoMetadata(primary, context.tools?.ffprobePath),
+          metadata,
+        );
+      } catch (error) {
+        warnings.push(
+          `ffprobe failed for ${displayName(primary)}: ${formatError(error)}`,
+        );
+      }
+
+      try {
+        metadata = mergeMetadata(
+          await probeEmbeddedMetadata(primary, context.tools?.exiftoolPath),
+          metadata,
+        );
+      } catch (error) {
+        warnings.push(
+          `exiftool failed for ${displayName(primary)}: ${formatError(error)}`,
+        );
+      }
+    }
+
+    const capabilities = new Set(genericVideoBundleHandler.capabilities);
+    if (metadata.gpsTrack && metadata.gpsTrack.length > 0)
+      capabilities.add('gps-track');
+
+    return {
+      handlerId: genericVideoBundleHandler.id,
+      handlerVersion: genericVideoBundleHandler.version,
+      formatFamily: 'generic-video',
+      primary: { ...primary, role: 'primary' },
+      supportFiles,
+      metadata,
+      capabilities: [...capabilities],
+      warnings,
+      errors: [],
+    };
+  },
+};
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/video/src/media-bundles/handlers/insta360.ts
+++ b/packages/video/src/media-bundles/handlers/insta360.ts
@@ -8,6 +8,7 @@ import type {
 import {
   displayName,
   fileExtension,
+  formatError,
   mergeMetadata,
   probeEmbeddedMetadata,
   probeVideoMetadata,
@@ -44,8 +45,16 @@ export const insta360BundleHandler: MediaBundleHandler = {
       const parsed = parsedByPath.get(file.path);
       return Boolean(parsed && (!bundleKey || parsed.bundleKey === bundleKey));
     });
+    const ignoredFiles = files.filter((file) => !bundleFiles.includes(file));
     const primary = choosePrimary(bundleFiles, parsedByPath);
     const warnings: string[] = [];
+    if (ignoredFiles.length > 0) {
+      warnings.push(
+        `ignored ${ignoredFiles.length} file(s) outside Insta360 bundle ${bundleKey ?? 'unknown'}: ${ignoredFiles
+          .map(displayName)
+          .join(', ')}`,
+      );
+    }
     let metadata: NormalizedMediaMetadata = {
       mimeType: primary.mimeType,
       private: {
@@ -58,33 +67,34 @@ export const insta360BundleHandler: MediaBundleHandler = {
       },
     };
 
-    const supportFiles: MediaBundleSupportFile[] = [];
-    for (const file of bundleFiles) {
-      if (file === primary) continue;
-      const parsed = parsedByPath.get(file.path);
-      let supportMetadata: NormalizedMediaMetadata | undefined;
-      if (context.probe === false) {
-        warnings.push(`probe disabled for support file ${displayName(file)}`);
-      } else {
-        try {
-          supportMetadata = await probeEmbeddedMetadata(
-            file,
-            context.tools?.exiftoolPath,
-          );
-        } catch (error) {
-          warnings.push(
-            `exiftool failed for support file ${displayName(file)}: ${formatError(error)}`,
-          );
+    const nonPrimaryBundleFiles = bundleFiles.filter(
+      (file) => file !== primary,
+    );
+    const supportFiles: MediaBundleSupportFile[] = await Promise.all(
+      nonPrimaryBundleFiles.map(async (file) => {
+        const parsed = parsedByPath.get(file.path);
+        let supportMetadata: NormalizedMediaMetadata | undefined;
+        if (context.probe !== false) {
+          try {
+            supportMetadata = await probeEmbeddedMetadata(
+              file,
+              context.tools?.exiftoolPath,
+            );
+          } catch (error) {
+            warnings.push(
+              `exiftool failed for support file ${displayName(file)}: ${formatError(error)}`,
+            );
+          }
         }
-      }
-      supportFiles.push({
-        file: { ...file, role: 'support' },
-        role: 'support',
-        relationship: relationshipForInsta360SupportFile(file, parsed),
-        visibility: context.defaultSupportFileVisibility ?? 'hidden-retained',
-        metadata: supportMetadata,
-      });
-    }
+        return {
+          file: { ...file, role: 'support' },
+          role: 'support',
+          relationship: relationshipForInsta360SupportFile(file, parsed),
+          visibility: context.defaultSupportFileVisibility ?? 'hidden-retained',
+          metadata: supportMetadata,
+        } satisfies MediaBundleSupportFile;
+      }),
+    );
 
     if (context.probe === false) {
       warnings.push(
@@ -121,7 +131,7 @@ export const insta360BundleHandler: MediaBundleHandler = {
           (candidate) => candidate?.gpsTrack && candidate.gpsTrack.length > 0,
         );
       if (supportGps) {
-        metadata = mergeMetadata(metadata, { gpsTrack: supportGps.gpsTrack });
+        metadata = { ...metadata, gpsTrack: supportGps.gpsTrack };
       }
     }
 
@@ -145,6 +155,10 @@ export const insta360BundleHandler: MediaBundleHandler = {
           files: Object.fromEntries(
             bundleFiles.map((file) => [file.path, parsedByPath.get(file.path)]),
           ),
+          ignoredFiles: ignoredFiles.map((file) => ({
+            file,
+            identity: parsedByPath.get(file.path) ?? null,
+          })),
         },
       },
     };
@@ -214,8 +228,4 @@ function relationshipForInsta360SupportFile(
   if (parsed?.prefix === 'VID' && parsed.streamIndex !== '00')
     return 'paired-video-stream';
   return 'support-file';
-}
-
-function formatError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/video/src/media-bundles/handlers/insta360.ts
+++ b/packages/video/src/media-bundles/handlers/insta360.ts
@@ -1,0 +1,221 @@
+import type {
+  MediaBundleHandler,
+  MediaBundleInspection,
+  MediaBundleSupportFile,
+  MediaFileDescriptor,
+  NormalizedMediaMetadata,
+} from '../types.js';
+import {
+  displayName,
+  fileExtension,
+  mergeMetadata,
+  probeEmbeddedMetadata,
+  probeVideoMetadata,
+} from '../utils.js';
+
+export interface Insta360FileIdentity {
+  prefix: 'VID' | 'LRV';
+  date: string;
+  time: string;
+  streamIndex: string;
+  sequence: string;
+  extension: string;
+  bundleKey: string;
+}
+
+const INSTA360_RE = /^(VID|LRV)_(\d{8})_(\d{6})_(\d{2})_(\d+)\.(insv|lrv)$/i;
+
+export const insta360BundleHandler: MediaBundleHandler = {
+  id: 'insta360-insv-lrv',
+  version: '1.0.0',
+  priority: 100,
+  capabilities: ['sidecar-binding', 'stitch-export', 'stream-info'],
+
+  supports(files) {
+    return files.some((file) => parseInsta360FileName(file));
+  },
+
+  async inspect(files, context): Promise<MediaBundleInspection> {
+    const parsedByPath = new Map(
+      files.map((file) => [file.path, parseInsta360FileName(file)] as const),
+    );
+    const bundleKey = chooseBundleKey(files, parsedByPath);
+    const bundleFiles = files.filter((file) => {
+      const parsed = parsedByPath.get(file.path);
+      return Boolean(parsed && (!bundleKey || parsed.bundleKey === bundleKey));
+    });
+    const primary = choosePrimary(bundleFiles, parsedByPath);
+    const warnings: string[] = [];
+    let metadata: NormalizedMediaMetadata = {
+      mimeType: primary.mimeType,
+      private: {
+        'happyvertical.video.insta360': {
+          primary: parsedByPath.get(primary.path) ?? null,
+          supportFiles: bundleFiles
+            .filter((file) => file !== primary)
+            .map((file) => parsedByPath.get(file.path) ?? null),
+        },
+      },
+    };
+
+    const supportFiles: MediaBundleSupportFile[] = [];
+    for (const file of bundleFiles) {
+      if (file === primary) continue;
+      const parsed = parsedByPath.get(file.path);
+      let supportMetadata: NormalizedMediaMetadata | undefined;
+      if (context.probe === false) {
+        warnings.push(`probe disabled for support file ${displayName(file)}`);
+      } else {
+        try {
+          supportMetadata = await probeEmbeddedMetadata(
+            file,
+            context.tools?.exiftoolPath,
+          );
+        } catch (error) {
+          warnings.push(
+            `exiftool failed for support file ${displayName(file)}: ${formatError(error)}`,
+          );
+        }
+      }
+      supportFiles.push({
+        file: { ...file, role: 'support' },
+        role: 'support',
+        relationship: relationshipForInsta360SupportFile(file, parsed),
+        visibility: context.defaultSupportFileVisibility ?? 'hidden-retained',
+        metadata: supportMetadata,
+      });
+    }
+
+    if (context.probe === false) {
+      warnings.push(
+        'probe disabled; returning file-level Insta360 bundle inspection',
+      );
+    } else {
+      try {
+        metadata = mergeMetadata(
+          await probeVideoMetadata(primary, context.tools?.ffprobePath),
+          metadata,
+        );
+      } catch (error) {
+        warnings.push(
+          `ffprobe failed for primary ${displayName(primary)}: ${formatError(error)}`,
+        );
+      }
+
+      try {
+        metadata = mergeMetadata(
+          await probeEmbeddedMetadata(primary, context.tools?.exiftoolPath),
+          metadata,
+        );
+      } catch (error) {
+        warnings.push(
+          `exiftool failed for primary ${displayName(primary)}: ${formatError(error)}`,
+        );
+      }
+    }
+
+    if (!metadata.gpsTrack || metadata.gpsTrack.length === 0) {
+      const supportGps = supportFiles
+        .map((support) => support.metadata)
+        .find(
+          (candidate) => candidate?.gpsTrack && candidate.gpsTrack.length > 0,
+        );
+      if (supportGps) {
+        metadata = mergeMetadata(metadata, { gpsTrack: supportGps.gpsTrack });
+      }
+    }
+
+    const capabilities = new Set(insta360BundleHandler.capabilities);
+    if (metadata.gpsTrack && metadata.gpsTrack.length > 0)
+      capabilities.add('gps-track');
+
+    return {
+      handlerId: insta360BundleHandler.id,
+      handlerVersion: insta360BundleHandler.version,
+      formatFamily: 'insta360',
+      primary: { ...primary, role: 'primary' },
+      supportFiles,
+      metadata,
+      capabilities: [...capabilities],
+      warnings,
+      errors: [],
+      raw: {
+        insta360: {
+          bundleKey,
+          files: Object.fromEntries(
+            bundleFiles.map((file) => [file.path, parsedByPath.get(file.path)]),
+          ),
+        },
+      },
+    };
+  },
+};
+
+export function parseInsta360FileName(
+  file: MediaFileDescriptor,
+): Insta360FileIdentity | null {
+  const match = INSTA360_RE.exec(displayName(file));
+  if (!match) return null;
+  const prefix = match[1].toUpperCase() as 'VID' | 'LRV';
+  const date = match[2];
+  const time = match[3];
+  const streamIndex = match[4];
+  const sequence = match[5];
+  const extension = match[6].toLowerCase();
+  return {
+    prefix,
+    date,
+    time,
+    streamIndex,
+    sequence,
+    extension,
+    bundleKey: `${date}_${time}_${sequence}`,
+  };
+}
+
+function chooseBundleKey(
+  files: MediaFileDescriptor[],
+  parsedByPath: Map<string, Insta360FileIdentity | null>,
+): string | null {
+  const candidate = files
+    .map((file) => parsedByPath.get(file.path))
+    .find((parsed) => parsed?.prefix === 'VID' && parsed.streamIndex === '00');
+  if (candidate) return candidate.bundleKey;
+  return (
+    files.map((file) => parsedByPath.get(file.path)).find(Boolean)?.bundleKey ??
+    null
+  );
+}
+
+function choosePrimary(
+  files: MediaFileDescriptor[],
+  parsedByPath: Map<string, Insta360FileIdentity | null>,
+): MediaFileDescriptor {
+  return (
+    files.find((file) => {
+      const parsed = parsedByPath.get(file.path);
+      return parsed?.prefix === 'VID' && parsed.streamIndex === '00';
+    }) ??
+    files.find((file) => {
+      const parsed = parsedByPath.get(file.path);
+      return parsed?.prefix === 'VID' && parsed.extension === 'insv';
+    }) ??
+    files.find((file) => fileExtension(file) === '.insv') ??
+    files[0]
+  );
+}
+
+function relationshipForInsta360SupportFile(
+  file: MediaFileDescriptor,
+  parsed: Insta360FileIdentity | null | undefined,
+): string {
+  if (parsed?.prefix === 'LRV' || fileExtension(file) === '.lrv')
+    return 'proxy-video';
+  if (parsed?.prefix === 'VID' && parsed.streamIndex !== '00')
+    return 'paired-video-stream';
+  return 'support-file';
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/video/src/media-bundles/index.ts
+++ b/packages/video/src/media-bundles/index.ts
@@ -1,0 +1,78 @@
+import { genericImageBundleHandler } from './handlers/generic-image.js';
+import { genericVideoBundleHandler } from './handlers/generic-video.js';
+import { insta360BundleHandler } from './handlers/insta360.js';
+import type {
+  InspectMediaBundleOptions,
+  MediaBundleHandler,
+  MediaBundleInspection,
+  MediaFileDescriptor,
+} from './types.js';
+
+export { genericImageBundleHandler } from './handlers/generic-image.js';
+export { genericVideoBundleHandler } from './handlers/generic-video.js';
+export {
+  type Insta360FileIdentity,
+  insta360BundleHandler,
+  parseInsta360FileName,
+} from './handlers/insta360.js';
+export * from './types.js';
+
+export const defaultMediaBundleHandlers: MediaBundleHandler[] = [
+  insta360BundleHandler,
+  genericVideoBundleHandler,
+  genericImageBundleHandler,
+];
+
+export async function inspectMediaBundle(
+  files: MediaFileDescriptor[],
+  options: InspectMediaBundleOptions = {},
+): Promise<MediaBundleInspection> {
+  if (files.length === 0) {
+    throw new Error('inspectMediaBundle requires at least one file');
+  }
+
+  const context = {
+    ...options,
+    defaultSupportFileVisibility:
+      options.defaultSupportFileVisibility ?? 'hidden-retained',
+  };
+  const handlers = options.handlers ?? defaultMediaBundleHandlers;
+  const orderedHandlers = handlers
+    .map((handler, index) => ({ handler, index }))
+    .sort(
+      (left, right) =>
+        right.handler.priority - left.handler.priority ||
+        left.index - right.index,
+    );
+
+  for (const { handler } of orderedHandlers) {
+    if (!(await handler.supports(files, context))) continue;
+    const inspection = await handler.inspect(files, context);
+    const validationWarnings = handler.validate
+      ? await handler.validate(inspection, context)
+      : [];
+    if (validationWarnings.length > 0) {
+      inspection.warnings.push(...validationWarnings);
+    }
+    return inspection;
+  }
+
+  return {
+    handlerId: 'unknown',
+    handlerVersion: '1.0.0',
+    formatFamily: 'unknown',
+    primary: { ...files[0], role: 'primary' },
+    supportFiles: files.slice(1).map((file) => ({
+      file: { ...file, role: file.role ?? 'support' },
+      role: 'support',
+      relationship: 'co-located-file',
+      visibility: context.defaultSupportFileVisibility,
+    })),
+    metadata: {
+      mimeType: files[0].mimeType,
+    },
+    capabilities: [],
+    warnings: ['no media bundle handler matched; returned unknown inspection'],
+    errors: [],
+  };
+}

--- a/packages/video/src/media-bundles/types.ts
+++ b/packages/video/src/media-bundles/types.ts
@@ -1,0 +1,137 @@
+export type MediaBundleFileRole =
+  | 'primary'
+  | 'support'
+  | 'metadata'
+  | 'unknown';
+
+export type MediaSupportFileVisibility =
+  | 'visible'
+  | 'hidden-retained'
+  | 'drop-after-extract';
+
+export type MediaFormatFamily =
+  | 'generic-image'
+  | 'generic-video'
+  | 'insta360'
+  | 'unknown';
+
+export type MediaBundleCapability =
+  | 'gps-track'
+  | 'image-metadata'
+  | 'sidecar-binding'
+  | 'stitch-export'
+  | 'stream-info'
+  | (string & {});
+
+export interface MediaFileDescriptor {
+  path: string;
+  relativePath?: string;
+  name?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  sha256?: string;
+  modifiedAt?: Date | string;
+  role?: MediaBundleFileRole;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedMediaDevice {
+  make?: string;
+  model?: string;
+  serialNumber?: string;
+  firmwareVersion?: string;
+}
+
+export interface NormalizedMediaStream {
+  kind: 'video' | 'audio' | 'data' | 'unknown';
+  codec?: string;
+  width?: number;
+  height?: number;
+  fps?: number;
+  durationMs?: number;
+  bitrate?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedGpsTrackPoint {
+  tSeconds: number;
+  recordedAt?: Date | string | null;
+  latitude: number;
+  longitude: number;
+  altitude?: number | null;
+  heading?: number | null;
+  speedMps?: number | null;
+  sourceFilePath?: string;
+}
+
+export interface NormalizedMediaMetadata {
+  captureTime?: Date | string | null;
+  device?: NormalizedMediaDevice;
+  width?: number;
+  height?: number;
+  durationMs?: number;
+  mimeType?: string;
+  streams?: NormalizedMediaStream[];
+  gpsTrack?: NormalizedGpsTrackPoint[];
+  raw?: Record<string, unknown>;
+  private?: Record<string, unknown>;
+}
+
+export interface MediaBundleSupportFile {
+  file: MediaFileDescriptor;
+  role: MediaBundleFileRole;
+  relationship: string;
+  visibility: MediaSupportFileVisibility;
+  metadata?: NormalizedMediaMetadata;
+}
+
+export interface MediaBundleInspection {
+  handlerId: string;
+  handlerVersion: string;
+  formatFamily: MediaFormatFamily;
+  primary: MediaFileDescriptor;
+  supportFiles: MediaBundleSupportFile[];
+  metadata: NormalizedMediaMetadata;
+  capabilities: MediaBundleCapability[];
+  warnings: string[];
+  errors: string[];
+  raw?: Record<string, unknown>;
+}
+
+export interface MediaBundleInspectTools {
+  ffprobePath?: string;
+  exiftoolPath?: string;
+}
+
+export interface MediaBundleInspectContext {
+  tools?: MediaBundleInspectTools;
+  probe?: boolean;
+  defaultSupportFileVisibility?: MediaSupportFileVisibility;
+}
+
+export interface MediaBundleHandler {
+  id: string;
+  version: string;
+  priority: number;
+  capabilities?: MediaBundleCapability[];
+  supports(
+    files: MediaFileDescriptor[],
+    context: MediaBundleInspectContext,
+  ): boolean | Promise<boolean>;
+  inspect(
+    files: MediaFileDescriptor[],
+    context: MediaBundleInspectContext,
+  ): Promise<MediaBundleInspection>;
+  validate?(
+    inspection: MediaBundleInspection,
+    context: MediaBundleInspectContext,
+  ): Promise<string[]> | string[];
+  deriveArtifacts?(
+    inspection: MediaBundleInspection,
+    context: MediaBundleInspectContext,
+  ): Promise<unknown[]> | unknown[];
+}
+
+export interface InspectMediaBundleOptions extends MediaBundleInspectContext {
+  handlers?: MediaBundleHandler[];
+}

--- a/packages/video/src/media-bundles/utils.ts
+++ b/packages/video/src/media-bundles/utils.ts
@@ -50,6 +50,10 @@ export function isImageFile(file: MediaFileDescriptor): boolean {
   return mime.startsWith('image/') || IMAGE_EXTENSIONS.has(fileExtension(file));
 }
 
+export function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export async function runJsonCommand(
   bin: string,
   args: string[],
@@ -267,7 +271,7 @@ export function parseExiftoolGpsRecord(
     lastLon = lon;
     out.push({
       tSeconds: Math.max(0, (epochMs - firstEpochMs) / 1000),
-      recordedAt: new Date(epochMs),
+      recordedAt: new Date(epochMs).toISOString(),
       latitude: lat,
       longitude: lon,
       altitude: toNumber(record.GPSAltitude),
@@ -290,7 +294,7 @@ export function parseExiftoolGpsRecord(
   return [
     {
       tSeconds: 0,
-      recordedAt: new Date(epochMs),
+      recordedAt: new Date(epochMs).toISOString(),
       latitude: lat,
       longitude: lon,
       altitude: toNumber(fallback.GPSAltitude),

--- a/packages/video/src/media-bundles/utils.ts
+++ b/packages/video/src/media-bundles/utils.ts
@@ -1,0 +1,353 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { basename, extname } from 'node:path';
+import { promisify } from 'node:util';
+
+import type {
+  MediaFileDescriptor,
+  NormalizedGpsTrackPoint,
+  NormalizedMediaDevice,
+  NormalizedMediaMetadata,
+  NormalizedMediaStream,
+} from './types.js';
+
+const execFile = promisify(execFileCallback);
+const VIDEO_EXTENSIONS = new Set([
+  '.mp4',
+  '.mov',
+  '.m4v',
+  '.avi',
+  '.webm',
+  '.insv',
+  '.lrv',
+]);
+const IMAGE_EXTENSIONS = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.webp',
+  '.gif',
+  '.tif',
+  '.tiff',
+  '.heic',
+  '.insp',
+]);
+
+export function displayName(file: MediaFileDescriptor): string {
+  return file.name || basename(file.relativePath || file.path);
+}
+
+export function fileExtension(file: MediaFileDescriptor): string {
+  return extname(displayName(file)).toLowerCase();
+}
+
+export function isVideoFile(file: MediaFileDescriptor): boolean {
+  const mime = (file.mimeType || '').toLowerCase();
+  return mime.startsWith('video/') || VIDEO_EXTENSIONS.has(fileExtension(file));
+}
+
+export function isImageFile(file: MediaFileDescriptor): boolean {
+  const mime = (file.mimeType || '').toLowerCase();
+  return mime.startsWith('image/') || IMAGE_EXTENSIONS.has(fileExtension(file));
+}
+
+export async function runJsonCommand(
+  bin: string,
+  args: string[],
+): Promise<Record<string, unknown>> {
+  const { stdout } = await execFile(bin, args, {
+    maxBuffer: 100 * 1024 * 1024,
+  });
+  return JSON.parse(stdout || '{}') as Record<string, unknown>;
+}
+
+export async function runJsonArrayCommand(
+  bin: string,
+  args: string[],
+): Promise<unknown[]> {
+  const { stdout } = await execFile(bin, args, {
+    maxBuffer: 100 * 1024 * 1024,
+  });
+  return JSON.parse(stdout || '[]') as unknown[];
+}
+
+export async function probeVideoMetadata(
+  file: MediaFileDescriptor,
+  ffprobePath = 'ffprobe',
+): Promise<NormalizedMediaMetadata> {
+  const probe = await runJsonCommand(ffprobePath, [
+    '-v',
+    'error',
+    '-print_format',
+    'json',
+    '-show_streams',
+    '-show_format',
+    file.path,
+  ]);
+  const format = isRecord(probe.format) ? probe.format : {};
+  const streams = Array.isArray(probe.streams)
+    ? probe.streams.filter(isRecord)
+    : [];
+  const normalizedStreams = streams.map(normalizeFfprobeStream);
+  const videoStream = normalizedStreams.find(
+    (stream) => stream.kind === 'video',
+  );
+  const tags = isRecord(format.tags) ? format.tags : {};
+  const durationMs = toDurationMs(format.duration);
+
+  return {
+    captureTime:
+      parseDateString(String(tags.creation_time || tags.CreateDate || '')) ??
+      null,
+    width: videoStream?.width,
+    height: videoStream?.height,
+    durationMs,
+    mimeType: file.mimeType,
+    streams: normalizedStreams,
+    raw: { ffprobe: probe },
+  };
+}
+
+export async function probeEmbeddedMetadata(
+  file: MediaFileDescriptor,
+  exiftoolPath = 'exiftool',
+): Promise<NormalizedMediaMetadata> {
+  const rows = await runJsonArrayCommand(exiftoolPath, [
+    '-ee',
+    '-G3:1',
+    '-json',
+    '-n',
+    file.path,
+  ]);
+  const row = rows[0] && isRecord(rows[0]) ? rows[0] : {};
+  const flat = flattenExiftoolRecord(row);
+  const device = readDevice(flat);
+  const gpsTrack = parseExiftoolGpsRecord(row, file.path);
+  const captureTime =
+    flat.DateTimeOriginal ||
+    flat.CreateDate ||
+    flat.MediaCreateDate ||
+    flat.GPSDateTime ||
+    '';
+  return {
+    captureTime: parseDateString(String(captureTime)) ?? null,
+    device,
+    width: toInteger(flat.ImageWidth ?? flat.ExifImageWidth),
+    height: toInteger(flat.ImageHeight ?? flat.ExifImageHeight),
+    gpsTrack,
+    raw: { exiftool: row },
+  };
+}
+
+export function mergeMetadata(
+  primary: NormalizedMediaMetadata,
+  fallback: NormalizedMediaMetadata,
+): NormalizedMediaMetadata {
+  return {
+    captureTime: primary.captureTime ?? fallback.captureTime,
+    device: {
+      ...fallback.device,
+      ...primary.device,
+    },
+    width: primary.width ?? fallback.width,
+    height: primary.height ?? fallback.height,
+    durationMs: primary.durationMs ?? fallback.durationMs,
+    mimeType: primary.mimeType ?? fallback.mimeType,
+    streams:
+      primary.streams && primary.streams.length > 0
+        ? primary.streams
+        : fallback.streams,
+    gpsTrack:
+      primary.gpsTrack && primary.gpsTrack.length > 0
+        ? primary.gpsTrack
+        : fallback.gpsTrack,
+    raw: {
+      ...fallback.raw,
+      ...primary.raw,
+    },
+    private: {
+      ...fallback.private,
+      ...primary.private,
+    },
+  };
+}
+
+function normalizeFfprobeStream(
+  stream: Record<string, unknown>,
+): NormalizedMediaStream {
+  const kind = String(
+    stream.codec_type || 'unknown',
+  ) as NormalizedMediaStream['kind'];
+  return {
+    kind: ['video', 'audio', 'data'].includes(kind) ? kind : 'unknown',
+    codec: readString(stream.codec_name),
+    width: toInteger(stream.width),
+    height: toInteger(stream.height),
+    fps: parseFrameRate(readString(stream.r_frame_rate)),
+    durationMs: toDurationMs(stream.duration),
+    bitrate: toInteger(stream.bit_rate),
+    metadata: stream,
+  };
+}
+
+function flattenExiftoolRecord(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    out[key] = value;
+    const suffix = key.split(':').at(-1);
+    if (suffix && !(suffix in out)) out[suffix] = value;
+  }
+  return out;
+}
+
+function readDevice(
+  row: Record<string, unknown>,
+): NormalizedMediaDevice | undefined {
+  const model = readString(row.Model);
+  const make = readString(row.Make) || inferMake(model);
+  const serialNumber = readString(row.SerialNumber);
+  const firmwareVersion = readString(row.Firmware);
+  if (!make && !model && !serialNumber && !firmwareVersion) return undefined;
+  return { make, model, serialNumber, firmwareVersion };
+}
+
+function inferMake(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const vendors = [
+    'Insta360',
+    'GoPro',
+    'DJI',
+    'Sony',
+    'Canon',
+    'Nikon',
+    'Ricoh',
+    'Panasonic',
+    'Fujifilm',
+  ];
+  const lowered = model.toLowerCase();
+  return vendors.find((vendor) => lowered.startsWith(vendor.toLowerCase()));
+}
+
+export function parseExiftoolGpsRecord(
+  row: Record<string, unknown>,
+  sourceFilePath?: string,
+): NormalizedGpsTrackPoint[] {
+  const grouped = new Map<string, Record<string, unknown>>();
+  const mainFields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    const docMatch = /^(Doc\d+):[^:]+:(\w+)$/.exec(key);
+    if (docMatch) {
+      const bucket = grouped.get(docMatch[1]) ?? {};
+      bucket[docMatch[2]] = value;
+      grouped.set(docMatch[1], bucket);
+      continue;
+    }
+    const mainMatch = /^Main:[^:]+:(\w+)$/.exec(key);
+    if (mainMatch) mainFields[mainMatch[1]] = value;
+  }
+
+  const out: NormalizedGpsTrackPoint[] = [];
+  let firstEpochMs: number | null = null;
+  let lastLat: number | null = null;
+  let lastLon: number | null = null;
+  for (const docId of [...grouped.keys()].sort(compareDocIds)) {
+    const record = grouped.get(docId);
+    if (!record) continue;
+    const lat = toNumber(record.GPSLatitude);
+    const lon = toNumber(record.GPSLongitude);
+    const epochMs =
+      record.GPSDateTime == null
+        ? null
+        : parseDateMs(String(record.GPSDateTime));
+    if (lat == null || lon == null || epochMs == null) continue;
+    if (firstEpochMs == null) firstEpochMs = epochMs;
+    if (lat === lastLat && lon === lastLon) continue;
+    lastLat = lat;
+    lastLon = lon;
+    out.push({
+      tSeconds: Math.max(0, (epochMs - firstEpochMs) / 1000),
+      recordedAt: new Date(epochMs),
+      latitude: lat,
+      longitude: lon,
+      altitude: toNumber(record.GPSAltitude),
+      heading: toNumber(record.GPSTrack),
+      speedMps: toNumber(record.GPSSpeed),
+      sourceFilePath,
+    });
+  }
+  if (out.length > 0) return out;
+
+  const flat = flattenExiftoolRecord(row);
+  const fallback = Object.keys(mainFields).length > 0 ? mainFields : flat;
+  const lat = toNumber(fallback.GPSLatitude);
+  const lon = toNumber(fallback.GPSLongitude);
+  const epochMs =
+    fallback.GPSDateTime == null
+      ? null
+      : parseDateMs(String(fallback.GPSDateTime));
+  if (lat == null || lon == null || epochMs == null) return [];
+  return [
+    {
+      tSeconds: 0,
+      recordedAt: new Date(epochMs),
+      latitude: lat,
+      longitude: lon,
+      altitude: toNumber(fallback.GPSAltitude),
+      heading: toNumber(fallback.GPSTrack ?? fallback.GPSImgDirection),
+      speedMps: toNumber(fallback.GPSSpeed),
+      sourceFilePath,
+    },
+  ];
+}
+
+function compareDocIds(left: string, right: string): number {
+  return Number(left.replace(/\D+/g, '')) - Number(right.replace(/\D+/g, ''));
+}
+
+function parseFrameRate(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const [num, den] = value.split('/').map(Number);
+  const fps = den ? num / den : num;
+  return Number.isFinite(fps) && fps > 0 ? fps : undefined;
+}
+
+function toDurationMs(value: unknown): number | undefined {
+  const seconds = Number(value);
+  return Number.isFinite(seconds) && seconds > 0
+    ? Math.round(seconds * 1000)
+    : undefined;
+}
+
+function toInteger(value: unknown): number | undefined {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : undefined;
+}
+
+function toNumber(value: unknown): number | null {
+  if (value == null || value === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function parseDateString(value: string): string | null {
+  const ms = parseDateMs(value);
+  return ms == null ? null : new Date(ms).toISOString();
+}
+
+function parseDateMs(value: string): number | null {
+  const normalized = value
+    .trim()
+    .replace(/^(\d{4}):(\d{2}):(\d{2})/, '$1-$2-$3');
+  if (!normalized) return null;
+  const ms = Date.parse(normalized);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/packages/video/vite.config.ts
+++ b/packages/video/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     rollupOptions: {
       external: [
         /^node:/,
+        '@happyvertical/images',
         '@happyvertical/logger',
         '@happyvertical/utils',
         'sharp',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -977,6 +977,9 @@ importers:
 
   packages/video:
     dependencies:
+      '@happyvertical/images':
+        specifier: workspace:*
+        version: link:../images
       '@happyvertical/logger':
         specifier: workspace:*
         version: link:../logger


### PR DESCRIPTION
## Summary
- Adds a pure media bundle inspection framework to @happyvertical/video.
- Adds explicit handler registration plus default generic video, generic image, and Insta360 INSV/LRV handlers.
- Normalizes canonical media metadata, support-file visibility, GPS tracks, warnings, raw metadata, and discovered capabilities.
- Covers handler priority/registration, private app handler override, Insta360 grouping, unrelated-file exclusion, and generic video fallback.

## Review fixes included
- Moved the work onto a fresh branch from current origin/main instead of the stale local branch where the first draft lived.
- Fixed the Insta360 handler so unrelated files and other bundle candidates are not retained as hidden support files for the selected bundle.
- Removed lint warnings caught by hooks: unused imports and a non-null assertion in GPS parsing.

## Validation
- pnpm --filter @happyvertical/video test
- pnpm exec tsc -p packages/video/tsconfig.json --noEmit
- pnpm --filter @happyvertical/video build
- git push pre-push hook: pnpm run typecheck
