### PR TITLE
[codex] Publish @happyvertical/documents to npmjs

### DIFF
--- a/.changeset/publish-documents.md
+++ b/.changeset/publish-documents.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/documents": patch
+---
+
+Publish @happyvertical/documents to public npm.

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -6,7 +6,13 @@ Document processing with hierarchical structure. Currently supports PDF document
 
 ## Installation
 
-This package is currently workspace-only. It depends on `@happyvertical/ocr`, `@happyvertical/pdf`, and `@happyvertical/spider`, which must move to public npm before `@happyvertical/documents` can be published there for anonymous installs.
+Install from the public npm registry:
+
+```bash
+npm install @happyvertical/documents
+```
+
+Anonymous installs also require the package's external `@happyvertical/ocr`, `@happyvertical/pdf`, and `@happyvertical/spider` dependencies to be available on public npm.
 
 ## Quick Start
 

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@happyvertical/documents",
   "version": "0.74.8",
-  "private": true,
   "description": "Multi-part document processing with support for PDF, HTML, and Markdown",
   "type": "module",
   "main": "dist/index.js",
@@ -16,6 +15,10 @@
     "AGENT.md",
     "metadata.json"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/happyvertical/sdk.git",


### PR DESCRIPTION
## Summary

- Remove the private package marker from `@happyvertical/documents`.
- Add the same public npm `publishConfig` used by the other SDK packages.
- Update the documents README installation note and add a patch changeset so release automation publishes the package.

## Why

`@happyvertical/documents` currently returns 404 from `registry.npmjs.org`, which blocks anonymous installs of the SMRT 0.32.0 dependency graph. The root cause in this repo was package metadata: `packages/documents/package.json` was still marked private and did not opt into public npm publishing.

Closes #1051.

## Validation

- `pnpm --filter @happyvertical/documents build`
- `pnpm --filter @happyvertical/documents test`
- packed manifest inspection confirmed `catalog:` and `workspace:*` dependencies rewrite to publishable semver ranges
- `pnpm run build`
- `pnpm run validate-build`
- pre-push hook: `pnpm run typecheck`