### PR TITLE
feat(sql): add acquireSession() for pinned-connection session locks

### DIFF
--- a/packages/sql/src/postgres.spec.ts
+++ b/packages/sql/src/postgres.spec.ts
@@ -238,6 +238,46 @@ describe('postgres tests', () => {
     expect(result).toBeNull();
   });
 
+  it('acquireSession holds a session advisory lock across queries until release', async () => {
+    if (!postgresAvailable) return;
+    expect(typeof db.acquireSession).toBe('function');
+
+    const lockKey = 918_273_645;
+    const session = await db.acquireSession?.();
+    if (!session) throw new Error('acquireSession returned no handle');
+    expect(session.isActive()).toBe(true);
+
+    try {
+      await session.query('SELECT pg_advisory_lock(?)', lockKey);
+
+      // A pooled connection (separate from the session's pinned one) must
+      // observe the lock as held.
+      const held = await db.query(
+        'SELECT pg_try_advisory_lock(?) AS got',
+        lockKey,
+      );
+      expect(held.rows[0].got).toBe(false);
+    } finally {
+      await session.release();
+    }
+
+    // release() frees the lock (pg_advisory_unlock_all) before dropping the
+    // connection, so this is deterministic, not racing the async teardown.
+    expect(session.isActive()).toBe(false);
+    const free = await db.query(
+      'SELECT pg_try_advisory_lock(?) AS got',
+      lockKey,
+    );
+    expect(free.rows[0].got).toBe(true);
+    // Clean up the lock taken by the assertion above (same pooled session).
+    await db.query('SELECT pg_advisory_unlock(?)', lockKey);
+
+    // Using a released session must fail clearly.
+    await expect(session.query('SELECT 1')).rejects.toThrow(
+      /Session has been released/,
+    );
+  });
+
   it('should preserve PostgreSQL JSONB existence operators in raw queries', async () => {
     if (!postgresAvailable) return;
 

--- a/packages/sql/src/postgres.spec.ts
+++ b/packages/sql/src/postgres.spec.ts
@@ -264,13 +264,22 @@ describe('postgres tests', () => {
     // release() frees the lock (pg_advisory_unlock_all) before dropping the
     // connection, so this is deterministic, not racing the async teardown.
     expect(session.isActive()).toBe(false);
-    const free = await db.query(
-      'SELECT pg_try_advisory_lock(?) AS got',
-      lockKey,
-    );
-    expect(free.rows[0].got).toBe(true);
-    // Clean up the lock taken by the assertion above (same pooled session).
-    await db.query('SELECT pg_advisory_unlock(?)', lockKey);
+
+    // Verify the lock is free on a *pinned* session so the acquire and the
+    // cleanup unlock happen on the same connection (a pooled try+unlock could
+    // land on different connections and leak the lock).
+    const verify = await db.acquireSession?.();
+    if (!verify) throw new Error('acquireSession returned no handle');
+    try {
+      const free = await verify.query(
+        'SELECT pg_try_advisory_lock(?) AS got',
+        lockKey,
+      );
+      expect(free.rows[0].got).toBe(true);
+    } finally {
+      // release() destroys the connection, which frees the lock just taken.
+      await verify.release();
+    }
 
     // Using a released session must fail clearly.
     await expect(session.query('SELECT 1')).rejects.toThrow(

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -1462,6 +1462,16 @@ async function createDatabase(
         // lost connection (nothing to talk to; backend exit frees them anyway).
         if (!lost) {
           try {
+            // A caller that left the connection in an aborted transaction
+            // (BEGIN, a failed statement, then release) would make
+            // pg_advisory_unlock_all() error with "current transaction is
+            // aborted". Roll back first (a no-op when no transaction is open)
+            // so the unlock runs and the deterministic-release contract holds.
+            await sessionClient.query('ROLLBACK');
+          } catch {
+            // No open transaction, or already gone — proceed to unlock.
+          }
+          try {
             await sessionClient.query('SELECT pg_advisory_unlock_all()');
           } catch {
             // Best-effort; the destroy below frees locks at backend exit.

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -15,6 +15,7 @@ import type {
   DatabaseInterface,
   IndexDefinition,
   SchemaInitializationOptions,
+  SessionHandle,
   TableInterface,
   TableSchemaInfo,
   TransactionHandle,
@@ -1405,6 +1406,76 @@ async function createDatabase(
   };
 
   /**
+   * Acquire a pinned connection from the pool for session-scoped state such as
+   * `pg_advisory_lock`. Every query on the returned handle runs on the same
+   * client until {@link SessionHandle.release} drops the connection (which
+   * frees any session locks it held). The connection is held for the handle's
+   * lifetime, so hold one session per process, not per operation.
+   */
+  const acquireSession = async (): Promise<SessionHandle> => {
+    const sessionClient = await pool.connect();
+    let released = false;
+    let lost = false;
+
+    // pg-pool removes its idle 'error' listener when a client is checked out.
+    // A session is pinned for the process lifetime and mostly idle between
+    // queries, so a backend disconnect/failover would emit 'error' on a
+    // listener-less client and crash the process. Absorb it and mark the
+    // session dead instead; the next query()/isActive() surfaces it.
+    sessionClient.on('error', () => {
+      lost = true;
+    });
+
+    return {
+      query: async (sql: string, ...values: any[]) => {
+        if (released) {
+          throw new DatabaseError('Session has been released', {});
+        }
+        if (lost) {
+          throw new DatabaseError('Session connection was lost', {});
+        }
+        const normalized = normalizePostgresRawQuery(sql, values);
+        try {
+          const result = await sessionClient.query(
+            normalized.sql,
+            normalized.values,
+          );
+          return {
+            rows: result.rows,
+            rowCount: result.rowCount ?? 0,
+          };
+        } catch (e) {
+          throw new DatabaseError('Failed to execute session query', {
+            sql: normalized.sql,
+            values: normalized.values,
+            originalError: formatDbError(e),
+          });
+        }
+      },
+      isActive: () => !released && !lost,
+      release: async () => {
+        if (released) return;
+        released = true;
+        // Free session advisory locks before tearing down so the contract
+        // "after release() the locks are gone" holds deterministically — the
+        // destroy below is async (TCP teardown) and resolves later. Skip on a
+        // lost connection (nothing to talk to; backend exit frees them anyway).
+        if (!lost) {
+          try {
+            await sessionClient.query('SELECT pg_advisory_unlock_all()');
+          } catch {
+            // Best-effort; the destroy below frees locks at backend exit.
+          }
+        }
+        // Destroy the physical connection rather than returning it to the pool.
+        // Returning it would NOT clear residual session state, which could then
+        // leak onto a connection later handed to unrelated code.
+        sessionClient.release(true);
+      },
+    };
+  };
+
+  /**
    * Checks if a table exists in the database
    *
    * @param tableName - Name of the table to check
@@ -2281,6 +2352,7 @@ async function createDatabase(
     initializeSchemas,
     transaction,
     beginTransaction,
+    acquireSession,
     getTableSchema,
     alterTable,
     vector: createVectorCapabilities(pool),

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -961,6 +961,34 @@ export interface DatabaseInterface {
   beginTransaction?: () => Promise<TransactionHandle>;
 
   /**
+   * Acquire a pinned single-connection session.
+   *
+   * Returns a {@link SessionHandle} whose queries all run on one underlying
+   * connection, enabling session-scoped state (e.g. PostgreSQL session advisory
+   * locks) that the pooled top-level {@link query} cannot hold reliably. The
+   * caller must {@link SessionHandle.release} it.
+   *
+   * Only meaningful for engines with session-scoped state, so it is currently
+   * implemented for PostgreSQL only; check for the method before calling
+   * (`if (db.acquireSession)`). Single-connection engines (SQLite, DuckDB) have
+   * no session-scoped locks to hold, so they leave it undefined.
+   *
+   * @returns Promise resolving to a SessionHandle
+   *
+   * @example Hold a Postgres session advisory lock
+   * ```typescript
+   * const session = await db.acquireSession();
+   * try {
+   *   await session.query('SELECT pg_advisory_lock($1)', 42);
+   *   // ... lock is held for the life of this session ...
+   * } finally {
+   *   await session.release(); // frees the lock and drops the connection
+   * }
+   * ```
+   */
+  acquireSession?: () => Promise<SessionHandle>;
+
+  /**
    * Retrieves the schema information for a table
    *
    * @param table - Table name
@@ -1069,6 +1097,51 @@ export interface TransactionHandle extends DatabaseInterface {
    * Whether the transaction is still active (not committed or rolled back)
    */
   isActive: () => boolean;
+}
+
+/**
+ * Pinned single-connection session handle.
+ *
+ * Obtained via {@link DatabaseInterface.acquireSession}. Unlike the pooled
+ * top-level `query` (which may run each statement on a different connection),
+ * every call on a session handle runs on the *same* underlying connection for
+ * the handle's lifetime. This is required for session-scoped state such as
+ * PostgreSQL session advisory locks (`pg_advisory_lock`), which must be
+ * acquired, observed, and released on one connection — and which release
+ * automatically if the connection drops (e.g. the process dies).
+ *
+ * A session holds one connection out of the pool (default max 20) for its
+ * entire lifetime, so it is meant to be held one-per-process, not per-operation.
+ * Always {@link SessionHandle.release} the handle when done, and release it
+ * *before* calling `db.client.end()` — a pinned connection keeps `pool.end()`
+ * from resolving.
+ */
+export interface SessionHandle {
+  /**
+   * Execute a raw query on this session's pinned connection.
+   * Same placeholder/return contract as {@link DatabaseInterface.query}.
+   * Throws if the session has been released or its connection was lost.
+   */
+  query: (
+    sql: string,
+    ...vars: any[]
+  ) => Promise<{ rows: Record<string, any>[]; rowCount: number }>;
+
+  /**
+   * Whether the session is still usable — not released and its connection has
+   * not errored/dropped. A long-lived lock holder can poll this without
+   * issuing a query.
+   */
+  isActive: () => boolean;
+
+  /**
+   * Release the session. Idempotent. After release the handle must not be used.
+   * Best-effort frees session-scoped locks, then drops the underlying
+   * connection (it is NOT returned to the pool) so the database releases any
+   * remaining session state — returning it to the pool would leak that state
+   * onto a later, unrelated checkout.
+   */
+  release: () => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `acquireSession()` to `@happyvertical/sql` — a pinned single-connection `SessionHandle` that enables session-scoped state the pooled top-level `query()` cannot hold.

The pooled `query()` runs each statement on an arbitrary pooled connection, so a `pg_advisory_lock` taken through it lands on a connection that is recycled back into the pool — silently releasing the lock or leaking it onto unrelated callers. `acquireSession()` checks out a dedicated client (`pool.connect()`) and pins every query on the returned handle to it, so a session advisory lock stays held for the handle's life and releases automatically when the connection drops (e.g. the owning process dies).

This is the primitive a **worker-liveness lease** in `@happyvertical/smrt-jobs` needs (issue [happyvertical/smrt#1474](https://github.com/happyvertical/smrt/issues/1474)): a worker holds a `pg_advisory_lock` for its lifetime; on death the dropped connection auto-frees it, giving instant cross-process crash detection.

## API

```ts
interface SessionHandle {
  query(sql: string, ...vars: any[]): Promise<{ rows; rowCount }>;
  isActive(): boolean;
  release(): Promise<void>;
}
interface DatabaseInterface {
  acquireSession?(): Promise<SessionHandle>; // Postgres only
}
```

Implemented for **Postgres** (the only engine with session-scoped locks); the optional method is left undefined on single-connection engines (SQLite/DuckDB have no session locks to hold).

## Robustness (from review)

- **Attaches an `'error'` listener** to the pinned client. pg-pool drops its idle listener on checkout, so a lifetime-pinned, mostly-idle session would crash the process with an uncaught `'error'` on any backend disconnect/failover. We absorb it and mark the session lost; the next `query()`/`isActive()` surfaces it.
- **`release()`** best-effort `pg_advisory_unlock_all()` then **destroys** the connection (`release(true)`) rather than returning it to the pool — so the lock is gone deterministically once `release()` resolves and no session state leaks into the pool.
- **`isActive()`** lets a long-lived holder check liveness without issuing a query.
- `query()`/`release()` guard against use-after-release.

## Consumer note

The advisory lock is **fast-path** liveness only. On host death / network partition the orphaned backend can hold the lock until TCP keepalive notices (potentially hours), so the smrt-jobs consumer keeps a **DB-lease TTL as the authoritative recovery path** and treats the lock as an instant-detection optimization.

## Caveats (documented on the API)

- A session holds one pool slot (default max 20) for its lifetime — hold one per process, not per operation.
- Release sessions **before** `db.client.end()` — a pinned connection keeps `pool.end()` from resolving.

## Testing

New gated test in `postgres.spec.ts` (runs against a local Postgres): a lock held on the session is observed as held from a pooled connection, `isActive()` flips on release, the lock is free immediately after `release()`, and a released session throws. Verified green against a real Postgres (40/40). Typecheck + build clean.