### PR TITLE
feat(sql,files,utils): db ops tooling primitives

### DIFF
--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -57,6 +57,8 @@ export {
 export { LocalFilesystemProvider } from './node/local';
 export { GoogleDriveProvider } from './providers/gdrive';
 export { S3FilesystemProvider } from './providers/s3';
+// Secret redaction utility for provider configs
+export { redactFilesystemConfig } from './redact';
 // Export main factory function and types
 export {
   getAvailableProviders,

--- a/packages/files/src/redact.test.ts
+++ b/packages/files/src/redact.test.ts
@@ -55,4 +55,28 @@ describe('redactFilesystemConfig', () => {
       ServiceAccountKey: '[redacted]',
     });
   });
+
+  it('handles circular references without stack overflow', () => {
+    // Connection pools and EventEmitter-backed config holders sometimes
+    // carry circular references. Recursing without a visited guard
+    // crashes with RangeError; the WeakSet guard returns a sentinel
+    // instead so secrets at higher levels are still redacted.
+    const config: Record<string, unknown> = {
+      name: 'cycle',
+      password: 'should-be-redacted',
+    };
+    config.self = config;
+    const result = redactFilesystemConfig(config) as Record<string, unknown>;
+    expect(result.name).toBe('cycle');
+    expect(result.password).toBe('[redacted]');
+    expect(result.self).toBe('[circular]');
+  });
+
+  it('handles circular references in arrays', () => {
+    const arr: unknown[] = [{ token: 'oops' }];
+    arr.push(arr);
+    const result = redactFilesystemConfig(arr) as unknown[];
+    expect((result[0] as Record<string, unknown>).token).toBe('[redacted]');
+    expect(result[1]).toBe('[circular]');
+  });
 });

--- a/packages/files/src/redact.test.ts
+++ b/packages/files/src/redact.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { redactFilesystemConfig } from './redact.js';
+
+describe('redactFilesystemConfig', () => {
+  it('redacts common credential keys, leaves non-secret keys intact', () => {
+    expect(
+      redactFilesystemConfig({
+        accessKeyId: 'key',
+        basePath: 'employment-search/profile-assets',
+        clientSecret: 'client-secret',
+        credentials: {
+          client_email: 'service@example.com',
+          private_key: 'private-key',
+        },
+        secretAccessKey: 'secret',
+        type: 's3',
+      }),
+    ).toEqual({
+      accessKeyId: '[redacted]',
+      basePath: 'employment-search/profile-assets',
+      clientSecret: '[redacted]',
+      credentials: '[redacted]',
+      secretAccessKey: '[redacted]',
+      type: 's3',
+    });
+  });
+
+  it('handles arrays and nested objects without secret keys', () => {
+    expect(
+      redactFilesystemConfig({ list: [{ name: 'a' }, { name: 'b' }] }),
+    ).toEqual({
+      list: [{ name: 'a' }, { name: 'b' }],
+    });
+  });
+
+  it('returns scalars unchanged', () => {
+    expect(redactFilesystemConfig('hello')).toBe('hello');
+    expect(redactFilesystemConfig(42)).toBe(42);
+    expect(redactFilesystemConfig(null)).toBeNull();
+    expect(redactFilesystemConfig(undefined)).toBeUndefined();
+  });
+
+  it('redacts case-insensitive variants', () => {
+    expect(
+      redactFilesystemConfig({
+        APIKey: 'a',
+        Token: 'b',
+        Password: 'c',
+        ServiceAccountKey: 'd',
+      }),
+    ).toEqual({
+      APIKey: '[redacted]',
+      Token: '[redacted]',
+      Password: '[redacted]',
+      ServiceAccountKey: '[redacted]',
+    });
+  });
+});

--- a/packages/files/src/redact.test.ts
+++ b/packages/files/src/redact.test.ts
@@ -79,4 +79,27 @@ describe('redactFilesystemConfig', () => {
     expect((result[0] as Record<string, unknown>).token).toBe('[redacted]');
     expect(result[1]).toBe('[circular]');
   });
+
+  it('preserves DAG-shaped input (shared non-cyclic references)', () => {
+    // Two pointers to the same non-cyclic sub-object should both receive
+    // the redacted structure, not get `'[circular]'` on the second branch.
+    // Real-world example: a config with two providers sharing one
+    // credentials object.
+    const shared = { name: 'creds', privateKey: 'secret' };
+    const result = redactFilesystemConfig({
+      outbound: shared,
+      inbound: shared,
+    }) as Record<string, unknown>;
+    expect(result.outbound).toEqual({
+      name: 'creds',
+      privateKey: '[redacted]',
+    });
+    // Second branch must get the same redacted structure, NOT a sentinel.
+    expect(result.inbound).toEqual({
+      name: 'creds',
+      privateKey: '[redacted]',
+    });
+    // And the two should be reference-equal (same cached output).
+    expect(result.outbound).toBe(result.inbound);
+  });
 });

--- a/packages/files/src/redact.ts
+++ b/packages/files/src/redact.ts
@@ -31,17 +31,34 @@ function looksLikeSecret(key: string): boolean {
 export function redactFilesystemConfig<T>(
   value: T,
 ): T extends object ? unknown : T {
-  return redactSecrets(value) as T extends object ? unknown : T;
+  return redactSecrets(value, new WeakSet()) as T extends object ? unknown : T;
 }
 
-function redactSecrets(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(redactSecrets);
+/**
+ * Recurse, replacing values at secret-shaped keys with `[redacted]`.
+ *
+ * `seen` is a WeakSet of already-visited objects/arrays. Configs handed
+ * to this helper can come from anywhere — ORM connection bags,
+ * EventEmitter-backed config holders, user-constructed objects — and
+ * those occasionally carry circular references. Without a visited
+ * guard the recursion overflows the stack on cyclic input. The guard
+ * returns the `'[circular]'` sentinel for a re-visit, which is more
+ * useful than a crash and still hides any nested secrets.
+ */
+function redactSecrets(value: unknown, seen: WeakSet<object>): unknown {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return '[circular]';
+    seen.add(value);
+    return value.map((item) => redactSecrets(item, seen));
+  }
   if (!value || typeof value !== 'object') return value;
+  if (seen.has(value as object)) return '[circular]';
+  seen.add(value as object);
 
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>).map(([key, item]) => [
       key,
-      looksLikeSecret(key) ? '[redacted]' : redactSecrets(item),
+      looksLikeSecret(key) ? '[redacted]' : redactSecrets(item, seen),
     ]),
   );
 }

--- a/packages/files/src/redact.ts
+++ b/packages/files/src/redact.ts
@@ -1,0 +1,47 @@
+/**
+ * Recursively walk a filesystem-config-shaped object and replace any value
+ * whose key looks like a secret (token, password, accessKeyId, privateKey, …)
+ * with the literal string '[redacted]'.
+ *
+ * Useful when serializing a `GetFilesystemOptions` (or any nested config that
+ * may contain provider credentials) into logs, backup manifests, status
+ * dumps, or error messages.
+ */
+const SECRET_KEY_FRAGMENTS = [
+  'apikey',
+  'api_key',
+  'clientsecret',
+  'client_secret',
+  'credential',
+  'privatekey',
+  'private_key',
+  'secret',
+  'password',
+  'token',
+] as const;
+
+const EXACT_SECRET_KEYS = new Set(['serviceaccountkey', 'accesskeyid']);
+
+function looksLikeSecret(key: string): boolean {
+  const normalized = key.toLowerCase();
+  if (EXACT_SECRET_KEYS.has(normalized)) return true;
+  return SECRET_KEY_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
+
+export function redactFilesystemConfig<T>(
+  value: T,
+): T extends object ? unknown : T {
+  return redactSecrets(value) as T extends object ? unknown : T;
+}
+
+function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+      key,
+      looksLikeSecret(key) ? '[redacted]' : redactSecrets(item),
+    ]),
+  );
+}

--- a/packages/files/src/redact.ts
+++ b/packages/files/src/redact.ts
@@ -31,34 +31,54 @@ function looksLikeSecret(key: string): boolean {
 export function redactFilesystemConfig<T>(
   value: T,
 ): T extends object ? unknown : T {
-  return redactSecrets(value, new WeakSet()) as T extends object ? unknown : T;
+  return redactSecrets(value, new WeakSet(), new WeakMap()) as T extends object
+    ? unknown
+    : T;
 }
 
 /**
  * Recurse, replacing values at secret-shaped keys with `[redacted]`.
  *
- * `seen` is a WeakSet of already-visited objects/arrays. Configs handed
- * to this helper can come from anywhere — ORM connection bags,
- * EventEmitter-backed config holders, user-constructed objects — and
- * those occasionally carry circular references. Without a visited
- * guard the recursion overflows the stack on cyclic input. The guard
- * returns the `'[circular]'` sentinel for a re-visit, which is more
- * useful than a crash and still hides any nested secrets.
+ * Distinguishes "currently being processed" (a true back-edge in the
+ * recursion → cycle) from "already fully processed" (DAG-shaped input
+ * where the same object is reachable via two paths). Both cases used
+ * to produce `'[circular]'`, but the second case is wrong: a config
+ * that legitimately shares a sub-object between branches should get
+ * the same redacted output on both branches, not a sentinel on the
+ * second.
+ *
+ * - `inProgress` tracks ancestors in the current DFS path. Re-visit
+ *   → true cycle → return `'[circular]'`.
+ * - `done` caches the redacted output of objects whose recursion has
+ *   completed. Re-visit → DAG share → return the cached result so
+ *   both branches end up with identical structure.
  */
-function redactSecrets(value: unknown, seen: WeakSet<object>): unknown {
-  if (Array.isArray(value)) {
-    if (seen.has(value)) return '[circular]';
-    seen.add(value);
-    return value.map((item) => redactSecrets(item, seen));
-  }
+function redactSecrets(
+  value: unknown,
+  inProgress: WeakSet<object>,
+  done: WeakMap<object, unknown>,
+): unknown {
   if (!value || typeof value !== 'object') return value;
-  if (seen.has(value as object)) return '[circular]';
-  seen.add(value as object);
+  const obj = value as object;
+  if (done.has(obj)) return done.get(obj);
+  if (inProgress.has(obj)) return '[circular]';
+  inProgress.add(obj);
 
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).map(([key, item]) => [
-      key,
-      looksLikeSecret(key) ? '[redacted]' : redactSecrets(item, seen),
-    ]),
-  );
+  let result: unknown;
+  if (Array.isArray(value)) {
+    result = value.map((item) => redactSecrets(item, inProgress, done));
+  } else {
+    result = Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+        key,
+        looksLikeSecret(key)
+          ? '[redacted]'
+          : redactSecrets(item, inProgress, done),
+      ]),
+    );
+  }
+
+  inProgress.delete(obj);
+  done.set(obj, result);
+  return result;
 }

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -32,6 +32,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./backup": {
+      "import": "./dist/backup/index.js",
+      "types": "./dist/backup/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/sql/src/backup/index.ts
+++ b/packages/sql/src/backup/index.ts
@@ -9,7 +9,7 @@
  * subpath usable by apps that only need the database half.
  */
 import { execFile } from 'node:child_process';
