### PR TITLE
feat(weather): add standardized historical providers

### DIFF
--- a/packages/files/src/filesystem.test.ts
+++ b/packages/files/src/filesystem.test.ts
@@ -80,6 +80,20 @@ describe('Filesystem Interface', () => {
       ).resolves.toBe('rooted once');
     });
 
+    it('should preserve base provider cache options for local filesystems', async () => {
+      const cacheDir = join(testDir, 'custom-cache');
+      const fsWithCache = new LocalFilesystemProvider({
+        basePath: testDir,
+        cacheDir,
+      });
+
+      await fsWithCache.cache.set('entry.txt', 'cached locally');
+
+      await expect(readFile(join(cacheDir, 'entry.txt'), 'utf8')).resolves.toBe(
+        'cached locally',
+      );
+    });
+
     it('should write and read binary files', async () => {
       const buffer = Buffer.from([1, 2, 3, 4, 5]);
       await fs.write('binary.bin', buffer);

--- a/packages/files/src/filesystem.test.ts
+++ b/packages/files/src/filesystem.test.ts
@@ -3,7 +3,11 @@ import { join } from 'node:path';
 import { getTempDirectory } from '@happyvertical/utils';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getFilesystem, LocalFilesystemProvider } from './index';
-import { FileNotFoundError, FilesystemError } from './shared/types';
+import {
+  FileNotFoundError,
+  FilesystemError,
+  InvalidPathError,
+} from './shared/types';
 
 describe('Filesystem Interface', () => {
   let testDir: string;
@@ -298,6 +302,20 @@ describe('Filesystem Interface', () => {
       await new Promise((resolve) => setTimeout(resolve, 10)); // Wait 10ms
       const retrieved2 = await fs.cache.get(key, 1); // 1 millisecond
       expect(retrieved2).toBeUndefined();
+    });
+
+    it('should reject absolute cache keys', async () => {
+      const absoluteKey = join(getTempDirectory(), 'have-cache-escape.txt');
+
+      await expect(
+        fs.cache.set(absoluteKey, 'cached data'),
+      ).rejects.toBeInstanceOf(InvalidPathError);
+      await expect(fs.cache.get(absoluteKey)).rejects.toBeInstanceOf(
+        InvalidPathError,
+      );
+      await expect(fs.cache.clear(absoluteKey)).rejects.toBeInstanceOf(
+        InvalidPathError,
+      );
     });
   });
 

--- a/packages/files/src/filesystem.test.ts
+++ b/packages/files/src/filesystem.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, rmdir } from 'node:fs/promises';
+import { mkdir, readFile, rmdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getTempDirectory } from '@happyvertical/utils';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -70,6 +70,14 @@ describe('Filesystem Interface', () => {
 
       const readContent = await fs.read('test.txt');
       expect(readContent).toBe(content);
+    });
+
+    it('should place local files directly under the configured base path', async () => {
+      await fs.write('nested/base-path.txt', 'rooted once');
+
+      await expect(
+        readFile(join(testDir, 'nested/base-path.txt'), 'utf8'),
+      ).resolves.toBe('rooted once');
     });
 
     it('should write and read binary files', async () => {

--- a/packages/files/src/node/local.ts
+++ b/packages/files/src/node/local.ts
@@ -11,7 +11,15 @@ import {
   unlink,
   writeFile,
 } from 'node:fs/promises';
-import { dirname, extname, join, resolve } from 'node:path';
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path';
 import { URL } from 'node:url';
 import { getTempDirectory } from '@happyvertical/utils';
 import { BaseFilesystemProvider } from '../shared/base';
@@ -23,6 +31,7 @@ import {
   type FileStats,
   type FilesystemCapabilities,
   FilesystemError,
+  InvalidPathError,
   type ListOptions,
   type LocalOptions,
   PermissionError,
@@ -78,6 +87,29 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
     this.validatePath(path);
     const normalized = this.normalizePath(path);
     return join(this.rootPath, normalized);
+  }
+
+  private resolveCachePath(path: string): string {
+    this.validatePath(path);
+
+    if (isAbsolute(path)) {
+      throw new InvalidPathError(path, this.providerType);
+    }
+
+    const normalized = this.normalizePath(path);
+    const cacheRoot = resolve(this.cacheDir);
+    const cachePath = resolve(cacheRoot, normalized);
+    const relativePath = relative(cacheRoot, cachePath);
+
+    if (
+      !relativePath ||
+      relativePath === '..' ||
+      relativePath.startsWith(`..${sep}`)
+    ) {
+      throw new InvalidPathError(path, this.providerType);
+    }
+
+    return cachePath;
   }
 
   /**
@@ -720,8 +752,7 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
    * Get data from cache if available and not expired (legacy)
    */
   async getCached(file: string, expiry = 300000): Promise<string | undefined> {
-    this.validatePath(file);
-    const cacheFile = resolve(this.cacheDir, file);
+    const cacheFile = this.resolveCachePath(file);
     const cached = existsSync(cacheFile);
     if (cached) {
       const stats = statSync(cacheFile);
@@ -739,8 +770,7 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
    * Set data in cache (legacy)
    */
   async setCached(file: string, data: string): Promise<void> {
-    this.validatePath(file);
-    const cacheFile = resolve(this.cacheDir, file);
+    const cacheFile = this.resolveCachePath(file);
     await mkdir(dirname(cacheFile), { recursive: true });
     await writeFile(cacheFile, data);
   }
@@ -759,8 +789,7 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
 
     clear: async (key?: string): Promise<void> => {
       if (key) {
-        this.validatePath(key);
-        const cacheFile = resolve(this.cacheDir, key);
+        const cacheFile = this.resolveCachePath(key);
         try {
           await unlink(cacheFile);
         } catch {

--- a/packages/files/src/node/local.ts
+++ b/packages/files/src/node/local.ts
@@ -55,7 +55,7 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
   private readonly rootPath: string;
 
   constructor(options: LocalOptions = {}) {
-    super(options);
+    super({ ...options, basePath: '' });
     this.rootPath = options.basePath
       ? resolve(options.basePath)
       : process.cwd();

--- a/packages/files/src/node/local.ts
+++ b/packages/files/src/node/local.ts
@@ -55,7 +55,7 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
   private readonly rootPath: string;
 
   constructor(options: LocalOptions = {}) {
-    super({ ...options, basePath: '' });
+    super({ ...options, applyBasePath: false });
     this.rootPath = options.basePath
       ? resolve(options.basePath)
       : process.cwd();
@@ -720,7 +720,8 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
    * Get data from cache if available and not expired (legacy)
    */
   async getCached(file: string, expiry = 300000): Promise<string | undefined> {
-    const cacheFile = resolve(getTempDirectory('cache'), file);
+    this.validatePath(file);
+    const cacheFile = resolve(this.cacheDir, file);
     const cached = existsSync(cacheFile);
     if (cached) {
       const stats = statSync(cacheFile);
@@ -738,7 +739,8 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
    * Set data in cache (legacy)
    */
   async setCached(file: string, data: string): Promise<void> {
-    const cacheFile = resolve(getTempDirectory('cache'), file);
+    this.validatePath(file);
+    const cacheFile = resolve(this.cacheDir, file);
     await mkdir(dirname(cacheFile), { recursive: true });
     await writeFile(cacheFile, data);
   }
@@ -757,7 +759,8 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
 
     clear: async (key?: string): Promise<void> => {
       if (key) {
-        const cacheFile = resolve(getTempDirectory('cache'), key);
+        this.validatePath(key);
+        const cacheFile = resolve(this.cacheDir, key);
         try {
           await unlink(cacheFile);
         } catch {
@@ -766,8 +769,7 @@ export class LocalFilesystemProvider extends BaseFilesystemProvider {
       } else {
         // Clear entire cache directory
         try {
-          const cacheDir = resolve(getTempDirectory('cache'));
-          await rmdir(cacheDir, { recursive: true });
+          await rmdir(this.cacheDir, { recursive: true });
         } catch {
           // Ignore errors if directory doesn't exist
         }

--- a/packages/files/src/shared/base.ts
+++ b/packages/files/src/shared/base.ts
@@ -25,12 +25,14 @@ import {
  */
 export abstract class BaseFilesystemProvider implements FilesystemInterface {
   protected basePath: string;
+  protected applyBasePath: boolean;
   protected cacheDir: string;
   protected createMissing: boolean;
   protected providerType: string;
 
   constructor(options: BaseProviderOptions = {}) {
     this.basePath = options.basePath || '';
+    this.applyBasePath = options.applyBasePath ?? true;
     // Use a universal cache directory approach - will be context-specific
     this.cacheDir = options.cacheDir || this.getDefaultCacheDir();
     this.createMissing = options.createMissing ?? true;
@@ -84,7 +86,7 @@ export abstract class BaseFilesystemProvider implements FilesystemInterface {
     let normalized = path.startsWith('/') ? path.slice(1) : path;
 
     // Combine with base path if configured
-    if (this.basePath) {
+    if (this.applyBasePath && this.basePath) {
       normalized = this.joinPaths(this.basePath, normalized);
     }
 

--- a/packages/files/src/shared/types.ts
+++ b/packages/files/src/shared/types.ts
@@ -436,6 +436,12 @@ export interface BaseProviderOptions {
   basePath?: string;
 
   /**
+   * Whether shared path normalization should prefix basePath.
+   * Providers that map basePath into their own storage root can disable this.
+   */
+  applyBasePath?: boolean;
+
+  /**
    * Cache directory location
    */
   cacheDir?: string;

--- a/packages/weather/src/__tests__/historical-weather.spec.ts
+++ b/packages/weather/src/__tests__/historical-weather.spec.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getWeatherAdapter } from '../index';
+import { EnvironmentCanadaProvider } from '../providers/environment-canada';
+import { GoogleWeatherProvider } from '../providers/google-weather';
+import { OpenMeteoProvider } from '../providers/open-meteo';
+import { OpenWeatherMapProvider } from '../providers/openweathermap';
+import { OpenWeatherMapOneCallProvider } from '../providers/openweathermap-onecall';
+import type { IWeatherProvider, WeatherForecast } from '../shared/types';
+import { UnsupportedWeatherCapabilityError } from '../shared/types';
+
+describe('standardized historical weather adapters', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('exposes fetchHistoricalForLocation on every provider', () => {
+    const providers: IWeatherProvider[] = [
+      new EnvironmentCanadaProvider(),
+      new OpenWeatherMapProvider({ apiKey: 'test-key' }),
+      new OpenWeatherMapOneCallProvider({ apiKey: 'test-key' }),
+      new GoogleWeatherProvider({ apiKey: 'test-key' }),
+      new OpenMeteoProvider(),
+    ];
+
+    for (const provider of providers) {
+      expect(typeof provider.fetchHistoricalForLocation).toBe('function');
+    }
+  });
+
+  it('throws typed unsupported-capability errors for unsupported adapters', async () => {
+    const provider = new OpenWeatherMapProvider({ apiKey: 'test-key' });
+
+    await expect(
+      provider.fetchHistoricalForLocation(51.0447, -114.0719, {
+        start: '2025-01-01T00:00:00Z',
+        end: '2025-01-01T01:00:00Z',
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedWeatherCapabilityError);
+  });
+
+  it('delegates Google historical requests to hourly history within the supported range', async () => {
+    const provider = new GoogleWeatherProvider({ apiKey: 'test-key' });
+    const now = new Date('2026-01-15T12:00:00Z');
+    vi.setSystemTime(now);
+    const forecast: WeatherForecast = {
+      timestamp: new Date('2026-01-15T11:00:00Z'),
+      temperature: -3,
+      humidity: 70,
+      windSpeed: 10,
+      conditions: 'Cloudy',
+      raw: { source: 'google-weather-history' },
+    };
+    const historySpy = vi
+      .spyOn(provider, 'fetchHourlyHistory')
+      .mockResolvedValue([forecast]);
+
+    const result = await provider.fetchHistoricalForLocation(
+      51.0447,
+      -114.0719,
+      {
+        start: '2026-01-15T10:00:00Z',
+        end: '2026-01-15T12:00:00Z',
+      },
+    );
+
+    expect(historySpy).toHaveBeenCalledWith(
+      51.0447,
+      -114.0719,
+      expect.objectContaining({ hours: 3 }),
+    );
+    expect(result).toEqual([forecast]);
+  });
+
+  it('transforms Open-Meteo archive rows into standard forecasts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          latitude: 52.268,
+          longitude: -114.093,
+          timezone: 'UTC',
+          hourly_units: { visibility: 'm' },
+          hourly: {
+            time: ['2026-01-15T18:00', '2026-01-15T19:00'],
+            temperature_2m: [-4.2, -3.8],
+            relative_humidity_2m: [76, 74],
+            precipitation: [0, 0.2],
+            weather_code: [3, 61],
+            cloud_cover: [100, 96],
+            wind_speed_10m: [18.4, 20.1],
+            wind_direction_10m: [270, 275],
+            wind_gusts_10m: [28, 31],
+            visibility: [12000, 10000],
+          },
+        }),
+      })),
+    );
+
+    const provider = new OpenMeteoProvider();
+    const forecasts = await provider.fetchHistoricalForLocation(
+      52.268,
+      -114.093,
+      {
+        start: '2026-01-15T18:00:00Z',
+        end: '2026-01-15T19:00:00Z',
+      },
+    );
+
+    expect(forecasts).toHaveLength(2);
+    expect(forecasts[0]).toMatchObject({
+      temperature: -4,
+      humidity: 76,
+      windSpeed: 18,
+      conditions: 'Overcast',
+      visibility: 12,
+      raw: expect.objectContaining({ source: 'open-meteo-archive' }),
+    });
+    expect(forecasts[1].conditions).toBe('Rain');
+  });
+
+  it('uses Environment Canada climate-hourly observations for Canadian historical requests', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          type: 'FeatureCollection',
+          features: [
+            {
+              id: '3025484.2026.1.15.12',
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [-113.8944, 52.1822],
+              },
+              properties: {
+                STATION_NAME: 'RED DEER REGIONAL A',
+                CLIMATE_IDENTIFIER: '3025484',
+                UTC_DATE: '2026-01-15T19:00:00',
+                TEMP: -2.6,
+                RELATIVE_HUMIDITY: 82,
+                PRECIP_AMOUNT: 0,
+                STATION_PRESSURE: 91.33,
+                VISIBILITY: 16.1,
+                WEATHER_ENG_DESC: 'Mostly Cloudy',
+                WIND_DIRECTION: 27,
+                WIND_SPEED: 13,
+                LONGITUDE_DECIMAL_DEGREES: -113.8944,
+                LATITUDE_DECIMAL_DEGREES: 52.1822,
+              },
+            },
+          ],
+        }),
+      })),
+    );
+
+    const provider = new EnvironmentCanadaProvider();
+    const forecasts = await provider.fetchHistoricalForLocation(
+      52.268,
+      -114.093,
+      {
+        start: '2026-01-15T19:00:00Z',
+        end: '2026-01-15T19:00:00Z',
+      },
+    );
+
+    expect(forecasts).toHaveLength(1);
+    expect(forecasts[0]).toMatchObject({
+      temperature: -3,
+      humidity: 82,
+      windDirection: 270,
+      raw: expect.objectContaining({
+        source: 'environment-canada-climate-hourly',
+        stationName: 'RED DEER REGIONAL A',
+      }),
+    });
+  });
+
+  it('creates an Open-Meteo adapter through getWeatherAdapter', async () => {
+    const adapter = await getWeatherAdapter({ provider: 'open-meteo' });
+    expect(adapter).toBeInstanceOf(OpenMeteoProvider);
+  });
+});

--- a/packages/weather/src/__tests__/historical-weather.spec.ts
+++ b/packages/weather/src/__tests__/historical-weather.spec.ts
@@ -83,7 +83,7 @@ describe('standardized historical weather adapters', () => {
           timezone: 'UTC',
           hourly_units: { visibility: 'm' },
           hourly: {
-            time: ['2026-01-15T18:00', '2026-01-15T19:00'],
+            time: ['2026-01-15T18:00', '2026-01-15T19:00:00Z'],
             temperature_2m: [-4.2, -3.8],
             relative_humidity_2m: [76, 74],
             precipitation: [0, 0.2],

--- a/packages/weather/src/__tests__/historical-weather.spec.ts
+++ b/packages/weather/src/__tests__/historical-weather.spec.ts
@@ -72,6 +72,50 @@ describe('standardized historical weather adapters', () => {
     expect(result).toEqual([forecast]);
   });
 
+  it('uses the Google hourly history slash endpoint', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        timeZone: { id: 'UTC' },
+        historyHours: [
+          {
+            interval: {
+              startTime: '2026-01-15T11:00:00Z',
+              endTime: '2026-01-15T12:00:00Z',
+            },
+            displayDateTime: {
+              year: 2026,
+              month: 1,
+              day: 15,
+              hours: 11,
+              utcOffset: '0s',
+            },
+            isDaytime: true,
+            weatherCondition: {
+              iconBaseUri: '',
+              description: { text: 'Cloudy', languageCode: 'en' },
+              type: 'CLOUDY',
+            },
+            temperature: { degrees: -3, unit: 'CELSIUS' },
+            relativeHumidity: 70,
+            wind: {
+              direction: { degrees: 270, cardinal: 'W' },
+              speed: { value: 3, unit: 'METERS_PER_SECOND' },
+            },
+          },
+        ],
+      }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GoogleWeatherProvider({ apiKey: 'test-key' });
+    await provider.fetchHourlyHistory(51.0447, -114.0719, { hours: 1 });
+
+    const requestedUrl = String(fetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toContain('/history/hours:lookup?');
+    expect(requestedUrl).not.toContain('/history.hours:lookup');
+  });
+
   it('transforms Open-Meteo archive rows into standard forecasts', async () => {
     vi.stubGlobal(
       'fetch',
@@ -175,6 +219,133 @@ describe('standardized historical weather adapters', () => {
         source: 'environment-canada-climate-hourly',
         stationName: 'RED DEER REGIONAL A',
       }),
+    });
+  });
+
+  it('selects the nearest Environment Canada station with data in the requested window', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          type: 'FeatureCollection',
+          features: [
+            {
+              id: 'near-padding-only',
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [-114.093, 52.268],
+              },
+              properties: {
+                STATION_NAME: 'NEAR PADDING ONLY',
+                CLIMATE_IDENTIFIER: 'near',
+                UTC_DATE: '2026-01-14T19:00:00',
+                TEMP: -1,
+                RELATIVE_HUMIDITY: 80,
+                WIND_SPEED: 10,
+                LONGITUDE_DECIMAL_DEGREES: -114.093,
+                LATITUDE_DECIMAL_DEGREES: 52.268,
+              },
+            },
+            {
+              id: 'far-window-match',
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [-113.8944, 52.1822],
+              },
+              properties: {
+                STATION_NAME: 'FAR WINDOW MATCH',
+                CLIMATE_IDENTIFIER: 'far',
+                UTC_DATE: '2026-01-15T19:00:00',
+                TEMP: -2.6,
+                RELATIVE_HUMIDITY: 82,
+                WIND_SPEED: 13,
+                LONGITUDE_DECIMAL_DEGREES: -113.8944,
+                LATITUDE_DECIMAL_DEGREES: 52.1822,
+              },
+            },
+          ],
+        }),
+      })),
+    );
+
+    const provider = new EnvironmentCanadaProvider();
+    const forecasts = await provider.fetchHistoricalForLocation(
+      52.268,
+      -114.093,
+      {
+        start: '2026-01-15T19:00:00Z',
+        end: '2026-01-15T19:00:00Z',
+      },
+    );
+
+    expect(forecasts).toHaveLength(1);
+    expect(forecasts[0].raw).toMatchObject({
+      stationName: 'FAR WINDOW MATCH',
+    });
+  });
+
+  it('follows Environment Canada climate-hourly pagination', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          type: 'FeatureCollection',
+          features: [],
+          links: [
+            {
+              rel: 'next',
+              href: 'https://api.weather.gc.ca/collections/climate-hourly/items?offset=2000',
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          type: 'FeatureCollection',
+          features: [
+            {
+              id: 'page-two-match',
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [-113.8944, 52.1822],
+              },
+              properties: {
+                STATION_NAME: 'PAGE TWO MATCH',
+                CLIMATE_IDENTIFIER: 'page-two',
+                UTC_DATE: '2026-01-15T19:00:00',
+                TEMP: -2.6,
+                RELATIVE_HUMIDITY: 82,
+                WIND_SPEED: 13,
+                LONGITUDE_DECIMAL_DEGREES: -113.8944,
+                LATITUDE_DECIMAL_DEGREES: 52.1822,
+              },
+            },
+          ],
+        }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new EnvironmentCanadaProvider();
+    const forecasts = await provider.fetchHistoricalForLocation(
+      52.268,
+      -114.093,
+      {
+        start: '2026-01-15T19:00:00Z',
+        end: '2026-01-15T19:00:00Z',
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1][0])).toContain('offset=2000');
+    expect(forecasts).toHaveLength(1);
+    expect(forecasts[0].raw).toMatchObject({
+      stationName: 'PAGE TWO MATCH',
     });
   });
 

