### PR TITLE
feat(social): add Garrula social publishing primitives

### DIFF
--- a/packages/social/README.md
+++ b/packages/social/README.md
@@ -13,14 +13,15 @@ A unified interface for publishing content to social platforms in the HAVE SDK.
 
 ## Overview
 
-The `@happyvertical/social` package provides adapters for publishing text, images, and videos to major social platforms including YouTube, Threads, X (Twitter), and Bluesky. Each adapter implements a consistent interface, making it easy to publish to multiple platforms with the same code.
+The `@happyvertical/social` package provides adapters for publishing links, text, images, and videos to major social platforms including YouTube, Facebook Pages, Threads, X (Twitter), and Bluesky. Each adapter implements a consistent interface, making it easy to publish to multiple platforms with the same code.
 
 ## Features
 
-- **Multi-Platform Support**: YouTube, Threads, X (Twitter), Bluesky
+- **Multi-Platform Support**: YouTube, Facebook Pages, Threads, X (Twitter), Bluesky
 - **Unified Interface**: Consistent API across all platforms
-- **OAuth Support**: Built-in OAuth 2.0 with PKCE for YouTube
-- **Media Publishing**: Support for text, images, and video content
+- **OAuth Support**: Built-in OAuth 2.0 with PKCE for YouTube and OAuth 1.0a/OAuth 2.0 support for X
+- **Media Publishing**: Support for link, text, image, and video content
+- **Safety Modes**: Dry-run and non-public publish modes for testing without public posts
 - **Cross-Posting**: Publish to multiple platforms simultaneously
 - **Analytics**: Retrieve post engagement metrics
 - **Platform Capabilities**: Query platform-specific limits and features
@@ -91,13 +92,18 @@ const adapters = await getSocialMulti([
     accessToken: process.env.X_ACCESS_TOKEN!,
     accessSecret: process.env.X_ACCESS_SECRET!,
   },
+  {
+    type: 'facebook',
+    pageId: process.env.FACEBOOK_PAGE_ID!,
+    accessToken: process.env.FACEBOOK_PAGE_ACCESS_TOKEN!,
+  },
 ]);
 
-// Publish to all platforms at once
+// Publish a story link to all supported platforms at once
 const results = await publishToAll(adapters, {
-  type: 'text',
+  type: 'link',
   text: 'Breaking news from Bentley!',
-  linkUrl: 'https://example.com/article',
+  url: 'https://example.com/article',
   tags: ['news', 'local'],
 });
 
@@ -109,6 +115,28 @@ for (const [platform, result] of results) {
     console.log(`${platform}: Failed - ${result.error?.message}`);
   }
 }
+```
+
+### Safety Modes
+
+Adapters default to public publishing for backward compatibility. Set `publishMode` when testing request shapes or creating non-public platform objects.
+
+```typescript
+const youtube = await getSocial({
+  type: 'youtube',
+  clientId: process.env.YOUTUBE_CLIENT_ID!,
+  clientSecret: process.env.YOUTUBE_CLIENT_SECRET!,
+  accessToken: 'user-access-token',
+  publishMode: 'private_or_scheduled',
+});
+
+const result = await youtube.publishVideo({
+  file: videoBuffer,
+  title: 'Council update',
+  isShort: true,
+});
+
+console.log(result.status); // "staged"
 ```
 
 ## Platform Adapters
@@ -175,6 +203,13 @@ await bluesky.publishImage({
   description: 'Image description',
   altText: 'Accessible alt text',
 });
+
+// Publish a first-class link card
+await bluesky.publishLink({
+  url: 'https://example.com/article',
+  title: 'Local story',
+  description: 'A short summary for the card',
+});
 ```
 
 ### X (Twitter)
@@ -208,7 +243,8 @@ await x.publishImage({
 await x.publishVideo({
   file: videoBuffer,
   description: 'Watch the latest update',
-  linkUrl: 'https://example.com', // Posted as reply for better algorithm
+  linkUrl: 'https://example.com', // Inline by default
+  linkBehavior: 'reply', // Optional: post the link as a reply instead
 });
 ```
 
@@ -232,6 +268,40 @@ await threads.publishImage({
   file: 'https://example.com/image.png', // URL required, not buffer
   description: 'Image caption',
 });
+
+// Publish a link attachment
+await threads.publishLink({
+  url: 'https://example.com/article',
+  text: 'Read the latest story',
+});
+```
+
+### Facebook Pages
+
+```typescript
+const facebook = await getSocial({
+  type: 'facebook',
+  pageId: 'page-id',
+  accessToken: 'page-access-token',
+});
+
+// Publish a Page feed link post
+await facebook.publishLink({
+  url: 'https://example.com/article',
+  text: 'Read the latest story',
+});
+
+// Create an unpublished Page post for testing
+const safeFacebook = await getSocial({
+  type: 'facebook',
+  pageId: 'page-id',
+  accessToken: 'page-access-token',
+  publishMode: 'private_or_scheduled',
+});
+
+await safeFacebook.publishText({
+  text: 'Draft post',
+});
 ```
 
 ## API Reference
@@ -252,6 +322,7 @@ interface SocialPlatform {
   publishVideo(video: VideoPost): Promise<PostResult>;
   publishImage(image: ImagePost): Promise<PostResult>;
   publishText(text: TextPost): Promise<PostResult>;
+  publishLink(link: LinkPost): Promise<PostResult>;
 
   // Management
   getPost(postId: string): Promise<Post>;
@@ -272,12 +343,13 @@ console.log(`Max video size: ${caps.maxVideoSize / (1024 * 1024)}MB`);
 console.log(`Supports scheduling: ${caps.scheduling}`);
 ```
 
-| Platform | Video | Image | Text | Scheduling | Max Video |
-|----------|-------|-------|------|------------|-----------|
-| YouTube | ✓ | ✗ | ✗ | ✓ | 256GB |
-| Threads | ✓ | ✓ | ✓ | ✗ | 1GB |
-| X | ✓ | ✓ | ✓ | ✗ | 512MB |
-| Bluesky | ✗ | ✓ | ✓ | ✗ | N/A |
+| Platform | Link | Video | Image | Text | Scheduling | Safe non-public mode | Max Video |
+|----------|------|-------|-------|------|------------|----------------------|-----------|
+| YouTube | ✗ | ✓ | ✗ | ✗ | ✓ | private upload | 256GB |
+| Facebook Pages | ✓ | ✓ | ✓ | ✓ | ✓ | unpublished/scheduled | 10GB |
+| Threads | ✓ | ✓ | ✓ | ✓ | ✗ | staged container | 1GB |
+| X | ✓ | ✓ | ✓ | ✓ | ✗ | staged media/dry run | 512MB |
+| Bluesky | ✓ | ✗ | ✓ | ✓ | ✗ | dry run/blob staging | N/A |
 
 ## Error Handling
 
@@ -316,6 +388,8 @@ interface VideoPost {
   visibility?: 'public' | 'unlisted' | 'private';
   scheduledAt?: Date;
   categoryId?: string; // YouTube category
+  isShort?: boolean;
+  linkBehavior?: 'inline' | 'attachment' | 'reply' | 'none';
 }
 
 interface ImagePost {
@@ -324,6 +398,7 @@ interface ImagePost {
   altText?: string;
   linkUrl?: string;
   tags?: string[];
+  linkBehavior?: 'inline' | 'attachment' | 'reply' | 'none';
 }
 
 interface TextPost {
@@ -331,22 +406,35 @@ interface TextPost {
   linkUrl?: string;
   tags?: string[];
   replyTo?: string; // Post ID to reply to
+  linkBehavior?: 'inline' | 'attachment' | 'reply' | 'none';
+}
+
+interface LinkPost {
+  url: string;
+  text?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  scheduledAt?: Date;
+  linkBehavior?: 'inline' | 'attachment' | 'reply' | 'none';
 }
 
 interface PostResult {
   id: string;
   url: string;
-  status: 'published' | 'scheduled' | 'processing';
+  status: 'published' | 'scheduled' | 'processing' | 'staged' | 'dry_run';
   publishedAt?: Date;
   scheduledAt?: Date;
 }
 
 interface PostAnalytics {
   views?: number;
+  impressions?: number;
   likes?: number;
   comments?: number;
   shares?: number;
   clicks?: number;
+  raw?: unknown;
   lastUpdated?: Date;
 }
 ```
@@ -376,12 +464,12 @@ youtube.authenticate().catch(async (error) => {
 ### Platform-Specific Optimization
 
 ```typescript
-// X: Post link as reply for better algorithm performance
-// The adapter handles this automatically when linkUrl is provided
+// X: Inline links by default, or post links as replies per account/post
 await x.publishVideo({
   file: videoBuffer,
   description: 'Watch the news',
-  linkUrl: 'https://example.com/article', // Posted as separate reply
+  linkUrl: 'https://example.com/article',
+  linkBehavior: 'reply',
 });
 
 // YouTube: Use scheduling for optimal posting times

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@happyvertical/social",
   "version": "0.73.2",
-  "description": "Social platform adapters for publishing to YouTube, Threads, X, and Bluesky",
+  "description": "Social platform adapters for publishing to YouTube, Facebook Pages, Threads, X, and Bluesky",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "test": "npx vitest run",
+    "test:live": "HV_SOCIAL_LIVE_SMOKE=1 npx vitest run src/live-smoke.optional.test.ts",
     "test:watch": "npx vitest",
     "build": "vite build",
     "build:watch": "vite build --watch",

--- a/packages/social/src/adapters/bluesky.ts
+++ b/packages/social/src/adapters/bluesky.ts
@@ -4,12 +4,16 @@
  * Implements SocialPlatform interface for Bluesky (AT Protocol) publishing.
  */
 
-import { createLogger } from '@happyvertical/logger';
-
+import {
+  createSafetyResult,
+  isPublicPublishMode,
+  resolvePublishMode,
+} from '../safety.js';
 import type {
   AuthResult,
   BlueskyConfig,
   ImagePost,
+  LinkPost,
   PlatformCapabilities,
   Post,
   PostAnalytics,
@@ -25,6 +29,28 @@ import {
 } from '../types.js';
 
 const DEFAULT_PDS = 'https://bsky.social';
+
+type BlueskyPostRecord = Record<string, unknown> & {
+  $type: 'app.bsky.feed.post';
+  text: string;
+  createdAt: string;
+};
+
+interface BlueskyReplyRef {
+  root: {
+    uri: string;
+    cid: string;
+  };
+  parent: {
+    uri: string;
+    cid: string;
+  };
+}
+
+interface BlueskyApiError {
+  message?: string;
+  error?: string;
+}
 
 /**
  * Bluesky adapter for publishing via AT Protocol
@@ -48,7 +74,6 @@ const DEFAULT_PDS = 'https://bsky.social';
 export class BlueskyAdapter implements SocialPlatform {
   readonly platform = 'bluesky' as const;
   private config: BlueskyConfig;
-  private logger: ReturnType<typeof createLogger>;
   private session?: {
     did: string;
     handle: string;
@@ -58,7 +83,6 @@ export class BlueskyAdapter implements SocialPlatform {
 
   constructor(config: BlueskyConfig) {
     this.config = config;
-    this.logger = createLogger({ level: 'info' });
   }
 
   private get pdsUrl(): string {
@@ -148,6 +172,27 @@ export class BlueskyAdapter implements SocialPlatform {
   }
 
   async publishImage(image: ImagePost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
+    const text = this.buildPostText(
+      image.description,
+      image.tags,
+      image.linkUrl,
+    );
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload: {
+          text,
+          altText: image.altText,
+          linkUrl: image.linkUrl,
+        },
+        note: 'Bluesky dry run: blob was not uploaded and no post was created.',
+      });
+    }
+
     if (!this.session) {
       await this.authenticate();
     }
@@ -177,13 +222,24 @@ export class BlueskyAdapter implements SocialPlatform {
 
     const blobData = await blobResponse.json();
 
-    // Create post with image embed
-    const text = this.buildPostText(
-      image.description,
-      image.tags,
-      image.linkUrl,
-    );
+    if (!isPublicPublishMode(publishMode)) {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload: {
+          text,
+          altText: image.altText,
+          blob: blobData.blob,
+          linkUrl: image.linkUrl,
+        },
+        remoteId: blobData.blob?.ref?.$link ?? blobData.blob?.cid,
+        staged: true,
+        note: 'Bluesky blob uploaded but no post record was created.',
+      });
+    }
 
+    // Create post with image embed
     const record = {
       $type: 'app.bsky.feed.post',
       text,
@@ -203,13 +259,10 @@ export class BlueskyAdapter implements SocialPlatform {
   }
 
   async publishText(text: TextPost): Promise<PostResult> {
-    if (!this.session) {
-      await this.authenticate();
-    }
-
+    const publishMode = resolvePublishMode(this.config);
     const postText = this.buildPostText(text.text, text.tags);
 
-    const record: any = {
+    const record: BlueskyPostRecord = {
       $type: 'app.bsky.feed.post',
       text: postText,
       createdAt: new Date().toISOString(),
@@ -246,9 +299,70 @@ export class BlueskyAdapter implements SocialPlatform {
       }
     }
 
+    if (!isPublicPublishMode(publishMode)) {
+      if (text.replyTo) {
+        record.replyTo = text.replyTo;
+      }
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'text',
+        payload: record,
+        note:
+          publishMode === 'dry_run'
+            ? 'Bluesky dry run: no post record was created.'
+            : 'Bluesky has no non-public text staging endpoint; no post record was created.',
+      });
+    }
+
+    if (!this.session) {
+      await this.authenticate();
+    }
+
     // Handle reply
     if (text.replyTo) {
       record.reply = await this.getReplyRef(text.replyTo);
+    }
+
+    return this.createPost(record);
+  }
+
+  async publishLink(link: LinkPost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
+    const postText = this.buildPostText(
+      link.text ?? link.title ?? link.description ?? link.url,
+      link.tags,
+    );
+
+    const record: BlueskyPostRecord = {
+      $type: 'app.bsky.feed.post',
+      text: postText,
+      createdAt: new Date().toISOString(),
+      embed: {
+        $type: 'app.bsky.embed.external',
+        external: {
+          uri: link.url,
+          title: link.title ?? link.url,
+          description: link.description ?? '',
+        },
+      },
+    };
+
+    if (!isPublicPublishMode(publishMode)) {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'link',
+        payload: record,
+        note:
+          publishMode === 'dry_run'
+            ? 'Bluesky dry run: no post record was created.'
+            : 'Bluesky has no non-public link staging endpoint; no post record was created.',
+      });
+    }
+
+    if (!this.session) {
+      await this.authenticate();
     }
 
     return this.createPost(record);
@@ -285,6 +399,7 @@ export class BlueskyAdapter implements SocialPlatform {
       url: `https://bsky.app/profile/${this.session?.handle}/post/${postId}`,
       status: 'published',
       publishedAt: new Date(),
+      metadata: { publishMode: resolvePublishMode(this.config) },
     };
   }
 
@@ -323,6 +438,13 @@ export class BlueskyAdapter implements SocialPlatform {
         likes: post.likeCount,
         shares: post.repostCount,
         comments: post.replyCount,
+        lastUpdated: new Date(),
+        raw: {
+          likeCount: post.likeCount,
+          repostCount: post.repostCount,
+          replyCount: post.replyCount,
+          quoteCount: post.quoteCount,
+        },
       },
     };
   }
@@ -365,21 +487,28 @@ export class BlueskyAdapter implements SocialPlatform {
       video: false, // Limited video support
       image: true,
       text: true,
+      link: true,
+      linkAttachment: true,
       scheduling: false,
       analytics: true,
+      rawAnalytics: true,
+      publishModes: ['dry_run', 'stage_remote', 'public'],
+      staging: true,
+      privatePublishing: false,
       maxVideoLength: 0,
       maxVideoSize: 0,
       supportedVideoFormats: [],
       aspectRatios: ['1:1', '16:9', '4:3'],
       maxTextLength: 300,
       maxHashtags: undefined, // No limit
+      supportedPostTypes: ['text', 'image', 'link'],
     };
   }
 
   /**
    * Get reply reference for threading
    */