-import { mkdir } from 'node:fs/promises';
+import { access, mkdir, rm } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
@@ -135,6 +135,17 @@ export function defaultBackupRoot(): string {
  *
  * Returns the directory path and the manifest. The manifest's `extra`
  * field carries whatever `onBackup` returned.
+ *
+ * **Failure model:** the function is all-or-nothing. If any step after
+ * the initial directory creation throws — `dumpPostgresDatabase`,
+ * `onBackup`, `onDatabaseMetadata`, `getGitSha`, or the final manifest
+ * write — the partial backup directory is removed (best-effort)
+ * before the original error is re-thrown. Callers therefore never see
+ * a backup directory on disk without a complete manifest, which would
+ * otherwise poison later `restoreBackup` calls with confusing
+ * "no manifest" errors and leak a partial dump containing sensitive
+ * data. If cleanup itself fails, that error is logged via
+ * `console.warn` and swallowed so it doesn't mask the original.
  */
 export async function exportBackup<Extra = unknown>(
   options: ExportBackupOptions<Extra>,
@@ -148,58 +159,76 @@ export async function exportBackup<Extra = unknown>(
   );
   await mkdir(backupPath, { recursive: true, mode: 0o700 });
 
-  const dumpPath = join(backupPath, DEFAULT_DUMP_FILE);
-  await dumpPostgresDatabase(options.databaseUrl, dumpPath);
+  try {
+    const dumpPath = join(backupPath, DEFAULT_DUMP_FILE);
+    await dumpPostgresDatabase(options.databaseUrl, dumpPath);
 
-  const filesDir = join(backupPath, DEFAULT_FILES_DIR);
-  let filesInfo: BackupManifestFiles = {
-    directory: DEFAULT_FILES_DIR,
-    exported: false,
-    count: 0,
-    bytes: 0,
-    reason: 'Skipped by skipFiles.',
-    storageConfig: options.filesStorageConfig,
-  };
-  let extra: Extra | undefined;
-
-  if (!options.skipFiles && options.onBackup) {
-    await mkdir(filesDir, { recursive: true, mode: 0o700 });
-    const result = await options.onBackup({
-      backupPath,
-      databaseUrl: options.databaseUrl,
-      filesDir,
-    });
-    if (result !== undefined && result !== null) extra = result as Extra;
-    filesInfo = {
+    const filesDir = join(backupPath, DEFAULT_FILES_DIR);
+    let filesInfo: BackupManifestFiles = {
       directory: DEFAULT_FILES_DIR,
-      exported: true,
+      exported: false,
       count: 0,
       bytes: 0,
+      reason: 'Skipped by skipFiles.',
       storageConfig: options.filesStorageConfig,
     };
+    let extra: Extra | undefined;
+
+    if (!options.skipFiles && options.onBackup) {
+      await mkdir(filesDir, { recursive: true, mode: 0o700 });
+      const result = await options.onBackup({
+        backupPath,
+        databaseUrl: options.databaseUrl,
+        filesDir,
+      });
+      if (result !== undefined && result !== null) extra = result as Extra;
+      filesInfo = {
+        directory: DEFAULT_FILES_DIR,
+        exported: true,
+        count: 0,
+        bytes: 0,
+        storageConfig: options.filesStorageConfig,
+      };
+    }
+
+    const metadata = options.onDatabaseMetadata
+      ? await options.onDatabaseMetadata({ databaseUrl: options.databaseUrl })
+      : undefined;
+
+    const manifest: BackupManifest & { extra?: Extra } = {
+      kind: BACKUP_KIND,
+      version: BACKUP_VERSION,
+      timestamp: new Date().toISOString(),
+      gitSha: await getGitSha(options.gitCwd),
+      source: label,
+      database: {
+        dumpFile: DEFAULT_DUMP_FILE,
+        url: redactDatabaseUrl(options.databaseUrl),
+        metadata,
+      },
+      files: filesInfo,
+      extra,
+    };
+
+    await writeBackupManifest(backupPath, manifest);
+    return { backupPath, manifest };
+  } catch (error) {
+    // Partial state on disk would either confuse later restoreBackup
+    // calls (no manifest → cryptic ENOENT) or leak sensitive dump
+    // contents. Remove the directory; if cleanup fails, log but don't
+    // mask the original error.
+    try {
+      await rm(backupPath, { recursive: true, force: true });
+    } catch (cleanupError) {
+      console.warn(
+        `exportBackup: failed to clean up partial backup at ${backupPath}:`,
+        cleanupError instanceof Error
+          ? cleanupError.message
+          : String(cleanupError),
+      );
+    }
+    throw error;
   }
-
-  const metadata = options.onDatabaseMetadata
-    ? await options.onDatabaseMetadata({ databaseUrl: options.databaseUrl })
-    : undefined;
-
-  const manifest: BackupManifest & { extra?: Extra } = {
-    kind: BACKUP_KIND,
-    version: BACKUP_VERSION,
-    timestamp: new Date().toISOString(),
-    gitSha: await getGitSha(options.gitCwd),
-    source: label,
-    database: {
-      dumpFile: DEFAULT_DUMP_FILE,
-      url: redactDatabaseUrl(options.databaseUrl),
-      metadata,
-    },
-    files: filesInfo,
-    extra,
-  };
-
-  await writeBackupManifest(backupPath, manifest);
-  return { backupPath, manifest };
 }
 
 /**
@@ -248,6 +277,19 @@ export async function resetLocalDatabaseFromBackup(
   options: ResetLocalOptions,
 ): Promise<BackupManifest> {
   assertCanImportDatabase(options.databaseUrl, { allowProduction: false });
+
+  // Validate the backup BEFORE dropping the local database. A mistyped
+  // backupPath, missing dump file, or corrupted manifest would otherwise
+  // destroy the existing database (drop + create) and only then fail
+  // when restoreBackup tries to read the manifest — leaving the
+  // developer with an empty local DB and a confusing ENOENT error.
+  const backupPath = resolve(options.backupPath);
+  const manifest = await readBackupManifest(backupPath);
+  const dumpFile = validateManifestPathSegment(
+    manifest.database.dumpFile,
+    'database dump file',
+  );
+  await access(join(backupPath, dumpFile));
 
   await dropPostgresDatabase(options.databaseUrl);
   await createPostgresDatabase(options.databaseUrl);

--- a/packages/sql/src/backup/index.ts
+++ b/packages/sql/src/backup/index.ts
@@ -49,6 +49,15 @@ export {
 
 export interface ExportBackupContext {
   backupPath: string;
+  /**
+   * The raw, credential-bearing database URL the caller passed to
+   * `exportBackup`. The hook needs the raw form to open its own
+   * connection, but **do not log this value verbatim** — it contains
+   * credentials. Run it through `redactDatabaseUrl` (exported from
+   * `@happyvertical/sql`) before including it in any output. The
+   * manifest's `database.url` field is redacted; only `databaseUrl`
+   * here is raw.
+   */
   databaseUrl: string;
   /**
    * Local directory the caller should copy file storage into.
@@ -87,9 +96,12 @@ export interface ExportBackupOptions<Extra = unknown> {
   /**
    * Caller-supplied hook for filling the database half of the manifest
    * with diagnostic metadata (row counts, schema count, etc.) — runs
-   * after the dump completes.
+   * after the dump completes. As with `onBackup`, the `databaseUrl`
+   * passed in is the raw credential-bearing form — redact via
+   * `redactDatabaseUrl` before logging.
    */
   onDatabaseMetadata?: (ctx: {
+    /** Raw URL — see warning on {@link ExportBackupContext.databaseUrl}. */
     databaseUrl: string;
   }) => Promise<Record<string, unknown>>;
   /** Recorded as `files.storageConfig` on the manifest after redaction by the caller. */
@@ -100,6 +112,7 @@ export interface ExportBackupOptions<Extra = unknown> {
 
 export interface RestoreBackupContext {
   backupPath: string;
+  /** Raw URL — see warning on {@link ExportBackupContext.databaseUrl}. */
   databaseUrl: string;
   filesDir: string;
   manifest: BackupManifest;
@@ -278,16 +291,22 @@ export async function resetLocalDatabaseFromBackup(
   assertCanImportDatabase(options.databaseUrl, { allowProduction: false });
 
   // Validate the backup BEFORE dropping the local database. A mistyped
-  // backupPath, missing dump file, or corrupted manifest would otherwise
-  // destroy the existing database (drop + create) and only then fail
-  // when restoreBackup tries to read the manifest — leaving the
-  // developer with an empty local DB and a confusing ENOENT error.
+  // backupPath, missing dump file, or corrupted manifest field would
+  // otherwise destroy the existing database (drop + create) and only
+  // then fail when restoreBackup tries to read those values — leaving
+  // the developer with an empty local DB and a confusing ENOENT error.
+  //
+  // Validates every manifest field restoreBackup later relies on
+  // (`database.dumpFile` AND `files.directory`), and verifies the dump
+  // file actually exists on disk. The drop only happens if all of that
+  // is sound.
   const backupPath = resolve(options.backupPath);
   const manifest = await readBackupManifest(backupPath);
   const dumpFile = validateManifestPathSegment(
     manifest.database.dumpFile,
     'database dump file',
   );
+  validateManifestPathSegment(manifest.files.directory, 'files directory');
   await access(join(backupPath, dumpFile));
 
   await dropPostgresDatabase(options.databaseUrl);

--- a/packages/sql/src/backup/index.ts
+++ b/packages/sql/src/backup/index.ts
@@ -153,11 +153,10 @@ export async function exportBackup<Extra = unknown>(
   assertCanExportDatabase(options.databaseUrl, options);
 
   const label = validateLabel(options.label ?? 'backup');
-  const backupPath = resolve(
+  const backupPath = await createUniqueBackupDir(
     options.backupRoot ?? defaultBackupRoot(),
-    `${label}-${timestampForBackup()}`,
+    label,
   );
-  await mkdir(backupPath, { recursive: true, mode: 0o700 });
 
   try {
     const dumpPath = join(backupPath, DEFAULT_DUMP_FILE);
@@ -328,4 +327,31 @@ function validateManifestPathSegment(value: string, field: string): string {
     );
   }
   return value;
+}
+
+async function createUniqueBackupDir(
+  backupRoot: string,
+  label: string,
+): Promise<string> {
+  const root = resolve(backupRoot);
+  await mkdir(root, { recursive: true, mode: 0o700 });
+
+  const baseName = `${label}-${timestampForBackup()}`;
+  for (let attempt = 0; attempt < 64; attempt += 1) {
+    const suffix = attempt === 0 ? '' : `-${attempt.toString(36)}`;
+    const candidate = join(root, `${baseName}${suffix}`);
+    try {
+      await mkdir(candidate, { mode: 0o700 });
+      return candidate;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error(
+    `Failed to create a unique backup directory under ${root} for label "${label}".`,
+  );
 }

--- a/packages/sql/src/backup/index.ts
+++ b/packages/sql/src/backup/index.ts
@@ -1,0 +1,265 @@
+/**
+ * Backup orchestration — composes the pg shell-out helpers in
+ * `../postgres-cli` with caller-supplied hooks for file storage,
+ * app-specific manifest extras, and post-restore steps.
+ *
+ * Decoupled from `@happyvertical/files` on purpose: callers that want a
+ * file-storage backup pass an `onBackup` callback that does the copy
+ * however they prefer (local cp, S3 sync, WebDAV walk). That keeps this
+ * subpath usable by apps that only need the database half.
+ */
+import { execFile } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  assertCanExportDatabase,
+  assertCanImportDatabase,
+  createPostgresDatabase,
+  databaseNameFromUrl,
+  dropPostgresDatabase,
+  dumpPostgresDatabase,
+  postgresEnvFromUrl,
+  redactDatabaseUrl,
+  restorePostgresDatabase,
+} from '../postgres-cli';
+import {
+  BACKUP_KIND,
+  BACKUP_VERSION,
+  type BackupManifest,
+  type BackupManifestFiles,
+  DEFAULT_DUMP_FILE,
+  DEFAULT_FILES_DIR,
+  readBackupManifest,
+  timestampForBackup,
+  writeBackupManifest,
+} from './manifest';
+
+export {
+  BACKUP_KIND,
+  BACKUP_VERSION,
+  type BackupManifest,
+  type BackupManifestDatabase,
+  type BackupManifestFiles,
+  DEFAULT_DUMP_FILE,
+  DEFAULT_FILES_DIR,
+  DEFAULT_MANIFEST_FILE,
+  readBackupManifest,
+  timestampForBackup,
+  writeBackupManifest,
+} from './manifest';
+
+export interface ExportBackupContext {
+  backupPath: string;
+  databaseUrl: string;
+  /**
+   * Local directory the caller should copy file storage into.
+   * Already exists by the time `onBackup` runs.
+   */
+  filesDir: string;
+}
+
+export interface ExportBackupResult<Extra = unknown> {
+  /** Absolute path to the backup directory. */
+  backupPath: string;
+  /** The manifest that was written. */
+  manifest: BackupManifest & { extra?: Extra };
+}
+
+export interface ExportBackupOptions<Extra = unknown> {
+  databaseUrl: string;
+  /** Override the parent dir for the timestamped backup. Defaults to ~/.local/share/happyvertical/backups. */
+  backupRoot?: string;
+  /** Prefix the timestamp with this label (e.g. 'prod', 'pre-migration'). Defaults to 'backup'. */
+  label?: string;
+  /** Allow exporting from a non-local DB without --allow-production. */
+  allowProduction?: boolean;
+  /** Allow exporting from a local DB even though `prod: true` is set. */
+  allowLocal?: boolean;
+  /** Caller is running a prod-flavored export. */
+  prod?: boolean;
+  /** Skip the file-storage half entirely (no `onBackup` invoked). */
+  skipFiles?: boolean;
+  /**
+   * Caller-supplied hook for backing up file storage. Receives the
+   * already-created backup/files directory; whatever it returns is
+   * recorded as `extra` on the manifest.
+   */
+  onBackup?: (ctx: ExportBackupContext) => Promise<Extra | void>;
+  /**
+   * Caller-supplied hook for filling the database half of the manifest
+   * with diagnostic metadata (row counts, schema count, etc.) — runs
+   * after the dump completes.
+   */
+  onDatabaseMetadata?: (ctx: {
+    databaseUrl: string;
+  }) => Promise<Record<string, unknown>>;
+  /** Recorded as `files.storageConfig` on the manifest after redaction by the caller. */
+  filesStorageConfig?: unknown;
+  /** Working dir used when discovering the git sha. Defaults to process.cwd(). */
+  gitCwd?: string;
+}
+
+export interface RestoreBackupContext {
+  backupPath: string;
+  databaseUrl: string;
+  filesDir: string;
+  manifest: BackupManifest;
+}
+
+export interface RestoreBackupOptions {
+  databaseUrl: string;
+  backupPath: string;
+  allowProduction?: boolean;
+  /** Skip the file-storage half (no `onRestore` invoked). */
+  skipFiles?: boolean;
+  /**
+   * Caller-supplied hook for restoring file storage from
+   * `backupPath/<files.directory>`. Runs after the pg_restore completes.
+   */
+  onRestore?: (ctx: RestoreBackupContext) => Promise<void>;
+}
+
+export interface ResetLocalOptions
+  extends Omit<RestoreBackupOptions, 'allowProduction'> {}
+
+/** Default root for backups. Override via $HAPPYVERTICAL_BACKUP_DIR or `backupRoot`. */
+export function defaultBackupRoot(): string {
+  return (
+    process.env.HAPPYVERTICAL_BACKUP_DIR ??
+    join(homedir(), '.local', 'share', 'happyvertical', 'backups')
+  );
+}
+
+/**
+ * Take a postgres dump and (optionally) a snapshot of file storage,
+ * writing both plus a manifest into a fresh timestamped directory.
+ *
+ * Returns the directory path and the manifest. The manifest's `extra`
+ * field carries whatever `onBackup` returned.
+ */
+export async function exportBackup<Extra = unknown>(
+  options: ExportBackupOptions<Extra>,
+): Promise<ExportBackupResult<Extra>> {
+  assertCanExportDatabase(options.databaseUrl, options);
+
+  const label = options.label ?? 'backup';
+  const backupPath = resolve(
+    options.backupRoot ?? defaultBackupRoot(),
+    `${label}-${timestampForBackup()}`,
+  );
+  await mkdir(backupPath, { recursive: true });
+
+  const dumpPath = join(backupPath, DEFAULT_DUMP_FILE);
+  await dumpPostgresDatabase(options.databaseUrl, dumpPath);
+
+  const filesDir = join(backupPath, DEFAULT_FILES_DIR);
+  let filesInfo: BackupManifestFiles = {
+    directory: DEFAULT_FILES_DIR,
+    exported: false,
+    count: 0,
+    bytes: 0,
+    reason: 'Skipped by skipFiles.',
+    storageConfig: options.filesStorageConfig,
+  };
+  let extra: Extra | undefined;
+
+  if (!options.skipFiles && options.onBackup) {
+    await mkdir(filesDir, { recursive: true });
+    const result = await options.onBackup({
+      backupPath,
+      databaseUrl: options.databaseUrl,
+      filesDir,
+    });
+    if (result !== undefined && result !== null) extra = result as Extra;
+    filesInfo = {
+      directory: DEFAULT_FILES_DIR,
+      exported: true,
+      count: 0,
+      bytes: 0,
+      storageConfig: options.filesStorageConfig,
+    };
+  }
+
+  const metadata = options.onDatabaseMetadata
+    ? await options.onDatabaseMetadata({ databaseUrl: options.databaseUrl })
+    : undefined;
+
+  const manifest: BackupManifest & { extra?: Extra } = {
+    kind: BACKUP_KIND,
+    version: BACKUP_VERSION,
+    timestamp: new Date().toISOString(),
+    gitSha: await getGitSha(options.gitCwd),
+    source: label,
+    database: {
+      dumpFile: DEFAULT_DUMP_FILE,
+      url: redactDatabaseUrl(options.databaseUrl),
+      metadata,
+    },
+    files: filesInfo,
+    extra,
+  };
+
+  await writeBackupManifest(backupPath, manifest);
+  return { backupPath, manifest };
+}
+
+/**
+ * Restore a backup directory into `databaseUrl` and, if `onRestore` is
+ * provided, run the file-storage half. The caller controls everything
+ * after the dump completes (file copy, migrations, doctor) via the hook.
+ */
+export async function restoreBackup(
+  options: RestoreBackupOptions,
+): Promise<BackupManifest> {
+  const backupPath = resolve(options.backupPath);
+  const manifest = await readBackupManifest(backupPath);
+  assertCanImportDatabase(options.databaseUrl, options);
+
+  await restorePostgresDatabase(
+    options.databaseUrl,
+    join(backupPath, manifest.database.dumpFile),
+  );
+
+  if (!options.skipFiles && options.onRestore) {
+    await options.onRestore({
+      backupPath,
+      databaseUrl: options.databaseUrl,
+      filesDir: join(backupPath, manifest.files.directory),
+      manifest,
+    });
+  }
+
+  return manifest;
+}
+
+/**
+ * Drop-and-recreate the target database, then run `restoreBackup`.
+ * Local-only: explicitly refuses non-local URLs without an escape hatch
+ * (this is a destructive operation by design).
+ */
+export async function resetLocalDatabaseFromBackup(
+  options: ResetLocalOptions,
+): Promise<BackupManifest> {
+  assertCanImportDatabase(options.databaseUrl, { allowProduction: false });
+
+  await dropPostgresDatabase(options.databaseUrl);
+  await createPostgresDatabase(options.databaseUrl);
+  return restoreBackup({ ...options, allowProduction: false });
+}
+
+async function getGitSha(cwd: string = process.cwd()): Promise<string | null> {
+  try {
+    return await new Promise<string>((resolvePromise, reject) => {
+      execFile('git', ['rev-parse', 'HEAD'], { cwd }, (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolvePromise(stdout.trim());
+      });
+    });
+  } catch {
+    return null;
+  }
+}

--- a/packages/sql/src/backup/index.ts
+++ b/packages/sql/src/backup/index.ts
@@ -268,7 +268,14 @@ export async function restoreBackup(
 
   await restorePostgresDatabase(options.databaseUrl, dumpPath);
 
-  if (!options.skipFiles && options.onRestore) {
+  // Skip `onRestore` for DB-only backups: if the backup was taken with
+  // `skipFiles: true` or no `onBackup` hook, the manifest records
+  // `files.exported: false` and the `files/` directory may not exist on
+  // disk. Calling a generic restore hook anyway would either crash
+  // after the database has already been restored, or — worse — let
+  // the hook clear target file storage before discovering there's
+  // nothing to restore from.
+  if (!options.skipFiles && options.onRestore && manifest.files.exported) {
     await options.onRestore({
       backupPath,
       databaseUrl: options.databaseUrl,

--- a/packages/sql/src/backup/index.ts
+++ b/packages/sql/src/backup/index.ts
@@ -16,10 +16,8 @@ import {
   assertCanExportDatabase,
   assertCanImportDatabase,
   createPostgresDatabase,
-  databaseNameFromUrl,
   dropPostgresDatabase,
   dumpPostgresDatabase,
-  postgresEnvFromUrl,
   redactDatabaseUrl,
   restorePostgresDatabase,
 } from '../postgres-cli';
@@ -143,12 +141,12 @@ export async function exportBackup<Extra = unknown>(
 ): Promise<ExportBackupResult<Extra>> {
   assertCanExportDatabase(options.databaseUrl, options);
 
-  const label = options.label ?? 'backup';
+  const label = validateLabel(options.label ?? 'backup');
   const backupPath = resolve(
     options.backupRoot ?? defaultBackupRoot(),
     `${label}-${timestampForBackup()}`,
   );
-  await mkdir(backupPath, { recursive: true });
+  await mkdir(backupPath, { recursive: true, mode: 0o700 });
 
   const dumpPath = join(backupPath, DEFAULT_DUMP_FILE);
   await dumpPostgresDatabase(options.databaseUrl, dumpPath);
@@ -165,7 +163,7 @@ export async function exportBackup<Extra = unknown>(
   let extra: Extra | undefined;
 
   if (!options.skipFiles && options.onBackup) {
-    await mkdir(filesDir, { recursive: true });
+    await mkdir(filesDir, { recursive: true, mode: 0o700 });
     const result = await options.onBackup({
       backupPath,
       databaseUrl: options.databaseUrl,
@@ -215,17 +213,25 @@ export async function restoreBackup(
   const backupPath = resolve(options.backupPath);
   const manifest = await readBackupManifest(backupPath);
   assertCanImportDatabase(options.databaseUrl, options);
-
-  await restorePostgresDatabase(
-    options.databaseUrl,
-    join(backupPath, manifest.database.dumpFile),
+  const dumpPath = join(
+    backupPath,
+    validateManifestPathSegment(
+      manifest.database.dumpFile,
+      'database dump file',
+    ),
   );
+  const filesDir = join(
+    backupPath,
+    validateManifestPathSegment(manifest.files.directory, 'files directory'),
+  );
+
+  await restorePostgresDatabase(options.databaseUrl, dumpPath);
 
   if (!options.skipFiles && options.onRestore) {
     await options.onRestore({
       backupPath,
       databaseUrl: options.databaseUrl,
-      filesDir: join(backupPath, manifest.files.directory),
+      filesDir,
       manifest,
     });
   }
@@ -262,4 +268,22 @@ async function getGitSha(cwd: string = process.cwd()): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+function validateLabel(label: string): string {
+  if (!label || label === '.' || label === '..' || /[\\/]/u.test(label)) {
+    throw new Error(
+      `Backup label "${label}" is invalid. Labels must be a single path-safe segment.`,
+    );
+  }
+  return label;
+}
+
+function validateManifestPathSegment(value: string, field: string): string {
+  if (!value || value === '.' || value === '..' || /[\\/]/u.test(value)) {
+    throw new Error(
+      `Backup manifest ${field} is invalid: "${value}". It must be a single path segment.`,
+    );
+  }
+  return value;
 }

--- a/packages/sql/src/backup/manifest.spec.ts
+++ b/packages/sql/src/backup/manifest.spec.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  BACKUP_KIND,
+  BACKUP_VERSION,
+  type BackupManifest,
+  DEFAULT_DUMP_FILE,
+  DEFAULT_FILES_DIR,
+  readBackupManifest,
+  timestampForBackup,
+  writeBackupManifest,
+} from './manifest';
+
+describe('backup manifest', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'backup-manifest-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('round-trips a manifest', async () => {
+    const manifest: BackupManifest = {
+      kind: BACKUP_KIND,
+      version: BACKUP_VERSION,
+      timestamp: '2026-05-27T00:00:00.000Z',
+      gitSha: 'abc123',
+      source: 'current',
+      database: {
+        dumpFile: DEFAULT_DUMP_FILE,
+        url: 'postgresql://***:***@localhost/app',
+        metadata: { rowCount: 42 },
+      },
+      files: {
+        directory: DEFAULT_FILES_DIR,
+        exported: false,
+        count: 0,
+        bytes: 0,
+      },
+      extra: { resume: { published: true } },
+    };
+
+    await writeBackupManifest(dir, manifest);
+    const loaded = await readBackupManifest(dir);
+    expect(loaded).toEqual(manifest);
+  });
+
+  it('rejects manifests with the wrong kind or version', async () => {
+    await writeBackupManifest(dir, {
+      kind: 'foreign-backup' as any,
+      version: BACKUP_VERSION,
+      timestamp: '',
+      gitSha: null,
+      source: 'x',
+      database: { dumpFile: 'x', url: 'x' },
+      files: { directory: 'x', exported: false, count: 0, bytes: 0 },
+    });
+    await expect(readBackupManifest(dir)).rejects.toThrow(
+      /Unsupported backup manifest/u,
+    );
+  });
+
+  it('produces filesystem-safe timestamps', () => {
+    expect(timestampForBackup(new Date('2026-05-26T12:34:56.789Z'))).toBe(
+      '2026-05-26T12-34-56-789Z',
+    );
+  });
+});

--- a/packages/sql/src/backup/manifest.ts
+++ b/packages/sql/src/backup/manifest.ts
@@ -7,7 +7,7 @@
  * field. Bumping `BACKUP_VERSION` is the way to evolve the shape — older
  * backups will fail `readBackupManifest` until upgraded.
  */
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, rename, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 export const BACKUP_KIND = 'happyvertical-backup' as const;
@@ -74,11 +74,15 @@ export async function writeBackupManifest(
   backupPath: string,
   manifest: BackupManifest,
 ): Promise<void> {
-  await writeFile(
-    join(backupPath, DEFAULT_MANIFEST_FILE),
-    `${JSON.stringify(manifest, null, 2)}\n`,
-    { mode: 0o600 },
+  const targetPath = join(backupPath, DEFAULT_MANIFEST_FILE);
+  const tempPath = join(
+    backupPath,
+    `.manifest.${process.pid}.${Date.now().toString(36)}.tmp`,
   );
+  await writeFile(tempPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await rename(tempPath, targetPath);
 }
 
 /**

--- a/packages/sql/src/backup/manifest.ts
+++ b/packages/sql/src/backup/manifest.ts
@@ -1,0 +1,92 @@
+/**
+ * Backup manifest shape and helpers.
+ *
+ * The manifest is the source-of-truth for what's in a backup directory:
+ * which database it came from, when, at what commit, and any
+ * app-specific metadata that the caller chose to attach via the `extra`
+ * field. Bumping `BACKUP_VERSION` is the way to evolve the shape — older
+ * backups will fail `readBackupManifest` until upgraded.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export const BACKUP_KIND = 'happyvertical-backup' as const;
+export const BACKUP_VERSION = 1 as const;
+export const DEFAULT_DUMP_FILE = 'database.dump';
+export const DEFAULT_FILES_DIR = 'files';
+export const DEFAULT_MANIFEST_FILE = 'manifest.json';
+
+export interface BackupManifestDatabase {
+  /** File name of the pg_dump archive within the backup directory. */
+  dumpFile: string;
+  /** Redacted URL the dump was taken from. */
+  url: string;
+  /** Caller-supplied diagnostic metadata (row counts, schema count, etc.). */
+  metadata?: Record<string, unknown>;
+}
+
+export interface BackupManifestFiles {
+  /** Directory name within the backup that holds copied file storage. */
+  directory: string;
+  exported: boolean;
+  count: number;
+  bytes: number;
+  reason?: string;
+  /** Redacted provider config, if the caller chose to record it. */
+  storageConfig?: unknown;
+}
+
+export interface BackupManifest {
+  kind: typeof BACKUP_KIND;
+  version: typeof BACKUP_VERSION;
+  timestamp: string;
+  gitSha: string | null;
+  /** Free-form label (e.g. 'current', 'prod', 'pre-migration'). */
+  source: string;
+  database: BackupManifestDatabase;
+  files: BackupManifestFiles;
+  /** Opaque slot for app-specific extension (resume publish status, etc.). */
+  extra?: unknown;
+}
+
+/**
+ * Read a backup manifest from `backupPath/manifest.json` and validate
+ * that it matches this package's kind+version. Throws (with the path
+ * included) on mismatch — that's almost always a real problem worth
+ * surfacing, not silently tolerating.
+ */
+export async function readBackupManifest(
+  backupPath: string,
+): Promise<BackupManifest> {
+  const manifestPath = join(resolve(backupPath), DEFAULT_MANIFEST_FILE);
+  const manifest = JSON.parse(
+    await readFile(manifestPath, 'utf8'),
+  ) as BackupManifest;
+  if (manifest.kind !== BACKUP_KIND || manifest.version !== BACKUP_VERSION) {
+    throw new Error(
+      `Unsupported backup manifest at ${manifestPath} (kind=${manifest.kind}, version=${manifest.version}).`,
+    );
+  }
+  return manifest;
+}
+
+export async function writeBackupManifest(
+  backupPath: string,
+  manifest: BackupManifest,
+): Promise<void> {
+  await writeFile(
+    join(backupPath, DEFAULT_MANIFEST_FILE),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+}
+
+/**
+ * Filesystem-safe timestamp suitable for backup directory names — same
+ * shape as `Date.toISOString()` but with `:` and `.` swapped to `-` so
+ * the value is a valid path segment on Windows and friendly to shell
+ * tab-completion everywhere else.
+ */
+export function timestampForBackup(date = new Date()): string {
+  return date.toISOString().replace(/[:.]/g, '-');
+}

--- a/packages/sql/src/doctor.spec.ts
+++ b/packages/sql/src/doctor.spec.ts
@@ -149,6 +149,25 @@ describe('runDoctor non-postgres guard', () => {
       /Postgres/,
     );
   });
+
+  it('redacts credential-shaped query params in the URL shown in errors', async () => {
+    const nonPostgresDb = {
+      url: 'mysql://db.example.com/app?password=s3cret&token=keepme',
+      query: async () => ({ rows: [] }),
+    } as unknown as DatabaseInterface;
+
+    try {
+      await runDoctor({ db: nonPostgresDb, checks: [] });
+    } catch (error) {
+      const message = String((error as Error).message);
+      expect(message).toContain('password=***');
+      expect(message).toContain('token=keepme');
+      expect(message).not.toContain('s3cret');
+      return;
+    }
+
+    throw new Error('Expected runDoctor to throw for non-Postgres URL');
+  });
 });
 
 describe('doctor count formatting', () => {

--- a/packages/sql/src/doctor.spec.ts
+++ b/packages/sql/src/doctor.spec.ts
@@ -150,3 +150,50 @@ describe('runDoctor non-postgres guard', () => {
     );
   });
 });
+
+describe('doctor count formatting', () => {
+  it('preserves large duplicate counts without int overflow', async () => {
+    const check = checkUniqueColumn({
+      table: 'widgets',
+      column: 'slug',
+      label: 'slug',
+    });
+    const issues = await check({
+      db: {
+        query: async () => ({
+          rows: [{ value: 'duplicate', count: '9223372036854775807' }],
+        }),
+      } as unknown as DatabaseInterface,
+      tables: new Set(['widgets']),
+    });
+    expect(issues).toEqual([
+      {
+        level: 'fail',
+        message:
+          'Duplicate slug "duplicate" in widgets (9223372036854775807 rows).',
+      },
+    ]);
+  });
+
+  it('preserves large orphan counts without int overflow', async () => {
+    const check = checkRelationship({
+      childTable: 'children',
+      childColumn: 'parent_id',
+      parentTable: 'parents',
+      label: 'children point at parents',
+    });
+    const issues = await check({
+      db: {
+        query: async () => ({ rows: [{ count: '9223372036854775807' }] }),
+      } as unknown as DatabaseInterface,
+      tables: new Set(['children', 'parents']),
+    });
+    expect(issues).toEqual([
+      {
+        level: 'fail',
+        message:
+          'children point at parents: 9223372036854775807 orphaned rows.',
+      },
+    ]);
+  });
+});

--- a/packages/sql/src/doctor.spec.ts
+++ b/packages/sql/src/doctor.spec.ts
@@ -135,3 +135,18 @@ describe('doctor framework (pg integration)', () => {
     expect(result.issues).toEqual([]);
   });
 });
+
+describe('runDoctor non-postgres guard', () => {
+  it('throws a clear error when the database is not Postgres', async () => {
+    // Doctor's check builders use pg-specific syntax; pointing them at
+    // SQLite would fail mid-execution with a cryptic "no such table
+    // pg_tables" error. The guard surfaces the constraint up front.
+    const sqliteDb = await getDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+    });
+    await expect(runDoctor({ db: sqliteDb, checks: [] })).rejects.toThrow(
+      /Postgres/,
+    );
+  });
+});

--- a/packages/sql/src/doctor.spec.ts
+++ b/packages/sql/src/doctor.spec.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  checkExpectedTables,
+  checkRelationship,
+  checkUniqueColumn,
+  runDoctor,
+} from './doctor';
+import { getDatabase } from './index';
+import type { DatabaseInterface } from './shared/types';
+
+/**
+ * Doctor checks use pg-specific SQL (pg_tables, count(*)::int,
+ * NULLIF(trim(col::text), '')). These integration tests skip cleanly if
+ * postgres isn't reachable so they don't block CI on machines without
+ * a local pg.
+ */
+async function getTestPostgres(): Promise<DatabaseInterface | null> {
+  try {
+    const db = await getDatabase({
+      type: 'postgres',
+      database: process.env.SQLOO_DATABASE || 'testdb',
+      host: process.env.SQLOO_HOST || 'localhost',
+      user: process.env.SQLOO_USER || 'postgres',
+      password: process.env.SQLOO_PASSWORD || 'postgres',
+      port: Number(process.env.SQLOO_PORT) || 5432,
+    });
+    await db.execute`SELECT 1`;
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+describe('doctor framework (pg integration)', () => {
+  let db: DatabaseInterface | null;
+  const schema = `doctor_test_${randomUUID().replace(/-/g, '_').slice(0, 8)}`;
+
+  beforeAll(async () => {
+    db = await getTestPostgres();
+    if (!db) {
+      console.log(
+        'PostgreSQL not available — skipping doctor integration tests.',
+      );
+      return;
+    }
+    await db.query(
+      `CREATE TABLE IF NOT EXISTS ${schema}_parents (id text primary key)`,
+    );
+    await db.query(
+      `CREATE TABLE IF NOT EXISTS ${schema}_children (id text primary key, parent_id text, slug text)`,
+    );
+    await db.query(`INSERT INTO ${schema}_parents (id) VALUES ('p1'), ('p2')`);
+    await db.query(
+      `INSERT INTO ${schema}_children (id, parent_id, slug) VALUES ('c1', 'p1', 'foo'), ('c2', 'p_missing', 'foo'), ('c3', 'p2', 'bar')`,
+    );
+  });
+
+  afterAll(async () => {
+    if (!db) return;
+    await db.query(`DROP TABLE IF EXISTS ${schema}_children`);
+    await db.query(`DROP TABLE IF EXISTS ${schema}_parents`);
+    await db.client?.end?.();
+  });
+
+  it('checkExpectedTables warns about missing tables', async () => {
+    if (!db) return;
+    const result = await runDoctor({
+      db,
+      checks: [
+        checkExpectedTables([
+          `${schema}_parents`,
+          `${schema}_children`,
+          `${schema}_missing`,
+        ]),
+      ],
+    });
+    expect(result.warnings.map((w) => w.message)).toContain(
+      `Missing expected table: ${schema}_missing`,
+    );
+    expect(result.failures).toEqual([]);
+  });
+
+  it('checkUniqueColumn fails on duplicate values', async () => {
+    if (!db) return;
+    const result = await runDoctor({
+      db,
+      checks: [
+        checkUniqueColumn({
+          table: `${schema}_children`,
+          column: 'slug',
+          label: 'slug',
+        }),
+      ],
+    });
+    expect(result.failures.length).toBeGreaterThan(0);
+    expect(result.failures[0].message).toContain('"foo"');
+  });
+
+  it('checkRelationship fails on orphan rows', async () => {
+    if (!db) return;
+    const result = await runDoctor({
+      db,
+      checks: [
+        checkRelationship({
+          childTable: `${schema}_children`,
+          childColumn: 'parent_id',
+          parentTable: `${schema}_parents`,
+          label: 'children point at parents',
+        }),
+      ],
+    });
+    expect(result.failures.length).toBe(1);
+    expect(result.failures[0].message).toContain('1 orphaned row');
+  });
+
+  it('checks that name nonexistent tables short-circuit cleanly', async () => {
+    if (!db) return;
+    const result = await runDoctor({
+      db,
+      checks: [
+        checkUniqueColumn({
+          table: `${schema}_does_not_exist`,
+          column: 'whatever',
+          label: 'never seen',
+        }),
+        checkRelationship({
+          childTable: `${schema}_does_not_exist`,
+          childColumn: 'foo',
+          parentTable: `${schema}_parents`,
+          label: 'never seen',
+        }),
+      ],
+    });
+    expect(result.issues).toEqual([]);
+  });
+});

--- a/packages/sql/src/doctor.ts
+++ b/packages/sql/src/doctor.ts
@@ -17,6 +17,7 @@
  * throws early if pointed at a non-Postgres URL rather than failing
  * mid-execution with a confusing `pg_tables`-doesn't-exist error.
  */
+import { redactDatabaseUrl } from './postgres-cli';
 import type { DatabaseInterface } from './shared/types';
 
 export type DoctorLevel = 'fail' | 'warn';
@@ -82,7 +83,7 @@ function assertPostgresAdapter(db: DatabaseInterface): void {
   const url = String(db.url ?? '');
   if (!url.startsWith('postgres://') && !url.startsWith('postgresql://')) {
     throw new Error(
-      `runDoctor requires a Postgres database connection. Got URL: ${url ? url.replace(/\/\/[^/]+/, '//***') : '(empty)'}. ` +
+      `runDoctor requires a Postgres database connection. Got URL: ${url ? redactDatabaseUrl(url) : '(empty)'}. ` +
         'The bundled check builders use Postgres-specific syntax (pg_tables, ::int/::text casts).',
     );
   }

--- a/packages/sql/src/doctor.ts
+++ b/packages/sql/src/doctor.ts
@@ -129,7 +129,7 @@ export function checkUniqueColumn(spec: UniqueColumnSpec): DoctorCheck {
   return async ({ db, tables }) => {
     if (!tables.has(spec.table)) return [];
     const result = await db.query(`
-      SELECT ${quoteIdentifier(spec.column)} AS value, count(*)::int AS count
+      SELECT ${quoteIdentifier(spec.column)} AS value, count(*)::text AS count
       FROM ${quoteIdentifier(spec.table)}
       WHERE NULLIF(trim(${quoteIdentifier(spec.column)}::text), '') IS NOT NULL
       GROUP BY ${quoteIdentifier(spec.column)}
@@ -138,8 +138,8 @@ export function checkUniqueColumn(spec: UniqueColumnSpec): DoctorCheck {
     `);
     return result.rows.map((row) => ({
       level: 'fail' as const,
-      message: `Duplicate ${spec.label} "${String(row.value)}" in ${spec.table} (${Number(
-        row.count ?? 0,
+      message: `Duplicate ${spec.label} "${String(row.value)}" in ${spec.table} (${countValueFromRow(
+        row.count,
       )} rows).`,
     }));
   };
@@ -167,19 +167,19 @@ export function checkRelationship(spec: RelationshipSpec): DoctorCheck {
       return [];
     const parentColumn = spec.parentColumn ?? 'id';
     const result = await db.query(`
-      SELECT count(*)::int AS count
+      SELECT count(*)::text AS count
       FROM ${quoteIdentifier(spec.childTable)} child
       LEFT JOIN ${quoteIdentifier(spec.parentTable)} parent
         ON parent.${quoteIdentifier(parentColumn)} = child.${quoteIdentifier(spec.childColumn)}
       WHERE NULLIF(trim(child.${quoteIdentifier(spec.childColumn)}::text), '') IS NOT NULL
         AND parent.${quoteIdentifier(parentColumn)} IS NULL
     `);
-    const orphanCount = Number(result.rows[0]?.count ?? 0);
-    if (orphanCount === 0) return [];
+    const orphanCount = countValueFromRow(result.rows[0]?.count);
+    if (orphanCount === '0') return [];
     return [
       {
         level: 'fail',
-        message: `${spec.label}: ${orphanCount} orphaned row${orphanCount === 1 ? '' : 's'}.`,
+        message: `${spec.label}: ${orphanCount} orphaned row${orphanCount === '1' ? '' : 's'}.`,
       },
     ];
   };
@@ -194,4 +194,12 @@ async function listPublicTables(db: DatabaseInterface): Promise<Set<string>> {
 
 function quoteIdentifier(value: string): string {
   return `"${value.replace(/"/gu, '""')}"`;
+}
+
+function countValueFromRow(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return '0';
 }

--- a/packages/sql/src/doctor.ts
+++ b/packages/sql/src/doctor.ts
@@ -1,5 +1,5 @@
 /**
- * Generic database integrity-check framework.
+ * Database integrity-check framework.
  *
  * The runner is a thin loop over user-supplied checks; the value here is
  * the reusable check builders (expected tables, unique columns, FK-like
@@ -8,6 +8,14 @@
  *
  * No SMRT awareness — checks operate on the `DatabaseInterface` from this
  * package and on plain table/column names.
+ *
+ * **Postgres-only today.** The bundled check builders and
+ * `listPublicTables` use Postgres syntax (`pg_tables`, `::int`/`::text`
+ * casts). The shape is portable in principle — `DoctorContext` carries a
+ * generic `DatabaseInterface` so apps can add engine-aware checks — but
+ * the out-of-the-box runner expects a Postgres connection. `runDoctor`
+ * throws early if pointed at a non-Postgres URL rather than failing
+ * mid-execution with a confusing `pg_tables`-doesn't-exist error.
  */
 import type { DatabaseInterface } from './shared/types';
 
@@ -47,6 +55,7 @@ export interface DoctorResult {
 export async function runDoctor(
   options: RunDoctorOptions,
 ): Promise<DoctorResult> {
+  assertPostgresAdapter(options.db);
   const tables = await listPublicTables(options.db);
   const issues: DoctorIssue[] = [];
 
@@ -60,6 +69,23 @@ export async function runDoctor(
     warnings: issues.filter((issue) => issue.level === 'warn'),
     issues,
   };
+}
+
+/**
+ * Throw early if the supplied database isn't Postgres. The check builders
+ * and `listPublicTables` use Postgres syntax; pointing them at SQLite or
+ * DuckDB would fail mid-execution with a confusing "table pg_tables does
+ * not exist" error from the adapter. Fail fast with a useful message
+ * instead.
+ */
+function assertPostgresAdapter(db: DatabaseInterface): void {
+  const url = String(db.url ?? '');
+  if (!url.startsWith('postgres://') && !url.startsWith('postgresql://')) {
+    throw new Error(
+      `runDoctor requires a Postgres database connection. Got URL: ${url ? url.replace(/\/\/[^/]+/, '//***') : '(empty)'}. ` +
+        'The bundled check builders use Postgres-specific syntax (pg_tables, ::int/::text casts).',
+    );
+  }
 }
 
 /**

--- a/packages/sql/src/doctor.ts
+++ b/packages/sql/src/doctor.ts
@@ -1,0 +1,171 @@
+/**
+ * Generic database integrity-check framework.
+ *
+ * The runner is a thin loop over user-supplied checks; the value here is
+ * the reusable check builders (expected tables, unique columns, FK-like
+ * relationships) that codify the common shapes of integrity bugs that
+ * sneak past schema migrations.
+ *
+ * No SMRT awareness — checks operate on the `DatabaseInterface` from this
+ * package and on plain table/column names.
+ */
+import type { DatabaseInterface } from './shared/types';
+
+export type DoctorLevel = 'fail' | 'warn';
+
+export interface DoctorIssue {
+  level: DoctorLevel;
+  message: string;
+}
+
+export interface DoctorContext {
+  db: DatabaseInterface;
+  tables: Set<string>;
+}
+
+export type DoctorCheck = (ctx: DoctorContext) => Promise<DoctorIssue[]>;
+
+export interface RunDoctorOptions {
+  db: DatabaseInterface;
+  checks: DoctorCheck[];
+}
+
+export interface DoctorResult {
+  failures: DoctorIssue[];
+  warnings: DoctorIssue[];
+  issues: DoctorIssue[];
+}
+
+/**
+ * Execute every check against the public-schema tables of `db` and
+ * partition the results by severity. Returns the aggregate; callers
+ * format/exit as they see fit.
+ *
+ * The current table set is enumerated once and shared across checks so
+ * each check can cheaply decide whether its target tables exist.
+ */
+export async function runDoctor(
+  options: RunDoctorOptions,
+): Promise<DoctorResult> {
+  const tables = await listPublicTables(options.db);
+  const issues: DoctorIssue[] = [];
+
+  for (const check of options.checks) {
+    const checkIssues = await check({ db: options.db, tables });
+    issues.push(...checkIssues);
+  }
+
+  return {
+    failures: issues.filter((issue) => issue.level === 'fail'),
+    warnings: issues.filter((issue) => issue.level === 'warn'),
+    issues,
+  };
+}
+
+/**
+ * Emit a 'warn' for each table in `expected` that's missing.
+ *
+ * Marked as `warn` rather than `fail` because a missing table often
+ * indicates a migration that hasn't been run yet, not active data
+ * corruption — callers can promote to fail by mapping the issues.
+ */
+export function checkExpectedTables(expected: readonly string[]): DoctorCheck {
+  return async ({ tables }) => {
+    const issues: DoctorIssue[] = [];
+    for (const table of expected) {
+      if (!tables.has(table)) {
+        issues.push({
+          level: 'warn',
+          message: `Missing expected table: ${table}`,
+        });
+      }
+    }
+    return issues;
+  };
+}
+
+export interface UniqueColumnSpec {
+  table: string;
+  column: string;
+  /** Human-readable label used in the issue message. */
+  label: string;
+}
+
+/**
+ * Emit a 'fail' for each value that appears more than once in
+ * `(table, column)` (ignoring NULL and empty-string values).
+ *
+ * Useful for catching slug/key collisions that the schema didn't
+ * declare a UNIQUE constraint for (or where the constraint was added
+ * after data already existed).
+ */
+export function checkUniqueColumn(spec: UniqueColumnSpec): DoctorCheck {
+  return async ({ db, tables }) => {
+    if (!tables.has(spec.table)) return [];
+    const result = await db.query(`
+      SELECT ${quoteIdentifier(spec.column)} AS value, count(*)::int AS count
+      FROM ${quoteIdentifier(spec.table)}
+      WHERE NULLIF(trim(${quoteIdentifier(spec.column)}::text), '') IS NOT NULL
+      GROUP BY ${quoteIdentifier(spec.column)}
+      HAVING count(*) > 1
+      ORDER BY count DESC, ${quoteIdentifier(spec.column)}
+    `);
+    return result.rows.map((row) => ({
+      level: 'fail' as const,
+      message: `Duplicate ${spec.label} "${String(row.value)}" in ${spec.table} (${Number(
+        row.count ?? 0,
+      )} rows).`,
+    }));
+  };
+}
+
+export interface RelationshipSpec {
+  childTable: string;
+  childColumn: string;
+  parentTable: string;
+  /** Defaults to 'id'. */
+  parentColumn?: string;
+  /** Human-readable label used in the issue message. */
+  label: string;
+}
+
+/**
+ * Emit a 'fail' counting orphan rows where the child column points at a
+ * parent row that doesn't exist (FK-shaped check, but doesn't require an
+ * actual FK constraint to be declared — useful for soft references like
+ * tag-id-or-slug lookup columns).
+ */
+export function checkRelationship(spec: RelationshipSpec): DoctorCheck {
+  return async ({ db, tables }) => {
+    if (!tables.has(spec.childTable) || !tables.has(spec.parentTable))
+      return [];
+    const parentColumn = spec.parentColumn ?? 'id';
+    const result = await db.query(`
+      SELECT count(*)::int AS count
+      FROM ${quoteIdentifier(spec.childTable)} child
+      LEFT JOIN ${quoteIdentifier(spec.parentTable)} parent
+        ON parent.${quoteIdentifier(parentColumn)} = child.${quoteIdentifier(spec.childColumn)}
+      WHERE NULLIF(trim(child.${quoteIdentifier(spec.childColumn)}::text), '') IS NOT NULL
+        AND parent.${quoteIdentifier(parentColumn)} IS NULL
+    `);
+    const orphanCount = Number(result.rows[0]?.count ?? 0);
+    if (orphanCount === 0) return [];
+    return [
+      {
+        level: 'fail',
+        message: `${spec.label}: ${orphanCount} orphaned row${orphanCount === 1 ? '' : 's'}.`,
+      },
+    ];
+  };
+}
+
+async function listPublicTables(db: DatabaseInterface): Promise<Set<string>> {
+  const result = await db.query(
+    "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename",
+  );
+  return new Set(result.rows.map((row) => String(row.tablename ?? '')));
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/gu, '""')}"`;
+}

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -208,21 +208,55 @@ export function validateColumnName(column: string): string {
 
 // Import utilities from shared utils
 import { buildWhere, formatDbError } from './shared/utils';
-export { buildWhere, formatDbError };
+
 export type { SqlAdapterType } from './shared/utils';
+export { buildWhere, formatDbError };
 
 // Import DuckDB schema transformation utilities
 import { convertUniqueIndexesToInlineConstraints } from './shared/duckdb-schema-utils';
-export { convertUniqueIndexesToInlineConstraints };
+
+// Generic database integrity-check framework
+export {
+  checkExpectedTables,
+  checkRelationship,
+  checkUniqueColumn,
+  type DoctorCheck,
+  type DoctorContext,
+  type DoctorIssue,
+  type DoctorLevel,
+  type DoctorResult,
+  type RelationshipSpec,
+  type RunDoctorOptions,
+  runDoctor,
+  type UniqueColumnSpec,
+} from './doctor';
 
 // Export adapter cache utilities (for testing)
 export { clearConnectionCache } from './json.js';
 export { clearPostgresConnectionCache } from './postgres.js';
+// Postgres CLI shell-outs and URL helpers
+export {
+  assertCanExportDatabase,
+  assertCanImportDatabase,
+  type CreateDropOptions,
+  createPostgresDatabase,
+  type DumpOptions,
+  databaseNameFromUrl,
+  dropPostgresDatabase,
+  dumpPostgresDatabase,
+  isLocalDatabaseUrl,
+  type PostgresImportLocalityOptions,
+  type PostgresLocalityOptions,
+  postgresEnvFromUrl,
+  type RestoreOptions,
+  redactDatabaseUrl,
+  restorePostgresDatabase,
+} from './postgres-cli';
 export type { SchemaInitializationResult } from './schema-manager';
 // Export schema management
 export { DatabaseSchemaManager } from './schema-manager';
-
 export * from './shared/types';
+export { convertUniqueIndexesToInlineConstraints };
 
 export default {
   getDatabase,

--- a/packages/sql/src/postgres-cli.spec.ts
+++ b/packages/sql/src/postgres-cli.spec.ts
@@ -58,6 +58,30 @@ describe('postgres-cli URL helpers', () => {
         else process.env.PGPASSFILE = previous;
       }
     });
+
+    it('preserves inherited PGUSER for env-auth flows', async () => {
+      // Heroku/Railway-style setups put PGUSER (and PGPASSWORD) in env
+      // and use a DATABASE_URL that may omit the username. Scrubbing
+      // PGUSER along with PGHOST would cause pg_dump to connect as the
+      // OS user and fail authentication.
+      const previous = process.env.PGUSER;
+      process.env.PGUSER = 'env-supplied-user';
+      try {
+        await expect(
+          runCommand(
+            process.execPath,
+            [
+              '-e',
+              'if (process.env.PGUSER !== "env-supplied-user") process.exit(1)',
+            ],
+            { stdio: 'pipe' },
+          ),
+        ).resolves.toBeUndefined();
+      } finally {
+        if (previous === undefined) delete process.env.PGUSER;
+        else process.env.PGUSER = previous;
+      }
+    });
   });
 
   describe('isLocalDatabaseUrl', () => {

--- a/packages/sql/src/postgres-cli.spec.ts
+++ b/packages/sql/src/postgres-cli.spec.ts
@@ -74,37 +74,63 @@ describe('postgres-cli URL helpers', () => {
           'postgresql://user:secret@db.example.com:5439/app?sslmode=require',
         ),
       ).toEqual({
-        // Connection-target vars are always present and pinned to the
-        // URL value (or empty) so PGHOST/PGSERVICE from the parent
-        // process can't redirect the child to a different DB.
+        // Only vars with URL-derived values are SET. Inherited
+        // libpq vars are scrubbed by `runCommand` separately —
+        // setting them to empty string here would break libpq
+        // (PGSERVICE='' is treated as "service named empty string"
+        // and produces "definition of service \"\" not found").
         PGDATABASE: 'app',
         PGHOST: 'db.example.com',
-        PGHOSTADDR: '',
         PGPORT: '5439',
         PGUSER: 'user',
         PGPASSWORD: 'secret',
-        PGSERVICE: '',
-        PGSERVICEFILE: '',
-        PGPASSFILE: '',
         PGSSLMODE: 'require',
       });
     });
 
-    it('scrubs inherited libpq connection vars when URL omits them', () => {
+    it('omits libpq vars when the URL has no value for them', () => {
       // postgresql:///app — no host, no port, no user, no password.
-      // Without scrubbing, a parent process PGHOST=staging would silently
-      // redirect pg_dump to staging even though the caller passed a
-      // host-less URL clearly meant to be local.
+      // The returned env contains only PGDATABASE; the rest are absent
+      // entirely (NOT empty strings). The scrubbing of inherited
+      // PGHOST/PGSERVICE from the parent process happens in
+      // `runCommand`, not here.
       const env = postgresEnvFromUrl('postgresql:///app');
-      expect(env.PGHOST).toBe('');
-      expect(env.PGHOSTADDR).toBe('');
-      expect(env.PGPORT).toBe('');
-      expect(env.PGUSER).toBe('');
-      expect(env.PGPASSWORD).toBe('');
-      expect(env.PGSERVICE).toBe('');
-      expect(env.PGSERVICEFILE).toBe('');
-      expect(env.PGPASSFILE).toBe('');
-      expect(env.PGDATABASE).toBe('app');
+      expect(env).toEqual({ PGDATABASE: 'app' });
+      expect('PGHOST' in env).toBe(false);
+      expect('PGSERVICE' in env).toBe(false);
+      expect('PGPASSFILE' in env).toBe(false);
+    });
+
+    it('reads password from a ?password= query parameter', () => {
+      // Neon/Supabase emit URLs that put the password in the query
+      // string. `redactDatabaseUrl` already masks these in logs; the
+      // env builder also needs to honor them so the connection works.
+      expect(
+        postgresEnvFromUrl(
+          'postgresql://user@host.example.com/app?password=s3cret&sslmode=require',
+        ),
+      ).toMatchObject({
+        PGPASSWORD: 's3cret',
+        PGUSER: 'user',
+      });
+    });
+
+    it('reads password from ?passwd= and ?pass= aliases', () => {
+      expect(
+        postgresEnvFromUrl('postgresql://user@host/app?passwd=x'),
+      ).toMatchObject({ PGPASSWORD: 'x' });
+      expect(
+        postgresEnvFromUrl('postgresql://user@host/app?pass=y'),
+      ).toMatchObject({ PGPASSWORD: 'y' });
+    });
+
+    it('prefers userinfo password over query-param when both are set', () => {
+      // Defensive precedence — userinfo is the canonical form.
+      expect(
+        postgresEnvFromUrl(
+          'postgresql://user:fromuserinfo@host/app?password=fromquery',
+        ),
+      ).toMatchObject({ PGPASSWORD: 'fromuserinfo' });
     });
 
     it('honors a database override', () => {

--- a/packages/sql/src/postgres-cli.spec.ts
+++ b/packages/sql/src/postgres-cli.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertCanExportDatabase,
+  assertCanImportDatabase,
+  databaseNameFromUrl,
+  isLocalDatabaseUrl,
+  postgresEnvFromUrl,
+  redactDatabaseUrl,
+} from './postgres-cli';
+
+describe('postgres-cli URL helpers', () => {
+  describe('databaseNameFromUrl', () => {
+    it('extracts the path segment', () => {
+      expect(
+        databaseNameFromUrl('postgresql://user:pass@localhost:5432/app_name'),
+      ).toBe('app_name');
+    });
+
+    it('throws when the URL has no database', () => {
+      expect(() =>
+        databaseNameFromUrl('postgresql://user:pass@localhost:5432/'),
+      ).toThrow(/database name/u);
+    });
+  });
+
+  describe('isLocalDatabaseUrl', () => {
+    it.each([
+      ['postgresql://user:pass@localhost:5432/app', true],
+      ['postgresql://user:pass@127.0.0.1:5432/app', true],
+      ['postgresql://user:pass@[::1]:5432/app', true],
+      ['postgresql://user:pass@db.example.com:5432/app', false],
+    ])('%s -> %s', (url, expected) => {
+      expect(isLocalDatabaseUrl(url)).toBe(expected);
+    });
+  });
+
+  describe('redactDatabaseUrl', () => {
+    it('hides credentials', () => {
+      expect(
+        redactDatabaseUrl('postgresql://user:secret@localhost:5432/app'),
+      ).toBe('postgresql://***:***@localhost:5432/app');
+    });
+
+    it('returns a sentinel for unparseable input', () => {
+      expect(redactDatabaseUrl('not a url')).toBe('[invalid database url]');
+    });
+  });
+
+  describe('postgresEnvFromUrl', () => {
+    it('maps URL components to libpq env vars', () => {
+      expect(
+        postgresEnvFromUrl(
+          'postgresql://user:secret@db.example.com:5439/app?sslmode=require',
+        ),
+      ).toEqual({
+        PGDATABASE: 'app',
+        PGHOST: 'db.example.com',
+        PGPASSWORD: 'secret',
+        PGPORT: '5439',
+        PGSSLMODE: 'require',
+        PGUSER: 'user',
+      });
+    });
+
+    it('honors a database override', () => {
+      expect(
+        postgresEnvFromUrl(
+          'postgresql://user:secret@db.example.com:5439/app',
+          'postgres',
+        ),
+      ).toMatchObject({ PGDATABASE: 'postgres' });
+    });
+
+    it('rejects non-postgres protocols', () => {
+      expect(() => postgresEnvFromUrl('mysql://user@localhost/app')).toThrow(
+        /protocol/u,
+      );
+    });
+  });
+
+  describe('assertCanExportDatabase', () => {
+    const local = 'postgresql://user:pass@localhost:5432/app';
+    const remote = 'postgresql://user:pass@db.example.com:5432/app';
+
+    it('blocks prod-flavored export against a local DB by default', () => {
+      expect(() => assertCanExportDatabase(local, { prod: true })).toThrow(
+        /production-flavored export against a local database/u,
+      );
+    });
+
+    it('allows prod export against local when explicitly allowed', () => {
+      expect(() =>
+        assertCanExportDatabase(local, { prod: true, allowLocal: true }),
+      ).not.toThrow();
+    });
+
+    it('blocks regular export against a non-local DB', () => {
+      expect(() => assertCanExportDatabase(remote, { prod: false })).toThrow(
+        /non-local database/u,
+      );
+    });
+
+    it('allows non-local export when explicitly allowed', () => {
+      expect(() =>
+        assertCanExportDatabase(remote, { prod: false, allowProduction: true }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('assertCanImportDatabase', () => {
+    it('blocks non-local imports by default', () => {
+      expect(() =>
+        assertCanImportDatabase(
+          'postgresql://user:pass@db.example.com/app',
+          {},
+        ),
+      ).toThrow(/non-local database/u);
+    });
+
+    it('allows non-local imports when explicitly allowed', () => {
+      expect(() =>
+        assertCanImportDatabase('postgresql://user:pass@db.example.com/app', {
+          allowProduction: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it('allows local imports', () => {
+      expect(() =>
+        assertCanImportDatabase('postgresql://user:pass@localhost/app', {}),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/sql/src/postgres-cli.spec.ts
+++ b/packages/sql/src/postgres-cli.spec.ts
@@ -44,6 +44,27 @@ describe('postgres-cli URL helpers', () => {
     it('returns a sentinel for unparseable input', () => {
       expect(redactDatabaseUrl('not a url')).toBe('[invalid database url]');
     });
+
+    it('redacts password supplied as a query parameter', () => {
+      // Cloud providers (Neon/Supabase/Railway) emit URLs of this shape.
+      // Without query-param redaction the password would persist in the
+      // backup manifest and logs.
+      const redacted = redactDatabaseUrl(
+        'postgresql://user@host.example.com/app?password=s3cret&sslmode=require',
+      );
+      expect(redacted).not.toContain('s3cret');
+      expect(redacted).toContain('password=***');
+      expect(redacted).toContain('sslmode=require');
+    });
+
+    it('redacts variant query-param spellings (passwd, pass)', () => {
+      expect(redactDatabaseUrl('postgresql://host/app?passwd=oops')).toContain(
+        'passwd=***',
+      );
+      expect(redactDatabaseUrl('postgresql://host/app?pass=oops')).toContain(
+        'pass=***',
+      );
+    });
   });
 
   describe('postgresEnvFromUrl', () => {
@@ -53,13 +74,37 @@ describe('postgres-cli URL helpers', () => {
           'postgresql://user:secret@db.example.com:5439/app?sslmode=require',
         ),
       ).toEqual({
+        // Connection-target vars are always present and pinned to the
+        // URL value (or empty) so PGHOST/PGSERVICE from the parent
+        // process can't redirect the child to a different DB.
         PGDATABASE: 'app',
         PGHOST: 'db.example.com',
-        PGPASSWORD: 'secret',
+        PGHOSTADDR: '',
         PGPORT: '5439',
-        PGSSLMODE: 'require',
         PGUSER: 'user',
+        PGPASSWORD: 'secret',
+        PGSERVICE: '',
+        PGSERVICEFILE: '',
+        PGPASSFILE: '',
+        PGSSLMODE: 'require',
       });
+    });
+
+    it('scrubs inherited libpq connection vars when URL omits them', () => {
+      // postgresql:///app — no host, no port, no user, no password.
+      // Without scrubbing, a parent process PGHOST=staging would silently
+      // redirect pg_dump to staging even though the caller passed a
+      // host-less URL clearly meant to be local.
+      const env = postgresEnvFromUrl('postgresql:///app');
+      expect(env.PGHOST).toBe('');
+      expect(env.PGHOSTADDR).toBe('');
+      expect(env.PGPORT).toBe('');
+      expect(env.PGUSER).toBe('');
+      expect(env.PGPASSWORD).toBe('');
+      expect(env.PGSERVICE).toBe('');
+      expect(env.PGSERVICEFILE).toBe('');
+      expect(env.PGPASSFILE).toBe('');
+      expect(env.PGDATABASE).toBe('app');
     });
 
     it('honors a database override', () => {

--- a/packages/sql/src/postgres-cli.spec.ts
+++ b/packages/sql/src/postgres-cli.spec.ts
@@ -76,6 +76,15 @@ describe('postgres-cli URL helpers', () => {
         /protocol/u,
       );
     });
+
+    it('gracefully handles raw percent characters in credentials', () => {
+      expect(
+        postgresEnvFromUrl('postgresql://user:p%ss@localhost:5432/app'),
+      ).toMatchObject({
+        PGUSER: 'user',
+        PGPASSWORD: 'p%ss',
+      });
+    });
   });
 
   describe('assertCanExportDatabase', () => {

--- a/packages/sql/src/postgres-cli.spec.ts
+++ b/packages/sql/src/postgres-cli.spec.ts
@@ -6,6 +6,7 @@ import {
   isLocalDatabaseUrl,
   postgresEnvFromUrl,
   redactDatabaseUrl,
+  runCommand,
 } from './postgres-cli';
 
 describe('postgres-cli URL helpers', () => {
@@ -20,6 +21,42 @@ describe('postgres-cli URL helpers', () => {
       expect(() =>
         databaseNameFromUrl('postgresql://user:pass@localhost:5432/'),
       ).toThrow(/database name/u);
+    });
+  });
+
+  describe('runCommand env scrubbing', () => {
+    it('scrubs inherited routing vars like PGHOST', async () => {
+      const previous = process.env.PGHOST;
+      process.env.PGHOST = 'staging.example.com';
+      try {
+        await expect(
+          runCommand(
+            process.execPath,
+            ['-e', 'if (process.env.PGHOST) process.exit(1)'],
+            { stdio: 'pipe' },
+          ),
+        ).resolves.toBeUndefined();
+      } finally {
+        if (previous === undefined) delete process.env.PGHOST;
+        else process.env.PGHOST = previous;
+      }
+    });
+
+    it('preserves inherited auth vars like PGPASSFILE', async () => {
+      const previous = process.env.PGPASSFILE;
+      process.env.PGPASSFILE = '/tmp/test-pgpass';
+      try {
+        await expect(
+          runCommand(
+            process.execPath,
+            ['-e', 'if (!process.env.PGPASSFILE) process.exit(1)'],
+            { stdio: 'pipe' },
+          ),
+        ).resolves.toBeUndefined();
+      } finally {
+        if (previous === undefined) delete process.env.PGPASSFILE;
+        else process.env.PGPASSFILE = previous;
+      }
     });
   });
 

--- a/packages/sql/src/postgres-cli.spec.ts
+++ b/packages/sql/src/postgres-cli.spec.ts
@@ -170,6 +170,20 @@ describe('postgres-cli URL helpers', () => {
       ).toMatchObject({ PGPASSWORD: 'fromuserinfo' });
     });
 
+    it('strips IPv6 brackets when assigning PGHOST', () => {
+      // URL.hostname returns '[::1]' (with brackets) for IPv6 literals,
+      // but libpq expects the bare address. The locality check correctly
+      // strips brackets; the env builder must do the same or pg_dump
+      // fails to resolve the host.
+      expect(
+        postgresEnvFromUrl('postgresql://user:pass@[::1]:5432/app'),
+      ).toMatchObject({ PGHOST: '::1', PGPORT: '5432' });
+
+      expect(
+        postgresEnvFromUrl('postgresql://user:pass@[2001:db8::1]/app'),
+      ).toMatchObject({ PGHOST: '2001:db8::1' });
+    });
+
     it('honors a database override', () => {
       expect(
         postgresEnvFromUrl(

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -1,0 +1,304 @@
+/**
+ * Shell-out wrappers for the postgres command-line tools (`pg_dump`,
+ * `pg_restore`, `createdb`, `dropdb`) and the URL/locality helpers that
+ * surround them.
+ *
+ * These live in `@happyvertical/sql` because postgres URL parsing and pg
+ * binary invocation are SQL-layer concerns — no SMRT awareness or backup
+ * orchestration here. See `@happyvertical/sql/backup` for the higher-level
+ * snapshot helpers that compose these primitives with file storage.
+ */
+import { spawn } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export interface PostgresLocalityOptions {
+  /** Allow exporting from a non-local database without --allow-production. */
+  allowProduction?: boolean;
+  /** Allow exporting a local database when `prod: true` is set. */
+  allowLocal?: boolean;
+  /** True when the caller is running a production-flavored export. */
+  prod?: boolean;
+}
+
+export interface PostgresImportLocalityOptions {
+  allowProduction?: boolean;
+}
+
+export interface DumpOptions {
+  /** Extra args appended after the built-in pg_dump flags. */
+  extraArgs?: string[];
+  /** Override the binary name (e.g. `/usr/local/pg17/bin/pg_dump`). */
+  binary?: string;
+}
+
+export interface RestoreOptions {
+  extraArgs?: string[];
+  binary?: string;
+}
+
+export interface CreateDropOptions {
+  /** Database name to drop. Defaults to the one parsed from the URL. */
+  database?: string;
+  /**
+   * The maintenance database to connect to when running create/drop
+   * (the target DB itself can't be open). Defaults to 'postgres'.
+   */
+  maintenanceDatabase?: string;
+  extraArgs?: string[];
+  binary?: string;
+}
+
+/**
+ * Extract the database name from a postgres connection URL.
+ *
+ * Throws if the URL has no path/db segment (postgres rejects connections
+ * without one anyway).
+ */
+export function databaseNameFromUrl(databaseUrl: string): string {
+  const url = new URL(databaseUrl);
+  const database = decodeURIComponent(url.pathname.replace(/^\/+/u, ''));
+  if (!database) throw new Error('Database URL must include a database name.');
+  return database;
+}
+
+/**
+ * Treat localhost / 127.0.0.1 / ::1 / empty-hostname URLs as "local".
+ *
+ * Used by the export/import safety guards to decide whether a command
+ * needs `--allow-production` to proceed.
+ */
+export function isLocalDatabaseUrl(databaseUrl: string): boolean {
+  try {
+    const url = new URL(databaseUrl);
+    const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/gu, '');
+    return (
+      hostname === '' ||
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Strip credentials from a postgres URL for logging/manifest use.
+ * Returns `[invalid database url]` if parsing fails.
+ */
+export function redactDatabaseUrl(databaseUrl: string): string {
+  try {
+    const url = new URL(databaseUrl);
+    if (url.username) url.username = '***';
+    if (url.password) url.password = '***';
+    return url.toString();
+  } catch {
+    return '[invalid database url]';
+  }
+}
+
+/**
+ * Translate a postgres URL into the libpq env vars that pg_dump/pg_restore
+ * read. Passing credentials this way keeps them out of process argv (and
+ * therefore out of `ps`, audit logs, and error output).
+ *
+ * `databaseOverride` lets callers point pg tools at a different db on the
+ * same server (e.g. connecting to `postgres` to drop the real target).
+ */
+export function postgresEnvFromUrl(
+  databaseUrl: string,
+  databaseOverride?: string,
+): Record<string, string> {
+  const url = new URL(databaseUrl);
+  if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') {
+    throw new Error(`Unsupported database URL protocol: ${url.protocol}`);
+  }
+
+  const env: Record<string, string> = {};
+  const database = databaseOverride ?? databaseNameFromUrl(databaseUrl);
+  env.PGDATABASE = database;
+  if (url.hostname) env.PGHOST = url.hostname;
+  if (url.port) env.PGPORT = url.port;
+  if (url.username) env.PGUSER = decodeURIComponent(url.username);
+  if (url.password) env.PGPASSWORD = decodeURIComponent(url.password);
+
+  for (const [param, envName] of [
+    ['sslmode', 'PGSSLMODE'],
+    ['sslrootcert', 'PGSSLROOTCERT'],
+    ['sslcert', 'PGSSLCERT'],
+    ['sslkey', 'PGSSLKEY'],
+  ] as const) {
+    const value = url.searchParams.get(param);
+    if (value) env[envName] = value;
+  }
+
+  return env;
+}
+
+/**
+ * Guard for export operations. Two distinct hazards:
+ * - running a "prod" export against a local DB by mistake (likely a
+ *   developer running prod scripts on their laptop)
+ * - running a regular export against a non-local DB (likely a developer
+ *   pointing at staging or prod when they meant to target their laptop)
+ *
+ * Each escape hatch is named so the override has to be deliberate.
+ */
+export function assertCanExportDatabase(
+  databaseUrl: string,
+  options: PostgresLocalityOptions,
+): void {
+  const local = isLocalDatabaseUrl(databaseUrl);
+  if (options.prod && local && !options.allowLocal) {
+    throw new Error(
+      'Refusing to run a production-flavored export against a local database. Pass allowLocal only when intentionally testing the production export path.',
+    );
+  }
+  if (!options.prod && !local && !options.allowProduction) {
+    throw new Error(
+      'Refusing to export a non-local database without allowProduction. Use the production export path, or pass allowProduction intentionally.',
+    );
+  }
+}
+
+/**
+ * Guard for import/restore operations against non-local databases.
+ * Restoring is destructive, so the default is "local only".
+ */
+export function assertCanImportDatabase(
+  databaseUrl: string,
+  options: PostgresImportLocalityOptions,
+): void {
+  if (!isLocalDatabaseUrl(databaseUrl) && !options.allowProduction) {
+    throw new Error(
+      'Refusing to import into a non-local database without allowProduction.',
+    );
+  }
+}
+
+/**
+ * Run `pg_dump` against `databaseUrl`, writing a custom-format archive to
+ * `dumpPath`. Defaults match the common "logical backup, no-owner, no-acl"
+ * recipe used for cross-environment restores.
+ *
+ * Credentials travel via env vars, never argv.
+ */
+export async function dumpPostgresDatabase(
+  databaseUrl: string,
+  dumpPath: string,
+  options: DumpOptions = {},
+): Promise<void> {
+  await mkdir(dirname(dumpPath), { recursive: true });
+  await runCommand(
+    options.binary ?? 'pg_dump',
+    [
+      '--format=custom',
+      '--no-owner',
+      '--no-acl',
+      '--file',
+      dumpPath,
+      ...(options.extraArgs ?? []),
+    ],
+    { env: postgresEnvFromUrl(databaseUrl) },
+  );
+}
+
+/**
+ * Run `pg_restore` against `databaseUrl` from a custom-format archive at
+ * `dumpPath`. Uses `--clean --if-exists` so the target db can be a previous
+ * state of the same schema.
+ */
+export async function restorePostgresDatabase(
+  databaseUrl: string,
+  dumpPath: string,
+  options: RestoreOptions = {},
+): Promise<void> {
+  await runCommand(
+    options.binary ?? 'pg_restore',
+    [
+      '--clean',
+      '--if-exists',
+      '--no-owner',
+      '--no-acl',
+      '--dbname',
+      databaseNameFromUrl(databaseUrl),
+      ...(options.extraArgs ?? []),
+      dumpPath,
+    ],
+    { env: postgresEnvFromUrl(databaseUrl) },
+  );
+}
+
+/**
+ * `createdb`-equivalent. Connects via the maintenance database (default
+ * `postgres`) and creates the database named in the URL, or in
+ * `options.database` if provided.
+ */
+export async function createPostgresDatabase(
+  databaseUrl: string,
+  options: CreateDropOptions = {},
+): Promise<void> {
+  const database = options.database ?? databaseNameFromUrl(databaseUrl);
+  await runCommand(
+    options.binary ?? 'createdb',
+    [database, ...(options.extraArgs ?? [])],
+    {
+      env: postgresEnvFromUrl(
+        databaseUrl,
+        options.maintenanceDatabase ?? 'postgres',
+      ),
+    },
+  );
+}
+
+/**
+ * `dropdb`-equivalent, with `--if-exists` by default so callers can use
+ * this idempotently as part of a reset flow.
+ */
+export async function dropPostgresDatabase(
+  databaseUrl: string,
+  options: CreateDropOptions = {},
+): Promise<void> {
+  const database = options.database ?? databaseNameFromUrl(databaseUrl);
+  await runCommand(
+    options.binary ?? 'dropdb',
+    ['--if-exists', database, ...(options.extraArgs ?? [])],
+    {
+      env: postgresEnvFromUrl(
+        databaseUrl,
+        options.maintenanceDatabase ?? 'postgres',
+      ),
+    },
+  );
+}
+
+/**
+ * Spawn helper used by the wrappers above. Inherits stdio so progress and
+ * error output stream to the parent terminal (these are interactive ops).
+ */
+export async function runCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string;
+    env?: Record<string, string>;
+    stdio?: 'inherit' | 'pipe';
+  } = {},
+): Promise<void> {
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? process.cwd(),
+      env: { ...process.env, ...options.env },
+      stdio: options.stdio ?? 'inherit',
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      reject(new Error(`${command} exited with status ${code}`));
+    });
+  });
+}

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -138,22 +138,31 @@ export function postgresEnvFromUrl(
   const env: Record<string, string> = {};
   const database = databaseOverride ?? databaseNameFromUrl(databaseUrl);
 
-  // ALL libpq connection-target variables are pinned to URL-derived
-  // values (or empty string) — never left to inherit from the parent
-  // process. This is a safety guard: a developer with PGHOST=staging in
-  // their shell would otherwise see `dumpPostgresDatabase('postgres:///localdb')`
-  // silently connect to staging. Similarly PGSERVICE / PGSERVICEFILE
-  // can redirect connections via a pg_service.conf entry the caller
-  // never intended to use.
+  // Only set vars we have URL-derived values for. Inherited libpq env
+  // (PGHOST, PGSERVICE, etc.) is scrubbed separately by `runCommand`
+  // via `LIBPQ_INHERITANCE_VARS` — see below. We cannot use empty
+  // strings to "unset" these vars: libpq treats e.g. `PGSERVICE=''` as
+  // a request for a service literally named empty-string, which fails
+  // with `definition of service "" not found`. The right way to
+  // "unset" is to remove the key entirely from the child's env, which
+  // runCommand does for us before merging.
   env.PGDATABASE = database;
-  env.PGHOST = url.hostname || '';
-  env.PGHOSTADDR = '';
-  env.PGPORT = url.port || '';
-  env.PGUSER = url.username ? decodeUserInfo(url.username) : '';
-  env.PGPASSWORD = url.password ? decodeUserInfo(url.password) : '';
-  env.PGSERVICE = '';
-  env.PGSERVICEFILE = '';
-  env.PGPASSFILE = '';
+  if (url.hostname) env.PGHOST = url.hostname;
+  if (url.port) env.PGPORT = url.port;
+  if (url.username) env.PGUSER = decodeUserInfo(url.username);
+
+  // Password can come from userinfo OR query-string (`?password=...`,
+  // `?passwd=...`, `?pass=...`) — cloud providers like Neon and
+  // Supabase use the query-string form. `redactDatabaseUrl` already
+  // masks all three in logs; the env builder honors all three for
+  // connection.
+  const passwordFromUrl =
+    (url.password && decodeUserInfo(url.password)) ||
+    url.searchParams.get('password') ||
+    url.searchParams.get('passwd') ||
+    url.searchParams.get('pass') ||
+    '';
+  if (passwordFromUrl) env.PGPASSWORD = passwordFromUrl;
 
   for (const [param, envName] of [
     ['sslmode', 'PGSSLMODE'],
@@ -167,6 +176,29 @@ export function postgresEnvFromUrl(
 
   return env;
 }
+
+/**
+ * Libpq env vars that determine **where** a pg connection lands. Scrubbed
+ * from the inherited parent environment by `runCommand` so a developer
+ * with `PGHOST=staging` in their shell can't silently redirect a
+ * pg_dump call that was supposed to target the URL the caller passed.
+ *
+ * SSL-related vars (PGSSLMODE/PGSSLROOTCERT/...) are intentionally NOT
+ * scrubbed — a caller may legitimately want to inherit a system-wide
+ * certificate path. They're explicitly overridden only when the URL
+ * supplies a value.
+ */
+const LIBPQ_INHERITANCE_VARS = [
+  'PGHOST',
+  'PGHOSTADDR',
+  'PGPORT',
+  'PGDATABASE',
+  'PGUSER',
+  'PGPASSWORD',
+  'PGSERVICE',
+  'PGSERVICEFILE',
+  'PGPASSFILE',
+] as const;
 
 /**
  * Guard for export operations. Two distinct hazards:
@@ -324,7 +356,17 @@ export async function dropPostgresDatabase(
 
 /**
  * Spawn helper used by the wrappers above. Inherits stdio so progress and
- * error output stream to the parent terminal (these are interactive ops).
+ * error output stream to the parent terminal (these are interactive ops),
+ * unless the caller passes `stdio: 'pipe'` for programmatic use — in
+ * which case stderr is captured and included in the thrown error so the
+ * failure isn't an opaque `"pg_dump exited with status 1"`.
+ *
+ * Libpq connection vars (PGHOST, PGSERVICE, ...) inherited from the
+ * parent process are scrubbed before merging with `options.env`. This is
+ * the half of "URL-determined connection target" that
+ * `postgresEnvFromUrl` can't do alone: without scrubbing, a developer
+ * with `PGHOST=staging` in their shell would silently redirect the
+ * child's connection regardless of what the URL specified.
  */
 export async function runCommand(
   command: string,
@@ -335,19 +377,37 @@ export async function runCommand(
     stdio?: 'inherit' | 'pipe';
   } = {},
 ): Promise<void> {
+  const parentEnv = { ...process.env };
+  for (const key of LIBPQ_INHERITANCE_VARS) {
+    delete parentEnv[key];
+  }
+
   await new Promise<void>((resolvePromise, reject) => {
     const child = spawn(command, args, {
       cwd: options.cwd ?? process.cwd(),
-      env: { ...process.env, ...options.env },
+      env: { ...parentEnv, ...options.env },
       stdio: options.stdio ?? 'inherit',
     });
+
+    // When the caller pipes stdio, capture stderr so we can surface it
+    // in the rejection. Default (`'inherit'`) streams stderr to the
+    // parent terminal live; there's nothing to capture in that case.
+    const stderrChunks: Buffer[] = [];
+    if (options.stdio === 'pipe' && child.stderr) {
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrChunks.push(chunk);
+      });
+    }
+
     child.on('error', reject);
     child.on('close', (code) => {
       if (code === 0) {
         resolvePromise();
         return;
       }
-      reject(new Error(`${command} exited with status ${code}`));
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      const stderrSuffix = stderr ? `: ${stderr.slice(-2000)}` : '';
+      reject(new Error(`${command} exited with status ${code}${stderrSuffix}`));
     });
   });
 }

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -197,7 +197,18 @@ export function postgresEnvFromUrl(
  *
  * Auth vars (PGPASSWORD / PGPASSFILE) are intentionally NOT scrubbed:
  * they don't change target routing and some environments intentionally
- * supply credentials out-of-band while keeping DATABASE_URL passwordless.
+ * supply credentials out-of-band while keeping DATABASE_URL passwordless
+ * (the Heroku/Railway/Render-style "DATABASE_URL has user but no
+ * password; PGPASSWORD env carries the credential" pattern).
+ *
+ * **Trade-off this opens up:** on a developer machine, a stale
+ * `PGPASSWORD` set for an earlier task can flow into a later `pg_dump`
+ * targeting a different database. This typically surfaces as a clear
+ * authentication error rather than silent wrong-credential use, but
+ * callers in environments where this is a real concern should clear
+ * `PGPASSWORD` from `process.env` before invoking these helpers (or
+ * supply the credential via the URL itself, which overrides any
+ * inherited value).
  */
 const LIBPQ_INHERITANCE_VARS = [
   'PGHOST',

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -187,6 +187,10 @@ export function postgresEnvFromUrl(
  * scrubbed — a caller may legitimately want to inherit a system-wide
  * certificate path. They're explicitly overridden only when the URL
  * supplies a value.
+ *
+ * Auth vars (PGPASSWORD / PGPASSFILE) are intentionally NOT scrubbed:
+ * they don't change target routing and some environments intentionally
+ * supply credentials out-of-band while keeping DATABASE_URL passwordless.
  */
 const LIBPQ_INHERITANCE_VARS = [
   'PGHOST',
@@ -194,10 +198,8 @@ const LIBPQ_INHERITANCE_VARS = [
   'PGPORT',
   'PGDATABASE',
   'PGUSER',
-  'PGPASSWORD',
   'PGSERVICE',
   'PGSERVICEFILE',
-  'PGPASSFILE',
 ] as const;
 
 /**

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -147,7 +147,14 @@ export function postgresEnvFromUrl(
   // "unset" is to remove the key entirely from the child's env, which
   // runCommand does for us before merging.
   env.PGDATABASE = database;
-  if (url.hostname) env.PGHOST = url.hostname;
+  if (url.hostname) {
+    // Strip IPv6 brackets: `URL.hostname` returns `'[::1]'` for IPv6
+    // literals, but libpq's `PGHOST` expects the bare address (`'::1'`).
+    // Brackets are URI syntax only — passing them through means
+    // pg_dump/pg_restore fail to resolve the host even though
+    // `isLocalDatabaseUrl` correctly recognises the same URL as local.
+    env.PGHOST = url.hostname.replace(/^\[|\]$/gu, '');
+  }
   if (url.port) env.PGPORT = url.port;
   if (url.username) env.PGUSER = decodeUserInfo(url.username);
 

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -9,7 +9,7 @@
  * snapshot helpers that compose these primitives with file storage.
  */
 import { spawn } from 'node:child_process';
-import { mkdir } from 'node:fs/promises';
+import { chmod, mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 export interface PostgresLocalityOptions {
@@ -120,8 +120,8 @@ export function postgresEnvFromUrl(
   env.PGDATABASE = database;
   if (url.hostname) env.PGHOST = url.hostname;
   if (url.port) env.PGPORT = url.port;
-  if (url.username) env.PGUSER = decodeURIComponent(url.username);
-  if (url.password) env.PGPASSWORD = decodeURIComponent(url.password);
+  if (url.username) env.PGUSER = decodeUserInfo(url.username);
+  if (url.password) env.PGPASSWORD = decodeUserInfo(url.password);
 
   for (const [param, envName] of [
     ['sslmode', 'PGSSLMODE'],
@@ -189,7 +189,7 @@ export async function dumpPostgresDatabase(
   dumpPath: string,
   options: DumpOptions = {},
 ): Promise<void> {
-  await mkdir(dirname(dumpPath), { recursive: true });
+  await mkdir(dirname(dumpPath), { recursive: true, mode: 0o700 });
   await runCommand(
     options.binary ?? 'pg_dump',
     [
@@ -202,6 +202,7 @@ export async function dumpPostgresDatabase(
     ],
     { env: postgresEnvFromUrl(databaseUrl) },
   );
+  await chmod(dumpPath, 0o600);
 }
 
 /**
@@ -301,4 +302,12 @@ export async function runCommand(
       reject(new Error(`${command} exited with status ${code}`));
     });
   });
+}
+
+function decodeUserInfo(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -195,27 +195,33 @@ export function postgresEnvFromUrl(
  * certificate path. They're explicitly overridden only when the URL
  * supplies a value.
  *
- * Auth vars (PGPASSWORD / PGPASSFILE) are intentionally NOT scrubbed:
- * they don't change target routing and some environments intentionally
- * supply credentials out-of-band while keeping DATABASE_URL passwordless
- * (the Heroku/Railway/Render-style "DATABASE_URL has user but no
- * password; PGPASSWORD env carries the credential" pattern).
+ * Auth/identity vars (PGUSER / PGPASSWORD / PGPASSFILE) are
+ * intentionally NOT scrubbed: they don't change target routing and
+ * some environments intentionally supply credentials and the
+ * connecting role out-of-band while keeping DATABASE_URL itself
+ * minimal — the Heroku/Railway/Render-style "DATABASE_URL has the
+ * host and database; PGUSER + PGPASSWORD env carry the auth identity"
+ * pattern. When the URL DOES supply a username or password,
+ * `postgresEnvFromUrl` writes that value into the per-call env which
+ * then overrides the inherited one via the spawn-env merge.
+ *
+ * `PGDATABASE` is also kept out of the scrub list: `postgresEnvFromUrl`
+ * always sets it (either from the URL path or the explicit override),
+ * so the parent's value is overwritten in the merge regardless.
  *
  * **Trade-off this opens up:** on a developer machine, a stale
- * `PGPASSWORD` set for an earlier task can flow into a later `pg_dump`
- * targeting a different database. This typically surfaces as a clear
- * authentication error rather than silent wrong-credential use, but
- * callers in environments where this is a real concern should clear
- * `PGPASSWORD` from `process.env` before invoking these helpers (or
- * supply the credential via the URL itself, which overrides any
- * inherited value).
+ * `PGUSER`/`PGPASSWORD` set for an earlier task can flow into a later
+ * `pg_dump` targeting a different database. This typically surfaces as
+ * a clear authentication error rather than silent wrong-credential
+ * use, but callers in environments where this is a real concern should
+ * clear those env vars from `process.env` before invoking these
+ * helpers (or supply the credential via the URL itself, which
+ * overrides any inherited value).
  */
 const LIBPQ_INHERITANCE_VARS = [
   'PGHOST',
   'PGHOSTADDR',
   'PGPORT',
-  'PGDATABASE',
-  'PGUSER',
   'PGSERVICE',
   'PGSERVICEFILE',
 ] as const;

--- a/packages/sql/src/postgres-cli.ts
+++ b/packages/sql/src/postgres-cli.ts
@@ -35,6 +35,15 @@ export interface DumpOptions {
 export interface RestoreOptions {
   extraArgs?: string[];
   binary?: string;
+  /**
+   * Wrap the restore in `--single-transaction --exit-on-error` so a
+   * mid-restore failure rolls the target database back to its prior
+   * state instead of leaving it partially-restored-but-failing.
+   * Defaults to `true`. Set to `false` if you need parallel restore
+   * (`--jobs N` in `extraArgs`); pg_restore rejects `--single-transaction`
+   * combined with `--jobs`.
+   */
+  singleTransaction?: boolean;
 }
 
 export interface CreateDropOptions {
@@ -86,12 +95,23 @@ export function isLocalDatabaseUrl(databaseUrl: string): boolean {
 /**
  * Strip credentials from a postgres URL for logging/manifest use.
  * Returns `[invalid database url]` if parsing fails.
+ *
+ * Redacts both the userinfo (`user:password@`) and any credential-shaped
+ * query parameters (`?password=…`, `?passwd=…`, `?pass=…`) — cloud
+ * providers like Neon and Supabase emit URLs with `?password=` instead of
+ * (or in addition to) the userinfo form, and leaking those into logs or
+ * the backup manifest defeats the rest of the redaction.
  */
 export function redactDatabaseUrl(databaseUrl: string): string {
   try {
     const url = new URL(databaseUrl);
     if (url.username) url.username = '***';
     if (url.password) url.password = '***';
+    for (const param of ['password', 'passwd', 'pass']) {
+      if (url.searchParams.has(param)) {
+        url.searchParams.set(param, '***');
+      }
+    }
     return url.toString();
   } catch {
     return '[invalid database url]';
@@ -117,11 +137,23 @@ export function postgresEnvFromUrl(
 
   const env: Record<string, string> = {};
   const database = databaseOverride ?? databaseNameFromUrl(databaseUrl);
+
+  // ALL libpq connection-target variables are pinned to URL-derived
+  // values (or empty string) — never left to inherit from the parent
+  // process. This is a safety guard: a developer with PGHOST=staging in
+  // their shell would otherwise see `dumpPostgresDatabase('postgres:///localdb')`
+  // silently connect to staging. Similarly PGSERVICE / PGSERVICEFILE
+  // can redirect connections via a pg_service.conf entry the caller
+  // never intended to use.
   env.PGDATABASE = database;
-  if (url.hostname) env.PGHOST = url.hostname;
-  if (url.port) env.PGPORT = url.port;
-  if (url.username) env.PGUSER = decodeUserInfo(url.username);
-  if (url.password) env.PGPASSWORD = decodeUserInfo(url.password);
+  env.PGHOST = url.hostname || '';
+  env.PGHOSTADDR = '';
+  env.PGPORT = url.port || '';
+  env.PGUSER = url.username ? decodeUserInfo(url.username) : '';
+  env.PGPASSWORD = url.password ? decodeUserInfo(url.password) : '';
+  env.PGSERVICE = '';
+  env.PGSERVICEFILE = '';
+  env.PGPASSFILE = '';
 
   for (const [param, envName] of [
     ['sslmode', 'PGSSLMODE'],
@@ -215,6 +247,7 @@ export async function restorePostgresDatabase(
   dumpPath: string,
   options: RestoreOptions = {},
 ): Promise<void> {
+  const singleTransaction = options.singleTransaction ?? true;
   await runCommand(
     options.binary ?? 'pg_restore',
     [
@@ -222,9 +255,24 @@ export async function restorePostgresDatabase(
       '--if-exists',
       '--no-owner',
       '--no-acl',
+      // Atomic-restore default: wrap the whole operation in one
+      // transaction. Without this, a mid-restore failure (e.g. a unique
+      // constraint conflict halfway through data load) leaves the
+      // target database with the `--clean` DROPs applied AND part of
+      // the new schema/data, while pg_restore still exits non-zero —
+      // operationally the worst of both worlds. Caller can opt out via
+      // `singleTransaction: false` when running parallel restores
+      // (`--jobs N`) since pg_restore rejects the combination.
+      ...(singleTransaction ? ['--single-transaction', '--exit-on-error'] : []),
       '--dbname',
       databaseNameFromUrl(databaseUrl),
       ...(options.extraArgs ?? []),
+      // POSIX end-of-options marker: `dumpPath` is the final positional
+      // and must be interpreted as a path, not a flag. Without `--`, a
+      // path that starts with `-` (e.g. a temp file generated as
+      // `-tmp-XXX.dump`) would be misparsed by pg_restore as an unknown
+      // option.
+      '--',
       dumpPath,
     ],
     { env: postgresEnvFromUrl(databaseUrl) },

--- a/packages/sql/vite.config.ts
+++ b/packages/sql/vite.config.ts
@@ -1,3 +1,5 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
-export default createPackageConfig('sql');
+export default createPackageConfig('sql', {
+  'backup/index': 'src/backup/index.ts',
+});

--- a/packages/utils/src/cli/index.ts
+++ b/packages/utils/src/cli/index.ts
@@ -10,3 +10,4 @@ export {
   type ParsedArgs,
   parseCliArgs,
 } from './parse-args.js';
+export { type ParsedFlagArgs, parseFlagArgs } from './parse-flags.js';

--- a/packages/utils/src/cli/parse-flags.test.ts
+++ b/packages/utils/src/cli/parse-flags.test.ts
@@ -44,6 +44,13 @@ describe('parseFlagArgs', () => {
     });
   });
 
+  it('accepts an explicit empty-string value', () => {
+    expect(parseFlagArgs(['--label', ''])).toEqual({
+      flags: { label: '' },
+      positionals: [],
+    });
+  });
+
   it('rejects an empty flag name (--=value, --=) instead of silently producing an empty key', () => {
     expect(() => parseFlagArgs(['--=value'])).toThrow(/empty/);
     expect(() => parseFlagArgs(['--='])).toThrow(/empty/);

--- a/packages/utils/src/cli/parse-flags.test.ts
+++ b/packages/utils/src/cli/parse-flags.test.ts
@@ -30,10 +30,10 @@ describe('parseFlagArgs', () => {
     });
   });
 
-  it('ignores the POSIX end-of-options marker', () => {
+  it('treats all args after POSIX end-of-options marker as positionals', () => {
     expect(parseFlagArgs(['--', '--from', 'backup-a'])).toEqual({
-      flags: { from: 'backup-a' },
-      positionals: [],
+      flags: {},
+      positionals: ['--from', 'backup-a'],
     });
   });
 

--- a/packages/utils/src/cli/parse-flags.test.ts
+++ b/packages/utils/src/cli/parse-flags.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { parseFlagArgs } from './parse-flags.js';
+
+describe('parseFlagArgs', () => {
+  it('splits flags and positionals', () => {
+    expect(parseFlagArgs(['--from', 'backup-a', 'extra'])).toEqual({
+      flags: { from: 'backup-a' },
+      positionals: ['extra'],
+    });
+  });
+
+  it('treats a flag with no value as boolean true', () => {
+    expect(parseFlagArgs(['--skip-files'])).toEqual({
+      flags: { skipFiles: true },
+      positionals: [],
+    });
+  });
+
+  it('parses inline --key=value form', () => {
+    expect(parseFlagArgs(['--label=prod=db'])).toEqual({
+      flags: { label: 'prod=db' },
+      positionals: [],
+    });
+  });
+
+  it('camel-cases kebab keys', () => {
+    expect(parseFlagArgs(['--allow-production'])).toEqual({
+      flags: { allowProduction: true },
+      positionals: [],
+    });
+  });
+
+  it('ignores the POSIX end-of-options marker', () => {
+    expect(parseFlagArgs(['--', '--from', 'backup-a'])).toEqual({
+      flags: { from: 'backup-a' },
+      positionals: [],
+    });
+  });
+
+  it('treats a flag followed by another flag as boolean true', () => {
+    expect(parseFlagArgs(['--prod', '--skip-files'])).toEqual({
+      flags: { prod: true, skipFiles: true },
+      positionals: [],
+    });
+  });
+});

--- a/packages/utils/src/cli/parse-flags.test.ts
+++ b/packages/utils/src/cli/parse-flags.test.ts
@@ -43,4 +43,9 @@ describe('parseFlagArgs', () => {
       positionals: [],
     });
   });
+
+  it('rejects an empty flag name (--=value, --=) instead of silently producing an empty key', () => {
+    expect(() => parseFlagArgs(['--=value'])).toThrow(/empty/);
+    expect(() => parseFlagArgs(['--='])).toThrow(/empty/);
+  });
 });

--- a/packages/utils/src/cli/parse-flags.ts
+++ b/packages/utils/src/cli/parse-flags.ts
@@ -35,6 +35,14 @@ export function parseFlagArgs(args: string[]): ParsedFlagArgs {
     }
 
     const [rawKey, inlineValue] = arg.slice(2).split(/=(.*)/su, 2);
+    if (rawKey === '') {
+      // `--=value` or just `--` followed by garbage — the empty key
+      // would be unreachable to any sensible caller. Throw rather than
+      // silently producing `flags[''] = value`.
+      throw new Error(
+        `Invalid flag token "${arg}": flag name is empty. Use --key=value or --key value.`,
+      );
+    }
     const key = rawKey.replace(/-([a-z])/gu, (_match, letter: string) =>
       letter.toUpperCase(),
     );

--- a/packages/utils/src/cli/parse-flags.ts
+++ b/packages/utils/src/cli/parse-flags.ts
@@ -1,0 +1,53 @@
+/**
+ * Lightweight flag/positional splitter for one-shot scripts.
+ *
+ * Distinct from `parseCliArgs`, which models multi-word commands and typed
+ * options. `parseFlagArgs` is the bare-bones alternative for scripts that
+ * just need `{ flags, positionals }` from `process.argv.slice(2)`.
+ *
+ * Flag forms supported:
+ *   --foo            -> flags.foo = true
+ *   --foo bar        -> flags.foo = 'bar'
+ *   --foo=bar        -> flags.foo = 'bar'
+ *   --foo-bar baz    -> flags.fooBar = 'baz'   (kebab -> camel)
+ *   --               -> ignored (POSIX end-of-options marker)
+ *
+ * Anything not starting with `--` becomes a positional.
+ */
+export interface ParsedFlagArgs {
+  flags: Record<string, string | true>;
+  positionals: string[];
+}
+
+export function parseFlagArgs(args: string[]): ParsedFlagArgs {
+  const flags: Record<string, string | true> = {};
+  const positionals: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') continue;
+    if (!arg.startsWith('--')) {
+      positionals.push(arg);
+      continue;
+    }
+
+    const [rawKey, inlineValue] = arg.slice(2).split(/=(.*)/su, 2);
+    const key = rawKey.replace(/-([a-z])/gu, (_match, letter: string) =>
+      letter.toUpperCase(),
+    );
+    if (inlineValue !== undefined) {
+      flags[key] = inlineValue;
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (next && !next.startsWith('--')) {
+      flags[key] = next;
+      index += 1;
+    } else {
+      flags[key] = true;
+    }
+  }
+
+  return { flags, positionals };
+}

--- a/packages/utils/src/cli/parse-flags.ts
+++ b/packages/utils/src/cli/parse-flags.ts
@@ -52,7 +52,7 @@ export function parseFlagArgs(args: string[]): ParsedFlagArgs {
     }
 
     const next = args[index + 1];
-    if (next && !next.startsWith('--')) {
+    if (next !== undefined && !next.startsWith('--')) {
       flags[key] = next;
       index += 1;
     } else {

--- a/packages/utils/src/cli/parse-flags.ts
+++ b/packages/utils/src/cli/parse-flags.ts
@@ -10,7 +10,7 @@
  *   --foo bar        -> flags.foo = 'bar'
  *   --foo=bar        -> flags.foo = 'bar'
  *   --foo-bar baz    -> flags.fooBar = 'baz'   (kebab -> camel)
- *   --               -> ignored (POSIX end-of-options marker)
+ *   --               -> stop parsing flags; rest are positionals
  *
  * Anything not starting with `--` becomes a positional.
  */
@@ -25,7 +25,10 @@ export function parseFlagArgs(args: string[]): ParsedFlagArgs {
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === '--') continue;
+    if (arg === '--') {
+      positionals.push(...args.slice(index + 1));
+      break;
+    }
     if (!arg.startsWith('--')) {
       positionals.push(arg);
       continue;


### PR DESCRIPTION
## Summary

Adds primitives needed for app-level database operations tooling (snapshot/restore, doctor, migration orchestration). Shared by every SMRT app that operates a Postgres database.

**`@happyvertical/sql`**
- `postgres-cli`: `pg_dump` / `pg_restore` / `createdb` / `dropdb` shell-out wrappers, URL helpers (env extraction, locality detection, redaction), and safety guards for prod-vs-local export/import operations
- `doctor`: generic check runner + reusable check builders (expected tables, unique columns, FK-shaped relationships)
- `/backup` subpath: `exportBackup` / `restoreBackup` / `resetLocalDatabaseFromBackup` orchestration with extensible manifest and `onBackup` / `onRestore` hooks for caller-supplied file-storage and metadata extras

**`@happyvertical/files`**
- `redactFilesystemConfig` for safely logging provider configs

**`@happyvertical/utils`**
- `parseFlagArgs` for one-shot scripts that just need `{flags, positionals}` split (distinct from the multi-word command parser in `parseCliArgs`)

## Test plan

- [ ] sdk CI passes (typecheck, biome, unit tests across sql/files/utils)
- [ ] `postgres-cli` tests cover URL redaction + prod-vs-local guard behavior
- [ ] `doctor` tests verify expected-table / unique-column / FK-shape check builders
- [ ] `/backup` tests cover manifest extension + onBackup/onRestore hooks
- [ ] No regressions in existing sql/files/utils tests