--- a/packages/weather/src/__tests__/historical-weather.spec.ts
+++ b/packages/weather/src/__tests__/historical-weather.spec.ts
@@ -6,12 +6,17 @@ import { OpenMeteoProvider } from '../providers/open-meteo';
 import { OpenWeatherMapProvider } from '../providers/openweathermap';
 import { OpenWeatherMapOneCallProvider } from '../providers/openweathermap-onecall';
 import type { IWeatherProvider, WeatherForecast } from '../shared/types';
-import { UnsupportedWeatherCapabilityError } from '../shared/types';
+import {
+  NoResultsError,
+  UnsupportedWeatherCapabilityError,
+  type WeatherError,
+} from '../shared/types';
 
 describe('standardized historical weather adapters', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('exposes fetchHistoricalForLocation on every provider', () => {
@@ -42,6 +47,7 @@ describe('standardized historical weather adapters', () => {
   it('delegates Google historical requests to hourly history within the supported range', async () => {
     const provider = new GoogleWeatherProvider({ apiKey: 'test-key' });
     const now = new Date('2026-01-15T12:00:00Z');
+    vi.useFakeTimers();
     vi.setSystemTime(now);
     const forecast: WeatherForecast = {
       timestamp: new Date('2026-01-15T11:00:00Z'),
@@ -70,6 +76,19 @@ describe('standardized historical weather adapters', () => {
       expect.objectContaining({ hours: 3 }),
     );
     expect(result).toEqual([forecast]);
+  });
+
+  it('rejects Google historical requests older than the 24-hour history window', async () => {
+    const provider = new GoogleWeatherProvider({ apiKey: 'test-key' });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+
+    await expect(
+      provider.fetchHistoricalForLocation(51.0447, -114.0719, {
+        start: '2026-01-14T10:59:00Z',
+        end: '2026-01-14T12:00:00Z',
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedWeatherCapabilityError);
   });
 
   it('uses the Google hourly history slash endpoint', async () => {
@@ -164,6 +183,67 @@ describe('standardized historical weather adapters', () => {
     expect(forecasts[1].conditions).toBe('Rain');
   });
 
+  it('surfaces Open-Meteo API error bodies as weather errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          error: true,
+          reason: 'Requested date is outside archive range',
+        }),
+      })),
+    );
+
+    const provider = new OpenMeteoProvider();
+
+    await expect(
+      provider.fetchForLocation(52.268, -114.093),
+    ).rejects.toMatchObject({
+      code: 'API_ERROR',
+      message: 'Requested date is outside archive range',
+      provider: 'Open-Meteo',
+    } satisfies Partial<WeatherError>);
+  });
+
+  it('skips Open-Meteo rows with missing required measurements', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          latitude: 52.268,
+          longitude: -114.093,
+          timezone: 'UTC',
+          hourly: {
+            time: ['2026-01-15T18:00', '2026-01-15T19:00:00Z'],
+            temperature_2m: [-4.2, -3.8],
+            relative_humidity_2m: [null, 74],
+            wind_speed_10m: [18.4, 20.1],
+            weather_code: [3, 61],
+          },
+        }),
+      })),
+    );
+
+    const provider = new OpenMeteoProvider();
+    const forecasts = await provider.fetchHistoricalForLocation(
+      52.268,
+      -114.093,
+      {
+        start: '2026-01-15T18:00:00Z',
+        end: '2026-01-15T19:00:00Z',
+      },
+    );
+
+    expect(forecasts).toHaveLength(1);
+    expect(forecasts[0]).toMatchObject({
+      timestamp: new Date('2026-01-15T19:00:00Z'),
+      humidity: 74,
+      windSpeed: 20,
+    });
+  });
+
   it('uses Environment Canada climate-hourly observations for Canadian historical requests', async () => {
     vi.stubGlobal(
       'fetch',
@@ -220,6 +300,73 @@ describe('standardized historical weather adapters', () => {
         stationName: 'RED DEER REGIONAL A',
       }),
     });
+  });
+
+  it('keeps Environment Canada raw-degree wind directions above encoded tens range', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          type: 'FeatureCollection',
+          features: [
+            {
+              id: '3025484.2026.1.15.12',
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [-113.8944, 52.1822],
+              },
+              properties: {
+                STATION_NAME: 'RED DEER REGIONAL A',
+                CLIMATE_IDENTIFIER: '3025484',
+                UTC_DATE: '2026-01-15T19:00:00',
+                TEMP: -2.6,
+                RELATIVE_HUMIDITY: 82,
+                WIND_DIRECTION: 350,
+                WIND_SPEED: 13,
+                LONGITUDE_DECIMAL_DEGREES: -113.8944,
+                LATITUDE_DECIMAL_DEGREES: 52.1822,
+              },
+            },
+          ],
+        }),
+      })),
+    );
+
+    const provider = new EnvironmentCanadaProvider();
+    const forecasts = await provider.fetchHistoricalForLocation(
+      52.268,
+      -114.093,
+      {
+        start: '2026-01-15T19:00:00Z',
+        end: '2026-01-15T19:00:00Z',
+      },
+    );
+
+    expect(forecasts[0].windDirection).toBe(350);
+  });
+
+  it('throws NoResultsError when Environment Canada returns no climate-hourly features', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          type: 'FeatureCollection',
+          features: [],
+        }),
+      })),
+    );
+
+    const provider = new EnvironmentCanadaProvider();
+
+    await expect(
+      provider.fetchHistoricalForLocation(52.268, -114.093, {
+        start: '2026-01-15T19:00:00Z',
+        end: '2026-01-15T19:00:00Z',
+      }),
+    ).rejects.toBeInstanceOf(NoResultsError);
   });
 
   it('selects the nearest Environment Canada station with data in the requested window', async () => {

--- a/packages/weather/src/index.ts
+++ b/packages/weather/src/index.ts
@@ -6,6 +6,7 @@
  * - OpenWeatherMap (free tier, global, 3-hour forecasts)
  * - OpenWeatherMap One Call (paid tier, global, hourly + daily)
  * - Google Weather (paid, global, 240h hourly + 10 day daily + alerts)
+ * - Open-Meteo (free/community, global forecast + long-range hourly archive)
  *
  * @example
  * ```typescript
@@ -39,6 +40,7 @@ import { loadEnvConfig } from '@happyvertical/utils';
 // Provider imports
 import { EnvironmentCanadaProvider } from './providers/environment-canada';
 import { GoogleWeatherProvider } from './providers/google-weather';
+import { OpenMeteoProvider } from './providers/open-meteo';
 import { OpenWeatherMapProvider } from './providers/openweathermap';
 import { OpenWeatherMapOneCallProvider } from './providers/openweathermap-onecall';
 import type {
@@ -53,8 +55,10 @@ export type {
   EnvironmentCanadaOptions,
   FetchOptions,
   GoogleWeatherOptions,
+  HistoricalFetchOptions,
   IWeatherAdapter,
   IWeatherProvider,
+  OpenMeteoOptions,
   OpenWeatherMapOneCallOptions,
   OpenWeatherMapOptions,
   PartialWeatherAdapterOptions,
@@ -69,6 +73,7 @@ export {
   InvalidLocationError,
   NoResultsError,
   RateLimitError,
+  UnsupportedWeatherCapabilityError,
   WeatherError,
 } from './shared/types';
 
@@ -211,9 +216,15 @@ function mergeConfig(
       };
     }
 
+    case 'open-meteo':
+      return {
+        provider: 'open-meteo',
+        timeout: merged.timeout,
+      };
+
     default:
       throw new WeatherError(
-        `Unknown provider: ${provider}. Supported providers: environment-canada, openweathermap, openweathermap-onecall, google-weather`,
+        `Unknown provider: ${provider}. Supported providers: environment-canada, openweathermap, openweathermap-onecall, google-weather, open-meteo`,
         'unknown',
         'INVALID_PROVIDER',
       );
@@ -266,6 +277,11 @@ export async function getWeatherAdapter(
     case 'google-weather':
       return new GoogleWeatherProvider({
         apiKey: config.apiKey,
+        timeout: config.timeout,
+      });
+
+    case 'open-meteo':
+      return new OpenMeteoProvider({
         timeout: config.timeout,
       });
 

--- a/packages/weather/src/providers/environment-canada.ts
+++ b/packages/weather/src/providers/environment-canada.ts
@@ -91,6 +91,12 @@ interface ECForecastData {
 
 interface ECClimateHourlyData {
   type: string;
+  links?: Array<{
+    rel?: string;
+    href?: string;
+    type?: string;
+    title?: string;
+  }>;
   features: Array<{
     id: string;
     type: string;
@@ -225,34 +231,17 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
 
     try {
       const url = this.buildClimateHourlyUrl(latitude, longitude, window);
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
-        options.timeout || this.timeout,
-      );
-
-      const response = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new WeatherError(
-          `API request failed: ${response.statusText}`,
-          this.name,
-          `HTTP_${response.status}`,
-        );
-      }
-
-      const data = (await response.json()) as ECClimateHourlyData;
+      const data = await this.fetchClimateHourlyPages(url, options.timeout);
       const stationForecasts = this.transformClimateHourly(
         data,
         latitude,
         longitude,
-      );
-      const forecasts = filterHistoricalWindow(
-        stationForecasts,
         window,
-        options.limit,
       );
+      const forecasts =
+        options.limit && options.limit > 0
+          ? stationForecasts.slice(0, options.limit)
+          : stationForecasts;
 
       if (forecasts.length === 0) {
         throw new NoResultsError(this.name, latitude, longitude);
@@ -306,6 +295,75 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     });
 
     return `${this.climateHourlyApiBase}?${params.toString()}`;
+  }
+
+  private async fetchClimateHourlyPages(
+    initialUrl: string,
+    timeout?: number,
+  ): Promise<ECClimateHourlyData> {
+    const features: ECClimateHourlyData['features'] = [];
+    const visited = new Set<string>();
+    let nextUrl: string | undefined = initialUrl;
+    let pageCount = 0;
+
+    while (nextUrl) {
+      if (visited.has(nextUrl)) {
+        throw new WeatherError(
+          'Environment Canada climate pagination loop detected',
+          this.name,
+          'PAGINATION_LOOP',
+        );
+      }
+
+      visited.add(nextUrl);
+      pageCount += 1;
+
+      if (pageCount > 50) {
+        throw new WeatherError(
+          'Environment Canada climate pagination exceeded safety limit',
+          this.name,
+          'PAGINATION_LIMIT',
+        );
+      }
+
+      const page = await this.fetchClimateHourlyPage(nextUrl, timeout);
+      features.push(...(page.features || []));
+      nextUrl = page.links?.find(
+        (link) => link.rel === 'next' && link.href,
+      )?.href;
+    }
+
+    return {
+      type: 'FeatureCollection',
+      features,
+    };
+  }
+
+  private async fetchClimateHourlyPage(
+    url: string,
+    timeout?: number,
+  ): Promise<ECClimateHourlyData> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      timeout || this.timeout,
+    );
+
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+
+      if (!response.ok) {
+        throw new WeatherError(
+          `API request failed: ${response.statusText}`,
+          this.name,
+          `HTTP_${response.status}`,
+        );
+      }
+
+      return (await response.json()) as ECClimateHourlyData;
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
 
   /**
@@ -402,6 +460,7 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     data: ECClimateHourlyData,
     latitude: number,
     longitude: number,
+    window?: { start: Date; end: Date },
   ): WeatherForecast[] {
     if (!data.features || data.features.length === 0) {
       throw new NoResultsError(this.name, latitude, longitude);
@@ -506,9 +565,17 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
       }
     }
 
-    const nearest = [...byStation.values()].sort(
-      (a, b) => a.distance - b.distance,
-    )[0];
+    const nearest = [...byStation.values()]
+      .map((group) => ({
+        distance: group.distance,
+        forecasts: window
+          ? filterHistoricalWindow(group.forecasts, window)
+          : group.forecasts.sort(
+              (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+            ),
+      }))
+      .filter((group) => group.forecasts.length > 0)
+      .sort((a, b) => a.distance - b.distance)[0];
 
     if (!nearest) {
       throw new NoResultsError(this.name, latitude, longitude);

--- a/packages/weather/src/providers/environment-canada.ts
+++ b/packages/weather/src/providers/environment-canada.ts
@@ -231,7 +231,11 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
 
     try {
       const url = this.buildClimateHourlyUrl(latitude, longitude, window);
-      const data = await this.fetchClimateHourlyPages(url, options.timeout);
+      const data = await this.fetchClimateHourlyPages(
+        url,
+        window,
+        options.timeout,
+      );
       const stationForecasts = this.transformClimateHourly(
         data,
         latitude,
@@ -284,8 +288,9 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     lng: number,
     window: { start: Date; end: Date },
   ): string {
-    // The climate collection can paginate in dense regions; fetchClimateHourlyPages
-    // follows every page before nearest-station selection.
+    // Padding helps discover stations near the requested point. Pagination keeps
+    // only observations inside the requested window so dense regions do not
+    // accumulate every padded row before nearest-station selection.
     const queryStart = new Date(window.start.getTime() - 24 * 60 * 60 * 1000);
     const queryEnd = new Date(window.end.getTime() + 24 * 60 * 60 * 1000);
     const bboxPadding = 1;
@@ -301,6 +306,7 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
 
   private async fetchClimateHourlyPages(
     initialUrl: string,
+    window: { start: Date; end: Date },
     timeout?: number,
   ): Promise<ECClimateHourlyData> {
     const features: ECClimateHourlyData['features'] = [];
@@ -329,7 +335,11 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
       }
 
       const page = await this.fetchClimateHourlyPage(nextUrl, timeout);
-      features.push(...(page.features || []));
+      features.push(
+        ...(page.features || []).filter((feature) =>
+          this.isClimateFeatureInWindow(feature, window),
+        ),
+      );
       nextUrl = page.links?.find(
         (link) => link.rel === 'next' && link.href,
       )?.href;
@@ -339,6 +349,26 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
       type: 'FeatureCollection',
       features,
     };
+  }
+
+  private isClimateFeatureInWindow(
+    feature: ECClimateHourlyData['features'][number],
+    window: { start: Date; end: Date },
+  ): boolean {
+    const rawTimestamp = feature.properties.UTC_DATE;
+    if (!rawTimestamp) {
+      return false;
+    }
+
+    const timestamp = parseEnvironmentCanadaUtcDate(rawTimestamp);
+    if (Number.isNaN(timestamp.getTime())) {
+      return false;
+    }
+
+    return (
+      timestamp.getTime() >= window.start.getTime() &&
+      timestamp.getTime() <= window.end.getTime()
+    );
   }
 
   private async fetchClimateHourlyPage(

--- a/packages/weather/src/providers/environment-canada.ts
+++ b/packages/weather/src/providers/environment-canada.ts
@@ -284,6 +284,8 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     lng: number,
     window: { start: Date; end: Date },
   ): string {
+    // The climate collection can paginate in dense regions; fetchClimateHourlyPages
+    // follows every page before nearest-station selection.
     const queryStart = new Date(window.start.getTime() - 24 * 60 * 60 * 1000);
     const queryEnd = new Date(window.end.getTime() + 24 * 60 * 60 * 1000);
     const bboxPadding = 1;
@@ -512,12 +514,9 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
         stationLongitude,
       );
       const weatherDescription = props.WEATHER_ENG_DESC || 'Unknown';
-      const windDirection =
-        typeof props.WIND_DIRECTION === 'number'
-          ? props.WIND_DIRECTION <= 36
-            ? props.WIND_DIRECTION * 10
-            : props.WIND_DIRECTION
-          : undefined;
+      const windDirection = normalizeEnvironmentCanadaWindDirection(
+        props.WIND_DIRECTION,
+      );
 
       const forecast: WeatherForecast = {
         timestamp,
@@ -565,6 +564,8 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
       }
     }
 
+    // V1 uses one nearest station with at least one observation in the window.
+    // Gap-filling from additional stations can be layered on later if needed.
     const nearest = [...byStation.values()]
       .map((group) => ({
         distance: group.distance,
@@ -635,4 +636,15 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
 function parseEnvironmentCanadaUtcDate(value: string): Date {
   const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value);
   return new Date(hasTimezone ? value : `${value}Z`);
+}
+
+function normalizeEnvironmentCanadaWindDirection(
+  value: number | null | undefined,
+): number | undefined {
+  if (typeof value !== 'number') {
+    return undefined;
+  }
+
+  // EC climate-hourly WIND_DIRECTION is reported in tens of degrees: 27 => 270.
+  return value <= 36 ? value * 10 : value;
 }

--- a/packages/weather/src/providers/environment-canada.ts
+++ b/packages/weather/src/providers/environment-canada.ts
@@ -10,8 +10,14 @@
  * Data Format: JSON via OGC API Features
  */
 
+import {
+  filterHistoricalWindow,
+  formatUtcDate,
+  normalizeHistoricalWindow,
+} from '../shared/historical';
 import type {
   FetchOptions,
+  HistoricalFetchOptions,
   IWeatherProvider,
   WeatherForecast,
 } from '../shared/types';
@@ -20,7 +26,12 @@ import {
   NoResultsError,
   WeatherError,
 } from '../shared/types';
-import { ensureValidCoordinates, isInCanada } from '../shared/utils';
+import {
+  calculateDistance,
+  ensureValidCoordinates,
+  isInCanada,
+  roundToInt,
+} from '../shared/utils';
 
 interface ECForecastData {
   type: string;
@@ -78,12 +89,47 @@ interface ECForecastData {
   }>;
 }
 
+interface ECClimateHourlyData {
+  type: string;
+  features: Array<{
+    id: string;
+    type: string;
+    geometry?: {
+      type: 'Point';
+      coordinates: [number, number];
+    };
+    properties: {
+      STATION_NAME?: string | null;
+      CLIMATE_IDENTIFIER?: string | null;
+      ID?: string | null;
+      LOCAL_DATE?: string | null;
+      UTC_DATE?: string | null;
+      TEMP?: number | null;
+      DEW_POINT_TEMP?: number | null;
+      HUMIDEX?: number | null;
+      PRECIP_AMOUNT?: number | null;
+      RELATIVE_HUMIDITY?: number | null;
+      STATION_PRESSURE?: number | null;
+      VISIBILITY?: number | null;
+      WEATHER_ENG_DESC?: string | null;
+      WINDCHILL?: number | null;
+      WIND_DIRECTION?: number | null;
+      WIND_SPEED?: number | null;
+      STN_ID?: string | number | null;
+      LONGITUDE_DECIMAL_DEGREES?: number | null;
+      LATITUDE_DECIMAL_DEGREES?: number | null;
+    };
+  }>;
+}
+
 export class EnvironmentCanadaProvider implements IWeatherProvider {
   readonly name = 'Environment Canada';
   readonly providerType = 'government' as const;
 
   private readonly apiBase =
     'https://api.weather.gc.ca/collections/citypageweather-realtime/items';
+  private readonly climateHourlyApiBase =
+    'https://api.weather.gc.ca/collections/climate-hourly/items';
   private readonly timeout: number;
 
   constructor(options: { timeout?: number } = {}) {
@@ -159,6 +205,77 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     }
   }
 
+  async fetchHistoricalForLocation(
+    latitude: number,
+    longitude: number,
+    options: HistoricalFetchOptions,
+  ): Promise<WeatherForecast[]> {
+    ensureValidCoordinates(this.name, latitude, longitude);
+
+    if (!isInCanada(latitude, longitude)) {
+      throw new InvalidLocationError(
+        this.name,
+        latitude,
+        longitude,
+        'Environment Canada historical climate observations only support Canadian locations',
+      );
+    }
+
+    const window = normalizeHistoricalWindow(this.name, options);
+
+    try {
+      const url = this.buildClimateHourlyUrl(latitude, longitude, window);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        options.timeout || this.timeout,
+      );
+
+      const response = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new WeatherError(
+          `API request failed: ${response.statusText}`,
+          this.name,
+          `HTTP_${response.status}`,
+        );
+      }
+
+      const data = (await response.json()) as ECClimateHourlyData;
+      const stationForecasts = this.transformClimateHourly(
+        data,
+        latitude,
+        longitude,
+      );
+      const forecasts = filterHistoricalWindow(
+        stationForecasts,
+        window,
+        options.limit,
+      );
+
+      if (forecasts.length === 0) {
+        throw new NoResultsError(this.name, latitude, longitude);
+      }
+
+      return forecasts;
+    } catch (error) {
+      if (error instanceof WeatherError) {
+        throw error;
+      }
+
+      if ((error as any).name === 'AbortError') {
+        throw new WeatherError('Request timeout', this.name, 'TIMEOUT');
+      }
+
+      throw new WeatherError(
+        `Failed to fetch historical weather data: ${(error as Error).message}`,
+        this.name,
+        'FETCH_ERROR',
+      );
+    }
+  }
+
   /**
    * Build Environment Canada API URL for given coordinates
    */
@@ -171,6 +288,24 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     });
 
     return `${this.apiBase}?${params.toString()}`;
+  }
+
+  private buildClimateHourlyUrl(
+    lat: number,
+    lng: number,
+    window: { start: Date; end: Date },
+  ): string {
+    const queryStart = new Date(window.start.getTime() - 24 * 60 * 60 * 1000);
+    const queryEnd = new Date(window.end.getTime() + 24 * 60 * 60 * 1000);
+    const bboxPadding = 1;
+    const params = new URLSearchParams({
+      f: 'json',
+      bbox: `${lng - bboxPadding},${lat - bboxPadding},${lng + bboxPadding},${lat + bboxPadding}`,
+      datetime: `${formatUtcDate(queryStart)}/${formatUtcDate(queryEnd)}`,
+      limit: '2000',
+    });
+
+    return `${this.climateHourlyApiBase}?${params.toString()}`;
   }
 
   /**
@@ -263,6 +398,127 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     return forecasts;
   }
 
+  private transformClimateHourly(
+    data: ECClimateHourlyData,
+    latitude: number,
+    longitude: number,
+  ): WeatherForecast[] {
+    if (!data.features || data.features.length === 0) {
+      throw new NoResultsError(this.name, latitude, longitude);
+    }
+
+    const byStation = new Map<
+      string,
+      { distance: number; forecasts: WeatherForecast[] }
+    >();
+
+    for (const feature of data.features) {
+      const props = feature.properties;
+      const timestamp = props.UTC_DATE
+        ? parseEnvironmentCanadaUtcDate(props.UTC_DATE)
+        : null;
+
+      if (!timestamp || Number.isNaN(timestamp.getTime())) {
+        continue;
+      }
+
+      const stationLatitude =
+        props.LATITUDE_DECIMAL_DEGREES || feature.geometry?.coordinates[1];
+      const stationLongitude =
+        props.LONGITUDE_DECIMAL_DEGREES || feature.geometry?.coordinates[0];
+
+      if (
+        typeof stationLatitude !== 'number' ||
+        typeof stationLongitude !== 'number'
+      ) {
+        continue;
+      }
+
+      const temperature =
+        typeof props.TEMP === 'number' ? props.TEMP : undefined;
+      if (temperature === undefined) {
+        continue;
+      }
+
+      const stationId = String(
+        props.CLIMATE_IDENTIFIER ||
+          props.STN_ID ||
+          props.STATION_NAME ||
+          'nearby',
+      );
+      const distance = calculateDistance(
+        latitude,
+        longitude,
+        stationLatitude,
+        stationLongitude,
+      );
+      const weatherDescription = props.WEATHER_ENG_DESC || 'Unknown';
+      const windDirection =
+        typeof props.WIND_DIRECTION === 'number'
+          ? props.WIND_DIRECTION <= 36
+            ? props.WIND_DIRECTION * 10
+            : props.WIND_DIRECTION
+          : undefined;
+
+      const forecast: WeatherForecast = {
+        timestamp,
+        temperature: roundToInt(temperature),
+        feelsLike:
+          typeof props.WINDCHILL === 'number'
+            ? roundToInt(props.WINDCHILL)
+            : typeof props.HUMIDEX === 'number'
+              ? roundToInt(props.HUMIDEX)
+              : undefined,
+        humidity: roundToInt(props.RELATIVE_HUMIDITY || 0),
+        windSpeed: roundToInt(props.WIND_SPEED || 0),
+        windDirection,
+        pressure:
+          typeof props.STATION_PRESSURE === 'number'
+            ? roundToInt(props.STATION_PRESSURE * 10)
+            : undefined,
+        conditions:
+          weatherDescription.toUpperCase() === 'NA'
+            ? 'Unknown'
+            : weatherDescription,
+        visibility:
+          typeof props.VISIBILITY === 'number' ? props.VISIBILITY : undefined,
+        precipAmount:
+          typeof props.PRECIP_AMOUNT === 'number'
+            ? props.PRECIP_AMOUNT
+            : undefined,
+        confidence: 100,
+        raw: {
+          source: 'environment-canada-climate-hourly',
+          stationId,
+          stationName: props.STATION_NAME,
+          stationLatitude,
+          stationLongitude,
+          stationDistanceKm: distance,
+          observation: props,
+        },
+      };
+
+      const group = byStation.get(stationId);
+      if (group) {
+        group.forecasts.push(forecast);
+      } else {
+        byStation.set(stationId, { distance, forecasts: [forecast] });
+      }
+    }
+
+    const nearest = [...byStation.values()].sort(
+      (a, b) => a.distance - b.distance,
+    )[0];
+
+    if (!nearest) {
+      throw new NoResultsError(this.name, latitude, longitude);
+    }
+
+    return nearest.forecasts.sort(
+      (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+    );
+  }
+
   /**
    * Test connection to Environment Canada API
    */
@@ -307,4 +563,9 @@ export class EnvironmentCanadaProvider implements IWeatherProvider {
     // Check if coordinates are within Canada's bounds
     return isInCanada(latitude, longitude);
   }
+}
+
+function parseEnvironmentCanadaUtcDate(value: string): Date {
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value);
+  return new Date(hasTimezone ? value : `${value}Z`);
 }

--- a/packages/weather/src/providers/google-weather.ts
+++ b/packages/weather/src/providers/google-weather.ts
@@ -393,7 +393,7 @@ export class GoogleWeatherProvider implements IWeatherProvider {
 
     const hours = options?.hours || 24;
     const url = this.buildUrl(
-      '/history.hours:lookup',
+      '/history/hours:lookup',
       latitude,
       longitude,
       `&hours=${hours}`,

--- a/packages/weather/src/providers/google-weather.ts
+++ b/packages/weather/src/providers/google-weather.ts
@@ -16,8 +16,14 @@
  * Data Format: JSON
  */
 
+import {
+  filterHistoricalWindow,
+  hoursBetween,
+  normalizeHistoricalWindow,
+} from '../shared/historical';
 import type {
   FetchOptions,
+  HistoricalFetchOptions,
   IWeatherProvider,
   WeatherAlert,
   WeatherForecast,
@@ -26,6 +32,7 @@ import {
   AuthenticationError,
   NoResultsError,
   RateLimitError,
+  UnsupportedWeatherCapabilityError,
   WeatherError,
 } from '../shared/types';
 import {
@@ -403,6 +410,47 @@ export class GoogleWeatherProvider implements IWeatherProvider {
     return data.historyHours.map((hour) =>
       this.transformHourlyForecast(hour, 'history'),
     );
+  }
+
+  async fetchHistoricalForLocation(
+    latitude: number,
+    longitude: number,
+    options: HistoricalFetchOptions,
+  ): Promise<WeatherForecast[]> {
+    ensureValidCoordinates(this.name, latitude, longitude);
+
+    const window = normalizeHistoricalWindow(this.name, options);
+    const now = new Date();
+    const oldestSupported = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+    if (window.end.getTime() > now.getTime()) {
+      throw new WeatherError(
+        'Google Weather historical lookup cannot end in the future',
+        this.name,
+        'INVALID_DATE_RANGE',
+      );
+    }
+
+    if (window.start.getTime() < oldestSupported.getTime()) {
+      throw new UnsupportedWeatherCapabilityError(
+        this.name,
+        'historical-weather',
+        'Google Weather hourly history is limited to the previous 24 hours.',
+      );
+    }
+
+    const hours = Math.min(24, hoursBetween(window.start, now));
+    const history = await this.fetchHourlyHistory(latitude, longitude, {
+      ...options,
+      hours,
+    });
+
+    const forecasts = filterHistoricalWindow(history, window, options.limit);
+    if (forecasts.length === 0) {
+      throw new NoResultsError(this.name, latitude, longitude);
+    }
+
+    return forecasts;
   }
 
   /**

--- a/packages/weather/src/providers/open-meteo.ts
+++ b/packages/weather/src/providers/open-meteo.ts
@@ -231,7 +231,7 @@ export class OpenMeteoProvider implements IWeatherProvider {
     const forecasts: WeatherForecast[] = [];
 
     for (let index = 0; index < hourly.time.length; index++) {
-      const timestamp = new Date(`${hourly.time[index]}Z`);
+      const timestamp = parseOpenMeteoTimestamp(hourly.time[index]);
       const temperature = hourly.temperature_2m?.[index];
 
       if (
@@ -282,6 +282,11 @@ function valueOrUndefined(
   value: number | null | undefined,
 ): number | undefined {
   return typeof value === 'number' ? value : undefined;
+}
+
+function parseOpenMeteoTimestamp(value: string): Date {
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value);
+  return new Date(hasTimezone ? value : `${value}Z`);
 }
 
 function describeOpenMeteoCode(code: number | null | undefined): string {

--- a/packages/weather/src/providers/open-meteo.ts
+++ b/packages/weather/src/providers/open-meteo.ts
@@ -3,6 +3,8 @@
  *
  * Uses Open-Meteo forecast and historical archive endpoints. The archive
  * endpoint provides long-range hourly weather backfill without an API key.
+ * Archive data is published with a 5-7 day lag, so very recent windows are
+ * rejected with a descriptive range error instead of a generic no-results error.
  */
 
 import {
@@ -22,6 +24,8 @@ import {
   metersToKilometers,
   roundToInt,
 } from '../shared/utils';
+
+const ARCHIVE_PUBLISHING_LAG_MS = 5 * 24 * 60 * 60 * 1000;
 
 interface OpenMeteoHourlyData {
   time: string[];
@@ -69,7 +73,7 @@ export class OpenMeteoProvider implements IWeatherProvider {
     const params = this.buildBaseParams(latitude, longitude);
     params.set('forecast_days', '7');
 
-    const data = await this.fetchJson<OpenMeteoResponse>(
+    const data = await this.fetchJson(
       `${this.forecastApiBase}?${params.toString()}`,
       options?.timeout,
     );
@@ -94,11 +98,25 @@ export class OpenMeteoProvider implements IWeatherProvider {
     ensureValidCoordinates(this.name, latitude, longitude);
 
     const window = normalizeHistoricalWindow(this.name, options);
+    const latestArchiveEnd = new Date(Date.now() - ARCHIVE_PUBLISHING_LAG_MS);
+
+    if (window.end.getTime() > latestArchiveEnd.getTime()) {
+      throw new WeatherError(
+        'Open-Meteo archive data is published with a 5-7 day lag',
+        this.name,
+        'INVALID_DATE_RANGE',
+        {
+          requestedEnd: window.end.toISOString(),
+          latestSupportedEnd: latestArchiveEnd.toISOString(),
+        },
+      );
+    }
+
     const params = this.buildBaseParams(latitude, longitude);
     params.set('start_date', formatUtcDate(window.start));
     params.set('end_date', formatUtcDate(window.end));
 
-    const data = await this.fetchJson<OpenMeteoResponse>(
+    const data = await this.fetchJson(
       `${this.archiveApiBase}?${params.toString()}`,
       options.timeout,
     );
@@ -165,7 +183,10 @@ export class OpenMeteoProvider implements IWeatherProvider {
     });
   }
 
-  private async fetchJson<T>(url: string, timeout?: number): Promise<T> {
+  private async fetchJson(
+    url: string,
+    timeout?: number,
+  ): Promise<OpenMeteoResponse> {
     const controller = new AbortController();
     const timeoutId = setTimeout(
       () => controller.abort(),
@@ -174,7 +195,6 @@ export class OpenMeteoProvider implements IWeatherProvider {
 
     try {
       const response = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeoutId);
 
       if (response.status === 429) {
         throw new RateLimitError(this.name);
@@ -199,10 +219,8 @@ export class OpenMeteoProvider implements IWeatherProvider {
         );
       }
 
-      return data as T;
+      return data;
     } catch (error) {
-      clearTimeout(timeoutId);
-
       if (error instanceof WeatherError) {
         throw error;
       }
@@ -216,6 +234,8 @@ export class OpenMeteoProvider implements IWeatherProvider {
         this.name,
         'FETCH_ERROR',
       );
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 
@@ -233,10 +253,14 @@ export class OpenMeteoProvider implements IWeatherProvider {
     for (let index = 0; index < hourly.time.length; index++) {
       const timestamp = parseOpenMeteoTimestamp(hourly.time[index]);
       const temperature = hourly.temperature_2m?.[index];
+      const humidity = valueOrUndefined(hourly.relative_humidity_2m?.[index]);
+      const windSpeed = valueOrUndefined(hourly.wind_speed_10m?.[index]);
 
       if (
         Number.isNaN(timestamp.getTime()) ||
-        typeof temperature !== 'number'
+        typeof temperature !== 'number' ||
+        humidity === undefined ||
+        windSpeed === undefined
       ) {
         continue;
       }
@@ -246,8 +270,8 @@ export class OpenMeteoProvider implements IWeatherProvider {
       forecasts.push({
         timestamp,
         temperature: roundToInt(temperature),
-        humidity: roundToInt(hourly.relative_humidity_2m?.[index] || 0),
-        windSpeed: roundToInt(hourly.wind_speed_10m?.[index] || 0),
+        humidity: roundToInt(humidity),
+        windSpeed: roundToInt(windSpeed),
         windDirection: valueOrUndefined(hourly.wind_direction_10m?.[index]),
         windGust:
           typeof hourly.wind_gusts_10m?.[index] === 'number'

--- a/packages/weather/src/providers/open-meteo.ts
+++ b/packages/weather/src/providers/open-meteo.ts
@@ -1,0 +1,335 @@
+/**
+ * OpenMeteoProvider - Fetch weather data from Open-Meteo APIs
+ *
+ * Uses Open-Meteo forecast and historical archive endpoints. The archive
+ * endpoint provides long-range hourly weather backfill without an API key.
+ */
+
+import {
+  filterHistoricalWindow,
+  formatUtcDate,
+  normalizeHistoricalWindow,
+} from '../shared/historical';
+import type {
+  FetchOptions,
+  HistoricalFetchOptions,
+  IWeatherProvider,
+  WeatherForecast,
+} from '../shared/types';
+import { NoResultsError, RateLimitError, WeatherError } from '../shared/types';
+import {
+  ensureValidCoordinates,
+  metersToKilometers,
+  roundToInt,
+} from '../shared/utils';
+
+interface OpenMeteoHourlyData {
+  time: string[];
+  temperature_2m?: Array<number | null>;
+  relative_humidity_2m?: Array<number | null>;
+  precipitation?: Array<number | null>;
+  weather_code?: Array<number | null>;
+  cloud_cover?: Array<number | null>;
+  wind_speed_10m?: Array<number | null>;
+  wind_direction_10m?: Array<number | null>;
+  wind_gusts_10m?: Array<number | null>;
+  visibility?: Array<number | null>;
+}
+
+interface OpenMeteoResponse {
+  latitude: number;
+  longitude: number;
+  timezone?: string;
+  hourly?: OpenMeteoHourlyData;
+  hourly_units?: Record<string, string>;
+  reason?: string;
+  error?: boolean;
+}
+
+export class OpenMeteoProvider implements IWeatherProvider {
+  readonly name = 'Open-Meteo';
+  readonly providerType = 'community' as const;
+
+  private readonly forecastApiBase = 'https://api.open-meteo.com/v1/forecast';
+  private readonly archiveApiBase =
+    'https://archive-api.open-meteo.com/v1/archive';
+  private readonly timeout: number;
+
+  constructor(options: { timeout?: number } = {}) {
+    this.timeout = options.timeout || 10000;
+  }
+
+  async fetchForLocation(
+    latitude: number,
+    longitude: number,
+    options?: FetchOptions,
+  ): Promise<WeatherForecast[]> {
+    ensureValidCoordinates(this.name, latitude, longitude);
+
+    const params = this.buildBaseParams(latitude, longitude);
+    params.set('forecast_days', '7');
+
+    const data = await this.fetchJson<OpenMeteoResponse>(
+      `${this.forecastApiBase}?${params.toString()}`,
+      options?.timeout,
+    );
+    const forecasts = this.transformHourlyData(data, 'open-meteo-forecast');
+
+    if (forecasts.length === 0) {
+      throw new NoResultsError(this.name, latitude, longitude);
+    }
+
+    if (options?.limit && options.limit > 0) {
+      return forecasts.slice(0, options.limit);
+    }
+
+    return forecasts;
+  }
+
+  async fetchHistoricalForLocation(
+    latitude: number,
+    longitude: number,
+    options: HistoricalFetchOptions,
+  ): Promise<WeatherForecast[]> {
+    ensureValidCoordinates(this.name, latitude, longitude);
+
+    const window = normalizeHistoricalWindow(this.name, options);
+    const params = this.buildBaseParams(latitude, longitude);
+    params.set('start_date', formatUtcDate(window.start));
+    params.set('end_date', formatUtcDate(window.end));
+
+    const data = await this.fetchJson<OpenMeteoResponse>(
+      `${this.archiveApiBase}?${params.toString()}`,
+      options.timeout,
+    );
+    const forecasts = filterHistoricalWindow(
+      this.transformHourlyData(data, 'open-meteo-archive'),
+      window,
+      options.limit,
+    );
+
+    if (forecasts.length === 0) {
+      throw new NoResultsError(this.name, latitude, longitude);
+    }
+
+    return forecasts;
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      const response = await fetch(
+        `${this.forecastApiBase}?latitude=51.0447&longitude=-114.0719&hourly=temperature_2m&forecast_days=1&timezone=UTC`,
+      );
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async supportsLocation(
+    latitude: number,
+    longitude: number,
+  ): Promise<boolean> {
+    return (
+      !Number.isNaN(latitude) &&
+      !Number.isNaN(longitude) &&
+      latitude >= -90 &&
+      latitude <= 90 &&
+      longitude >= -180 &&
+      longitude <= 180
+    );
+  }
+
+  private buildBaseParams(
+    latitude: number,
+    longitude: number,
+  ): URLSearchParams {
+    return new URLSearchParams({
+      latitude: latitude.toString(),
+      longitude: longitude.toString(),
+      hourly: [
+        'temperature_2m',
+        'relative_humidity_2m',
+        'precipitation',
+        'weather_code',
+        'cloud_cover',
+        'wind_speed_10m',
+        'wind_direction_10m',
+        'wind_gusts_10m',
+        'visibility',
+      ].join(','),
+      temperature_unit: 'celsius',
+      wind_speed_unit: 'kmh',
+      precipitation_unit: 'mm',
+      timezone: 'UTC',
+    });
+  }
+
+  private async fetchJson<T>(url: string, timeout?: number): Promise<T> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      timeout || this.timeout,
+    );
+
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeoutId);
+
+      if (response.status === 429) {
+        throw new RateLimitError(this.name);
+      }
+
+      if (!response.ok) {
+        throw new WeatherError(
+          `API request failed: ${response.statusText}`,
+          this.name,
+          `HTTP_${response.status}`,
+        );
+      }
+
+      const data = (await response.json()) as OpenMeteoResponse;
+
+      if (data.error) {
+        throw new WeatherError(
+          data.reason || 'Open-Meteo API returned an error',
+          this.name,
+          'API_ERROR',
+          data,
+        );
+      }
+
+      return data as T;
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      if (error instanceof WeatherError) {
+        throw error;
+      }
+
+      if ((error as any).name === 'AbortError') {
+        throw new WeatherError('Request timeout', this.name, 'TIMEOUT');
+      }
+
+      throw new WeatherError(
+        `Failed to fetch weather data: ${(error as Error).message}`,
+        this.name,
+        'FETCH_ERROR',
+      );
+    }
+  }
+
+  private transformHourlyData(
+    data: OpenMeteoResponse,
+    source: string,
+  ): WeatherForecast[] {
+    const hourly = data.hourly;
+    if (!hourly?.time?.length) {
+      return [];
+    }
+
+    const forecasts: WeatherForecast[] = [];
+
+    for (let index = 0; index < hourly.time.length; index++) {
+      const timestamp = new Date(`${hourly.time[index]}Z`);
+      const temperature = hourly.temperature_2m?.[index];
+
+      if (
+        Number.isNaN(timestamp.getTime()) ||
+        typeof temperature !== 'number'
+      ) {
+        continue;
+      }
+
+      const weatherCode = hourly.weather_code?.[index];
+
+      forecasts.push({
+        timestamp,
+        temperature: roundToInt(temperature),
+        humidity: roundToInt(hourly.relative_humidity_2m?.[index] || 0),
+        windSpeed: roundToInt(hourly.wind_speed_10m?.[index] || 0),
+        windDirection: valueOrUndefined(hourly.wind_direction_10m?.[index]),
+        windGust:
+          typeof hourly.wind_gusts_10m?.[index] === 'number'
+            ? roundToInt(hourly.wind_gusts_10m[index]!)
+            : undefined,
+        conditions: describeOpenMeteoCode(weatherCode),
+        cloudCover: valueOrUndefined(hourly.cloud_cover?.[index]),
+        visibility:
+          typeof hourly.visibility?.[index] === 'number'
+            ? roundToInt(metersToKilometers(hourly.visibility[index]!))
+            : undefined,
+        precipAmount: valueOrUndefined(hourly.precipitation?.[index]),
+        confidence: source === 'open-meteo-archive' ? 100 : 90,
+        raw: {
+          source,
+          weatherCode,
+          latitude: data.latitude,
+          longitude: data.longitude,
+          timezone: data.timezone,
+          units: data.hourly_units,
+        },
+      });
+    }
+
+    return forecasts.sort(
+      (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+    );
+  }
+}
+
+function valueOrUndefined(
+  value: number | null | undefined,
+): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function describeOpenMeteoCode(code: number | null | undefined): string {
+  switch (code) {
+    case 0:
+      return 'Clear sky';
+    case 1:
+      return 'Mainly clear';
+    case 2:
+      return 'Partly cloudy';
+    case 3:
+      return 'Overcast';
+    case 45:
+    case 48:
+      return 'Fog';
+    case 51:
+    case 53:
+    case 55:
+      return 'Drizzle';
+    case 56:
+    case 57:
+      return 'Freezing drizzle';
+    case 61:
+    case 63:
+    case 65:
+      return 'Rain';
+    case 66:
+    case 67:
+      return 'Freezing rain';
+    case 71:
+    case 73:
+    case 75:
+      return 'Snow';
+    case 77:
+      return 'Snow grains';
+    case 80:
+    case 81:
+    case 82:
+      return 'Rain showers';
+    case 85:
+    case 86:
+      return 'Snow showers';
+    case 95:
+      return 'Thunderstorm';
+    case 96:
+    case 99:
+      return 'Thunderstorm with hail';
+    default:
+      return 'Unknown';
+  }
+}

--- a/packages/weather/src/providers/openweathermap-onecall.ts
+++ b/packages/weather/src/providers/openweathermap-onecall.ts
@@ -20,12 +20,14 @@
 
 import type {
   FetchOptions,
+  HistoricalFetchOptions,
   IWeatherProvider,
   WeatherForecast,
 } from '../shared/types';
 import {
   AuthenticationError,
   RateLimitError,
+  UnsupportedWeatherCapabilityError,
   WeatherError,
 } from '../shared/types';
 import {
@@ -206,6 +208,19 @@ export class OpenWeatherMapOneCallProvider implements IWeatherProvider {
         'FETCH_ERROR',
       );
     }
+  }
+
+  async fetchHistoricalForLocation(
+    latitude: number,
+    longitude: number,
+    _options: HistoricalFetchOptions,
+  ): Promise<WeatherForecast[]> {
+    ensureValidCoordinates(this.name, latitude, longitude);
+    throw new UnsupportedWeatherCapabilityError(
+      this.name,
+      'historical-weather',
+      'OpenWeatherMap One Call historical data is not exposed through the standardized adapter yet.',
+    );
   }
 
   /**

--- a/packages/weather/src/providers/openweathermap.ts
+++ b/packages/weather/src/providers/openweathermap.ts
@@ -185,7 +185,7 @@ export class OpenWeatherMapProvider implements IWeatherProvider {
     throw new UnsupportedWeatherCapabilityError(
       this.name,
       'historical-weather',
-      'OpenWeatherMap forecast API does not support standardized historical weather backfill.',
+      'The OpenWeatherMap forecast adapter does not expose OpenWeatherMap historical products yet.',
     );
   }
 

--- a/packages/weather/src/providers/openweathermap.ts
+++ b/packages/weather/src/providers/openweathermap.ts
@@ -17,12 +17,14 @@
 
 import type {
   FetchOptions,
+  HistoricalFetchOptions,
   IWeatherProvider,
   WeatherForecast,
 } from '../shared/types';
 import {
   AuthenticationError,
   RateLimitError,
+  UnsupportedWeatherCapabilityError,
   WeatherError,
 } from '../shared/types';
 import {
@@ -172,6 +174,19 @@ export class OpenWeatherMapProvider implements IWeatherProvider {
         'FETCH_ERROR',
       );
     }
+  }
+
+  async fetchHistoricalForLocation(
+    latitude: number,
+    longitude: number,
+    _options: HistoricalFetchOptions,
+  ): Promise<WeatherForecast[]> {
+    ensureValidCoordinates(this.name, latitude, longitude);
+    throw new UnsupportedWeatherCapabilityError(
+      this.name,
+      'historical-weather',
+      'OpenWeatherMap forecast API does not support standardized historical weather backfill.',
+    );
   }
 
   /**

--- a/packages/weather/src/shared/historical.ts
+++ b/packages/weather/src/shared/historical.ts
@@ -12,6 +12,16 @@ export function normalizeHistoricalWindow(
   provider: string,
   options: HistoricalFetchOptions,
 ): HistoricalWindow {
+  const interval = options.interval || 'hourly';
+  if (interval !== 'hourly') {
+    throw new WeatherError(
+      `Unsupported historical weather interval: ${interval}`,
+      provider,
+      'UNSUPPORTED_INTERVAL',
+      { interval },
+    );
+  }
+
   const start = parseHistoricalDate(provider, options.start, 'start');
   const end = parseHistoricalDate(
     provider,
@@ -57,6 +67,7 @@ export function filterHistoricalWindow<T extends WeatherForecast>(
 export function hoursBetween(start: Date, end: Date): number {
   return Math.max(
     1,
+    // +1 ensures the requested window is fully covered before filtering.
     Math.ceil((end.getTime() - start.getTime()) / HOUR_MS) + 1,
   );
 }

--- a/packages/weather/src/shared/historical.ts
+++ b/packages/weather/src/shared/historical.ts
@@ -1,0 +1,85 @@
+import type { HistoricalFetchOptions, WeatherForecast } from './types';
+import { WeatherError } from './types';
+
+export interface HistoricalWindow {
+  start: Date;
+  end: Date;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export function normalizeHistoricalWindow(
+  provider: string,
+  options: HistoricalFetchOptions,
+): HistoricalWindow {
+  const start = parseHistoricalDate(provider, options.start, 'start');
+  const end = parseHistoricalDate(
+    provider,
+    options.end || options.start,
+    'end',
+  );
+
+  if (end.getTime() < start.getTime()) {
+    throw new WeatherError(
+      'Historical weather end time must be after start time',
+      provider,
+      'INVALID_DATE_RANGE',
+      {
+        start: start.toISOString(),
+        end: end.toISOString(),
+      },
+    );
+  }
+
+  return { start, end };
+}
+
+export function filterHistoricalWindow<T extends WeatherForecast>(
+  forecasts: T[],
+  window: HistoricalWindow,
+  limit?: number,
+): T[] {
+  const filtered = forecasts
+    .filter(
+      (forecast) =>
+        forecast.timestamp.getTime() >= window.start.getTime() &&
+        forecast.timestamp.getTime() <= window.end.getTime(),
+    )
+    .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+  if (limit && limit > 0) {
+    return filtered.slice(0, limit);
+  }
+
+  return filtered;
+}
+
+export function hoursBetween(start: Date, end: Date): number {
+  return Math.max(
+    1,
+    Math.ceil((end.getTime() - start.getTime()) / HOUR_MS) + 1,
+  );
+}
+
+export function formatUtcDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function parseHistoricalDate(
+  provider: string,
+  value: Date | string,
+  field: string,
+): Date {
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new WeatherError(
+      `Invalid historical weather ${field} time`,
+      provider,
+      'INVALID_DATE_RANGE',
+      { [field]: value },
+    );
+  }
+
+  return date;
+}

--- a/packages/weather/src/shared/types.ts
+++ b/packages/weather/src/shared/types.ts
@@ -76,6 +76,20 @@ export interface FetchOptions {
 }
 
 /**
+ * Fetch options for historical weather data.
+ */
+export interface HistoricalFetchOptions extends FetchOptions {
+  /** Start of the requested historical window */
+  start: Date | string;
+
+  /** End of the requested historical window. Defaults to start. */
+  end?: Date | string;
+
+  /** Requested granularity. Providers may support only hourly data. */
+  interval?: 'hourly';
+}
+
+/**
  * Core weather provider interface
  * All weather providers must implement this interface
  */
@@ -98,6 +112,23 @@ export interface IWeatherProvider {
     latitude: number,
     longitude: number,
     options?: FetchOptions,
+  ): Promise<WeatherForecast[]>;
+
+  /**
+   * Fetch historical weather observations for a location.
+   *
+   * Providers that cannot serve historical data must reject with
+   * UnsupportedWeatherCapabilityError instead of silently falling back.
+   *
+   * @param latitude - Location latitude (-90 to 90)
+   * @param longitude - Location longitude (-180 to 180)
+   * @param options - Historical fetch options
+   * @returns Array of historical weather observations
+   */
+  fetchHistoricalForLocation(
+    latitude: number,
+    longitude: number,
+    options: HistoricalFetchOptions,
   ): Promise<WeatherForecast[]>;
 
   /**
@@ -166,6 +197,15 @@ export interface GoogleWeatherOptions {
 }
 
 /**
+ * Open-Meteo provider options
+ */
+export interface OpenMeteoOptions {
+  provider: 'open-meteo';
+  /** Request timeout in milliseconds (default: 10000) */
+  timeout?: number;
+}
+
+/**
  * Weather alert from Google Weather API
  */
 export interface WeatherAlert {
@@ -192,7 +232,8 @@ export type WeatherAdapterOptions =
   | EnvironmentCanadaOptions
   | OpenWeatherMapOptions
   | OpenWeatherMapOneCallOptions
-  | GoogleWeatherOptions;
+  | GoogleWeatherOptions
+  | OpenMeteoOptions;
 
 /**
  * Partial provider options for environment variable configuration
@@ -202,12 +243,14 @@ export type PartialWeatherAdapterOptions = Partial<
 > &
   Partial<Omit<OpenWeatherMapOptions, 'provider'>> &
   Partial<Omit<OpenWeatherMapOneCallOptions, 'provider'>> &
-  Partial<Omit<GoogleWeatherOptions, 'provider'>> & {
+  Partial<Omit<GoogleWeatherOptions, 'provider'>> &
+  Partial<Omit<OpenMeteoOptions, 'provider'>> & {
     provider?:
       | 'environment-canada'
       | 'openweathermap'
       | 'openweathermap-onecall'
-      | 'google-weather';
+      | 'google-weather'
+      | 'open-meteo';
   };
 
 /**
@@ -286,5 +329,21 @@ export class NoResultsError extends WeatherError {
       { latitude, longitude },
     );
     this.name = 'NoResultsError';
+  }
+}
+
+/**
+ * Unsupported capability error - thrown when a provider cannot serve an optional capability.
+ */
+export class UnsupportedWeatherCapabilityError extends WeatherError {
+  constructor(provider: string, capability: string, message?: string) {
+    super(
+      message ||
+        `${provider} does not support weather capability: ${capability}`,
+      provider,
+      'UNSUPPORTED_CAPABILITY',
+      { capability },
+    );
+    this.name = 'UnsupportedWeatherCapabilityError';
   }
 }


### PR DESCRIPTION
## Summary
- Add standardized historical weather lookup to the weather provider contract.
- Implement Google history delegation, Environment Canada historical lookup, Open-Meteo archive support, and typed unsupported-capability behavior.
- Keep local file writes under the configured filesystem base path for QA ingest flows.

## Tests
- pnpm --filter @happyvertical/weather exec vitest run src/__tests__/historical-weather.spec.ts
- pnpm --filter @happyvertical/files exec vitest run src/filesystem.test.ts
- pnpm --filter @happyvertical/weather build
- pnpm --filter @happyvertical/files build
- pnpm typecheck (via pre-push hook)
- git diff --check