-  private async getReplyRef(parentUri: string): Promise<any> {
+  private async getReplyRef(parentUri: string): Promise<BlueskyReplyRef> {
     const response = await fetch(
       `${this.pdsUrl}/xrpc/app.bsky.feed.getPostThread?uri=${encodeURIComponent(parentUri)}&depth=0`,
       {
@@ -445,9 +574,9 @@ export class BlueskyAdapter implements SocialPlatform {
    */
   private async handleError(response: Response): Promise<never> {
     const text = await response.text();
-    let error;
+    let error: BlueskyApiError;
     try {
-      error = JSON.parse(text);
+      error = JSON.parse(text) as BlueskyApiError;
     } catch {
       error = { message: text };
     }

--- a/packages/social/src/adapters/bluesky.ts
+++ b/packages/social/src/adapters/bluesky.ts
@@ -4,6 +4,7 @@
  * Implements SocialPlatform interface for Bluesky (AT Protocol) publishing.
  */
 
+import { resolveMediaData } from '../media.js';
 import {
   createSafetyResult,
   isPublicPublishMode,
@@ -156,19 +157,12 @@ export class BlueskyAdapter implements SocialPlatform {
     };
   }
 
-  async publishVideo(video: VideoPost): Promise<PostResult> {
-    // Bluesky supports video via embed
-    // For now, post with link to video
-    const text = this.buildPostText(
-      video.description,
-      video.tags,
-      video.linkUrl,
+  async publishVideo(_video: VideoPost): Promise<PostResult> {
+    throw new SocialError(
+      'Bluesky video publishing is not supported yet',
+      'NOT_SUPPORTED',
+      'bluesky',
     );
-
-    return this.publishText({
-      text,
-      linkUrl: video.linkUrl,
-    });
   }
 
   async publishImage(image: ImagePost): Promise<PostResult> {
@@ -197,12 +191,11 @@ export class BlueskyAdapter implements SocialPlatform {
       await this.authenticate();
     }
 
-    // Upload blob first
-    const imageData = Buffer.isBuffer(image.file)
-      ? image.file
-      : await fetch(image.file)
-          .then((r) => r.arrayBuffer())
-          .then(Buffer.from);
+    // Upload blob first.
+    const imageData = await resolveMediaData(image.file, {
+      explicitMimeType: image.mimeType,
+      fallbackMimeType: 'image/png',
+    });
 
     const blobResponse = await fetch(
       `${this.pdsUrl}/xrpc/com.atproto.repo.uploadBlob`,
@@ -210,9 +203,9 @@ export class BlueskyAdapter implements SocialPlatform {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${this.session?.accessJwt}`,
-          'Content-Type': 'image/png',
+          'Content-Type': imageData.mimeType,
         },
-        body: new Uint8Array(imageData),
+        body: new Uint8Array(imageData.data),
       },
     );
 
@@ -232,6 +225,7 @@ export class BlueskyAdapter implements SocialPlatform {
           altText: image.altText,
           blob: blobData.blob,
           linkUrl: image.linkUrl,
+          mimeType: imageData.mimeType,
         },
         remoteId: blobData.blob?.ref?.$link ?? blobData.blob?.cid,
         staged: true,
@@ -300,14 +294,12 @@ export class BlueskyAdapter implements SocialPlatform {
     }
 
     if (!isPublicPublishMode(publishMode)) {
-      if (text.replyTo) {
-        record.replyTo = text.replyTo;
-      }
       return createSafetyResult({
         platform: this.platform,
         mode: publishMode,
         postType: 'text',
         payload: record,
+        metadata: text.replyTo ? { replyTo: text.replyTo } : undefined,
         note:
           publishMode === 'dry_run'
             ? 'Bluesky dry run: no post record was created.'

--- a/packages/social/src/adapters/facebook.ts
+++ b/packages/social/src/adapters/facebook.ts
@@ -447,16 +447,20 @@ export class FacebookPageAdapter implements SocialPlatform {
         case 'post_reactions_by_type_total':
           analytics.likes =
             typeof value === 'object' && value !== null
-              ? Object.values(value).reduce<number>(
-                  (sum, count) => sum + (typeof count === 'number' ? count : 0),
-                  0,
-                )
+              ? this.sumPositiveReactions(value as Record<string, unknown>)
               : undefined;
           break;
       }
     }
 
     return analytics;
+  }
+
+  private sumPositiveReactions(reactions: Record<string, unknown>): number {
+    return ['like', 'love', 'haha', 'wow'].reduce((sum, key) => {
+      const count = reactions[key];
+      return sum + (typeof count === 'number' ? count : 0);
+    }, 0);
   }
 
   private async handleError(response: Response): Promise<never> {

--- a/packages/social/src/adapters/facebook.ts
+++ b/packages/social/src/adapters/facebook.ts
@@ -1,0 +1,465 @@
+/**
+ * Facebook Pages Adapter
+ *
+ * Implements SocialPlatform interface for Facebook Page publishing.
+ */
+
+import {
+  createSafetyResult,
+  isPublicPublishMode,
+  resolvePublishMode,
+} from '../safety.js';
+import type {
+  AuthResult,
+  FacebookPageConfig,
+  ImagePost,
+  LinkPost,
+  PlatformCapabilities,
+  Post,
+  PostAnalytics,
+  PostResult,
+  PublishMode,
+  SocialPlatform,
+  TextPost,
+  VideoPost,
+} from '../types.js';
+import {
+  SocialAuthError,
+  SocialError,
+  SocialRateLimitError,
+} from '../types.js';
+
+interface FacebookInsight {
+  name?: string;
+  values?: Array<{ value?: unknown }>;
+}
+
+interface FacebookApiError {
+  error?: {
+    code?: number | string;
+    message?: string;
+  };
+}
+
+/**
+ * Facebook Page adapter for publishing feed posts and Page videos.
+ */
+export class FacebookPageAdapter implements SocialPlatform {
+  readonly platform = 'facebook' as const;
+  private config: FacebookPageConfig;
+
+  constructor(config: FacebookPageConfig) {
+    this.config = config;
+  }
+
+  private get graphUrl(): string {
+    return `https://graph.facebook.com/${this.config.apiVersion ?? 'v24.0'}`;
+  }
+
+  async authenticate(): Promise<AuthResult> {
+    const response = await fetch(
+      `${this.graphUrl}/${this.config.pageId}?fields=id,name,link&access_token=${encodeURIComponent(this.config.accessToken)}`,
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    return {
+      accessToken: this.config.accessToken,
+    };
+  }
+
+  async refreshToken(_refreshToken: string): Promise<AuthResult> {
+    throw new SocialError(
+      'Facebook Page access tokens are refreshed through Meta OAuth',
+      'NOT_IMPLEMENTED',
+      'facebook',
+    );
+  }
+
+  async publishText(text: TextPost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'text',
+        payload: {
+          message: this.buildPostText(text.text, text.tags),
+          link: text.linkUrl,
+        },
+      });
+    }
+
+    return this.createFeedPost(
+      {
+        message: this.buildPostText(text.text, text.tags),
+        ...(text.linkUrl ? { link: text.linkUrl } : {}),
+        ...this.safetyFeedFields(publishMode, text.scheduledAt),
+      },
+      publishMode,
+    );
+  }
+
+  async publishLink(link: LinkPost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
+    const payload = {
+      message: this.buildPostText(
+        link.text ?? link.title ?? link.description ?? '',
+        link.tags,
+      ),
+      link: link.url,
+      ...this.safetyFeedFields(publishMode, link.scheduledAt),
+    };
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'link',
+        payload,
+      });
+    }
+
+    return this.createFeedPost(payload, publishMode);
+  }
+
+  async publishImage(image: ImagePost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload: {
+          caption: this.buildPostText(image.description, image.tags),
+          url: typeof image.file === 'string' ? image.file : undefined,
+          link: image.linkUrl,
+        },
+      });
+    }
+
+    const form = new FormData();
+    form.set('access_token', this.config.accessToken);
+    form.set('caption', this.buildPostText(image.description, image.tags));
+    for (const [key, value] of Object.entries(
+      this.safetyFeedFields(publishMode, image.scheduledAt),
+    )) {
+      if (value !== undefined) form.set(key, value);
+    }
+
+    if (typeof image.file === 'string') {
+      form.set('url', image.file);
+    } else {
+      form.set('source', new Blob([new Uint8Array(image.file)]));
+    }
+
+    const response = await fetch(
+      `${this.graphUrl}/${this.config.pageId}/photos`,
+      {
+        method: 'POST',
+        body: form,
+      },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    const data = await response.json();
+    return this.toPostResult(
+      data.post_id ?? data.id,
+      this.safetyResultStatus(publishMode, image.scheduledAt),
+      publishMode,
+    );
+  }
+
+  async publishVideo(video: VideoPost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'video',
+        payload: {
+          title: video.title,
+          description: this.buildPostText(video.description, video.tags),
+          fileUrl: typeof video.file === 'string' ? video.file : undefined,
+          link: video.linkUrl,
+          scheduledAt: video.scheduledAt?.toISOString(),
+        },
+      });
+    }
+
+    const form = new FormData();
+    form.set('access_token', this.config.accessToken);
+    form.set('description', this.buildPostText(video.description, video.tags));
+    for (const [key, value] of Object.entries(
+      this.safetyFeedFields(publishMode, video.scheduledAt),
+    )) {
+      if (value !== undefined) form.set(key, value);
+    }
+    if (video.title) {
+      form.set('title', video.title);
+    }
+    if (video.linkUrl) {
+      form.set('embeddable', 'true');
+    }
+
+    if (typeof video.file === 'string') {
+      form.set('file_url', video.file);
+    } else {
+      form.set('source', new Blob([new Uint8Array(video.file)]));
+    }
+
+    const response = await fetch(
+      `${this.graphUrl}/${this.config.pageId}/videos`,
+      {
+        method: 'POST',
+        body: form,
+      },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    const data = await response.json();
+    return this.toPostResult(
+      data.id,
+      this.safetyResultStatus(publishMode, video.scheduledAt, 'processing'),
+      publishMode,
+    );
+  }
+
+  async getPost(postId: string): Promise<Post> {
+    const response = await fetch(
+      `${this.graphUrl}/${postId}?fields=id,message,created_time,permalink_url,attachments{media_type},insights.metric(post_impressions,post_clicks,post_reactions_by_type_total,post_comments,post_shares)&access_token=${encodeURIComponent(this.config.accessToken)}`,
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    const data = await response.json();
+    const mediaType = data.attachments?.data?.[0]?.media_type;
+
+    return {
+      id: data.id,
+      url: data.permalink_url ?? `https://www.facebook.com/${data.id}`,
+      type:
+        mediaType === 'video'
+          ? 'video'
+          : mediaType === 'photo'
+            ? 'image'
+            : 'text',
+      description: data.message,
+      publishedAt: data.created_time ? new Date(data.created_time) : new Date(),
+      visibility: 'public',
+      analytics: this.parseInsights(data.insights?.data ?? []),
+    };
+  }
+
+  async deletePost(postId: string): Promise<void> {
+    const response = await fetch(
+      `${this.graphUrl}/${postId}?access_token=${encodeURIComponent(this.config.accessToken)}`,
+      { method: 'DELETE' },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+  }
+
+  async getAnalytics(postId: string): Promise<PostAnalytics> {
+    const post = await this.getPost(postId);
+    return post.analytics ?? {};
+  }
+
+  getCapabilities(): PlatformCapabilities {
+    return {
+      video: true,
+      image: true,
+      text: true,
+      link: true,
+      linkAttachment: true,
+      scheduling: true,
+      analytics: true,
+      rawAnalytics: true,
+      publishModes: [
+        'dry_run',
+        'stage_remote',
+        'private_or_scheduled',
+        'public',
+      ],
+      staging: true,
+      privatePublishing: true,
+      maxVideoLength: 240 * 60,
+      maxVideoSize: 10 * 1024 * 1024 * 1024,
+      supportedVideoFormats: ['mp4', 'mov'],
+      aspectRatios: ['16:9', '1:1', '9:16', '4:5'],
+      maxTextLength: 63206,
+      maxHashtags: undefined,
+      supportedPostTypes: ['text', 'image', 'video', 'link'],
+    };
+  }
+
+  private async createFeedPost(
+    fields: Record<string, string | undefined>,
+    publishMode: PublishMode = 'public',
+  ): Promise<PostResult> {
+    const body = new URLSearchParams();
+    body.set('access_token', this.config.accessToken);
+
+    for (const [key, value] of Object.entries(fields)) {
+      if (value !== undefined && value !== '') {
+        body.set(key, value);
+      }
+    }
+
+    const response = await fetch(
+      `${this.graphUrl}/${this.config.pageId}/feed`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    const data = await response.json();
+    const status =
+      fields.published === 'false' && fields.scheduled_publish_time
+        ? 'scheduled'
+        : fields.published === 'false'
+          ? 'staged'
+          : 'published';
+    return this.toPostResult(data.id, status, publishMode);
+  }
+
+  private toPostResult(
+    id: string,
+    status: PostResult['status'],
+    publishMode: PublishMode = 'public',
+  ): PostResult {
+    return {
+      id,
+      url: `https://www.facebook.com/${id}`,
+      status,
+      publishedAt: status === 'published' ? new Date() : undefined,
+      metadata: {
+        publishMode,
+        safety: publishMode !== 'public',
+      },
+    };
+  }
+
+  private safetyFeedFields(
+    publishMode: ReturnType<typeof resolvePublishMode>,
+    scheduledAt?: Date,
+  ): Record<string, string | undefined> {
+    if (isPublicPublishMode(publishMode)) {
+      return {};
+    }
+
+    return {
+      published: 'false',
+      ...(scheduledAt
+        ? {
+            scheduled_publish_time: Math.floor(
+              scheduledAt.getTime() / 1000,
+            ).toString(),
+          }
+        : {}),
+    };
+  }
+
+  private safetyResultStatus(
+    publishMode: ReturnType<typeof resolvePublishMode>,
+    scheduledAt?: Date,
+    publicStatus: PostResult['status'] = 'published',
+  ): PostResult['status'] {
+    if (isPublicPublishMode(publishMode)) return publicStatus;
+    return scheduledAt ? 'scheduled' : 'staged';
+  }
+
+  private buildPostText(text?: string, tags?: string[]): string {
+    let result = text ?? '';
+
+    if (tags && tags.length > 0) {
+      const hashtags = tags.map((tag) =>
+        tag.startsWith('#') ? tag : `#${tag}`,
+      );
+      result +=
+        result.length > 0 ? `\n\n${hashtags.join(' ')}` : hashtags.join(' ');
+    }
+
+    return result;
+  }
+
+  private parseInsights(insights: FacebookInsight[]): PostAnalytics {
+    const analytics: PostAnalytics = { lastUpdated: new Date(), raw: insights };
+
+    for (const insight of insights) {
+      const value = insight.values?.[0]?.value;
+      switch (insight.name) {
+        case 'post_impressions':
+          analytics.views = typeof value === 'number' ? value : undefined;
+          analytics.impressions = analytics.views;
+          break;
+        case 'post_clicks':
+          analytics.clicks = typeof value === 'number' ? value : undefined;
+          break;
+        case 'post_comments':
+          analytics.comments = typeof value === 'number' ? value : undefined;
+          break;
+        case 'post_shares':
+          analytics.shares = typeof value === 'number' ? value : undefined;
+          break;
+        case 'post_reactions_by_type_total':
+          analytics.likes =
+            typeof value === 'object' && value !== null
+              ? Object.values(value).reduce<number>(
+                  (sum, count) => sum + (typeof count === 'number' ? count : 0),
+                  0,
+                )
+              : undefined;
+          break;
+      }
+    }
+
+    return analytics;
+  }
+
+  private async handleError(response: Response): Promise<never> {
+    const text = await response.text();
+    let error: FacebookApiError;
+    try {
+      error = JSON.parse(text) as FacebookApiError;
+    } catch {
+      error = { error: { message: text } };
+    }
+
+    if (response.status === 401 || error.error?.code === 190) {
+      throw new SocialAuthError(
+        'facebook',
+        error.error?.message ?? 'Unauthorized',
+      );
+    }
+
+    if (response.status === 429 || error.error?.code === 4) {
+      throw new SocialRateLimitError('facebook');
+    }
+
+    throw new SocialError(
+      error.error?.message ?? 'API request failed',
+      error.error?.code?.toString() ?? 'API_ERROR',
+      'facebook',
+      response.status,
+    );
+  }
+}

--- a/packages/social/src/adapters/facebook.ts
+++ b/packages/social/src/adapters/facebook.ts
@@ -133,7 +133,11 @@ export class FacebookPageAdapter implements SocialPlatform {
         mode: publishMode,
         postType: 'image',
         payload: {
-          caption: this.buildPostText(image.description, image.tags),
+          caption: this.buildPostText(
+            image.description,
+            image.tags,
+            image.linkUrl,
+          ),
           url: typeof image.file === 'string' ? image.file : undefined,
           link: image.linkUrl,
         },
@@ -142,7 +146,10 @@ export class FacebookPageAdapter implements SocialPlatform {
 
     const form = new FormData();
     form.set('access_token', this.config.accessToken);
-    form.set('caption', this.buildPostText(image.description, image.tags));
+    form.set(
+      'caption',
+      this.buildPostText(image.description, image.tags, image.linkUrl),
+    );
     for (const [key, value] of Object.entries(
       this.safetyFeedFields(publishMode, image.scheduledAt),
     )) {
@@ -184,7 +191,11 @@ export class FacebookPageAdapter implements SocialPlatform {
         postType: 'video',
         payload: {
           title: video.title,
-          description: this.buildPostText(video.description, video.tags),
+          description: this.buildPostText(
+            video.description,
+            video.tags,
+            video.linkUrl,
+          ),
           fileUrl: typeof video.file === 'string' ? video.file : undefined,
           link: video.linkUrl,
           scheduledAt: video.scheduledAt?.toISOString(),
@@ -194,7 +205,10 @@ export class FacebookPageAdapter implements SocialPlatform {
 
     const form = new FormData();
     form.set('access_token', this.config.accessToken);
-    form.set('description', this.buildPostText(video.description, video.tags));
+    form.set(
+      'description',
+      this.buildPostText(video.description, video.tags, video.linkUrl),
+    );
     for (const [key, value] of Object.entries(
       this.safetyFeedFields(publishMode, video.scheduledAt),
     )) {
@@ -253,7 +267,9 @@ export class FacebookPageAdapter implements SocialPlatform {
           ? 'video'
           : mediaType === 'photo'
             ? 'image'
-            : 'text',
+            : mediaType === 'share'
+              ? 'link'
+              : 'text',
       description: data.message,
       publishedAt: data.created_time ? new Date(data.created_time) : new Date(),
       visibility: 'public',
@@ -387,8 +403,16 @@ export class FacebookPageAdapter implements SocialPlatform {
     return scheduledAt ? 'scheduled' : 'staged';
   }
 
-  private buildPostText(text?: string, tags?: string[]): string {
+  private buildPostText(
+    text?: string,
+    tags?: string[],
+    linkUrl?: string,
+  ): string {
     let result = text ?? '';
+
+    if (linkUrl && !result.includes(linkUrl)) {
+      result += result.length > 0 ? `\n\n${linkUrl}` : linkUrl;
+    }
 
     if (tags && tags.length > 0) {
       const hashtags = tags.map((tag) =>

--- a/packages/social/src/adapters/threads.ts
+++ b/packages/social/src/adapters/threads.ts
@@ -5,11 +5,15 @@
  * Uses Meta Graph API.
  */
 
-import { createLogger } from '@happyvertical/logger';
-
+import {
+  createSafetyResult,
+  isPublicPublishMode,
+  resolvePublishMode,
+} from '../safety.js';
 import type {
   AuthResult,
   ImagePost,
+  LinkPost,
   PlatformCapabilities,
   Post,
   PostAnalytics,
@@ -26,6 +30,18 @@ import {
 } from '../types.js';
 
 const THREADS_API_URL = 'https://graph.threads.net/v1.0';
+
+interface ThreadsInsight {
+  name?: string;
+  values?: Array<{ value?: unknown }>;
+}
+
+interface ThreadsApiError {
+  error?: {
+    code?: number | string;
+    message?: string;
+  };
+}
 
 /**
  * Threads adapter for publishing via Meta Graph API
@@ -49,11 +65,9 @@ const THREADS_API_URL = 'https://graph.threads.net/v1.0';
 export class ThreadsAdapter implements SocialPlatform {
   readonly platform = 'threads' as const;
   private config: ThreadsConfig;
-  private logger: ReturnType<typeof createLogger>;
 
   constructor(config: ThreadsConfig) {
     this.config = config;
-    this.logger = createLogger({ level: 'info' });
   }
 
   async authenticate(): Promise<AuthResult> {
@@ -91,18 +105,32 @@ export class ThreadsAdapter implements SocialPlatform {
   }
 
   async publishVideo(video: VideoPost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
     // Step 1: Create media container
-    const text = this.buildPostText(
-      video.description,
-      video.tags,
-      video.linkUrl,
-    );
+    const text = this.buildPostText(video.description, video.tags);
 
     // For video, we need a URL (can't upload buffer directly)
     const videoUrl = Buffer.isBuffer(video.file)
       ? await this.uploadToTempStorage(video.file, 'video/mp4')
       : video.file;
 
+    const payload = {
+      media_type: 'VIDEO',
+      video_url: videoUrl,
+      text,
+      ...(video.linkUrl ? { link_attachment: video.linkUrl } : {}),
+    };
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'video',
+        payload,
+        note: 'Threads dry run: media container was not created.',
+      });
+    }
+
     const containerResponse = await fetch(
       `${THREADS_API_URL}/${this.config.userId}/threads`,
       {
@@ -111,11 +139,7 @@ export class ThreadsAdapter implements SocialPlatform {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${this.config.accessToken}`,
         },
-        body: JSON.stringify({
-          media_type: 'VIDEO',
-          video_url: videoUrl,
-          text,
-        }),
+        body: JSON.stringify(payload),
       },
     );
 
@@ -129,23 +153,49 @@ export class ThreadsAdapter implements SocialPlatform {
     // Step 2: Wait for container to be ready
     await this.waitForContainer(containerId);
 
+    if (!isPublicPublishMode(publishMode)) {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'video',
+        payload,
+        remoteId: containerId,
+        staged: true,
+        note: 'Threads media container created but not published.',
+      });
+    }
+
     // Step 3: Publish the container
-    return this.publishContainer(containerId);
+    return this.publishContainer(containerId, publishMode);
   }
 
   async publishImage(image: ImagePost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
     // Step 1: Create media container
-    const text = this.buildPostText(
-      image.description,
-      image.tags,
-      image.linkUrl,
-    );
+    const text = this.buildPostText(image.description, image.tags);
 
     // For image, we need a URL
     const imageUrl = Buffer.isBuffer(image.file)
       ? await this.uploadToTempStorage(image.file, 'image/png')
       : image.file;
 
+    const payload = {
+      media_type: 'IMAGE',
+      image_url: imageUrl,
+      text,
+      ...(image.linkUrl ? { link_attachment: image.linkUrl } : {}),
+    };
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload,
+        note: 'Threads dry run: media container was not created.',
+      });
+    }
+
     const containerResponse = await fetch(
       `${THREADS_API_URL}/${this.config.userId}/threads`,
       {
@@ -154,11 +204,7 @@ export class ThreadsAdapter implements SocialPlatform {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${this.config.accessToken}`,
         },
-        body: JSON.stringify({
-          media_type: 'IMAGE',
-          image_url: imageUrl,
-          text,
-        }),
+        body: JSON.stringify(payload),
       },
     );
 
@@ -172,22 +218,49 @@ export class ThreadsAdapter implements SocialPlatform {
     // Step 2: Wait for container to be ready
     await this.waitForContainer(containerId);
 
+    if (!isPublicPublishMode(publishMode)) {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload,
+        remoteId: containerId,
+        staged: true,
+        note: 'Threads media container created but not published.',
+      });
+    }
+
     // Step 3: Publish the container
-    return this.publishContainer(containerId);
+    return this.publishContainer(containerId, publishMode);
   }
 
   async publishText(text: TextPost): Promise<PostResult> {
-    const postText = this.buildPostText(text.text, text.tags, text.linkUrl);
+    const publishMode = resolvePublishMode(this.config);
+    const postText = this.buildPostText(text.text, text.tags);
 
     // Step 1: Create text container
-    const body: Record<string, any> = {
+    const body: Record<string, unknown> = {
       media_type: 'TEXT',
       text: postText,
     };
 
+    if (text.linkUrl) {
+      body.link_attachment = text.linkUrl;
+    }
+
     // Handle reply
     if (text.replyTo) {
       body.reply_to_id = text.replyTo;
+    }
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'text',
+        payload: body,
+        note: 'Threads dry run: text container was not created.',
+      });
     }
 
     const containerResponse = await fetch(
@@ -209,8 +282,30 @@ export class ThreadsAdapter implements SocialPlatform {
     const containerData = await containerResponse.json();
     const containerId = containerData.id;
 
+    if (!isPublicPublishMode(publishMode)) {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'text',
+        payload: body,
+        remoteId: containerId,
+        staged: true,
+        note: 'Threads text container created but not published.',
+      });
+    }
+
     // Step 2: Publish the container (text doesn't need processing wait)
-    return this.publishContainer(containerId);
+    return this.publishContainer(containerId, publishMode);
+  }
+
+  async publishLink(link: LinkPost): Promise<PostResult> {
+    return this.publishText({
+      text: link.text ?? link.title ?? link.description ?? link.url,
+      tags: link.tags,
+      linkUrl: link.url,
+      scheduledAt: link.scheduledAt,
+      linkBehavior: link.linkBehavior,
+    });
   }
 
   /**
@@ -267,7 +362,10 @@ export class ThreadsAdapter implements SocialPlatform {
   /**
    * Publish a prepared container
    */
-  private async publishContainer(containerId: string): Promise<PostResult> {
+  private async publishContainer(
+    containerId: string,
+    publishMode = 'public',
+  ): Promise<PostResult> {
     const publishResponse = await fetch(
       `${THREADS_API_URL}/${this.config.userId}/threads_publish`,
       {
@@ -307,6 +405,7 @@ export class ThreadsAdapter implements SocialPlatform {
         `https://www.threads.net/@${this.config.userId}/post/${publishData.id}`,
       status: 'published',
       publishedAt: new Date(),
+      metadata: { publishMode },
     };
   }
 
@@ -406,30 +505,30 @@ export class ThreadsAdapter implements SocialPlatform {
       video: true,
       image: true,
       text: true,
+      link: true,
+      linkAttachment: true,
       scheduling: false,
       analytics: true,
+      rawAnalytics: true,
+      requiresPublicMediaUrl: true,
+      publishModes: ['dry_run', 'stage_remote', 'public'],
+      staging: true,
+      privatePublishing: false,
       maxVideoLength: 300, // 5 minutes
       maxVideoSize: 1024 * 1024 * 1024, // 1GB
       supportedVideoFormats: ['mp4', 'mov'],
       aspectRatios: ['1:1', '4:5', '9:16'],
       maxTextLength: 500,
       maxHashtags: undefined,
+      supportedPostTypes: ['text', 'image', 'video', 'link'],
     };
   }
 
   /**
    * Build post text with hashtags and link
    */
-  private buildPostText(
-    text?: string,
-    tags?: string[],
-    linkUrl?: string,
-  ): string {
+  private buildPostText(text?: string, tags?: string[]): string {
     let result = text ?? '';
-
-    if (linkUrl && !result.includes(linkUrl)) {
-      result += `\n\n${linkUrl}`;
-    }
 
     if (tags && tags.length > 0) {
       const hashtags = tags.map((t) => (t.startsWith('#') ? t : `#${t}`));
@@ -447,29 +546,33 @@ export class ThreadsAdapter implements SocialPlatform {
   /**
    * Parse insights data into PostAnalytics
    */
-  private parseInsights(insights: any[]): PostAnalytics {
+  private parseInsights(insights: ThreadsInsight[]): PostAnalytics {
     const analytics: PostAnalytics = {};
 
     for (const insight of insights) {
+      const value = insight.values?.[0]?.value;
       switch (insight.name) {
         case 'views':
-          analytics.views = insight.values?.[0]?.value ?? 0;
+          analytics.views = typeof value === 'number' ? value : undefined;
+          analytics.impressions = analytics.views;
           break;
         case 'likes':
-          analytics.likes = insight.values?.[0]?.value ?? 0;
+          analytics.likes = typeof value === 'number' ? value : undefined;
           break;
         case 'replies':
-          analytics.comments = insight.values?.[0]?.value ?? 0;
+          analytics.comments = typeof value === 'number' ? value : undefined;
           break;
         case 'reposts':
         case 'quotes':
-          analytics.shares =
-            (analytics.shares ?? 0) + (insight.values?.[0]?.value ?? 0);
+          if (typeof value === 'number') {
+            analytics.shares = (analytics.shares ?? 0) + value;
+          }
           break;
       }
     }
 
     analytics.lastUpdated = new Date();
+    analytics.raw = insights;
     return analytics;
   }
 
@@ -493,9 +596,9 @@ export class ThreadsAdapter implements SocialPlatform {
    */
   private async handleError(response: Response): Promise<never> {
     const text = await response.text();
-    let error;
+    let error: ThreadsApiError;
     try {
-      error = JSON.parse(text);
+      error = JSON.parse(text) as ThreadsApiError;
     } catch {
       error = { error: { message: text } };
     }

--- a/packages/social/src/adapters/threads.ts
+++ b/packages/social/src/adapters/threads.ts
@@ -18,6 +18,7 @@ import type {
   Post,
   PostAnalytics,
   PostResult,
+  PublishMode,
   SocialPlatform,
   TextPost,
   ThreadsConfig,
@@ -364,7 +365,7 @@ export class ThreadsAdapter implements SocialPlatform {
    */
   private async publishContainer(
     containerId: string,
-    publishMode = 'public',
+    publishMode: PublishMode = 'public',
   ): Promise<PostResult> {
     const publishResponse = await fetch(
       `${THREADS_API_URL}/${this.config.userId}/threads_publish`,

--- a/packages/social/src/adapters/threads.ts
+++ b/packages/social/src/adapters/threads.ts
@@ -107,9 +107,26 @@ export class ThreadsAdapter implements SocialPlatform {
 
   async publishVideo(video: VideoPost): Promise<PostResult> {
     const publishMode = resolvePublishMode(this.config);
-    // Step 1: Create media container
     const text = this.buildPostText(video.description, video.tags);
 
+    const dryRunPayload = {
+      media_type: 'VIDEO',
+      ...(typeof video.file === 'string' ? { video_url: video.file } : {}),
+      text,
+      ...(video.linkUrl ? { link_attachment: video.linkUrl } : {}),
+    };
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'video',
+        payload: dryRunPayload,
+        note: 'Threads dry run: media container was not created.',
+      });
+    }
+
+    // Step 1: Create media container
     // For video, we need a URL (can't upload buffer directly)
     const videoUrl = Buffer.isBuffer(video.file)
       ? await this.uploadToTempStorage(video.file, 'video/mp4')
@@ -121,16 +138,6 @@ export class ThreadsAdapter implements SocialPlatform {
       text,
       ...(video.linkUrl ? { link_attachment: video.linkUrl } : {}),
     };
-
-    if (publishMode === 'dry_run') {
-      return createSafetyResult({
-        platform: this.platform,
-        mode: publishMode,
-        postType: 'video',
-        payload,
-        note: 'Threads dry run: media container was not created.',
-      });
-    }
 
     const containerResponse = await fetch(
       `${THREADS_API_URL}/${this.config.userId}/threads`,
@@ -172,9 +179,26 @@ export class ThreadsAdapter implements SocialPlatform {
 
   async publishImage(image: ImagePost): Promise<PostResult> {
     const publishMode = resolvePublishMode(this.config);
-    // Step 1: Create media container
     const text = this.buildPostText(image.description, image.tags);
 
+    const dryRunPayload = {
+      media_type: 'IMAGE',
+      ...(typeof image.file === 'string' ? { image_url: image.file } : {}),
+      text,
+      ...(image.linkUrl ? { link_attachment: image.linkUrl } : {}),
+    };
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload: dryRunPayload,
+        note: 'Threads dry run: media container was not created.',
+      });
+    }
+
+    // Step 1: Create media container
     // For image, we need a URL
     const imageUrl = Buffer.isBuffer(image.file)
       ? await this.uploadToTempStorage(image.file, 'image/png')
@@ -186,16 +210,6 @@ export class ThreadsAdapter implements SocialPlatform {
       text,
       ...(image.linkUrl ? { link_attachment: image.linkUrl } : {}),
     };
-
-    if (publishMode === 'dry_run') {
-      return createSafetyResult({
-        platform: this.platform,
-        mode: publishMode,
-        postType: 'image',
-        payload,
-        note: 'Threads dry run: media container was not created.',
-      });
-    }
 
     const containerResponse = await fetch(
       `${THREADS_API_URL}/${this.config.userId}/threads`,

--- a/packages/social/src/adapters/x.ts
+++ b/packages/social/src/adapters/x.ts
@@ -780,7 +780,11 @@ export class XAdapter implements SocialPlatform {
   }
 
   private usesOAuth2(): boolean {
-    return this.config.authType === 'oauth2' || !this.config.accessSecret;
+    if (this.config.authType) {
+      return this.config.authType === 'oauth2';
+    }
+
+    return !this.config.accessSecret;
   }
 
   private requireOAuth1Config(): {
@@ -839,9 +843,12 @@ export class XAdapter implements SocialPlatform {
     url: string,
     body?: unknown,
   ): Promise<Response> {
+    const parsedUrl = new URL(url);
+    const signatureParams = Object.fromEntries(parsedUrl.searchParams);
+    const signingUrl = `${parsedUrl.origin}${parsedUrl.pathname}`;
     const authHeader = this.usesOAuth2()
       ? `Bearer ${this.config.accessToken}`
-      : this.generateOAuthSignature(method, url.split('?')[0], {});
+      : this.generateOAuthSignature(method, signingUrl, signatureParams);
 
     const options: RequestInit = {
       method,
@@ -902,7 +909,10 @@ export class XAdapter implements SocialPlatform {
         : Object.fromEntries(
             Object.entries(params).map(([k, v]) => [k, String(v)]),
           );
-    const queryParams = method === 'GET' ? stringParams : {};
+    const queryParams =
+      method === 'GET' || (!isFormData && !(params instanceof FormData))
+        ? stringParams
+        : {};
     const authHeader = this.generateOAuthSignature(method, url, queryParams);
 
     const options: RequestInit = {

--- a/packages/social/src/adapters/x.ts
+++ b/packages/social/src/adapters/x.ts
@@ -5,9 +5,10 @@
  * Uses Twitter API v2.
  */
 
-import { createHmac } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 
 import { createLogger } from '@happyvertical/logger';
+import { type ResolvedMediaData, resolveMediaData } from '../media.js';
 import {
   createSafetyResult,
   isPublicPublishMode,
@@ -36,6 +37,7 @@ import {
 const X_API_URL = 'https://api.twitter.com/2';
 const X_UPLOAD_URL = 'https://upload.twitter.com/1.1';
 const X_API_MEDIA_UPLOAD_URL = 'https://api.x.com/2/media/upload';
+const X_API_MEDIA_METADATA_URL = 'https://api.x.com/2/media/metadata';
 const X_OAUTH_TOKEN_URL = 'https://api.x.com/2/oauth2/token';
 
 /**
@@ -129,7 +131,7 @@ export class XAdapter implements SocialPlatform {
   }
 
   private generateNonce(): string {
-    return crypto.randomUUID().replace(/-/g, '');
+    return randomUUID().replace(/-/g, '');
   }
 
   private percentEncode(str: string): string {
@@ -234,7 +236,7 @@ export class XAdapter implements SocialPlatform {
 
     // Upload video first. This is safe for stage modes; media is not public
     // until attached to a post.
-    const mediaId = await this.uploadMedia(video.file, 'video');
+    const mediaId = await this.uploadMedia(video.file, 'video', video.mimeType);
 
     if (!isPublicPublishMode(publishMode)) {
       return createSafetyResult({
@@ -300,7 +302,7 @@ export class XAdapter implements SocialPlatform {
 
     // Upload image first. This is safe for stage modes; media is not public
     // until attached to a post.
-    const mediaId = await this.uploadMedia(image.file, 'image');
+    const mediaId = await this.uploadMedia(image.file, 'image', image.mimeType);
 
     if (!isPublicPublishMode(publishMode)) {
       if (image.altText) {
@@ -424,20 +426,24 @@ export class XAdapter implements SocialPlatform {
   private async uploadMedia(
     file: Buffer | string,
     type: 'image' | 'video',
+    mimeType?: string,
   ): Promise<string> {
     if (this.usesOAuth2()) {
-      return this.uploadMediaV2(file, type);
+      return this.uploadMediaV2(file, type, mimeType);
     }
 
-    return this.uploadMediaOAuth1(file, type);
+    return this.uploadMediaOAuth1(file, type, mimeType);
   }
 
-  private async readMediaData(file: Buffer | string): Promise<Buffer> {
-    return Buffer.isBuffer(file)
-      ? file
-      : await fetch(file)
-          .then((r) => r.arrayBuffer())
-          .then(Buffer.from);
+  private async readMediaData(
+    file: Buffer | string,
+    type: 'image' | 'video',
+    mimeType?: string,
+  ): Promise<ResolvedMediaData> {
+    return resolveMediaData(file, {
+      explicitMimeType: mimeType,
+      fallbackMimeType: type === 'video' ? 'video/mp4' : 'image/png',
+    });
   }
 
   /**
@@ -446,14 +452,15 @@ export class XAdapter implements SocialPlatform {
   private async uploadMediaV2(
     file: Buffer | string,
     type: 'image' | 'video',
+    mimeType?: string,
   ): Promise<string> {
-    const mediaData = await this.readMediaData(file);
-    const mediaType = type === 'video' ? 'video/mp4' : 'image/png';
+    const mediaData = await this.readMediaData(file, type, mimeType);
+    const mediaType = mediaData.mimeType;
     const mediaCategory = type === 'video' ? 'tweet_video' : 'tweet_image';
 
     const initResponse = await this.makeBearerUploadRequest('POST', {
       command: 'INIT',
-      total_bytes: String(mediaData.length),
+      total_bytes: String(mediaData.data.length),
       media_type: mediaType,
       media_category: mediaCategory,
     });
@@ -475,13 +482,16 @@ export class XAdapter implements SocialPlatform {
     const chunkSize = 5 * 1024 * 1024;
     let segmentIndex = 0;
 
-    for (let offset = 0; offset < mediaData.length; offset += chunkSize) {
-      const chunk = mediaData.subarray(offset, offset + chunkSize);
+    for (let offset = 0; offset < mediaData.data.length; offset += chunkSize) {
+      const chunk = mediaData.data.subarray(offset, offset + chunkSize);
       const formData = new FormData();
       formData.append('command', 'APPEND');
       formData.append('media_id', mediaId);
       formData.append('segment_index', segmentIndex.toString());
-      formData.append('media', new Blob([new Uint8Array(chunk)]));
+      formData.append(
+        'media',
+        new Blob([new Uint8Array(chunk)], { type: mediaType }),
+      );
 
       const appendResponse = await this.makeBearerUploadRequest(
         'POST',
@@ -527,10 +537,11 @@ export class XAdapter implements SocialPlatform {
   private async uploadMediaOAuth1(
     file: Buffer | string,
     type: 'image' | 'video',
+    mimeType?: string,
   ): Promise<string> {
-    const mediaData = await this.readMediaData(file);
+    const mediaData = await this.readMediaData(file, type, mimeType);
 
-    const mediaType = type === 'video' ? 'video/mp4' : 'image/png';
+    const mediaType = mediaData.mimeType;
     const mediaCategory = type === 'video' ? 'tweet_video' : 'tweet_image';
 
     // INIT
@@ -539,7 +550,7 @@ export class XAdapter implements SocialPlatform {
       `${X_UPLOAD_URL}/media/upload.json`,
       {
         command: 'INIT',
-        total_bytes: mediaData.length,
+        total_bytes: mediaData.data.length,
         media_type: mediaType,
         media_category: mediaCategory,
       },
@@ -556,14 +567,17 @@ export class XAdapter implements SocialPlatform {
     const chunkSize = 5 * 1024 * 1024; // 5MB chunks
     let segmentIndex = 0;
 
-    for (let offset = 0; offset < mediaData.length; offset += chunkSize) {
-      const chunk = mediaData.subarray(offset, offset + chunkSize);
+    for (let offset = 0; offset < mediaData.data.length; offset += chunkSize) {
+      const chunk = mediaData.data.subarray(offset, offset + chunkSize);
 
       const formData = new FormData();
       formData.append('command', 'APPEND');
       formData.append('media_id', mediaId);
       formData.append('segment_index', segmentIndex.toString());
-      formData.append('media', new Blob([new Uint8Array(chunk)]));
+      formData.append(
+        'media',
+        new Blob([new Uint8Array(chunk)], { type: mediaType }),
+      );
 
       const appendResponse = await this.makeUploadRequest(
         'POST',
@@ -671,14 +685,27 @@ export class XAdapter implements SocialPlatform {
     altText: string,
   ): Promise<void> {
     if (this.usesOAuth2()) {
-      this.logger.warn('X OAuth 2.0 alt text metadata is not implemented yet');
+      const response = await this.makeRequest(
+        'POST',
+        X_API_MEDIA_METADATA_URL,
+        {
+          id: mediaId,
+          metadata: {
+            alt_text: { text: altText },
+          },
+        },
+      );
+
+      if (!response.ok) {
+        await this.handleError(response);
+      }
       return;
     }
 
     const url = `${X_UPLOAD_URL}/media/metadata/create.json`;
     const authHeader = this.generateOAuthSignature('POST', url, {});
 
-    await fetch(url, {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         Authorization: authHeader,
@@ -689,6 +716,10 @@ export class XAdapter implements SocialPlatform {
         alt_text: { text: altText },
       }),
     });
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
   }
 
   /**
@@ -707,7 +738,7 @@ export class XAdapter implements SocialPlatform {
   async getPost(postId: string): Promise<Post> {
     const response = await this.makeRequest(
       'GET',
-      `${X_API_URL}/tweets/${postId}?tweet.fields=created_at,public_metrics,attachments`,
+      `${X_API_URL}/tweets/${postId}?tweet.fields=created_at,public_metrics,attachments&expansions=attachments.media_keys&media.fields=type`,
     );
 
     if (!response.ok) {
@@ -720,7 +751,7 @@ export class XAdapter implements SocialPlatform {
     return {
       id: tweet.id,
       url: `https://x.com/i/status/${tweet.id}`,
-      type: tweet.attachments?.media_keys ? 'image' : 'text',
+      type: this.resolvePostType(tweet, data.includes?.media),
       description: tweet.text,
       publishedAt: new Date(tweet.created_at),
       visibility: 'public',
@@ -817,22 +848,72 @@ export class XAdapter implements SocialPlatform {
     linkBehavior: LinkBehavior = 'inline',
   ): string {
     let result = text ?? '';
+    const suffixParts: string[] = [];
 
-    if (linkUrl && linkBehavior === 'inline' && !result.includes(linkUrl)) {
-      result += result.length > 0 ? `\n\n${linkUrl}` : linkUrl;
+    if (linkUrl && linkBehavior === 'inline') {
+      result = result.replace(linkUrl, '').trim();
+      suffixParts.push(linkUrl);
     }
 
     if (tags && tags.length > 0) {
       const hashtags = tags.map((t) => (t.startsWith('#') ? t : `#${t}`));
-      result += `\n\n${hashtags.join(' ')}`;
+      suffixParts.push(hashtags.join(' '));
     }
 
-    // Truncate to 280 chars
-    if (result.length > 280) {
-      result = `${result.substring(0, 277)}...`;
+    const suffix = suffixParts.join('\n\n');
+    if (!suffix) {
+      return this.truncatePostText(result, 280);
     }
 
-    return result;
+    const separator = result.length > 0 ? '\n\n' : '';
+    const suffixBudget = suffix.length + separator.length;
+    if (suffixBudget >= 280) {
+      return this.truncatePostText(suffix, 280);
+    }
+
+    const textBudget = 280 - suffixBudget;
+    const truncatedText = this.truncatePostText(result, textBudget);
+
+    return truncatedText ? `${truncatedText}${separator}${suffix}` : suffix;
+  }
+
+  private truncatePostText(text: string, maxLength: number): string {
+    if (text.length <= maxLength) {
+      return text;
+    }
+
+    if (maxLength <= 3) {
+      return text.slice(0, maxLength);
+    }
+
+    return `${text.slice(0, maxLength - 3)}...`;
+  }
+
+  private resolvePostType(
+    tweet: { attachments?: { media_keys?: string[] } },
+    media?: Array<{ media_key?: string; type?: string }>,
+  ): Post['type'] {
+    const mediaKey = tweet.attachments?.media_keys?.[0];
+    if (!mediaKey) {
+      return 'text';
+    }
+
+    const mediaType =
+      media?.find((item) => item.media_key === mediaKey)?.type ??
+      this.inferMediaTypeFromKey(mediaKey);
+
+    if (mediaType === 'video' || mediaType === 'animated_gif') {
+      return 'video';
+    }
+
+    return 'image';
+  }
+
+  private inferMediaTypeFromKey(mediaKey: string): string | undefined {
+    if (mediaKey.startsWith('13_')) return 'video';
+    if (mediaKey.startsWith('7_')) return 'animated_gif';
+    if (mediaKey.startsWith('3_')) return 'photo';
+    return undefined;
   }
 
   /**

--- a/packages/social/src/adapters/x.ts
+++ b/packages/social/src/adapters/x.ts
@@ -8,10 +8,16 @@
 import { createHmac } from 'node:crypto';
 
 import { createLogger } from '@happyvertical/logger';
-
+import {
+  createSafetyResult,
+  isPublicPublishMode,
+  resolvePublishMode,
+} from '../safety.js';
 import type {
   AuthResult,
   ImagePost,
+  LinkBehavior,
+  LinkPost,
   PlatformCapabilities,
   Post,
   PostAnalytics,
@@ -29,6 +35,8 @@ import {
 
 const X_API_URL = 'https://api.twitter.com/2';
 const X_UPLOAD_URL = 'https://upload.twitter.com/1.1';
+const X_API_MEDIA_UPLOAD_URL = 'https://api.x.com/2/media/upload';
+const X_OAUTH_TOKEN_URL = 'https://api.x.com/2/oauth2/token';
 
 /**
  * X (Twitter) adapter for publishing
@@ -69,8 +77,9 @@ export class XAdapter implements SocialPlatform {
     url: string,
     params: Record<string, string>,
   ): string {
+    const { apiKey, apiSecret, accessSecret } = this.requireOAuth1Config();
     const oauthParams: Record<string, string> = {
-      oauth_consumer_key: this.config.apiKey,
+      oauth_consumer_key: apiKey,
       oauth_nonce: this.generateNonce(),
       oauth_signature_method: 'HMAC-SHA1',
       oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
@@ -95,7 +104,7 @@ export class XAdapter implements SocialPlatform {
     ].join('&');
 
     // Create signing key
-    const signingKey = `${this.percentEncode(this.config.apiSecret)}&${this.percentEncode(this.config.accessSecret)}`;
+    const signingKey = `${this.percentEncode(apiSecret)}&${this.percentEncode(accessSecret)}`;
 
     // Generate HMAC-SHA1 signature
     const signature = this.hmacSha1(signatureBase, signingKey);
@@ -136,7 +145,10 @@ export class XAdapter implements SocialPlatform {
 
   async authenticate(): Promise<AuthResult> {
     // Verify credentials by getting current user
-    const response = await this.makeRequest('GET', `${X_API_URL}/users/me`);
+    const response = await this.makeRequest(
+      'GET',
+      `${X_API_URL}/users/me?user.fields=username,name`,
+    );
 
     if (!response.ok) {
       throw new SocialAuthError('x', 'Invalid credentials');
@@ -144,24 +156,97 @@ export class XAdapter implements SocialPlatform {
 
     return {
       accessToken: this.config.accessToken,
+      refreshToken: this.config.refreshToken,
     };
   }
 
-  async refreshToken(_refreshToken: string): Promise<AuthResult> {
-    // OAuth 1.0a doesn't use refresh tokens
-    throw new SocialError(
-      'OAuth 1.0a does not support token refresh',
-      'NOT_SUPPORTED',
-      'x',
-    );
+  async refreshToken(refreshToken: string): Promise<AuthResult> {
+    if (!this.usesOAuth2()) {
+      throw new SocialError(
+        'OAuth 1.0a does not support token refresh',
+        'NOT_SUPPORTED',
+        'x',
+      );
+    }
+    if (!this.config.clientId || !this.config.clientSecret) {
+      throw new SocialAuthError('x', 'Missing OAuth 2.0 client credentials');
+    }
+
+    const response = await fetch(X_OAUTH_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: this.basicAuthHeader(
+          this.config.clientId,
+          this.config.clientSecret,
+        ),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+    });
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    const token = await response.json();
+    return {
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token,
+      expiresAt:
+        typeof token.expires_in === 'number'
+          ? new Date(Date.now() + token.expires_in * 1000)
+          : undefined,
+      tokenType: token.token_type,
+      scopes:
+        typeof token.scope === 'string' ? token.scope.split(' ') : undefined,
+    };
+  }
+
+  private basicAuthHeader(clientId: string, clientSecret: string): string {
+    return `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString(
+      'base64',
+    )}`;
   }
 
   async publishVideo(video: VideoPost): Promise<PostResult> {
-    // Upload video first
+    const publishMode = resolvePublishMode(this.config);
+    const linkBehavior = this.resolveLinkBehavior(video.linkBehavior);
+    const text = this.buildPostText(
+      video.description,
+      video.tags,
+      video.linkUrl,
+      linkBehavior,
+    );
+    const payload = { text, linkBehavior, tags: video.tags };
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'video',
+        payload,
+        note: 'X dry run: media was not uploaded and no post was created.',
+      });
+    }
+
+    // Upload video first. This is safe for stage modes; media is not public
+    // until attached to a post.
     const mediaId = await this.uploadMedia(video.file, 'video');
 
-    // Create tweet with video
-    const text = this.buildPostText(video.description, video.tags);
+    if (!isPublicPublishMode(publishMode)) {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'video',
+        payload: { ...payload, mediaId },
+        remoteId: mediaId,
+        staged: true,
+        note: 'X media uploaded but no post was created.',
+      });
+    }
 
     const response = await this.makeRequest('POST', `${X_API_URL}/tweets`, {
       text,
@@ -174,8 +259,7 @@ export class XAdapter implements SocialPlatform {
 
     const data = await response.json();
 
-    // If link provided, post as reply for better algorithm performance
-    if (video.linkUrl) {
+    if (video.linkUrl && linkBehavior === 'reply') {
       await this.postLinkReply(data.data.id, video.linkUrl);
     }
 
@@ -184,17 +268,56 @@ export class XAdapter implements SocialPlatform {
       url: `https://x.com/i/status/${data.data.id}`,
       status: 'published',
       publishedAt: new Date(),
+      metadata: { publishMode },
     };
   }
 
   async publishImage(image: ImagePost): Promise<PostResult> {
-    // Upload image first
+    const publishMode = resolvePublishMode(this.config);
+    const linkBehavior = this.resolveLinkBehavior(image.linkBehavior);
+    const text = this.buildPostText(
+      image.description,
+      image.tags,
+      image.linkUrl,
+      linkBehavior,
+    );
+    const payload = {
+      text,
+      linkBehavior,
+      tags: image.tags,
+      altText: image.altText,
+    };
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload,
+        note: 'X dry run: media was not uploaded and no post was created.',
+      });
+    }
+
+    // Upload image first. This is safe for stage modes; media is not public
+    // until attached to a post.
     const mediaId = await this.uploadMedia(image.file, 'image');
 
-    // Create tweet with image
-    const text = this.buildPostText(image.description, image.tags);
+    if (!isPublicPublishMode(publishMode)) {
+      if (image.altText) {
+        await this.setMediaAltText(mediaId, image.altText);
+      }
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'image',
+        payload: { ...payload, mediaId },
+        remoteId: mediaId,
+        staged: true,
+        note: 'X media uploaded but no post was created.',
+      });
+    }
 
-    const body: any = {
+    const body: Record<string, unknown> = {
       text,
       media: { media_ids: [mediaId] },
     };
@@ -217,8 +340,7 @@ export class XAdapter implements SocialPlatform {
 
     const data = await response.json();
 
-    // If link provided, post as reply
-    if (image.linkUrl) {
+    if (image.linkUrl && linkBehavior === 'reply') {
       await this.postLinkReply(data.data.id, image.linkUrl);
     }
 
@@ -227,17 +349,38 @@ export class XAdapter implements SocialPlatform {
       url: `https://x.com/i/status/${data.data.id}`,
       status: 'published',
       publishedAt: new Date(),
+      metadata: { publishMode },
     };
   }
 
   async publishText(text: TextPost): Promise<PostResult> {
-    const postText = this.buildPostText(text.text, text.tags);
+    const publishMode = resolvePublishMode(this.config);
+    const linkBehavior = this.resolveLinkBehavior(text.linkBehavior);
+    const postText = this.buildPostText(
+      text.text,
+      text.tags,
+      text.linkUrl,
+      linkBehavior,
+    );
 
-    const body: any = { text: postText };
+    const body: Record<string, unknown> = { text: postText };
 
     // Handle reply
     if (text.replyTo) {
       body.reply = { in_reply_to_tweet_id: text.replyTo };
+    }
+
+    if (!isPublicPublishMode(publishMode)) {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'text',
+        payload: body,
+        note:
+          publishMode === 'dry_run'
+            ? 'X dry run: no post was created.'
+            : 'X has no non-public text staging endpoint; no post was created.',
+      });
     }
 
     const response = await this.makeRequest(
@@ -252,8 +395,7 @@ export class XAdapter implements SocialPlatform {
 
     const data = await response.json();
 
-    // If link provided (and not a reply), post as separate reply
-    if (text.linkUrl && !text.replyTo) {
+    if (text.linkUrl && linkBehavior === 'reply' && !text.replyTo) {
       await this.postLinkReply(data.data.id, text.linkUrl);
     }
 
@@ -262,7 +404,18 @@ export class XAdapter implements SocialPlatform {
       url: `https://x.com/i/status/${data.data.id}`,
       status: 'published',
       publishedAt: new Date(),
+      metadata: { publishMode },
     };
+  }
+
+  async publishLink(link: LinkPost): Promise<PostResult> {
+    return this.publishText({
+      text: link.text ?? link.title ?? link.description ?? link.url,
+      tags: link.tags,
+      linkUrl: link.url,
+      scheduledAt: link.scheduledAt,
+      linkBehavior: link.linkBehavior,
+    });
   }
 
   /**
@@ -272,11 +425,110 @@ export class XAdapter implements SocialPlatform {
     file: Buffer | string,
     type: 'image' | 'video',
   ): Promise<string> {
-    const mediaData = Buffer.isBuffer(file)
+    if (this.usesOAuth2()) {
+      return this.uploadMediaV2(file, type);
+    }
+
+    return this.uploadMediaOAuth1(file, type);
+  }
+
+  private async readMediaData(file: Buffer | string): Promise<Buffer> {
+    return Buffer.isBuffer(file)
       ? file
       : await fetch(file)
           .then((r) => r.arrayBuffer())
           .then(Buffer.from);
+  }
+
+  /**
+   * Upload media using X API v2 and OAuth 2.0 user context.
+   */
+  private async uploadMediaV2(
+    file: Buffer | string,
+    type: 'image' | 'video',
+  ): Promise<string> {
+    const mediaData = await this.readMediaData(file);
+    const mediaType = type === 'video' ? 'video/mp4' : 'image/png';
+    const mediaCategory = type === 'video' ? 'tweet_video' : 'tweet_image';
+
+    const initResponse = await this.makeBearerUploadRequest('POST', {
+      command: 'INIT',
+      total_bytes: String(mediaData.length),
+      media_type: mediaType,
+      media_category: mediaCategory,
+    });
+
+    if (!initResponse.ok) {
+      throw new SocialError('Media upload init failed', 'UPLOAD_FAILED', 'x');
+    }
+
+    const initData = await initResponse.json();
+    const mediaId = initData.data?.id;
+    if (!mediaId) {
+      throw new SocialError(
+        'Media upload init did not return a media id',
+        'UPLOAD_FAILED',
+        'x',
+      );
+    }
+
+    const chunkSize = 5 * 1024 * 1024;
+    let segmentIndex = 0;
+
+    for (let offset = 0; offset < mediaData.length; offset += chunkSize) {
+      const chunk = mediaData.subarray(offset, offset + chunkSize);
+      const formData = new FormData();
+      formData.append('command', 'APPEND');
+      formData.append('media_id', mediaId);
+      formData.append('segment_index', segmentIndex.toString());
+      formData.append('media', new Blob([new Uint8Array(chunk)]));
+
+      const appendResponse = await this.makeBearerUploadRequest(
+        'POST',
+        formData,
+      );
+
+      if (!appendResponse.ok) {
+        throw new SocialError(
+          'Media upload append failed',
+          'UPLOAD_FAILED',
+          'x',
+        );
+      }
+
+      segmentIndex++;
+    }
+
+    const finalizeResponse = await this.makeBearerUploadRequest('POST', {
+      command: 'FINALIZE',
+      media_id: mediaId,
+    });
+
+    if (!finalizeResponse.ok) {
+      throw new SocialError(
+        'Media upload finalize failed',
+        'UPLOAD_FAILED',
+        'x',
+      );
+    }
+
+    const finalizeData = await finalizeResponse.json();
+
+    if (type === 'video' && finalizeData.data?.processing_info) {
+      await this.waitForProcessing(mediaId);
+    }
+
+    return mediaId;
+  }
+
+  /**
+   * Upload media using legacy OAuth 1.0a upload endpoints.
+   */
+  private async uploadMediaOAuth1(
+    file: Buffer | string,
+    type: 'image' | 'video',
+  ): Promise<string> {
+    const mediaData = await this.readMediaData(file);
 
     const mediaType = type === 'video' ? 'video/mp4' : 'image/png';
     const mediaCategory = type === 'video' ? 'tweet_video' : 'tweet_image';
@@ -367,17 +619,23 @@ export class XAdapter implements SocialPlatform {
     const maxChecks = 60; // 5 minutes max
 
     while (checkCount < maxChecks) {
-      const statusResponse = await this.makeUploadRequest(
-        'GET',
-        `${X_UPLOAD_URL}/media/upload.json`,
-        {
-          command: 'STATUS',
-          media_id: mediaId,
-        },
-      );
+      const statusResponse = this.usesOAuth2()
+        ? await this.makeBearerUploadRequest('GET', {
+            command: 'STATUS',
+            media_id: mediaId,
+          })
+        : await this.makeUploadRequest(
+            'GET',
+            `${X_UPLOAD_URL}/media/upload.json`,
+            {
+              command: 'STATUS',
+              media_id: mediaId,
+            },
+          );
 
       const statusData = await statusResponse.json();
-      const processingInfo = statusData.processing_info;
+      const processingInfo =
+        statusData.processing_info ?? statusData.data?.processing_info;
 
       if (!processingInfo || processingInfo.state === 'succeeded') {
         return;
@@ -412,6 +670,11 @@ export class XAdapter implements SocialPlatform {
     mediaId: string,
     altText: string,
   ): Promise<void> {
+    if (this.usesOAuth2()) {
+      this.logger.warn('X OAuth 2.0 alt text metadata is not implemented yet');
+      return;
+    }
+
     const url = `${X_UPLOAD_URL}/media/metadata/create.json`;
     const authHeader = this.generateOAuthSignature('POST', url, {});
 
@@ -466,6 +729,9 @@ export class XAdapter implements SocialPlatform {
         shares: tweet.public_metrics?.retweet_count,
         comments: tweet.public_metrics?.reply_count,
         views: tweet.public_metrics?.impression_count,
+        impressions: tweet.public_metrics?.impression_count,
+        lastUpdated: new Date(),
+        raw: tweet.public_metrics,
       },
     };
   }
@@ -491,22 +757,66 @@ export class XAdapter implements SocialPlatform {
       video: true,
       image: true,
       text: true,
+      link: true,
+      linkAttachment: false,
       scheduling: false, // Would need Twitter Ads API
       analytics: true,
+      rawAnalytics: true,
+      publishModes: ['dry_run', 'stage_remote', 'public'],
+      staging: true,
+      privatePublishing: false,
       maxVideoLength: 140, // 2 minutes 20 seconds
       maxVideoSize: 512 * 1024 * 1024, // 512MB
       supportedVideoFormats: ['mp4', 'mov'],
       aspectRatios: ['16:9', '1:1', '9:16'],
       maxTextLength: 280,
       maxHashtags: undefined, // No hard limit
+      supportedPostTypes: ['text', 'image', 'video', 'link'],
+    };
+  }
+
+  private resolveLinkBehavior(override?: LinkBehavior): LinkBehavior {
+    return override ?? this.config.linkBehavior ?? 'inline';
+  }
+
+  private usesOAuth2(): boolean {
+    return this.config.authType === 'oauth2' || !this.config.accessSecret;
+  }
+
+  private requireOAuth1Config(): {
+    apiKey: string;
+    apiSecret: string;
+    accessSecret: string;
+  } {
+    if (
+      !this.config.apiKey ||
+      !this.config.apiSecret ||
+      !this.config.accessSecret
+    ) {
+      throw new SocialAuthError('x', 'Missing OAuth 1.0a credentials');
+    }
+
+    return {
+      apiKey: this.config.apiKey,
+      apiSecret: this.config.apiSecret,
+      accessSecret: this.config.accessSecret,
     };
   }
 
   /**
    * Build post text with hashtags
    */
-  private buildPostText(text?: string, tags?: string[]): string {
+  private buildPostText(
+    text?: string,
+    tags?: string[],
+    linkUrl?: string,
+    linkBehavior: LinkBehavior = 'inline',
+  ): string {
     let result = text ?? '';
+
+    if (linkUrl && linkBehavior === 'inline' && !result.includes(linkUrl)) {
+      result += result.length > 0 ? `\n\n${linkUrl}` : linkUrl;
+    }
 
     if (tags && tags.length > 0) {
       const hashtags = tags.map((t) => (t.startsWith('#') ? t : `#${t}`));
@@ -529,11 +839,9 @@ export class XAdapter implements SocialPlatform {
     url: string,
     body?: unknown,
   ): Promise<Response> {
-    const authHeader = this.generateOAuthSignature(
-      method,
-      url.split('?')[0],
-      {},
-    );
+    const authHeader = this.usesOAuth2()
+      ? `Bearer ${this.config.accessToken}`
+      : this.generateOAuthSignature(method, url.split('?')[0], {});
 
     const options: RequestInit = {
       method,
@@ -545,6 +853,33 @@ export class XAdapter implements SocialPlatform {
 
     if (body) {
       options.body = JSON.stringify(body);
+    }
+
+    return fetch(url, options);
+  }
+
+  private async makeBearerUploadRequest(
+    method: string,
+    params: FormData | Record<string, string>,
+  ): Promise<Response> {
+    let url = X_API_MEDIA_UPLOAD_URL;
+    const options: RequestInit = {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.config.accessToken}`,
+      },
+    };
+
+    if (method === 'GET' && !(params instanceof FormData)) {
+      url = `${url}?${new URLSearchParams(params).toString()}`;
+    } else if (params instanceof FormData) {
+      options.body = params;
+    } else {
+      const formData = new FormData();
+      for (const [key, value] of Object.entries(params)) {
+        formData.append(key, value);
+      }
+      options.body = formData;
     }
 
     return fetch(url, options);

--- a/packages/social/src/adapters/youtube.ts
+++ b/packages/social/src/adapters/youtube.ts
@@ -5,9 +5,10 @@
  * Uses YouTube Data API v3.
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { createLogger, type Logger } from '@happyvertical/logger';
+import { resolveMediaData } from '../media.js';
 import {
   createSafetyResult,
   isPublicPublishMode,
@@ -120,7 +121,7 @@ export class YouTubeAdapter implements SocialPlatform {
    * Generate OAuth authorization URL
    */
   getAuthorizationUrl(options: AuthorizationOptions = {}): AuthorizationResult {
-    const state = options.state ?? crypto.randomUUID();
+    const state = options.state ?? randomUUID();
     const scopes = options.scopes ?? DEFAULT_SCOPES;
 
     // Generate PKCE code verifier and challenge
@@ -297,12 +298,11 @@ export class YouTubeAdapter implements SocialPlatform {
       },
     };
 
-    // Get video data
-    const videoData = Buffer.isBuffer(video.file)
-      ? video.file
-      : await fetch(video.file)
-          .then((r) => r.arrayBuffer())
-          .then(Buffer.from);
+    // Get video data.
+    const videoData = await resolveMediaData(video.file, {
+      explicitMimeType: video.mimeType,
+      fallbackMimeType: 'video/mp4',
+    });
 
     // Initialize resumable upload
     const initResponse = await fetch(
@@ -312,8 +312,8 @@ export class YouTubeAdapter implements SocialPlatform {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
-          'X-Upload-Content-Type': 'video/*',
-          'X-Upload-Content-Length': videoData.length.toString(),
+          'X-Upload-Content-Type': videoData.mimeType,
+          'X-Upload-Content-Length': videoData.data.length.toString(),
         },
         body: JSON.stringify(metadata),
       },
@@ -336,10 +336,10 @@ export class YouTubeAdapter implements SocialPlatform {
     const uploadResponse = await fetch(uploadUrl, {
       method: 'PUT',
       headers: {
-        'Content-Type': 'video/*',
-        'Content-Length': videoData.length.toString(),
+        'Content-Type': videoData.mimeType,
+        'Content-Length': videoData.data.length.toString(),
       },
-      body: new Uint8Array(videoData),
+      body: new Uint8Array(videoData.data),
     });
 
     if (!uploadResponse.ok) {
@@ -350,7 +350,12 @@ export class YouTubeAdapter implements SocialPlatform {
 
     // Upload thumbnail if provided
     if (video.thumbnail) {
-      await this.uploadThumbnail(result.id, video.thumbnail, accessToken);
+      await this.uploadThumbnail(
+        result.id,
+        video.thumbnail,
+        accessToken,
+        video.thumbnailMimeType,
+      );
     }
 
     const status: PostResult['status'] = video.scheduledAt
@@ -383,13 +388,13 @@ export class YouTubeAdapter implements SocialPlatform {
     videoId: string,
     thumbnail: Buffer | string,
     accessToken: string,
+    thumbnailMimeType?: string,
   ): Promise<boolean> {
     try {
-      const thumbnailData = Buffer.isBuffer(thumbnail)
-        ? thumbnail
-        : await fetch(thumbnail)
-            .then((r) => r.arrayBuffer())
-            .then(Buffer.from);
+      const thumbnailData = await resolveMediaData(thumbnail, {
+        explicitMimeType: thumbnailMimeType,
+        fallbackMimeType: 'image/png',
+      });
 
       const response = await fetch(
         `${YOUTUBE_UPLOAD_URL}/thumbnails/set?videoId=${videoId}`,
@@ -397,9 +402,9 @@ export class YouTubeAdapter implements SocialPlatform {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'image/png',
+            'Content-Type': thumbnailData.mimeType,
           },
-          body: new Uint8Array(thumbnailData),
+          body: new Uint8Array(thumbnailData.data),
         },
       );
 

--- a/packages/social/src/adapters/youtube.ts
+++ b/packages/social/src/adapters/youtube.ts
@@ -471,6 +471,8 @@ export class YouTubeAdapter implements SocialPlatform {
       throw new SocialError('Video not found', 'NOT_FOUND', 'youtube', 404);
     }
 
+    const statistics = video.statistics ?? {};
+
     return {
       id: video.id,
       url: `https://youtube.com/watch?v=${video.id}`,
@@ -480,11 +482,11 @@ export class YouTubeAdapter implements SocialPlatform {
       publishedAt: new Date(video.snippet.publishedAt),
       visibility: video.status.privacyStatus,
       analytics: {
-        views: this.parseMetric(video.statistics.viewCount),
-        likes: this.parseMetric(video.statistics.likeCount),
-        comments: this.parseMetric(video.statistics.commentCount),
+        views: this.parseMetric(statistics.viewCount),
+        likes: this.parseMetric(statistics.likeCount),
+        comments: this.parseMetric(statistics.commentCount),
         lastUpdated: new Date(),
-        raw: video.statistics,
+        raw: statistics,
       },
     };
   }

--- a/packages/social/src/adapters/youtube.ts
+++ b/packages/social/src/adapters/youtube.ts
@@ -5,14 +5,21 @@
  * Uses YouTube Data API v3.
  */
 
-import { createLogger, type Logger } from '@happyvertical/logger';
+import { createHash } from 'node:crypto';
 
+import { createLogger, type Logger } from '@happyvertical/logger';
+import {
+  createSafetyResult,
+  isPublicPublishMode,
+  resolvePublishMode,
+} from '../safety.js';
 import type {
   AuthorizationOptions,
   AuthorizationResult,
   AuthResult,
   CodeExchangeParams,
   ImagePost,
+  LinkPost,
   PlatformCapabilities,
   Post,
   PostAnalytics,
@@ -67,6 +74,13 @@ const DEFAULT_SCOPES = [
   'https://www.googleapis.com/auth/youtube.upload',
   'https://www.googleapis.com/auth/youtube.readonly',
 ];
+
+interface YouTubeApiError {
+  error?: {
+    code?: number | string;
+    message?: string;
+  };
+}
 
 /**
  * YouTube adapter for video publishing
@@ -237,6 +251,29 @@ export class YouTubeAdapter implements SocialPlatform {
   }
 
   async publishVideo(video: VideoPost): Promise<PostResult> {
+    const publishMode = resolvePublishMode(this.config);
+    const safeVisibility = isPublicPublishMode(publishMode)
+      ? (video.visibility ?? 'public')
+      : 'private';
+
+    if (publishMode === 'dry_run') {
+      return createSafetyResult({
+        platform: this.platform,
+        mode: publishMode,
+        postType: 'video',
+        payload: {
+          title: video.title ?? 'Untitled',
+          description: this.buildDescription(video),
+          tags: video.tags,
+          categoryId: video.categoryId ?? DEFAULT_CATEGORY_ID,
+          privacyStatus: safeVisibility,
+          isShort: video.isShort ?? false,
+          scheduledAt: video.scheduledAt?.toISOString(),
+        },
+        note: 'YouTube dry run: no video was uploaded.',
+      });
+    }
+
     const accessToken = this.currentAccessToken ?? this.config.accessToken;
     if (!accessToken) {
       throw new SocialAuthError('youtube', 'No access token');
@@ -251,7 +288,7 @@ export class YouTubeAdapter implements SocialPlatform {
         categoryId: video.categoryId ?? DEFAULT_CATEGORY_ID,
       },
       status: {
-        privacyStatus: video.visibility ?? 'public',
+        privacyStatus: safeVisibility,
         selfDeclaredMadeForKids: false,
         ...(video.scheduledAt && {
           publishAt: video.scheduledAt.toISOString(),
@@ -316,15 +353,24 @@ export class YouTubeAdapter implements SocialPlatform {
       await this.uploadThumbnail(result.id, video.thumbnail, accessToken);
     }
 
+    const status: PostResult['status'] = video.scheduledAt
+      ? 'scheduled'
+      : isPublicPublishMode(publishMode)
+        ? 'processing'
+        : 'staged';
+
     return {
       id: result.id,
       url: `https://youtube.com/watch?v=${result.id}`,
-      status: video.scheduledAt ? 'scheduled' : 'processing',
-      publishedAt: video.scheduledAt ? undefined : new Date(),
+      status,
+      publishedAt: status === 'processing' ? new Date() : undefined,
       scheduledAt: video.scheduledAt,
       metadata: {
         channelId: result.snippet?.channelId,
         channelTitle: result.snippet?.channelTitle,
+        publishMode,
+        privacyStatus: metadata.status.privacyStatus,
+        safety: !isPublicPublishMode(publishMode),
       },
     };
   }
@@ -393,6 +439,14 @@ export class YouTubeAdapter implements SocialPlatform {
     );
   }
 
+  async publishLink(_link: LinkPost): Promise<PostResult> {
+    throw new SocialError(
+      'YouTube does not support link-only posts',
+      'NOT_SUPPORTED',
+      'youtube',
+    );
+  }
+
   async getPost(postId: string): Promise<Post> {
     const accessToken = this.currentAccessToken ?? this.config.accessToken;
     if (!accessToken) {
@@ -426,9 +480,11 @@ export class YouTubeAdapter implements SocialPlatform {
       publishedAt: new Date(video.snippet.publishedAt),
       visibility: video.status.privacyStatus,
       analytics: {
-        views: parseInt(video.statistics.viewCount, 10),
-        likes: parseInt(video.statistics.likeCount, 10),
-        comments: parseInt(video.statistics.commentCount, 10),
+        views: this.parseMetric(video.statistics.viewCount),
+        likes: this.parseMetric(video.statistics.likeCount),
+        comments: this.parseMetric(video.statistics.commentCount),
+        lastUpdated: new Date(),
+        raw: video.statistics,
       },
     };
   }
@@ -459,14 +515,20 @@ export class YouTubeAdapter implements SocialPlatform {
       video: true,
       image: false,
       text: false,
+      link: false,
       scheduling: true,
       analytics: true,
+      rawAnalytics: true,
+      publishModes: ['dry_run', 'private_or_scheduled', 'public'],
+      staging: false,
+      privatePublishing: true,
       maxVideoLength: 60 * 60 * 12, // 12 hours (with verification)
       maxVideoSize: 256 * 1024 * 1024 * 1024, // 256GB
       supportedVideoFormats: ['mp4', 'mov', 'avi', 'wmv', 'flv', 'webm'],
       aspectRatios: ['16:9', '9:16', '1:1', '4:3'],
       maxTextLength: 5000, // Description
       maxHashtags: 15,
+      supportedPostTypes: ['video'],
     };
   }
 
@@ -480,12 +542,22 @@ export class YouTubeAdapter implements SocialPlatform {
       description += `\n\n${video.linkUrl}`;
     }
 
-    if (video.tags && video.tags.length > 0) {
-      const hashtags = video.tags.map((t) => (t.startsWith('#') ? t : `#${t}`));
+    const tags = video.isShort
+      ? Array.from(new Set([...(video.tags ?? []), 'Shorts']))
+      : video.tags;
+
+    if (tags && tags.length > 0) {
+      const hashtags = tags.map((t) => (t.startsWith('#') ? t : `#${t}`));
       description += `\n\n${hashtags.join(' ')}`;
     }
 
     return description;
+  }
+
+  private parseMetric(value: unknown): number | undefined {
+    if (value === undefined || value === null || value === '') return undefined;
+    const parsed = Number.parseInt(String(value), 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
   }
 
   /**
@@ -493,11 +565,11 @@ export class YouTubeAdapter implements SocialPlatform {
    */
   private async handleError(response: Response): Promise<never> {
     const text = await response.text();
-    let error;
+    let error: YouTubeApiError;
     try {
-      error = JSON.parse(text);
+      error = JSON.parse(text) as YouTubeApiError;
     } catch {
-      error = { message: text };
+      error = { error: { message: text } };
     }
 
     if (response.status === 401) {
@@ -517,7 +589,7 @@ export class YouTubeAdapter implements SocialPlatform {
 
     throw new SocialError(
       error.error?.message ?? 'API request failed',
-      error.error?.code ?? 'API_ERROR',
+      error.error?.code?.toString() ?? 'API_ERROR',
       'youtube',
       response.status,
     );
@@ -539,10 +611,7 @@ export class YouTubeAdapter implements SocialPlatform {
    * Generate PKCE code challenge from verifier using S256
    */
   private generateCodeChallenge(verifier: string): string {
-    // Use Node.js crypto for synchronous SHA-256 hashing
-    const { createHash } = require('node:crypto');
     const hash = createHash('sha256').update(verifier).digest();
-    // Base64url encode the hash
     return Buffer.from(hash)
       .toString('base64')
       .replace(/\+/g, '-')

--- a/packages/social/src/index.spec.ts
+++ b/packages/social/src/index.spec.ts
@@ -167,6 +167,49 @@ describe('social package', () => {
       });
     });
 
+    it('should require OAuth 1.0a credentials when authType is explicit', async () => {
+      const adapter = new XAdapter({
+        type: 'x',
+        authType: 'oauth1',
+        accessToken: 'token',
+      });
+
+      await expect(adapter.authenticate()).rejects.toThrow(
+        'Missing OAuth 1.0a credentials',
+      );
+    });
+
+    it('should sign X OAuth 1.0a requests with query parameters', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ data: { id: 'user-1' } }), {
+          status: 200,
+        }),
+      );
+
+      const adapter = new XAdapter({
+        type: 'x',
+        authType: 'oauth1',
+        apiKey: 'key',
+        apiSecret: 'secret',
+        accessToken: 'token',
+        accessSecret: 'access-secret',
+      });
+
+      await adapter.authenticate();
+
+      const authorization = String(
+        (fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>)
+          .Authorization,
+      );
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        'https://api.twitter.com/2/users/me?user.fields=username,name',
+      );
+      expect(authorization).toContain('oauth_signature=');
+      expect(authorization).not.toContain('user.fields');
+    });
+
     it('should stage X OAuth2 media through v2 upload endpoints', async () => {
       const fetchMock = vi.mocked(fetch);
       fetchMock
@@ -324,6 +367,58 @@ describe('social package', () => {
       expect(result.metadata?.safety).toBe(true);
     });
 
+    it('should include article links in Facebook Page video descriptions', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ id: 'video-1' }), { status: 200 }),
+      );
+
+      const adapter = new FacebookPageAdapter({
+        type: 'facebook',
+        accessToken: 'page-token',
+        pageId: 'page-1',
+      });
+
+      await adapter.publishVideo({
+        file: 'https://cdn.example.com/video.mp4',
+        title: 'Story video',
+        description: 'Story from Bentley',
+        linkUrl: 'https://bentleyalberta.com/story',
+      });
+
+      const body = fetchMock.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get('description')).toContain('Story from Bentley');
+      expect(body.get('description')).toContain(
+        'https://bentleyalberta.com/story',
+      );
+    });
+
+    it('should read Facebook Page share attachments as link posts', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 'page-1_post-1',
+            message: 'Story from Bentley',
+            created_time: '2026-05-08T15:00:00+0000',
+            permalink_url: 'https://facebook.com/page-1_post-1',
+            attachments: { data: [{ media_type: 'share' }] },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const adapter = new FacebookPageAdapter({
+        type: 'facebook',
+        accessToken: 'page-token',
+        pageId: 'page-1',
+      });
+
+      await expect(adapter.getPost('page-1_post-1')).resolves.toMatchObject({
+        type: 'link',
+      });
+    });
+
     it('should dry-run YouTube video uploads without fetching media', async () => {
       const fetchMock = vi.mocked(fetch);
       const adapter = new YouTubeAdapter({
@@ -389,6 +484,42 @@ describe('social package', () => {
       expect(result.status).toBe('staged');
       expect(result.metadata?.privacyStatus).toBe('private');
       expect(result.metadata?.safety).toBe(true);
+    });
+
+    it('should preserve unavailable YouTube statistics as undefined', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: 'video-1',
+                snippet: {
+                  title: 'Story video',
+                  description: 'Story from Bentley',
+                  publishedAt: '2026-05-08T15:00:00Z',
+                },
+                status: { privacyStatus: 'private' },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const adapter = new YouTubeAdapter({
+        type: 'youtube',
+        clientId: 'client',
+        clientSecret: 'secret',
+        accessToken: 'token',
+      });
+
+      const post = await adapter.getPost('video-1');
+
+      expect(post.analytics?.views).toBeUndefined();
+      expect(post.analytics?.likes).toBeUndefined();
+      expect(post.analytics?.comments).toBeUndefined();
+      expect(post.analytics?.raw).toEqual({});
     });
 
     it('should dry-run Bluesky link records without authenticating', async () => {

--- a/packages/social/src/index.spec.ts
+++ b/packages/social/src/index.spec.ts
@@ -252,6 +252,112 @@ describe('social package', () => {
       expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
+    it('should send X OAuth2 alt text metadata after media upload', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: { id: 'media-1', media_key: '3_media-1' },
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: { id: 'media-1', media_key: '3_media-1' },
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      const adapter = new XAdapter({
+        type: 'x',
+        authType: 'oauth2',
+        accessToken: 'oauth2-token',
+        publishMode: 'stage_remote',
+      });
+
+      await adapter.publishImage({
+        file: Buffer.from('image-bytes'),
+        description: 'Story from Bentley',
+        altText: 'A photo from Bentley',
+        mimeType: 'image/jpeg',
+      });
+
+      expect(String(fetchMock.mock.calls[3]?.[0])).toBe(
+        'https://api.x.com/2/media/metadata',
+      );
+      expect(fetchMock.mock.calls[3]?.[1]?.headers).toMatchObject({
+        Authorization: 'Bearer oauth2-token',
+      });
+      expect(JSON.parse(String(fetchMock.mock.calls[3]?.[1]?.body))).toEqual({
+        id: 'media-1',
+        metadata: {
+          alt_text: { text: 'A photo from Bentley' },
+        },
+      });
+    });
+
+    it('should keep inline X link URLs and hashtags outside truncated text', async () => {
+      const adapter = new XAdapter({
+        type: 'x',
+        apiKey: 'key',
+        apiSecret: 'secret',
+        accessToken: 'token',
+        accessSecret: 'access-secret',
+        publishMode: 'dry_run',
+      });
+
+      const result = await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'a'.repeat(270),
+        tags: ['news'],
+      });
+      const payload = result.metadata?.payload as { text: string };
+
+      expect(payload.text.length).toBeLessThanOrEqual(280);
+      expect(payload.text).toContain('https://bentleyalberta.com/story');
+      expect(payload.text).toContain('#news');
+      expect(
+        payload.text.endsWith('https://bentleyalberta.com/story\n\n#news'),
+      ).toBe(true);
+    });
+
+    it('should classify X media posts from expanded media types', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              id: 'tweet-1',
+              text: 'Story video',
+              created_at: '2026-05-08T15:00:00Z',
+              attachments: { media_keys: ['13_media-1'] },
+              public_metrics: {},
+            },
+            includes: {
+              media: [{ media_key: '13_media-1', type: 'video' }],
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const adapter = new XAdapter({
+        type: 'x',
+        authType: 'oauth2',
+        accessToken: 'oauth2-token',
+      });
+
+      await expect(adapter.getPost('tweet-1')).resolves.toMatchObject({
+        type: 'video',
+      });
+    });
+
     it('should publish Threads link posts using link_attachment', async () => {
       const fetchMock = vi.mocked(fetch);
       fetchMock
@@ -393,6 +499,55 @@ describe('social package', () => {
       );
     });
 
+    it('should count only positive Facebook reactions as likes', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 'page-1_post-1',
+            message: 'Story from Bentley',
+            created_time: '2026-05-08T15:00:00+0000',
+            permalink_url: 'https://facebook.com/page-1_post-1',
+            insights: {
+              data: [
+                {
+                  name: 'post_reactions_by_type_total',
+                  values: [
+                    {
+                      value: {
+                        like: 3,
+                        love: 2,
+                        haha: 1,
+                        wow: 1,
+                        sad: 5,
+                        angry: 7,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const adapter = new FacebookPageAdapter({
+        type: 'facebook',
+        accessToken: 'page-token',
+        pageId: 'page-1',
+      });
+
+      const post = await adapter.getPost('page-1_post-1');
+
+      expect(post.analytics?.likes).toBe(7);
+      expect(post.analytics?.raw).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'post_reactions_by_type_total' }),
+        ]),
+      );
+    });
+
     it('should read Facebook Page share attachments as link posts', async () => {
       const fetchMock = vi.mocked(fetch);
       fetchMock.mockResolvedValue(
@@ -486,6 +641,48 @@ describe('social package', () => {
       expect(result.metadata?.safety).toBe(true);
     });
 
+    it('should upload YouTube thumbnails with the detected MIME type', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response('', {
+            status: 200,
+            headers: { Location: 'https://upload.youtube.test/session' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              id: 'video-1',
+              snippet: {
+                channelId: 'channel-1',
+                channelTitle: 'Bentley',
+              },
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      const adapter = new YouTubeAdapter({
+        type: 'youtube',
+        clientId: 'client',
+        clientSecret: 'secret',
+        accessToken: 'token',
+        publishMode: 'private_or_scheduled',
+      });
+
+      await adapter.publishVideo({
+        file: Buffer.from('video-bytes'),
+        thumbnail: Buffer.from([0xff, 0xd8, 0xff, 0xdb]),
+        title: 'Story video',
+      });
+
+      expect(fetchMock.mock.calls[2]?.[1]?.headers).toMatchObject({
+        'Content-Type': 'image/jpeg',
+      });
+    });
+
     it('should preserve unavailable YouTube statistics as undefined', async () => {
       const fetchMock = vi.mocked(fetch);
       fetchMock.mockResolvedValue(
@@ -541,6 +738,91 @@ describe('social package', () => {
         text: 'Story from Bentley',
       });
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject Bluesky video publishing until video support exists', async () => {
+      const adapter = new BlueskyAdapter({
+        type: 'bluesky',
+        identifier: 'test.bsky.social',
+        password: 'app-password',
+      });
+
+      await expect(
+        adapter.publishVideo({
+          file: Buffer.from('video-bytes'),
+          description: 'Story video',
+        }),
+      ).rejects.toMatchObject({
+        code: 'NOT_SUPPORTED',
+        platform: 'bluesky',
+      });
+    });
+
+    it('should omit invalid Bluesky replyTo fields from safety payloads', async () => {
+      const adapter = new BlueskyAdapter({
+        type: 'bluesky',
+        identifier: 'test.bsky.social',
+        password: 'app-password',
+        publishMode: 'dry_run',
+      });
+
+      const result = await adapter.publishText({
+        text: 'Reply from Bentley',
+        replyTo: 'at://did:plc:test/app.bsky.feed.post/parent',
+      });
+      const payload = result.metadata?.payload as Record<string, unknown>;
+
+      expect(payload.replyTo).toBeUndefined();
+      expect(payload.reply).toBeUndefined();
+      expect(result.metadata?.replyTo).toBe(
+        'at://did:plc:test/app.bsky.feed.post/parent',
+      );
+    });
+
+    it('should upload Bluesky image blobs with the detected MIME type', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              did: 'did:plc:test',
+              handle: 'test.bsky.social',
+              accessJwt: 'access-jwt',
+              refreshJwt: 'refresh-jwt',
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(Buffer.from([0xff, 0xd8, 0xff, 0xdb]), {
+            status: 200,
+            headers: { 'content-type': 'image/jpeg' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              blob: { ref: { $link: 'blob-1' }, mimeType: 'image/jpeg' },
+            }),
+            { status: 200 },
+          ),
+        );
+
+      const adapter = new BlueskyAdapter({
+        type: 'bluesky',
+        identifier: 'test.bsky.social',
+        password: 'app-password',
+        publishMode: 'stage_remote',
+      });
+
+      await adapter.publishImage({
+        file: 'https://cdn.example.com/story.jpg',
+        description: 'Story from Bentley',
+      });
+
+      expect(fetchMock.mock.calls[2]?.[1]?.headers).toMatchObject({
+        'Content-Type': 'image/jpeg',
+      });
     });
   });
 

--- a/packages/social/src/index.spec.ts
+++ b/packages/social/src/index.spec.ts
@@ -10,6 +10,7 @@ import {
   XAdapter,
   YouTubeAdapter,
 } from './index.js';
+import { resolveMediaData } from './media.js';
 
 describe('social package', () => {
   beforeEach(() => {
@@ -421,6 +422,46 @@ describe('social package', () => {
       );
     });
 
+    it('should dry-run Threads buffer videos without temp upload', async () => {
+      const fetchMock = vi.mocked(fetch);
+      const adapter = new ThreadsAdapter({
+        type: 'threads',
+        accessToken: 'token',
+        userId: 'threads-user',
+        publishMode: 'dry_run',
+      });
+
+      const result = await adapter.publishVideo({
+        file: Buffer.from('video-bytes'),
+        description: 'Story video',
+      });
+      const payload = result.metadata?.payload as Record<string, unknown>;
+
+      expect(result.status).toBe('dry_run');
+      expect(payload.video_url).toBeUndefined();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should dry-run Threads buffer images without temp upload', async () => {
+      const fetchMock = vi.mocked(fetch);
+      const adapter = new ThreadsAdapter({
+        type: 'threads',
+        accessToken: 'token',
+        userId: 'threads-user',
+        publishMode: 'dry_run',
+      });
+
+      const result = await adapter.publishImage({
+        file: Buffer.from('image-bytes'),
+        description: 'Story image',
+      });
+      const payload = result.metadata?.payload as Record<string, unknown>;
+
+      expect(result.status).toBe('dry_run');
+      expect(payload.image_url).toBeUndefined();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('should publish Facebook Page link posts to the feed endpoint', async () => {
       const fetchMock = vi.mocked(fetch);
       fetchMock.mockResolvedValue(
@@ -823,6 +864,22 @@ describe('social package', () => {
       expect(fetchMock.mock.calls[2]?.[1]?.headers).toMatchObject({
         'Content-Type': 'image/jpeg',
       });
+    });
+
+    it('should reject failed URL media fetches', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response('not found', {
+          status: 404,
+          statusText: 'Not Found',
+        }),
+      );
+
+      await expect(
+        resolveMediaData('https://cdn.example.com/missing.jpg'),
+      ).rejects.toThrow(
+        'Failed to fetch media from https://cdn.example.com/missing.jpg: 404 Not Found - not found',
+      );
     });
   });
 

--- a/packages/social/src/index.spec.ts
+++ b/packages/social/src/index.spec.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   BlueskyAdapter,
+  FacebookPageAdapter,
   getSocial,
   SocialAuthError,
   SocialError,
@@ -11,6 +12,14 @@ import {
 } from './index.js';
 
 describe('social package', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe('exports', () => {
     it('should export getSocial factory function', () => {
       expect(typeof getSocial).toBe('function');
@@ -21,6 +30,7 @@ describe('social package', () => {
       expect(ThreadsAdapter).toBeDefined();
       expect(XAdapter).toBeDefined();
       expect(BlueskyAdapter).toBeDefined();
+      expect(FacebookPageAdapter).toBeDefined();
     });
 
     it('should export error classes', () => {
@@ -71,6 +81,335 @@ describe('social package', () => {
       });
       expect(adapter).toBeInstanceOf(BlueskyAdapter);
       expect(adapter.platform).toBe('bluesky');
+    });
+
+    it('should create FacebookPageAdapter', async () => {
+      const adapter = await getSocial({
+        type: 'facebook',
+        accessToken: 'test-token',
+        pageId: 'test-page-id',
+      });
+      expect(adapter).toBeInstanceOf(FacebookPageAdapter);
+      expect(adapter.platform).toBe('facebook');
+    });
+  });
+
+  describe('link publishing', () => {
+    it('should dry-run X link posts without calling the API', async () => {
+      const fetchMock = vi.mocked(fetch);
+      const adapter = new XAdapter({
+        type: 'x',
+        apiKey: 'key',
+        apiSecret: 'secret',
+        accessToken: 'token',
+        accessSecret: 'access-secret',
+        publishMode: 'dry_run',
+      });
+
+      const result = await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'Story from Bentley',
+      });
+
+      expect(result.status).toBe('dry_run');
+      expect(result.metadata?.publishMode).toBe('dry_run');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should publish X link posts with inline URLs by default', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ data: { id: 'tweet-1' } }), {
+          status: 200,
+        }),
+      );
+
+      const adapter = new XAdapter({
+        type: 'x',
+        apiKey: 'key',
+        apiSecret: 'secret',
+        accessToken: 'token',
+        accessSecret: 'access-secret',
+      });
+
+      await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'Story from Bentley',
+      });
+
+      const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+      expect(body.text).toContain('Story from Bentley');
+      expect(body.text).toContain('https://bentleyalberta.com/story');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should publish X OAuth2 link posts with bearer auth', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ data: { id: 'tweet-1' } }), {
+          status: 200,
+        }),
+      );
+
+      const adapter = new XAdapter({
+        type: 'x',
+        authType: 'oauth2',
+        accessToken: 'oauth2-token',
+      });
+
+      await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'Story from Bentley',
+      });
+
+      expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+        Authorization: 'Bearer oauth2-token',
+      });
+    });
+
+    it('should stage X OAuth2 media through v2 upload endpoints', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: { id: 'media-1', media_key: '13_media-1' },
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: { id: 'media-1', media_key: '13_media-1' },
+            }),
+            { status: 200 },
+          ),
+        );
+
+      const adapter = new XAdapter({
+        type: 'x',
+        authType: 'oauth2',
+        accessToken: 'oauth2-token',
+        publishMode: 'stage_remote',
+      });
+
+      const result = await adapter.publishVideo({
+        file: Buffer.from('video-bytes'),
+        description: 'Story from Bentley',
+      });
+
+      expect(result.status).toBe('staged');
+      expect(result.id).toBe('media-1');
+      expect(result.metadata?.remoteId).toBe('media-1');
+      expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+        'https://api.x.com/2/media/upload',
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('should publish Threads link posts using link_attachment', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ id: 'container-1' }), { status: 200 }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ id: 'thread-1' }), { status: 200 }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              id: 'thread-1',
+              permalink: 'https://threads.net/@test/post/thread-1',
+            }),
+            { status: 200 },
+          ),
+        );
+
+      const adapter = new ThreadsAdapter({
+        type: 'threads',
+        accessToken: 'token',
+        userId: 'threads-user',
+      });
+
+      await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'Story from Bentley',
+      });
+
+      const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+      expect(body.media_type).toBe('TEXT');
+      expect(body.text).toBe('Story from Bentley');
+      expect(body.link_attachment).toBe('https://bentleyalberta.com/story');
+    });
+
+    it('should stage Threads link containers without publishing', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'container-1' }), { status: 200 }),
+      );
+
+      const adapter = new ThreadsAdapter({
+        type: 'threads',
+        accessToken: 'token',
+        userId: 'threads-user',
+        publishMode: 'stage_remote',
+      });
+
+      const result = await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'Story from Bentley',
+      });
+
+      expect(result.status).toBe('staged');
+      expect(result.id).toBe('container-1');
+      expect(result.metadata?.publishMode).toBe('stage_remote');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+        '/threads-user/threads',
+      );
+    });
+
+    it('should publish Facebook Page link posts to the feed endpoint', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ id: 'page-1_post-1' }), { status: 200 }),
+      );
+
+      const adapter = new FacebookPageAdapter({
+        type: 'facebook',
+        accessToken: 'page-token',
+        pageId: 'page-1',
+      });
+
+      await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'Story from Bentley',
+      });
+
+      const firstCall = fetchMock.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const [url, init] = firstCall ?? [];
+      expect(String(url)).toContain('/page-1/feed');
+      expect(init?.method).toBe('POST');
+      const body = init?.body as URLSearchParams;
+      expect(body.get('message')).toBe('Story from Bentley');
+      expect(body.get('link')).toBe('https://bentleyalberta.com/story');
+      expect(body.get('access_token')).toBe('page-token');
+    });
+
+    it('should create unpublished Facebook Page link posts in safe mode', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ id: 'page-1_post-1' }), { status: 200 }),
+      );
+
+      const adapter = new FacebookPageAdapter({
+        type: 'facebook',
+        accessToken: 'page-token',
+        pageId: 'page-1',
+        publishMode: 'private_or_scheduled',
+      });
+
+      const result = await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        text: 'Story from Bentley',
+      });
+
+      const body = fetchMock.mock.calls[0]?.[1]?.body as URLSearchParams;
+      expect(body.get('published')).toBe('false');
+      expect(result.status).toBe('staged');
+      expect(result.metadata?.safety).toBe(true);
+    });
+
+    it('should dry-run YouTube video uploads without fetching media', async () => {
+      const fetchMock = vi.mocked(fetch);
+      const adapter = new YouTubeAdapter({
+        type: 'youtube',
+        clientId: 'client',
+        clientSecret: 'secret',
+        accessToken: 'token',
+        publishMode: 'dry_run',
+      });
+
+      const result = await adapter.publishVideo({
+        file: 'https://cdn.example.com/video.mp4',
+        title: 'Story video',
+        isShort: true,
+      });
+
+      expect(result.status).toBe('dry_run');
+      expect(result.metadata?.payload).toMatchObject({
+        title: 'Story video',
+        privacyStatus: 'private',
+        isShort: true,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should keep YouTube safe-mode uploads private and staged', async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response('', {
+            status: 200,
+            headers: { Location: 'https://upload.youtube.test/session' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              id: 'video-1',
+              snippet: {
+                channelId: 'channel-1',
+                channelTitle: 'Bentley',
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+
+      const adapter = new YouTubeAdapter({
+        type: 'youtube',
+        clientId: 'client',
+        clientSecret: 'secret',
+        accessToken: 'token',
+        publishMode: 'private_or_scheduled',
+      });
+
+      const result = await adapter.publishVideo({
+        file: Buffer.from('video-bytes'),
+        title: 'Story video',
+      });
+
+      const metadata = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+      expect(metadata.status.privacyStatus).toBe('private');
+      expect(result.status).toBe('staged');
+      expect(result.metadata?.privacyStatus).toBe('private');
+      expect(result.metadata?.safety).toBe(true);
+    });
+
+    it('should dry-run Bluesky link records without authenticating', async () => {
+      const fetchMock = vi.mocked(fetch);
+      const adapter = new BlueskyAdapter({
+        type: 'bluesky',
+        identifier: 'test.bsky.social',
+        password: 'app-password',
+        publishMode: 'dry_run',
+      });
+
+      const result = await adapter.publishLink({
+        url: 'https://bentleyalberta.com/story',
+        title: 'Story from Bentley',
+      });
+
+      expect(result.status).toBe('dry_run');
+      expect(result.metadata?.payload).toMatchObject({
+        text: 'Story from Bentley',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -146,6 +146,9 @@ export async function publishToAll(
     url?: string;
     tags?: string[];
     altText?: string;
+    mimeType?: string;
+    thumbnail?: Buffer | string;
+    thumbnailMimeType?: string;
   },
 ): Promise<Map<string, { success: boolean; result?: unknown; error?: Error }>> {
   const results = new Map<
@@ -198,6 +201,7 @@ export async function publishToAll(
               linkUrl: content.linkUrl,
               tags: content.tags,
               altText: content.altText,
+              mimeType: content.mimeType,
             });
             break;
           case 'video':
@@ -214,6 +218,9 @@ export async function publishToAll(
               description: content.description ?? content.text,
               linkUrl: content.linkUrl,
               tags: content.tags,
+              mimeType: content.mimeType,
+              thumbnail: content.thumbnail,
+              thumbnailMimeType: content.thumbnailMimeType,
             });
             break;
         }

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -6,12 +6,14 @@
  */
 
 export { BlueskyAdapter } from './adapters/bluesky.js';
+export { FacebookPageAdapter } from './adapters/facebook.js';
 export { ThreadsAdapter } from './adapters/threads.js';
 export { XAdapter } from './adapters/x.js';
 export { YouTubeAdapter } from './adapters/youtube.js';
 export * from './types.js';
 
 import { BlueskyAdapter } from './adapters/bluesky.js';
+import { FacebookPageAdapter } from './adapters/facebook.js';
 import { ThreadsAdapter } from './adapters/threads.js';
 import { XAdapter } from './adapters/x.js';
 import { YouTubeAdapter } from './adapters/youtube.js';
@@ -72,6 +74,9 @@ export async function getSocial(config: SocialConfig): Promise<SocialPlatform> {
     case 'threads':
       adapter = new ThreadsAdapter(config);
       break;
+    case 'facebook':
+      adapter = new FacebookPageAdapter(config);
+      break;
     case 'x':
       adapter = new XAdapter(config);
       break;
@@ -80,7 +85,7 @@ export async function getSocial(config: SocialConfig): Promise<SocialPlatform> {
       break;
     default:
       throw new SocialError(
-        `Unknown platform type: ${(config as any).type}`,
+        `Unknown platform type: ${(config as { type?: string }).type}`,
         'UNKNOWN_PLATFORM',
       );
   }
@@ -132,12 +137,13 @@ export async function getSocialMulti(
 export async function publishToAll(
   adapters: SocialPlatform[],
   content: {
-    type: 'text' | 'image' | 'video';
+    type: 'text' | 'image' | 'video' | 'link';
     text?: string;
     description?: string;
     file?: Buffer | string;
     title?: string;
     linkUrl?: string;
+    url?: string;
     tags?: string[];
     altText?: string;
   },
@@ -150,7 +156,7 @@ export async function publishToAll(
   await Promise.all(
     adapters.map(async (adapter) => {
       try {
-        let result;
+        let result: unknown;
 
         switch (content.type) {
           case 'text':
@@ -160,6 +166,24 @@ export async function publishToAll(
               tags: content.tags,
             });
             break;
+          case 'link': {
+            const url = content.url ?? content.linkUrl;
+            if (!url) {
+              throw new SocialError(
+                'Link URL required',
+                'MISSING_LINK_URL',
+                adapter.platform,
+              );
+            }
+            result = await adapter.publishLink({
+              url,
+              text: content.text,
+              title: content.title,
+              description: content.description,
+              tags: content.tags,
+            });
+            break;
+          }
           case 'image':
             if (!content.file) {
               throw new SocialError(

--- a/packages/social/src/live-smoke.optional.test.ts
+++ b/packages/social/src/live-smoke.optional.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { XAdapter, YouTubeAdapter } from './index.js';
+
+const runLiveSmoke =
+  process.env.HV_SOCIAL_LIVE_SMOKE === '1' ||
+  process.env.SOCIAL_LIVE_SMOKE === '1';
+
+const describeLive = runLiveSmoke ? describe : describe.skip;
+
+function requiredEnv(names: string[]): Record<string, string> {
+  const values: Record<string, string> = {};
+  const missing: string[] = [];
+
+  for (const name of names) {
+    const value = process.env[name];
+    if (!value) {
+      missing.push(name);
+    } else {
+      values[name] = value;
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing live social smoke test env: ${missing.join(', ')}`,
+    );
+  }
+
+  return values;
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { raw: text };
+  }
+}
+
+describeLive('live social credential smoke tests', () => {
+  it('validates X OAuth 1.0a credentials with a read-only users/me request', async () => {
+    const env = requiredEnv([
+      'BLINDMANPRESS_X_CONSUMER_KEY',
+      'BLINDMANPRESS_X_SECRET_KEY',
+      'BLINDMANPRESS_ACCESS_TOKEN',
+      'BLINDMANPRESS_ACCESS_TOKEN_SECRET',
+    ]);
+
+    const adapter = new XAdapter({
+      type: 'x',
+      apiKey: env.BLINDMANPRESS_X_CONSUMER_KEY,
+      apiSecret: env.BLINDMANPRESS_X_SECRET_KEY,
+      accessToken: env.BLINDMANPRESS_ACCESS_TOKEN,
+      accessSecret: env.BLINDMANPRESS_ACCESS_TOKEN_SECRET,
+      publishMode: 'dry_run',
+    });
+
+    await expect(adapter.authenticate()).resolves.toMatchObject({
+      accessToken: env.BLINDMANPRESS_ACCESS_TOKEN,
+    });
+  });
+
+  it('builds a YouTube Shorts OAuth consent URL without a network write', () => {
+    const env = requiredEnv(['YOUTUBE_CLIENT_ID', 'YOUTUBE_CLIENT_SECRET']);
+    const redirectUri =
+      process.env.YOUTUBE_REDIRECT_URI ??
+      'https://mac.tail8e7e73.ts.net/network/settings/social/callback/youtube';
+    const codeVerifier =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~';
+    const adapter = new YouTubeAdapter({
+      type: 'youtube',
+      clientId: env.YOUTUBE_CLIENT_ID,
+      clientSecret: env.YOUTUBE_CLIENT_SECRET,
+      redirectUri,
+      publishMode: 'dry_run',
+    });
+
+    const auth = adapter.getAuthorizationUrl({
+      codeVerifier,
+      redirectUri,
+      state: 'live-smoke-state',
+    });
+    const parsed = new URL(auth.url);
+
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(
+      'https://accounts.google.com/o/oauth2/v2/auth',
+    );
+    expect(parsed.searchParams.get('client_id')).toBe(env.YOUTUBE_CLIENT_ID);
+    expect(parsed.searchParams.get('redirect_uri')).toBe(redirectUri);
+    expect(parsed.searchParams.get('access_type')).toBe('offline');
+    expect(parsed.searchParams.get('prompt')).toBe('consent');
+    expect(parsed.searchParams.get('state')).toBe('live-smoke-state');
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(parsed.searchParams.get('scope')?.split(' ')).toEqual(
+      expect.arrayContaining([
+        'https://www.googleapis.com/auth/youtube.upload',
+        'https://www.googleapis.com/auth/youtube.readonly',
+      ]),
+    );
+    expect(auth.codeVerifier).toBe(codeVerifier);
+  });
+
+  it('checks the YouTube OAuth client secret at the token endpoint without a real auth code', async () => {
+    const env = requiredEnv(['YOUTUBE_CLIENT_ID', 'YOUTUBE_CLIENT_SECRET']);
+    const redirectUri =
+      process.env.YOUTUBE_REDIRECT_URI ??
+      'https://mac.tail8e7e73.ts.net/network/settings/social/callback/youtube';
+
+    const response = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: env.YOUTUBE_CLIENT_ID,
+        client_secret: env.YOUTUBE_CLIENT_SECRET,
+        code: 'codex-live-smoke-invalid-code',
+        grant_type: 'authorization_code',
+        redirect_uri: redirectUri,
+      }),
+    });
+    const body = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(body.error).not.toBe('invalid_client');
+  });
+
+  it.skipIf(!process.env.YOUTUBE_REFRESH_TOKEN)(
+    'refreshes YouTube credentials and reads channel metadata when a refresh token is available',
+    async () => {
+      const env = requiredEnv([
+        'YOUTUBE_CLIENT_ID',
+        'YOUTUBE_CLIENT_SECRET',
+        'YOUTUBE_REFRESH_TOKEN',
+      ]);
+      const refreshToken = env.YOUTUBE_REFRESH_TOKEN;
+
+      const adapter = new YouTubeAdapter({
+        type: 'youtube',
+        clientId: env.YOUTUBE_CLIENT_ID,
+        clientSecret: env.YOUTUBE_CLIENT_SECRET,
+        refreshToken,
+        publishMode: 'dry_run',
+      });
+
+      const auth = await adapter.refreshToken(refreshToken);
+      expect(auth.accessToken).toBeTruthy();
+
+      const response = await fetch(
+        'https://www.googleapis.com/youtube/v3/channels?part=id,snippet&mine=true',
+        {
+          headers: { Authorization: `Bearer ${auth.accessToken}` },
+        },
+      );
+      const body = await readJson(response);
+
+      expect(response.ok, JSON.stringify(body)).toBe(true);
+      expect(Array.isArray(body.items)).toBe(true);
+    },
+  );
+});

--- a/packages/social/src/live-smoke.optional.test.ts
+++ b/packages/social/src/live-smoke.optional.test.ts
@@ -44,31 +44,33 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 describeLive('live social credential smoke tests', () => {
   it('validates X OAuth 1.0a credentials with a read-only users/me request', async () => {
     const env = requiredEnv([
-      'BLINDMANPRESS_X_CONSUMER_KEY',
-      'BLINDMANPRESS_X_SECRET_KEY',
-      'BLINDMANPRESS_ACCESS_TOKEN',
-      'BLINDMANPRESS_ACCESS_TOKEN_SECRET',
+      'X_CONSUMER_KEY',
+      'X_API_SECRET',
+      'X_ACCESS_TOKEN',
+      'X_ACCESS_TOKEN_SECRET',
     ]);
 
     const adapter = new XAdapter({
       type: 'x',
-      apiKey: env.BLINDMANPRESS_X_CONSUMER_KEY,
-      apiSecret: env.BLINDMANPRESS_X_SECRET_KEY,
-      accessToken: env.BLINDMANPRESS_ACCESS_TOKEN,
-      accessSecret: env.BLINDMANPRESS_ACCESS_TOKEN_SECRET,
+      apiKey: env.X_CONSUMER_KEY,
+      apiSecret: env.X_API_SECRET,
+      accessToken: env.X_ACCESS_TOKEN,
+      accessSecret: env.X_ACCESS_TOKEN_SECRET,
       publishMode: 'dry_run',
     });
 
     await expect(adapter.authenticate()).resolves.toMatchObject({
-      accessToken: env.BLINDMANPRESS_ACCESS_TOKEN,
+      accessToken: env.X_ACCESS_TOKEN,
     });
   });
 
   it('builds a YouTube Shorts OAuth consent URL without a network write', () => {
-    const env = requiredEnv(['YOUTUBE_CLIENT_ID', 'YOUTUBE_CLIENT_SECRET']);
-    const redirectUri =
-      process.env.YOUTUBE_REDIRECT_URI ??
-      'https://mac.tail8e7e73.ts.net/network/settings/social/callback/youtube';
+    const env = requiredEnv([
+      'YOUTUBE_CLIENT_ID',
+      'YOUTUBE_CLIENT_SECRET',
+      'YOUTUBE_REDIRECT_URI',
+    ]);
+    const redirectUri = env.YOUTUBE_REDIRECT_URI;
     const codeVerifier =
       'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~';
     const adapter = new YouTubeAdapter({
@@ -105,10 +107,12 @@ describeLive('live social credential smoke tests', () => {
   });
 
   it('checks the YouTube OAuth client secret at the token endpoint without a real auth code', async () => {
-    const env = requiredEnv(['YOUTUBE_CLIENT_ID', 'YOUTUBE_CLIENT_SECRET']);
-    const redirectUri =
-      process.env.YOUTUBE_REDIRECT_URI ??
-      'https://mac.tail8e7e73.ts.net/network/settings/social/callback/youtube';
+    const env = requiredEnv([
+      'YOUTUBE_CLIENT_ID',
+      'YOUTUBE_CLIENT_SECRET',
+      'YOUTUBE_REDIRECT_URI',
+    ]);
+    const redirectUri = env.YOUTUBE_REDIRECT_URI;
 
     const response = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',

--- a/packages/social/src/media.ts
+++ b/packages/social/src/media.ts
@@ -1,0 +1,87 @@
+export interface ResolvedMediaData {
+  data: Buffer;
+  mimeType: string;
+}
+
+export async function resolveMediaData(
+  file: Buffer | string,
+  options: {
+    explicitMimeType?: string;
+    fallbackMimeType?: string;
+  } = {},
+): Promise<ResolvedMediaData> {
+  const explicitMimeType = normalizeMimeType(options.explicitMimeType);
+
+  if (Buffer.isBuffer(file)) {
+    return {
+      data: file,
+      mimeType:
+        explicitMimeType ??
+        detectMimeType(file) ??
+        options.fallbackMimeType ??
+        'application/octet-stream',
+    };
+  }
+
+  const response = await fetch(file);
+  const data = Buffer.from(await response.arrayBuffer());
+
+  return {
+    data,
+    mimeType:
+      explicitMimeType ??
+      normalizeMimeType(response.headers.get('content-type')) ??
+      detectMimeType(data) ??
+      options.fallbackMimeType ??
+      'application/octet-stream',
+  };
+}
+
+export function normalizeMimeType(value?: string | null): string | undefined {
+  const mimeType = value?.split(';')[0]?.trim().toLowerCase();
+  if (!mimeType || !/^[a-z0-9.+-]+\/[a-z0-9.+-]+$/.test(mimeType)) {
+    return undefined;
+  }
+
+  return mimeType;
+}
+
+function detectMimeType(data: Buffer): string | undefined {
+  if (data.length >= 8 && data.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return 'image/png';
+  }
+
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8) {
+    return 'image/jpeg';
+  }
+
+  const header = data.subarray(0, 12).toString('ascii');
+  if (header.startsWith('GIF87a') || header.startsWith('GIF89a')) {
+    return 'image/gif';
+  }
+
+  if (header.startsWith('RIFF') && header.slice(8, 12) === 'WEBP') {
+    return 'image/webp';
+  }
+
+  if (data.length >= 12 && data.subarray(4, 8).toString('ascii') === 'ftyp') {
+    const brand = data.subarray(8, 12).toString('ascii');
+    return brand === 'qt  ' ? 'video/quicktime' : 'video/mp4';
+  }
+
+  if (
+    data.length >= 4 &&
+    data[0] === 0x1a &&
+    data[1] === 0x45 &&
+    data[2] === 0xdf &&
+    data[3] === 0xa3
+  ) {
+    return 'video/webm';
+  }
+
+  return undefined;
+}
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);

--- a/packages/social/src/media.ts
+++ b/packages/social/src/media.ts
@@ -24,6 +24,15 @@ export async function resolveMediaData(
   }
 
   const response = await fetch(file);
+  if (!response.ok) {
+    const snippet = await response.text();
+    throw new Error(
+      `Failed to fetch media from ${file}: ${response.status} ${response.statusText}${
+        snippet ? ` - ${snippet.slice(0, 200)}` : ''
+      }`,
+    );
+  }
+
   const data = Buffer.from(await response.arrayBuffer());
 
   return {

--- a/packages/social/src/safety.ts
+++ b/packages/social/src/safety.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import type {
   BaseSocialConfig,
   PostResult,
@@ -23,10 +25,11 @@ export function createSafetyResult(options: {
   remoteId?: string;
   staged?: boolean;
   note?: string;
+  metadata?: Record<string, unknown>;
 }): PostResult {
   const status = options.mode === 'dry_run' ? 'dry_run' : 'staged';
   const id =
-    options.remoteId ?? `${options.platform}-${status}-${crypto.randomUUID()}`;
+    options.remoteId ?? `${options.platform}-${status}-${randomUUID()}`;
 
   return {
     id,
@@ -40,6 +43,7 @@ export function createSafetyResult(options: {
       remoteId: options.remoteId,
       payload: options.payload,
       note: options.note,
+      ...options.metadata,
     },
   };
 }

--- a/packages/social/src/safety.ts
+++ b/packages/social/src/safety.ts
@@ -1,0 +1,45 @@
+import type {
+  BaseSocialConfig,
+  PostResult,
+  PublishMode,
+  SocialPlatformType,
+} from './types.js';
+
+export function resolvePublishMode(
+  config: Pick<BaseSocialConfig, 'publishMode'>,
+): PublishMode {
+  return config.publishMode ?? 'public';
+}
+
+export function isPublicPublishMode(mode: PublishMode): boolean {
+  return mode === 'public';
+}
+
+export function createSafetyResult(options: {
+  platform: SocialPlatformType;
+  mode: PublishMode;
+  postType: 'text' | 'image' | 'video' | 'link';
+  payload?: unknown;
+  remoteId?: string;
+  staged?: boolean;
+  note?: string;
+}): PostResult {
+  const status = options.mode === 'dry_run' ? 'dry_run' : 'staged';
+  const id =
+    options.remoteId ?? `${options.platform}-${status}-${crypto.randomUUID()}`;
+
+  return {
+    id,
+    url: '',
+    status,
+    metadata: {
+      publishMode: options.mode,
+      safety: true,
+      staged: options.staged ?? status === 'staged',
+      postType: options.postType,
+      remoteId: options.remoteId,
+      payload: options.payload,
+      note: options.note,
+    },
+  };
+}

--- a/packages/social/src/types.ts
+++ b/packages/social/src/types.ts
@@ -268,6 +268,12 @@ export interface VideoPost {
   file: Buffer | string;
 
   /**
+   * MIME type for the video file. Detected from URLs and common buffer
+   * signatures when omitted.
+   */
+  mimeType?: string;
+
+  /**
    * Video title (YouTube, some platforms)
    */
   title?: string;
@@ -281,6 +287,12 @@ export interface VideoPost {
    * Custom thumbnail image
    */
   thumbnail?: Buffer | string;
+
+  /**
+   * MIME type for the thumbnail image. Detected from URLs and common buffer
+   * signatures when omitted.
+   */
+  thumbnailMimeType?: string;
 
   /**
    * Hashtags to include
@@ -327,6 +339,12 @@ export interface ImagePost {
    * Image file buffer or URL
    */
   file: Buffer | string;
+
+  /**
+   * MIME type for the image file. Detected from URLs and common buffer
+   * signatures when omitted.
+   */
+  mimeType?: string;
 
   /**
    * Alt text for accessibility

--- a/packages/social/src/types.ts
+++ b/packages/social/src/types.ts
@@ -7,7 +7,30 @@
 /**
  * Supported social platforms
  */
-export type SocialPlatformType = 'youtube' | 'threads' | 'x' | 'bluesky';
+export type SocialPlatformType =
+  | 'youtube'
+  | 'threads'
+  | 'x'
+  | 'bluesky'
+  | 'facebook';
+
+/**
+ * How adapters should attach links to posts.
+ */
+export type LinkBehavior = 'inline' | 'attachment' | 'reply' | 'none';
+
+/**
+ * Safety mode for publish operations.
+ * - dry_run: Build and validate payloads without platform API writes
+ * - stage_remote: Use non-public staging endpoints where available
+ * - private_or_scheduled: Create a non-public/private/scheduled platform object where available
+ * - public: Publish publicly
+ */
+export type PublishMode =
+  | 'dry_run'
+  | 'stage_remote'
+  | 'private_or_scheduled'
+  | 'public';
 
 /**
  * Base configuration for social platform adapters
@@ -38,6 +61,12 @@ export interface BaseSocialConfig {
    * @default 30000
    */
   timeout?: number;
+
+  /**
+   * Controls whether publish calls create public content.
+   * Defaults to public for backward compatibility.
+   */
+  publishMode?: PublishMode;
 }
 
 /**
@@ -90,30 +119,81 @@ export interface ThreadsConfig extends BaseSocialConfig {
 }
 
 /**
+ * Facebook Page configuration
+ */
+export interface FacebookPageConfig extends BaseSocialConfig {
+  type: 'facebook';
+
+  /**
+   * Page access token with pages_manage_posts permission
+   */
+  accessToken: string;
+
+  /**
+   * Facebook Page ID
+   */
+  pageId: string;
+
+  /**
+   * Optional Graph API version.
+   * @default v24.0
+   */
+  apiVersion?: string;
+}
+
+/**
  * X (Twitter) configuration
  */
 export interface XConfig extends BaseSocialConfig {
   type: 'x';
 
   /**
-   * API key (consumer key)
+   * Authentication mode. OAuth 2.0 is used when accessSecret is omitted.
+   *
+   * @default 'oauth1' when accessSecret is present, otherwise 'oauth2'
    */
-  apiKey: string;
+  authType?: 'oauth1' | 'oauth2';
 
   /**
-   * API secret (consumer secret)
+   * API key (consumer key) for OAuth 1.0a.
    */
-  apiSecret: string;
+  apiKey?: string;
 
   /**
-   * User access token
+   * API secret (consumer secret) for OAuth 1.0a.
+   */
+  apiSecret?: string;
+
+  /**
+   * User access token.
    */
   accessToken: string;
 
   /**
-   * User access token secret
+   * User access token secret for OAuth 1.0a.
    */
-  accessSecret: string;
+  accessSecret?: string;
+
+  /**
+   * OAuth 2.0 client ID for refresh-token flows.
+   */
+  clientId?: string;
+
+  /**
+   * OAuth 2.0 client secret for confidential clients.
+   */
+  clientSecret?: string;
+
+  /**
+   * OAuth 2.0 refresh token.
+   */
+  refreshToken?: string;
+
+  /**
+   * Default handling for links.
+   * @default 'inline'
+   */
+  linkBehavior?: LinkBehavior;
 }
 
 /**
@@ -144,6 +224,7 @@ export interface BlueskyConfig extends BaseSocialConfig {
 export type SocialConfig =
   | YouTubeConfig
   | ThreadsConfig
+  | FacebookPageConfig
   | XConfig
   | BlueskyConfig;
 
@@ -231,6 +312,11 @@ export interface VideoPost {
    * Whether this is a Short (YouTube)
    */
   isShort?: boolean;
+
+  /**
+   * Override the adapter/account default link behavior for this post.
+   */
+  linkBehavior?: LinkBehavior;
 }
 
 /**
@@ -266,6 +352,11 @@ export interface ImagePost {
    * Scheduled publish time
    */
   scheduledAt?: Date;
+
+  /**
+   * Override the adapter/account default link behavior for this post.
+   */
+  linkBehavior?: LinkBehavior;
 }
 
 /**
@@ -296,6 +387,51 @@ export interface TextPost {
    * Reply to post ID (for threads/replies)
    */
   replyTo?: string;
+
+  /**
+   * Override the adapter/account default link behavior for this post.
+   */
+  linkBehavior?: LinkBehavior;
+}
+
+/**
+ * Link post content
+ */
+export interface LinkPost {
+  /**
+   * URL to share
+   */
+  url: string;
+
+  /**
+   * Post text/caption
+   */
+  text?: string;
+
+  /**
+   * Link title for platforms that support link cards
+   */
+  title?: string;
+
+  /**
+   * Link description for platforms that support link cards
+   */
+  description?: string;
+
+  /**
+   * Hashtags to include
+   */
+  tags?: string[];
+
+  /**
+   * Scheduled publish time
+   */
+  scheduledAt?: Date;
+
+  /**
+   * Override the adapter/account default link behavior for this post.
+   */
+  linkBehavior?: LinkBehavior;
 }
 
 /**
@@ -315,7 +451,7 @@ export interface PostResult {
   /**
    * Publication status
    */
-  status: 'published' | 'scheduled' | 'processing';
+  status: 'published' | 'scheduled' | 'processing' | 'staged' | 'dry_run';
 
   /**
    * When the post was/will be published
@@ -350,7 +486,7 @@ export interface Post {
   /**
    * Post type
    */
-  type: 'video' | 'image' | 'text';
+  type: 'video' | 'image' | 'text' | 'link';
 
   /**
    * Post title (if applicable)
@@ -388,6 +524,11 @@ export interface PostAnalytics {
   views?: number;
 
   /**
+   * Impression count when the platform distinguishes it from views
+   */
+  impressions?: number;
+
+  /**
    * Like/favorite count
    */
   likes?: number;
@@ -406,6 +547,11 @@ export interface PostAnalytics {
    * Click count (for links)
    */
   clicks?: number;
+
+  /**
+   * Raw platform analytics payload for debugging and future reporting
+   */
+  raw?: unknown;
 
   /**
    * When analytics were last updated
@@ -433,6 +579,16 @@ export interface PlatformCapabilities {
   text: boolean;
 
   /**
+   * Supports first-class link posts or link attachments
+   */
+  link: boolean;
+
+  /**
+   * Supports native link attachments/cards instead of plain inline URLs
+   */
+  linkAttachment?: boolean;
+
+  /**
    * Supports scheduled posting
    */
   scheduling: boolean;
@@ -441,6 +597,31 @@ export interface PlatformCapabilities {
    * Supports analytics retrieval
    */
   analytics: boolean;
+
+  /**
+   * Analytics can include raw platform payloads
+   */
+  rawAnalytics?: boolean;
+
+  /**
+   * Safety modes supported by this adapter.
+   */
+  publishModes?: PublishMode[];
+
+  /**
+   * Supports a non-public remote staging step before final publish.
+   */
+  staging?: boolean;
+
+  /**
+   * Supports creating private, unpublished, or scheduled platform content.
+   */
+  privatePublishing?: boolean;
+
+  /**
+   * Media publishing requires a publicly accessible URL, not a Buffer upload
+   */
+  requiresPublicMediaUrl?: boolean;
 
   /**
    * Maximum video duration in seconds
@@ -471,6 +652,11 @@ export interface PlatformCapabilities {
    * Maximum number of hashtags
    */
   maxHashtags?: number;
+
+  /**
+   * Supported high-level post types
+   */
+  supportedPostTypes?: Array<'text' | 'image' | 'video' | 'link'>;
 }
 
 /**
@@ -506,6 +692,11 @@ export interface SocialPlatform {
    * Publish a text post
    */
   publishText(text: TextPost): Promise<PostResult>;
+
+  /**
+   * Publish a link post
+   */
+  publishLink(link: LinkPost): Promise<PostResult>;
 
   /**
    * Get a post by ID


### PR DESCRIPTION
## Summary
- Add LinkPost/publishLink, publish modes, dry-run/staged safety results, and normalized raw analytics fields to @happyvertical/social.
- Add a first-class Facebook Page adapter for feed link/text/image posts and Page video uploads.
- Update X, Threads, YouTube, and Bluesky adapters for Garrula v1 link/video workflows, safe non-public testing modes, and docs.
- Add focused request-shape/unit coverage plus optional live smoke tests for read-only credential checks.

## Validation
- pnpm --dir packages/social test
- pnpm --dir packages/social build
- pnpm exec biome check --write packages/social/src/index.ts packages/social/src/index.spec.ts packages/social/src/types.ts packages/social/src/safety.ts packages/social/src/adapters/facebook.ts packages/social/src/adapters/x.ts packages/social/src/adapters/threads.ts packages/social/src/adapters/youtube.ts packages/social/src/adapters/bluesky.ts packages/social/src/live-smoke.optional.test.ts
- git diff --check
- pre-push hook: pnpm typecheck

## Notes
- Optional live smoke tests were added but not run here because the social credential env vars were not present in this shell.
- The existing local video WebP frame extraction change is intentionally not included in this PR; it appears to belong to origin/codex/fix-webp-frame-extraction.