### PR TITLE
fix(analytics): bind MatomoAdmin capability methods so detached calls keep their instance

### DIFF
--- a/packages/analytics/src/shared/providers/matomo-admin.test.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.test.ts
@@ -668,6 +668,49 @@ describe('MatomoAdmin.user lifecycle', () => {
     expect(result.error).toMatch(/Site 7 was not found/);
   });
 
+  it('mint-then-verify works with detached method references (#1043)', async () => {
+    // Regression: `AnalyticsAdminInterface` marks capability methods optional
+    // and documents feature-checking them, so callers narrow by pulling the
+    // method into a local — detaching `this`. Unbound prototype methods then
+    // ran with `this === undefined`, and minted-token verification failed
+    // with "Cannot read properties of undefined (reading
+    // 'cloneTransportWithToken')".
+    const responses = [
+      jsonResponse({ value: 'minted-token-abc' }),
+      jsonResponse({
+        idsite: '19',
+        name: 'Anytown',
+        main_url: 'https://anytown.example.com',
+      }),
+    ];
+    const { calls } = setFetchMock(() => nextResponse(responses));
+    const admin = new MatomoAdmin({
+      baseUrl: 'https://m.example.com',
+      tokenAuth: 'super-user-token',
+    });
+
+    const { mintUserToken, verifyTokenSiteAccess } = admin;
+    expect(typeof mintUserToken).toBe('function');
+    expect(typeof verifyTokenSiteAccess).toBe('function');
+
+    const minted = await mintUserToken({
+      login: 'tenant-user',
+      passwordConfirmation: 'tenant-password',
+    });
+    expect(minted.token).toBe('minted-token-abc');
+
+    const access = await verifyTokenSiteAccess({
+      tokenAuth: minted.token,
+      siteId: '19',
+    });
+    expect(access.error).toBeUndefined();
+    expect(access.ok).toBe(true);
+    expect(access.access).toBe('view');
+    // The verification probe must run under the freshly minted token, not
+    // the super-user token the admin was constructed with.
+    expect(calls[1].body.get('token_auth')).toBe('minted-token-abc');
+  });
+
   it('mintUserToken forwards the per-call passwordConfirmation', async () => {
     const { calls } = setFetchMock(() =>
       jsonResponse({ value: 'mint-token-abc' }),

--- a/packages/analytics/src/shared/providers/matomo-admin.ts
+++ b/packages/analytics/src/shared/providers/matomo-admin.ts
@@ -341,6 +341,28 @@ export class MatomoAdmin implements AnalyticsAdminInterface {
       ...options,
       baseUrl: this.baseUrl,
     });
+
+    // `AnalyticsAdminInterface` marks capability methods optional and tells
+    // callers to feature-check them (`typeof admin.mintUserToken ===
+    // 'function'`). The idiomatic TypeScript narrowing for that is to pull
+    // the method into a local before calling it, which detaches `this`.
+    // Bind every interface method so detached calls still hit this instance
+    // instead of crashing with `this === undefined` (surfaced in production
+    // as "Cannot read properties of undefined (reading
+    // 'cloneTransportWithToken')" during minted-token verification —
+    // https://github.com/happyvertical/sdk/issues/1043).
+    this.createSite = this.createSite.bind(this);
+    this.listSites = this.listSites.bind(this);
+    this.getSite = this.getSite.bind(this);
+    this.deleteSite = this.deleteSite.bind(this);
+    this.createUser = this.createUser.bind(this);
+    this.getUser = this.getUser.bind(this);
+    this.deleteUser = this.deleteUser.bind(this);
+    this.setUserAccess = this.setUserAccess.bind(this);
+    this.verifyUserSiteAccess = this.verifyUserSiteAccess.bind(this);
+    this.verifyTokenSiteAccess = this.verifyTokenSiteAccess.bind(this);
+    this.mintUserToken = this.mintUserToken.bind(this);
+    this.health = this.health.bind(this);
   }
 
   private cloneTransportWithToken(tokenAuth: string): MatomoAdminTransport {

--- a/packages/analytics/src/shared/types.ts
+++ b/packages/analytics/src/shared/types.ts
@@ -1323,6 +1323,12 @@ export interface AnalyticsHealthResult {
  * particular provider can't support (e.g. `mintUserToken` against GA4) are left
  * out of that provider's admin object — callers should feature-check via
  * `typeof admin.mintUserToken === 'function'`.
+ *
+ * Because that feature-check idiom typically narrows a method into a local
+ * (`const fn = admin.mintUserToken; if (fn) await fn(...)`), implementations
+ * MUST keep these methods detachment-safe — i.e. bind them to the instance so a
+ * detached/destructured reference still carries `this`. See `MatomoAdmin`'s
+ * constructor for the reference implementation (https://github.com/happyvertical/sdk/issues/1043).
  */
 export interface AnalyticsAdminInterface {
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1043.

## Problem
`AnalyticsAdminInterface` documents its capability methods as optional and tells callers to feature-check them (`typeof admin.mintUserToken === 'function'`). The idiomatic narrowing for that pulls the method into a local (`const fn = admin.verifyTokenSiteAccess; await fn(...)`), which **detaches `this`**. `MatomoAdmin`'s methods were plain prototype methods, so the detached call ran with `this === undefined` (ESM strict mode) and `this.cloneTransportWithToken(...)` threw `Cannot read properties of undefined (reading 'cloneTransportWithToken')`. The method's own catch folded that TypeError into `{ ok: false, error: ... }`, surfacing as the prod message `Minted token cannot read site N: ...`. The transport construction itself was fine — the receiver was lost.

## Fix
Bind all 12 `AnalyticsAdminInterface` methods to the instance in the `MatomoAdmin` constructor. No behavior change for normally-attached calls; detached/destructured calls now keep `this`. Also codifies the detachment-safety expectation on the interface doc so future admin providers don't reintroduce this.

## Tests
- New regression test in `matomo-admin.test.ts` exercises the mint-then-verify path via **detached** `mintUserToken` + `verifyTokenSiteAccess` against a mocked transport, asserting the verify probe runs under the minted token. Red-green confirmed (fails without the bind block).
- `pnpm --filter @happyvertical/analytics test`: 64 passed / 5 skipped (live-Matomo suite). Build clean.

Found in anytown.ai prod via an integration-health doctor sweep.