### PR TITLE
feat: add payments backend interface package

### DIFF
--- a/packages/payments/README.md
+++ b/packages/payments/README.md
@@ -1,0 +1,41 @@
+# @happyvertical/payments
+
+Provider-neutral payment primitives for Happy Vertical quotes, settlement, x402 proof verification, and payouts.
+
+This package intentionally contains only the interface and shared conformance tests. Concrete backends such as Base USDC, Stripe Checkout, or bank rails can live in sibling adapter packages while sharing the same quote/status/payout contract.
+
+## Install
+
+```bash
+npm install @happyvertical/payments
+```
+
+## PaymentBackend shape
+
+A backend declares its capabilities and implements:
+
+- `createPaymentOption(input)` — create a unique address or checkout URL for a quote.
+- `watchPayment(input)` — stream/poll payment updates for a quote option.
+- `getStatus(input)` — idempotently return the current state of a quote option.
+- `verifyX402Proof(input)` — optional x402 `X-Payment` proof verification for crypto-capable backends.
+- `sendPayout(input)` — send a native payout or refund through the backend.
+
+## Adapter conformance
+
+Adapters can import `createPaymentBackendConformanceCases()` and run the returned cases in their own test suite:
+
+```ts
+import { createPaymentBackendConformanceCases } from '@happyvertical/payments';
+import { describe, it } from 'vitest';
+import { createBaseUsdcAdapter } from './base-usdc';
+
+describe('BaseUsdcAdapter conformance', () => {
+  for (const testCase of createPaymentBackendConformanceCases({
+    createBackend: createBaseUsdcAdapter,
+  })) {
+    it(testCase.name, testCase.run);
+  }
+});
+```
+
+The initial suite checks stable capabilities, quote option creation, and idempotent status reads. Adapter-specific issues can extend it with watch, x402, refund, and payout cases.

--- a/packages/payments/metadata.json
+++ b/packages/payments/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "payments",
+  "description": "Payment backend abstraction for quote settlement, x402 proof verification, and payouts",
+  "category": "payments",
+  "language": "typescript",
+  "package": "@happyvertical/payments"
+}

