### PR TITLE
ci: pass release secrets through merge orchestrator

### DIFF
--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -46,7 +46,10 @@ jobs:
       always() &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     uses: ./.github/workflows/publish.yml
-    secrets: inherit
+    secrets:
+      HAVE_RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
+      HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   summary:
     needs: [test, publish]


### PR DESCRIPTION
## Summary
- pass release workflow_call secrets explicitly from shared-merge-orchestrator.yml into publish.yml
- fixes the nested reusable workflow validation failure from On Merge to Main run 28006860264

## Root Cause
GitHub failed before starting the publish runner with:

`Secret NPM_TOKEN is required, but not provided while calling.`

The orchestrator called publish.yml with `secrets: inherit`; the required workflow_call secrets need to be mapped explicitly at this nested call boundary.

## Validation
- pre-commit workflow validation hook passed: yamllint + act --list
- pre-push typecheck passed