### PR TITLE
fix(video): extract animated webp frames individually

### DIFF
--- a/packages/video/src/adapters/ffmpeg.ts
+++ b/packages/video/src/adapters/ffmpeg.ts
@@ -682,9 +682,7 @@ export class FFmpegProcessor implements VideoProcessor {
 
       // Extract each frame as PNG using sharp's page option
       for (let i = 0; i < frameCount; i++) {
-        const frame = await sharp(webp, { animated: true, page: i })
-          .png()
-          .toBuffer();
+        const frame = await sharp(webp, { page: i, pages: 1 }).png().toBuffer();
 
         const framePath = join(
           tempDir,

--- a/packages/video/src/index.spec.ts
+++ b/packages/video/src/index.spec.ts
@@ -1,5 +1,39 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import sharp from 'sharp';
 import { describe, expect, it } from 'vitest';
 import { FFmpegProcessor } from './index.js';
+
+async function createTwoFrameAnimatedWebp(): Promise<Buffer> {
+  const width = 8;
+  const frameHeight = 8;
+  const frameCount = 2;
+  const channels = 4;
+  const raw = Buffer.alloc(width * frameHeight * frameCount * channels);
+
+  for (let y = 0; y < frameHeight * frameCount; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const offset = (y * width + x) * channels;
+      const isFirstFrame = y < frameHeight;
+      raw[offset] = isFirstFrame ? 255 : 0;
+      raw[offset + 1] = isFirstFrame ? 0 : 255;
+      raw[offset + 2] = 0;
+      raw[offset + 3] = 255;
+    }
+  }
+
+  return sharp(raw, {
+    raw: {
+      width,
+      height: frameHeight * frameCount,
+      channels,
+      pageHeight: frameHeight,
+    },
+  })
+    .webp({ loop: 0, delay: [100, 100] })
+    .toBuffer();
+}
 
 describe('video package', () => {
   describe('exports', () => {
@@ -21,6 +55,69 @@ describe('video package', () => {
         ffprobePath: '/custom/ffprobe',
       });
       expect(processor).toBeInstanceOf(FFmpegProcessor);
+    });
+
+    it('extracts animated WEBP pages as individual frame images', async () => {
+      const frameHeight = 8;
+      const tempRoot = await mkdtemp(join(tmpdir(), 'video-webp-'));
+      const inspectedFrames: Array<{
+        height: number | undefined;
+        firstPixel: number[];
+      }> = [];
+
+      try {
+        const processor = new FFmpegProcessor({ tempDir: tempRoot });
+        (
+          processor as unknown as {
+            runFFmpeg: (args: string[]) => Promise<void>;
+          }
+        ).runFFmpeg = async (args) => {
+          const inputFlagIndex = args.lastIndexOf('-i');
+          if (inputFlagIndex < 0 || inputFlagIndex === args.length - 1) {
+            throw new Error('Expected FFmpeg args to include an input pattern');
+          }
+
+          const inputPattern = args[inputFlagIndex + 1];
+          const outputPath = args.at(-1);
+          if (!inputPattern || !outputPath) {
+            throw new Error('Expected FFmpeg input pattern and output path');
+          }
+
+          const frameDir = dirname(inputPattern);
+          for (let frame = 1; frame <= 2; frame += 1) {
+            const framePath = join(
+              frameDir,
+              `frame_${String(frame).padStart(4, '0')}.png`,
+            );
+            const metadata = await sharp(framePath).metadata();
+            const pixels = await sharp(framePath).raw().toBuffer();
+            inspectedFrames.push({
+              height: metadata.height,
+              firstPixel: Array.from(pixels.slice(0, 3)),
+            });
+          }
+
+          await writeFile(outputPath, Buffer.from('mp4'));
+        };
+
+        const result = await processor.convertWebpToMp4(
+          await createTwoFrameAnimatedWebp(),
+        );
+
+        expect(result.toString()).toBe('mp4');
+        expect(inspectedFrames.map((frame) => frame.height)).toEqual([
+          frameHeight,
+          frameHeight,
+        ]);
+        expect(inspectedFrames[0].firstPixel[0]).toBeGreaterThan(
+          inspectedFrames[0].firstPixel[1],
+        );
+        expect(inspectedFrames[1].firstPixel[1]).toBeGreaterThan(
+          inspectedFrames[1].firstPixel[0],
+        );
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- fix animated WebP-to-MP4 conversion to extract one page per frame instead of loading all animation pages for each frame
- add a regression test that builds a two-frame animated WebP and verifies the generated PNG frame inputs are individual pages

## Why
`sharp(webp, { animated: true, page: i })` treats `animated: true` as loading every page. For the first frame, this can produce a stacked multi-page image instead of a single frame, which breaks downstream MP4 assembly. Using `{ page: i, pages: 1 }` makes each loop iteration extract exactly one frame.

## Validation
- `pnpm turbo run build --filter=@happyvertical/video^...`
- `pnpm --filter @happyvertical/video test`
- `pnpm --filter @happyvertical/video build`
- pre-push `pnpm typecheck` via lefthook