--- a/packages/payments/package.json
+++ b/packages/payments/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@happyvertical/payments",
+  "version": "0.74.0",
+  "description": "Payment backend abstraction for quotes, settlement, x402 proof verification, and payouts",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "AGENT.md",
+    "metadata.json"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/payments"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/payments#readme",
+  "license": "MIT",
+  "scripts": {
+    "test": "npx vitest run",
+    "test:watch": "npx vitest",
+    "build": "vite build",
+    "build:watch": "vite build --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "25.0.10",
+    "typescript": "^5.9.3",
+    "vite": "7.3.2",
+    "vite-plugin-dts": "4.5.4",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/payments/src/conformance.ts
+++ b/packages/payments/src/conformance.ts
@@ -15,11 +15,13 @@ export interface PaymentBackendConformanceCase {
   run: () => Promise<void>;
 }
 
-const DEFAULT_SAMPLE_INPUT: CreatePaymentOptionInput = {
-  quoteId: 'quote-conformance-1',
-  usdAmount: 12.34,
-  expiresAt: new Date('2030-01-01T00:00:00.000Z'),
-};
+function createDefaultSampleInput(): CreatePaymentOptionInput {
+  return {
+    quoteId: 'quote-conformance-1',
+    usdAmount: 12.34,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  };
+}
 
 export function createPaymentBackendConformanceCases(
   options: PaymentBackendConformanceOptions,
@@ -35,7 +37,7 @@ export function createPaymentBackendConformanceCases(
       name: 'creates a payment option for a quote',
       run: async () => {
         const backend = options.createBackend();
-        const input = options.sampleInput ?? DEFAULT_SAMPLE_INPUT;
+        const input = options.sampleInput ?? createDefaultSampleInput();
         const option = await backend.createPaymentOption(input);
         assertPaymentOption(backend.capabilities, input, option);
       },
@@ -44,7 +46,7 @@ export function createPaymentBackendConformanceCases(
       name: 'returns an idempotent quote status',
       run: async () => {
         const backend = options.createBackend();
-        const input = options.sampleInput ?? DEFAULT_SAMPLE_INPUT;
+        const input = options.sampleInput ?? createDefaultSampleInput();
         const option = await backend.createPaymentOption(input);
         const status = await backend.getStatus({
           quoteId: option.quoteId,

--- a/packages/payments/src/conformance.ts
+++ b/packages/payments/src/conformance.ts
@@ -1,0 +1,95 @@
+import type {
+  CreatePaymentOptionInput,
+  PaymentBackend,
+  PaymentBackendCapabilities,
+  PaymentOption,
+} from './types';
+
+export interface PaymentBackendConformanceOptions {
+  createBackend: () => PaymentBackend;
+  sampleInput?: CreatePaymentOptionInput;
+}
+
+export interface PaymentBackendConformanceCase {
+  name: string;
+  run: () => Promise<void>;
+}
+
+const DEFAULT_SAMPLE_INPUT: CreatePaymentOptionInput = {
+  quoteId: 'quote-conformance-1',
+  usdAmount: 12.34,
+  expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+};
+
+export function createPaymentBackendConformanceCases(
+  options: PaymentBackendConformanceOptions,
+): PaymentBackendConformanceCase[] {
+  return [
+    {
+      name: 'declares stable payment capabilities',
+      run: async () => {
+        assertCapabilities(options.createBackend().capabilities);
+      },
+    },
+    {
+      name: 'creates a payment option for a quote',
+      run: async () => {
+        const backend = options.createBackend();
+        const input = options.sampleInput ?? DEFAULT_SAMPLE_INPUT;
+        const option = await backend.createPaymentOption(input);
+        assertPaymentOption(backend.capabilities, input, option);
+      },
+    },
+    {
+      name: 'returns an idempotent quote status',
+      run: async () => {
+        const backend = options.createBackend();
+        const input = options.sampleInput ?? DEFAULT_SAMPLE_INPUT;
+        const option = await backend.createPaymentOption(input);
+        const status = await backend.getStatus({
+          quoteId: option.quoteId,
+          payTo: option.payTo,
+        });
+
+        assert(status.backendId === backend.capabilities.id, 'status backend id mismatch');
+        assert(status.quoteId === option.quoteId, 'status quote id mismatch');
+        assert(status.payTo === option.payTo, 'status payTo mismatch');
+      },
+    },
+  ];
+}
+
+function assertCapabilities(capabilities: PaymentBackendCapabilities): void {
+  assert(capabilities.id.length > 0, 'capability id is required');
+  assert(capabilities.settlementCurrency.length > 0, 'settlement currency is required');
+  assert(capabilities.chainId.length > 0, 'chain id/provider id is required');
+  assert(
+    capabilities.typicalConfirmationLatencyMs >= 0,
+    'typical confirmation latency must be non-negative',
+  );
+}
+
+function assertPaymentOption(
+  capabilities: PaymentBackendCapabilities,
+  input: CreatePaymentOptionInput,
+  option: PaymentOption,
+): void {
+  assert(option.backendId === capabilities.id, 'payment option backend id mismatch');
+  assert(option.quoteId === input.quoteId, 'payment option quote id mismatch');
+  assert(option.usdAmount === input.usdAmount, 'payment option amount mismatch');
+  assert(option.payTo.length > 0, 'payment option payTo is required');
+  assert(
+    option.settlementCurrency === capabilities.settlementCurrency,
+    'payment option settlement currency mismatch',
+  );
+  assert(
+    option.settlementShape === capabilities.settlementShape,
+    'payment option settlement shape mismatch',
+  );
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/packages/payments/src/index.test.ts
+++ b/packages/payments/src/index.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPaymentBackendConformanceCases,
+  type PaymentBackend,
+  type PaymentUpdate,
+} from './index';
+
+function createMemoryBackend(): PaymentBackend {
+  const updates = new Map<string, PaymentUpdate>();
+
+  return {
+    capabilities: {
+      id: 'memory-usd',
+      settlementCurrency: 'USD',
+      chainId: 'memory',
+      x402Capable: false,
+      typicalConfirmationLatencyMs: 0,
+      supportsRefunds: true,
+      settlementShape: 'url',
+    },
+    async createPaymentOption(input) {
+      const option = {
+        backendId: 'memory-usd',
+        quoteId: input.quoteId,
+        settlementShape: 'url' as const,
+        settlementCurrency: 'USD',
+        payTo: `https://payments.example/quotes/${input.quoteId}`,
+        usdAmount: input.usdAmount,
+        expiresAt: input.expiresAt,
+      };
+      updates.set(input.quoteId, {
+        backendId: option.backendId,
+        quoteId: option.quoteId,
+        payTo: option.payTo,
+        status: 'pending',
+      });
+      return option;
+    },
+    async *watchPayment(input) {
+      yield await this.getStatus(input);
+    },
+    async getStatus(input) {
+      const update = updates.get(input.quoteId);
+      if (!update) {
+        throw new Error(`unknown quote ${input.quoteId}`);
+      }
+      return update;
+    },
+    async sendPayout(input) {
+      return {
+        id: 'payout-memory-1',
+        status: 'confirmed',
+        destination: input.destination,
+        amount: input.amount,
+        currency: input.currency,
+      };
+    },
+  };
+}
+
+describe('payment backend conformance suite', () => {
+  for (const testCase of createPaymentBackendConformanceCases({
+    createBackend: createMemoryBackend,
+  })) {
+    it(testCase.name, async () => {
+      await expect(testCase.run()).resolves.toBeUndefined();
+    });
+  }
+});

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @happyvertical/payments - payment backend abstractions.
+ *
+ * This package defines the provider-neutral interface used by checkout, x402,
+ * fiat checkout, and payout adapters. Concrete adapters live beside this
+ * package and prove compatibility with the shared conformance suite.
+ */
+
+export * from './conformance';
+export * from './types';
+
+/** @internal */
+export const PACKAGE_VERSION_INITIALIZED = true;

--- a/packages/payments/src/types.ts
+++ b/packages/payments/src/types.ts
@@ -1,0 +1,119 @@
+export type PaymentSettlementShape = 'address' | 'url';
+
+export type PaymentStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'expired'
+  | 'failed'
+  | 'refunded';
+
+export interface PaymentBackendCapabilities {
+  /** Stable machine id, for example `base-usdc` or `stripe-checkout`. */
+  id: string;
+  /** Settlement currency shown to operators and invoices, for example `USDC`. */
+  settlementCurrency: string;
+  /** Chain/network id for crypto backends, or provider id for fiat backends. */
+  chainId: string;
+  /** Whether this backend can verify an x402 `X-Payment` proof. */
+  x402Capable: boolean;
+  /** Typical confirmation latency in milliseconds for UX and timeout hints. */
+  typicalConfirmationLatencyMs: number;
+  /** Whether this backend can return funds through `sendPayout`. */
+  supportsRefunds: boolean;
+  /** Crypto backends usually return an address; fiat backends may return URLs. */
+  settlementShape: PaymentSettlementShape;
+}
+
+export interface CreatePaymentOptionInput {
+  quoteId: string;
+  usdAmount: number;
+  expiresAt: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PaymentOption {
+  backendId: string;
+  quoteId: string;
+  settlementShape: PaymentSettlementShape;
+  settlementCurrency: string;
+  payTo: string;
+  usdAmount: number;
+  nativeAmount?: string;
+  memo?: string;
+  expiresAt: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface WatchPaymentInput {
+  quoteId: string;
+  payTo: string;
+  signal?: AbortSignal;
+}
+
+export interface PaymentUpdate {
+  backendId: string;
+  quoteId: string;
+  payTo: string;
+  status: PaymentStatus;
+  txHash?: string;
+  paidAmount?: string;
+  paidAt?: Date;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface GetPaymentStatusInput {
+  quoteId: string;
+  payTo: string;
+}
+
+export interface VerifyX402ProofInput {
+  quoteId: string;
+  payTo: string;
+  usdAmount: number;
+  xPaymentHeader: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface X402ProofVerification {
+  valid: boolean;
+  quoteId: string;
+  payTo: string;
+  txHash?: string;
+  payer?: string;
+  paidAmount?: string;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SendPayoutInput {
+  destination: string;
+  amount: string;
+  currency: string;
+  memo?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PayoutResult {
+  id: string;
+  status: PaymentStatus;
+  txHash?: string;
+  destination: string;
+  amount: string;
+  currency: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PaymentBackend {
+  readonly capabilities: PaymentBackendCapabilities;
+
+  createPaymentOption(input: CreatePaymentOptionInput): Promise<PaymentOption>;
+
+  watchPayment(input: WatchPaymentInput): AsyncIterable<PaymentUpdate>;
+
+  getStatus(input: GetPaymentStatusInput): Promise<PaymentUpdate>;
+
+  verifyX402Proof?(input: VerifyX402ProofInput): Promise<X402ProofVerification>;
+
+  sendPayout(input: SendPayoutInput): Promise<PayoutResult>;
+}

--- a/packages/payments/tsconfig.json
+++ b/packages/payments/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/payments/vite.config.ts
+++ b/packages/payments/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('payments');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "compilerOptions": {
     // Language and Environment
     "target": "ES2023",
@@ -48,6 +48,7 @@
     { "path": "./packages/files" },
     { "path": "./packages/sql" },
     { "path": "./packages/ai" },
+    { "path": "./packages/payments" },
 
     { "path": "./packages/analytics" },
 
@@ -72,3 +73,5 @@
     { "path": "./packages/projects" }
   ]
 }
+
+


### PR DESCRIPTION
## Summary
- add `@happyvertical/payments` package scaffold for the PaymentBackend abstraction
- export quote option, status, x402 proof verification, and payout types
- include a shared conformance-case scaffold and unit coverage with a memory backend
- register the package in the root TypeScript project references

## Verification
- `npx -y -p typescript@5.9.3 -p @types/node@25.0.10 tsc --noEmit --target ES2023 --lib ES2023,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --strict --skipLibCheck tmp/happyvertical-payments/src/index.ts tmp/happyvertical-payments/src/conformance.ts tmp/happyvertical-payments/src/types.ts --types node`

Closes #1028.