### PR TITLE
feat(sql): add aggregate query builder

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -162,6 +162,10 @@ buildWhere([
 // WHERE (status = $1 AND price > $2) OR (status = $3 AND priority = $4)
 ```
 
+Condition keys with explicit operator suffixes are emitted as SQL
+field/expression text. Keep those keys developer-controlled; do not pass
+end-user input as condition keys.
+
 ### Aggregate Query Building
 
 ```typescript

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -145,6 +145,7 @@ const { sql, values } = buildWhere({
   status: 'active',
   'price >': 100,
   'category in': ['electronics', 'books'],
+  'status not in': ['archived'],
   'name like': '%shirt%',
   deleted_at: null,         // IS NULL
   'updated_at !=': null,    // IS NOT NULL
@@ -160,6 +161,37 @@ buildWhere([
 ]);
 // WHERE (status = $1 AND price > $2) OR (status = $3 AND priority = $4)
 ```
+
+### Aggregate Query Building
+
+```typescript
+import { buildAggregate } from '@happyvertical/sql';
+
+const aggregate = buildAggregate(
+  {
+    from: 'orders',
+    select: [
+      { bucket: 'month', column: 'created_at', as: 'month' },
+      { column: 'customer_id' },
+      { fn: 'sum', column: 'total', as: 'revenue' },
+      { fn: 'count', as: 'order_count' },
+    ],
+    where: { status: 'paid' },
+    having: { 'revenue >': 0 },
+    orderBy: ['month ASC', 'revenue DESC'],
+    limit: 100,
+  },
+  1,
+  'postgres',
+);
+
+const rows = await db.query(aggregate.sql, aggregate.values);
+```
+
+`buildAggregate()` emits parameterized SQL and values, reuses `buildWhere()`
+semantics for `where` and `having`, and maps time buckets per adapter:
+PostgreSQL, DuckDB, and JSON use `date_trunc(...)`; SQLite uses portable
+`strftime(...)`/`date(...)` expressions.
 
 ### Schema Synchronization
 

--- a/packages/sql/src/aggregate.spec.ts
+++ b/packages/sql/src/aggregate.spec.ts
@@ -77,6 +77,22 @@ describe('aggregate SQL builder', () => {
     expect(result.values).toEqual([2]);
   });
 
+  it('handles uppercase count and rejects distinct count without a column', () => {
+    expect(
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'COUNT', as: 'order_count' }],
+      }).sql,
+    ).toBe('SELECT COUNT(*) AS order_count FROM orders');
+
+    expect(() =>
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'count', distinct: true, as: 'order_count' }],
+      }),
+    ).toThrow('Aggregate count with distinct requires a column');
+  });
+
   it('builds OR/AND having clauses with stable placeholder order', () => {
     const result = buildAggregate({
       from: 'orders',
@@ -132,11 +148,51 @@ describe('aggregate SQL builder', () => {
       "strftime('%Y-%m-%d 00:00:00', created_at)",
     );
     expect(bucketExpr('sqlite', 'week', 'created_at')).toBe(
-      "date(created_at, printf('-%d days', (CAST(strftime('%w', created_at) AS INTEGER) + 6) % 7))",
+      "strftime('%Y-%m-%d 00:00:00', date(created_at, printf('-%d days', (CAST(strftime('%w', created_at) AS INTEGER) + 6) % 7)))",
     );
     expect(bucketExpr('sqlite', 'quarter', 'created_at')).toBe(
-      "date(strftime('%Y-', created_at) || printf('%02d', ((CAST(strftime('%m', created_at) AS INTEGER) - 1) / 3) * 3 + 1) || '-01')",
+      "strftime('%Y-%m-%d 00:00:00', date(strftime('%Y-', created_at) || printf('%02d', ((CAST(strftime('%m', created_at) AS INTEGER) - 1) / 3) * 3 + 1) || '-01'))",
     );
+  });
+
+  it('emits SQLite-safe offset without limit', () => {
+    const spec: AggregateSpec = {
+      from: 'orders',
+      select: [{ fn: 'count', as: 'count' }],
+      offset: 5,
+    };
+
+    expect(buildAggregate(spec, 1, 'sqlite')).toEqual({
+      sql: 'SELECT COUNT(*) AS count FROM orders LIMIT -1 OFFSET $1',
+      values: [5],
+    });
+    expect(buildAggregate(spec, 1, 'postgres')).toEqual({
+      sql: 'SELECT COUNT(*) AS count FROM orders OFFSET $1',
+      values: [5],
+    });
+  });
+
+  it('executes SQLite offset without limit', async () => {
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    await syncSchema({
+      db,
+      schema: 'CREATE TABLE orders (id TEXT PRIMARY KEY)',
+    });
+    await db.insert('orders', [{ id: '1' }, { id: '2' }]);
+
+    const aggregate = buildAggregate(
+      {
+        from: 'orders',
+        select: [{ column: 'id' }],
+        orderBy: 'id ASC',
+        offset: 1,
+      },
+      1,
+      'sqlite',
+    );
+
+    const result = await db.query(aggregate.sql, ...aggregate.values);
+    expect(result.rows).toEqual([{ id: '2' }]);
   });
 
   it('executes generated aggregate SQL against SQLite', async () => {

--- a/packages/sql/src/aggregate.spec.ts
+++ b/packages/sql/src/aggregate.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type AggregateSpec,
+  bucketExpr,
+  buildAggregate,
+  getDatabase,
+  syncSchema,
+} from './index.js';
+
+const tenantId = 'tenant_id';
+const customerId = 'customer_id';
+const createdAt = 'created_at';
+const deletedAt = 'deleted_at';
+const avgTotal = 'avg_total';
+
+describe('aggregate SQL builder', () => {
+  it('builds grouped aggregate queries with where, having, order, limit, and offset', () => {
+    const result = buildAggregate(
+      {
+        from: 'orders',
+        select: [
+          { column: 'customer_id' },
+          { fn: 'count', as: 'order_count' },
+          { fn: 'sum', column: 'total', as: 'revenue' },
+          { fn: 'avg', column: 'total', as: 'avg_total' },
+          { fn: 'min', column: 'total', as: 'min_total' },
+          { fn: 'max', column: 'total', as: 'max_total' },
+        ],
+        where: {
+          status: 'paid',
+          'created_at >=': new Date('2026-01-01T00:00:00.000Z'),
+          [deletedAt]: null,
+        },
+        having: {
+          'revenue >': 100,
+        },
+        orderBy: ['revenue DESC', 'customer_id ASC'],
+        limit: 10,
+        offset: 20,
+      },
+      1,
+      'postgres',
+    );
+
+    expect(result.sql).toBe(
+      'SELECT customer_id AS customer_id, COUNT(*) AS order_count, SUM(total) AS revenue, AVG(total) AS avg_total, MIN(total) AS min_total, MAX(total) AS max_total FROM orders WHERE status = $1 AND created_at >= $2 AND deleted_at IS NULL GROUP BY customer_id HAVING SUM(total) > $3 ORDER BY revenue DESC, customer_id ASC LIMIT $4 OFFSET $5',
+    );
+    expect(result.values).toEqual([
+      'paid',
+      '2026-01-01T00:00:00.000Z',
+      100,
+      10,
+      20,
+    ]);
+  });
+
+  it('uses aliases and distinct aggregate expressions', () => {
+    const result = buildAggregate({
+      from: 'events',
+      select: [
+        { column: 'tenant_id', as: 'tenant' },
+        {
+          fn: 'count',
+          column: 'profile_id',
+          distinct: true,
+          as: 'unique_profiles',
+        },
+      ],
+      having: {
+        'unique_profiles >=': 2,
+      },
+    });
+
+    expect(result.sql).toBe(
+      'SELECT tenant_id AS tenant, COUNT(DISTINCT profile_id) AS unique_profiles FROM events GROUP BY tenant_id HAVING COUNT(DISTINCT profile_id) >= $1',
+    );
+    expect(result.values).toEqual([2]);
+  });
+
+  it('builds OR/AND having clauses with stable placeholder order', () => {
+    const result = buildAggregate({
+      from: 'orders',
+      select: [
+        { column: 'customer_id' },
+        { fn: 'sum', column: 'total', as: 'revenue' },
+      ],
+      having: [
+        [{ 'revenue >': 100 }, { 'customer_id in': ['a', 'b'] }],
+        [{ revenue: null }],
+      ],
+    });
+
+    expect(result.sql).toBe(
+      'SELECT customer_id AS customer_id, SUM(total) AS revenue FROM orders GROUP BY customer_id HAVING (SUM(total) > $1 AND customer_id IN ($2, $3)) OR (SUM(total) IS NULL)',
+    );
+    expect(result.values).toEqual([100, 'a', 'b']);
+  });
+
+  it('casts date predicates for DuckDB and JSON but not SQLite/Postgres', () => {
+    const spec: AggregateSpec = {
+      from: 'orders',
+      select: [{ fn: 'count', as: 'count' }],
+      where: { 'created_at >': new Date('2026-01-01T00:00:00.000Z') },
+      having: { 'count >': 0 },
+    };
+
+    expect(buildAggregate(spec, 1, 'duckdb').sql).toBe(
+      'SELECT COUNT(*) AS count FROM orders WHERE created_at > CAST($1 AS TIMESTAMP) HAVING COUNT(*) > $2',
+    );
+    expect(buildAggregate(spec, 1, 'json').sql).toBe(
+      'SELECT COUNT(*) AS count FROM orders WHERE created_at > CAST($1 AS TIMESTAMP) HAVING COUNT(*) > $2',
+    );
+    expect(buildAggregate(spec, 1, 'sqlite').sql).toBe(
+      'SELECT COUNT(*) AS count FROM orders WHERE created_at > $1 HAVING COUNT(*) > $2',
+    );
+    expect(buildAggregate(spec, 1, 'postgres').sql).toBe(
+      'SELECT COUNT(*) AS count FROM orders WHERE created_at > $1 HAVING COUNT(*) > $2',
+    );
+  });
+
+  it('builds adapter-specific time bucket expressions', () => {
+    expect(bucketExpr('postgres', 'day', 'created_at')).toBe(
+      "date_trunc('day', created_at)",
+    );
+    expect(bucketExpr('duckdb', 'month', 'created_at')).toBe(
+      "date_trunc('month', created_at)",
+    );
+    expect(bucketExpr('json', 'hour', 'created_at')).toBe(
+      "date_trunc('hour', created_at)",
+    );
+    expect(bucketExpr('sqlite', 'day', 'created_at')).toBe(
+      "strftime('%Y-%m-%d 00:00:00', created_at)",
+    );
+    expect(bucketExpr('sqlite', 'week', 'created_at')).toBe(
+      "date(created_at, printf('-%d days', (CAST(strftime('%w', created_at) AS INTEGER) + 6) % 7))",
+    );
+    expect(bucketExpr('sqlite', 'quarter', 'created_at')).toBe(
+      "date(strftime('%Y-', created_at) || printf('%02d', ((CAST(strftime('%m', created_at) AS INTEGER) - 1) / 3) * 3 + 1) || '-01')",
+    );
+  });
+
+  it('executes generated aggregate SQL against SQLite', async () => {
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    await syncSchema({
+      db,
+      schema: `
+        CREATE TABLE orders (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT,
+          customer_id TEXT,
+          status TEXT,
+          total REAL,
+          created_at TEXT,
+          deleted_at TEXT
+        )
+      `,
+    });
+    await db.insert('orders', [
+      {
+        id: '1',
+        [tenantId]: 'tenant-a',
+        [customerId]: 'customer-a',
+        status: 'paid',
+        total: 10,
+        [createdAt]: '2026-01-01T00:00:00.000Z',
+        [deletedAt]: null,
+      },
+      {
+        id: '2',
+        [tenantId]: 'tenant-a',
+        [customerId]: 'customer-a',
+        status: 'paid',
+        total: 30,
+        [createdAt]: '2026-01-02T00:00:00.000Z',
+        [deletedAt]: null,
+      },
+      {
+        id: '3',
+        [tenantId]: 'tenant-a',
+        [customerId]: 'customer-b',
+        status: 'paid',
+        total: 5,
+        [createdAt]: '2026-01-02T00:00:00.000Z',
+        [deletedAt]: null,
+      },
+      {
+        id: '4',
+        [tenantId]: 'tenant-b',
+        [customerId]: 'customer-a',
+        status: 'paid',
+        total: 100,
+        [createdAt]: '2026-01-02T00:00:00.000Z',
+        [deletedAt]: null,
+      },
+    ]);
+
+    const aggregate = buildAggregate(
+      {
+        from: 'orders',
+        select: [
+          { column: 'customer_id' },
+          { fn: 'sum', column: 'total', as: 'revenue' },
+          { fn: 'avg', column: 'total', as: 'avg_total' },
+        ],
+        where: {
+          [tenantId]: 'tenant-a',
+          status: 'paid',
+          [deletedAt]: null,
+        },
+        having: { 'revenue >': 20 },
+        orderBy: 'revenue DESC',
+      },
+      1,
+      'sqlite',
+    );
+
+    const result = await db.query(aggregate.sql, ...aggregate.values);
+    expect(result.rows).toEqual([
+      {
+        [customerId]: 'customer-a',
+        revenue: 40,
+        [avgTotal]: 20,
+      },
+    ]);
+  });
+
+  it('rejects unsafe identifiers and invalid aggregate shapes', () => {
+    expect(() =>
+      buildAggregate({
+        from: 'orders;drop',
+        select: [{ fn: 'count', as: 'c' }],
+      }),
+    ).toThrow('Invalid SQL identifier');
+    expect(() =>
+      buildAggregate({ from: 'orders', select: [{ fn: 'sum', as: 'total' }] }),
+    ).toThrow('Aggregate sum requires a column');
+    expect(() =>
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'count', as: 'count' }],
+        orderBy: 'count SIDEWAYS',
+      }),
+    ).toThrow('Invalid aggregate order direction');
+    expect(() =>
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'count', as: 'count' }],
+        having: { 'count in': [] },
+      }),
+    ).toThrow('requires at least one value');
+  });
+});

--- a/packages/sql/src/aggregate.spec.ts
+++ b/packages/sql/src/aggregate.spec.ts
@@ -248,5 +248,26 @@ describe('aggregate SQL builder', () => {
         having: { 'count in': [] },
       }),
     ).toThrow('requires at least one value');
+    expect(() =>
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'count', as: 'count' }],
+        where: { 'tenant_id = tenant_id OR status': 'paid' },
+      }),
+    ).toThrow('Invalid SQL identifier');
+    expect(() =>
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'count', as: 'count' }],
+        where: [[{ 'tenant_id = tenant_id OR status': 'paid' }]],
+      }),
+    ).toThrow('Invalid SQL identifier');
+    expect(() =>
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'count', as: 'count' }],
+        having: { 'count = count OR count': 1 },
+      }),
+    ).toThrow('Invalid SQL identifier');
   });
 });

--- a/packages/sql/src/aggregate.ts
+++ b/packages/sql/src/aggregate.ts
@@ -184,9 +184,7 @@ function expandHavingKey(
   const expression =
     expressionByAlias.get(parsed.field) ?? validateSqlIdentifier(parsed.field);
 
-  return parsed.operator === '='
-    ? expression
-    : `${expression} ${parsed.operator}`;
+  return `${expression} ${parsed.operator}`;
 }
 
 function expandHaving(

--- a/packages/sql/src/aggregate.ts
+++ b/packages/sql/src/aggregate.ts
@@ -146,7 +146,7 @@ function selectExpression(
 function validateWhereShape(where: AggregateSpec['where']): void {
   if (!where) return;
   const validateKey = (key: string) => {
-    const [field] = key.trim().split(/\s+/);
+    const { field } = parseConditionKey(key);
     if (field) validateSqlIdentifier(field);
   };
   if (Array.isArray(where)) {
@@ -162,23 +162,14 @@ function validateWhereShape(where: AggregateSpec['where']): void {
 
 function parseConditionKey(key: string): { field: string; operator: string } {
   const trimmed = key.trim();
-  const operators = [
-    ' not in',
-    ' like',
-    ' in',
-    ' !=',
-    ' >=',
-    ' <=',
-    ' >',
-    ' <',
-    ' =',
-  ];
+  const operators = ['not in', 'like', 'in', '!=', '>=', '<=', '>', '<', '='];
   const lower = trimmed.toLowerCase();
   for (const operator of operators) {
-    if (lower.endsWith(operator)) {
+    const suffix = ` ${operator}`;
+    if (lower.endsWith(suffix)) {
       return {
-        field: trimmed.slice(0, -operator.length).trim(),
-        operator: operator.trim(),
+        field: trimmed.slice(0, -suffix.length).trim(),
+        operator,
       };
     }
   }

--- a/packages/sql/src/aggregate.ts
+++ b/packages/sql/src/aggregate.ts
@@ -1,5 +1,9 @@
 import type { WhereClause } from './shared/types.js';
-import { buildWhere, type SqlAdapterType } from './shared/utils.js';
+import {
+  buildWhere,
+  parseConditionKey,
+  type SqlAdapterType,
+} from './shared/utils.js';
 
 export type AggregateTimeBucketUnit =
   | 'minute'
@@ -98,11 +102,11 @@ export function bucketExpr(
     case 'day':
       return `strftime('%Y-%m-%d 00:00:00', ${col})`;
     case 'week':
-      return `date(${col}, printf('-%d days', (CAST(strftime('%w', ${col}) AS INTEGER) + 6) % 7))`;
+      return `strftime('%Y-%m-%d 00:00:00', date(${col}, printf('-%d days', (CAST(strftime('%w', ${col}) AS INTEGER) + 6) % 7)))`;
     case 'month':
       return `strftime('%Y-%m-01 00:00:00', ${col})`;
     case 'quarter':
-      return `date(strftime('%Y-', ${col}) || printf('%02d', ((CAST(strftime('%m', ${col}) AS INTEGER) - 1) / 3) * 3 + 1) || '-01')`;
+      return `strftime('%Y-%m-%d 00:00:00', date(strftime('%Y-', ${col}) || printf('%02d', ((CAST(strftime('%m', ${col}) AS INTEGER) - 1) / 3) * 3 + 1) || '-01'))`;
     case 'year':
       return `strftime('%Y-01-01 00:00:00', ${col})`;
   }
@@ -111,8 +115,12 @@ export function bucketExpr(
 function aggregateExpression(
   expr: Extract<AggregateSelectExpr, { fn: AggregateFunction }>,
 ): string {
+  const normalizedFn = String(expr.fn).toLowerCase();
   const fn = validateSqlIdentifier(String(expr.fn)).toUpperCase();
-  if (expr.fn === 'count' && !expr.column) {
+  if (normalizedFn === 'count' && !expr.column) {
+    if (expr.distinct) {
+      throw new Error(`Aggregate ${expr.fn} with distinct requires a column`);
+    }
     return 'COUNT(*)';
   }
   if (!expr.column) {
@@ -158,22 +166,6 @@ function validateWhereShape(where: AggregateSpec['where']): void {
     return;
   }
   for (const key of Object.keys(where)) validateKey(key);
-}
-
-function parseConditionKey(key: string): { field: string; operator: string } {
-  const trimmed = key.trim();
-  const operators = ['not in', 'like', 'in', '!=', '>=', '<=', '>', '<', '='];
-  const lower = trimmed.toLowerCase();
-  for (const operator of operators) {
-    const suffix = ` ${operator}`;
-    if (lower.endsWith(suffix)) {
-      return {
-        field: trimmed.slice(0, -suffix.length).trim(),
-        operator,
-      };
-    }
-  }
-  return { field: trimmed, operator: '=' };
 }
 
 function expandHavingKey(
@@ -297,6 +289,11 @@ export function buildAggregate(
   if (spec.limit !== undefined) {
     pagingSql.push(`LIMIT ${placeholder(nextParamIndex++)}`);
     pagingValues.push(spec.limit);
+  } else if (
+    spec.offset !== undefined &&
+    normalizeAdapter(adapterType) === 'sqlite'
+  ) {
+    pagingSql.push('LIMIT -1');
   }
   if (spec.offset !== undefined) {
     pagingSql.push(`OFFSET ${placeholder(nextParamIndex++)}`);

--- a/packages/sql/src/aggregate.ts
+++ b/packages/sql/src/aggregate.ts
@@ -1,0 +1,333 @@
+import type { WhereClause } from './shared/types.js';
+import { buildWhere, type SqlAdapterType } from './shared/utils.js';
+
+export type AggregateTimeBucketUnit =
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'quarter'
+  | 'year';
+
+export type AggregateFunction =
+  | 'count'
+  | 'sum'
+  | 'avg'
+  | 'min'
+  | 'max'
+  | (string & {});
+
+export type AggregateSelectExpr =
+  | { column: string; as?: string }
+  | {
+      fn: AggregateFunction;
+      column?: string;
+      as: string;
+      distinct?: boolean;
+    }
+  | {
+      bucket: AggregateTimeBucketUnit;
+      column: string;
+      as: string;
+    };
+
+export interface AggregateSpec {
+  from: string;
+  select: AggregateSelectExpr[];
+  where?: WhereClause;
+  groupBy?: string[];
+  having?: WhereClause;
+  orderBy?: string | string[];
+  limit?: number;
+  offset?: number;
+}
+
+export interface AggregateBuildResult {
+  sql: string;
+  values: any[];
+}
+
+const VALID_DIRECTIONS = new Set(['ASC', 'DESC']);
+const VALID_BUCKET_UNITS = new Set<AggregateTimeBucketUnit>([
+  'minute',
+  'hour',
+  'day',
+  'week',
+  'month',
+  'quarter',
+  'year',
+]);
+
+function validateSqlIdentifier(identifier: string): string {
+  if (!/^[a-zA-Z0-9_.]+$/.test(identifier)) {
+    throw new Error(`Invalid SQL identifier: ${identifier}`);
+  }
+  return identifier;
+}
+
+function normalizeAdapter(adapterType?: SqlAdapterType): SqlAdapterType {
+  return adapterType ?? 'sqlite';
+}
+
+function placeholder(index: number): string {
+  return `$${index}`;
+}
+
+export function bucketExpr(
+  adapterType: SqlAdapterType | undefined,
+  unit: AggregateTimeBucketUnit,
+  column: string,
+): string {
+  if (!VALID_BUCKET_UNITS.has(unit)) {
+    throw new Error(`Invalid aggregate bucket unit: ${unit}`);
+  }
+
+  const col = validateSqlIdentifier(column);
+  const adapter = normalizeAdapter(adapterType);
+
+  if (adapter === 'postgres' || adapter === 'duckdb' || adapter === 'json') {
+    return `date_trunc('${unit}', ${col})`;
+  }
+
+  switch (unit) {
+    case 'minute':
+      return `strftime('%Y-%m-%d %H:%M:00', ${col})`;
+    case 'hour':
+      return `strftime('%Y-%m-%d %H:00:00', ${col})`;
+    case 'day':
+      return `strftime('%Y-%m-%d 00:00:00', ${col})`;
+    case 'week':
+      return `date(${col}, printf('-%d days', (CAST(strftime('%w', ${col}) AS INTEGER) + 6) % 7))`;
+    case 'month':
+      return `strftime('%Y-%m-01 00:00:00', ${col})`;
+    case 'quarter':
+      return `date(strftime('%Y-', ${col}) || printf('%02d', ((CAST(strftime('%m', ${col}) AS INTEGER) - 1) / 3) * 3 + 1) || '-01')`;
+    case 'year':
+      return `strftime('%Y-01-01 00:00:00', ${col})`;
+  }
+}
+
+function aggregateExpression(
+  expr: Extract<AggregateSelectExpr, { fn: AggregateFunction }>,
+): string {
+  const fn = validateSqlIdentifier(String(expr.fn)).toUpperCase();
+  if (expr.fn === 'count' && !expr.column) {
+    return 'COUNT(*)';
+  }
+  if (!expr.column) {
+    throw new Error(`Aggregate ${expr.fn} requires a column`);
+  }
+  const col = validateSqlIdentifier(expr.column);
+  const distinct = expr.distinct ? 'DISTINCT ' : '';
+  return `${fn}(${distinct}${col})`;
+}
+
+function selectExpression(
+  expr: AggregateSelectExpr,
+  adapterType: SqlAdapterType | undefined,
+): { expression: string; alias: string; groupingCandidate: boolean } {
+  if ('column' in expr && !('fn' in expr) && !('bucket' in expr)) {
+    const column = validateSqlIdentifier(expr.column);
+    const alias = validateSqlIdentifier(expr.as ?? expr.column);
+    return { expression: column, alias, groupingCandidate: true };
+  }
+  if ('bucket' in expr) {
+    const expression = bucketExpr(adapterType, expr.bucket, expr.column);
+    const alias = validateSqlIdentifier(expr.as);
+    return { expression, alias, groupingCandidate: true };
+  }
+
+  const expression = aggregateExpression(expr);
+  const alias = validateSqlIdentifier(expr.as);
+  return { expression, alias, groupingCandidate: false };
+}
+
+function validateWhereShape(where: AggregateSpec['where']): void {
+  if (!where) return;
+  const validateKey = (key: string) => {
+    const [field] = key.trim().split(/\s+/);
+    if (field) validateSqlIdentifier(field);
+  };
+  if (Array.isArray(where)) {
+    for (const andGroup of where) {
+      for (const condition of andGroup) {
+        for (const key of Object.keys(condition)) validateKey(key);
+      }
+    }
+    return;
+  }
+  for (const key of Object.keys(where)) validateKey(key);
+}
+
+function parseConditionKey(key: string): { field: string; operator: string } {
+  const trimmed = key.trim();
+  const operators = [
+    ' not in',
+    ' like',
+    ' in',
+    ' !=',
+    ' >=',
+    ' <=',
+    ' >',
+    ' <',
+    ' =',
+  ];
+  const lower = trimmed.toLowerCase();
+  for (const operator of operators) {
+    if (lower.endsWith(operator)) {
+      return {
+        field: trimmed.slice(0, -operator.length).trim(),
+        operator: operator.trim(),
+      };
+    }
+  }
+  return { field: trimmed, operator: '=' };
+}
+
+function expandHavingKey(
+  key: string,
+  expressionByAlias: Map<string, string>,
+): string {
+  const parsed = parseConditionKey(key);
+  const expression =
+    expressionByAlias.get(parsed.field) ?? validateSqlIdentifier(parsed.field);
+
+  return parsed.operator === '='
+    ? expression
+    : `${expression} ${parsed.operator}`;
+}
+
+function expandHaving(
+  having: WhereClause,
+  expressionByAlias: Map<string, string>,
+): WhereClause {
+  const expandCondition = (condition: Record<string, any>) =>
+    Object.fromEntries(
+      Object.entries(condition).map(([key, value]) => [
+        expandHavingKey(key, expressionByAlias),
+        value,
+      ]),
+    );
+  if (Array.isArray(having)) {
+    return having.map((andGroup: Record<string, any>[]) =>
+      andGroup.map((condition: Record<string, any>) =>
+        expandCondition(condition),
+      ),
+    );
+  }
+
+  return expandCondition(having);
+}
+
+function buildHaving(
+  having: AggregateSpec['having'],
+  expressionByAlias: Map<string, string>,
+  startIndex: number,
+  adapterType: SqlAdapterType | undefined,
+): AggregateBuildResult {
+  if (!having) return { sql: '', values: [] };
+  const expanded = expandHaving(having, expressionByAlias);
+  const built = buildWhere(expanded, startIndex, adapterType);
+
+  return {
+    sql: built.sql ? built.sql.replace(/^WHERE/, 'HAVING') : '',
+    values: built.values,
+  };
+}
+
+function buildOrderBy(orderBy: string | string[] | undefined): string {
+  if (!orderBy) return '';
+  const items = Array.isArray(orderBy) ? orderBy : [orderBy];
+  const parts = items.map((item) => {
+    const [field, direction = 'ASC'] = item.trim().split(/\s+/);
+    const normalizedDirection = direction.toUpperCase();
+    if (!VALID_DIRECTIONS.has(normalizedDirection)) {
+      throw new Error(`Invalid aggregate order direction: ${direction}`);
+    }
+    const orderExpr = validateSqlIdentifier(field);
+    return `${orderExpr} ${normalizedDirection}`;
+  });
+  return `ORDER BY ${parts.join(', ')}`;
+}
+
+export function buildAggregate(
+  spec: AggregateSpec,
+  startIndex = 1,
+  adapterType?: SqlAdapterType,
+): AggregateBuildResult {
+  const from = validateSqlIdentifier(spec.from);
+  if (spec.select.length === 0) {
+    throw new Error(
+      'AggregateSpec.select must contain at least one expression',
+    );
+  }
+
+  validateWhereShape(spec.where);
+
+  const expressionByAlias = new Map<string, string>();
+  const groupingAliases: string[] = [];
+  const selectSql = spec.select.map((expr) => {
+    const selected = selectExpression(expr, adapterType);
+    expressionByAlias.set(selected.alias, selected.expression);
+    if (selected.groupingCandidate) {
+      groupingAliases.push(selected.alias);
+    }
+    return `${selected.expression} AS ${selected.alias}`;
+  });
+
+  const where = spec.where
+    ? buildWhere(spec.where, startIndex, adapterType)
+    : { sql: '', values: [] };
+  let nextParamIndex = startIndex + where.values.length;
+
+  const groupByItems = spec.groupBy ?? groupingAliases;
+  const groupBySql =
+    groupByItems.length > 0
+      ? `GROUP BY ${groupByItems
+          .map((item) =>
+            expressionByAlias.has(item)
+              ? expressionByAlias.get(item)
+              : validateSqlIdentifier(item),
+          )
+          .join(', ')}`
+      : '';
+
+  const having = buildHaving(
+    spec.having,
+    expressionByAlias,
+    nextParamIndex,
+    adapterType,
+  );
+  nextParamIndex += having.values.length;
+
+  const orderBySql = buildOrderBy(spec.orderBy);
+
+  const pagingValues: any[] = [];
+  const pagingSql: string[] = [];
+  if (spec.limit !== undefined) {
+    pagingSql.push(`LIMIT ${placeholder(nextParamIndex++)}`);
+    pagingValues.push(spec.limit);
+  }
+  if (spec.offset !== undefined) {
+    pagingSql.push(`OFFSET ${placeholder(nextParamIndex++)}`);
+    pagingValues.push(spec.offset);
+  }
+
+  const sql = [
+    `SELECT ${selectSql.join(', ')}`,
+    `FROM ${from}`,
+    where.sql,
+    groupBySql,
+    having.sql,
+    orderBySql,
+    pagingSql.join(' '),
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return {
+    sql,
+    values: [...where.values, ...having.values, ...pagingValues],
+  };
+}

--- a/packages/sql/src/index.spec.ts
+++ b/packages/sql/src/index.spec.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildWhere, getDatabase, syncSchema } from './index';
 
 const _TMP_DIR = path.resolve(`${tmpdir()}/kissd`);
+const deletedAt = 'deleted_at';
 
 it.skip('should be able to get the adapter for a postgres database', async () => {
   const db = await getDatabase({
@@ -66,7 +67,7 @@ it('should handle basic usage with different operators', () => {
 
 it('should handle NULL values correctly', () => {
   const result = buildWhere({
-    deleted_at: null,
+    [deletedAt]: null,
     'updated_at !=': null,
     status: 'active',
   });
@@ -94,7 +95,7 @@ it('should handle date filtering with null check (no adapter)', () => {
   const result = buildWhere({
     'created_at >': startDate,
     'created_at <=': endDate,
-    deleted_at: null,
+    [deletedAt]: null,
   });
 
   // Without adapter type, Date objects are ISO strings without CAST
@@ -154,14 +155,39 @@ it('should handle LIKE operators for search', () => {
 it('should handle IN clauses with arrays', () => {
   const result = buildWhere({
     'role in': ['admin', 'editor'],
+    'status not in': ['archived', 'deleted'],
     active: true,
     'last_login !=': null,
   });
 
   expect(result.sql).toBe(
-    'WHERE role IN ($1, $2) AND active = $3 AND last_login IS NOT NULL',
+    'WHERE role IN ($1, $2) AND status NOT IN ($3, $4) AND active = $5 AND last_login IS NOT NULL',
   );
-  expect(result.values).toEqual(['admin', 'editor', true]);
+  expect(result.values).toEqual([
+    'admin',
+    'editor',
+    'archived',
+    'deleted',
+    true,
+  ]);
+});
+
+it('should handle expression fields with spaces', () => {
+  const result = buildWhere({
+    'COUNT(DISTINCT user_id) >=': 2,
+    'SUM(total_amount) >': 100,
+  });
+
+  expect(result.sql).toBe(
+    'WHERE COUNT(DISTINCT user_id) >= $1 AND SUM(total_amount) > $2',
+  );
+  expect(result.values).toEqual([2, 100]);
+});
+
+it('should reject empty IN clauses', () => {
+  expect(() => buildWhere({ 'role in': [] })).toThrow(
+    'IN requires at least one value',
+  );
 });
 
 // 2D Array WHERE tests (OR/AND compound logic)
@@ -223,7 +249,7 @@ describe('buildWhere 2D array support', () => {
 
   it('should handle NULL values within 2D array', () => {
     const result = buildWhere([
-      [{ deleted_at: null }, { status: 'active' }],
+      [{ [deletedAt]: null }, { status: 'active' }],
       [{ 'deleted_at !=': null }],
     ]);
 

--- a/packages/sql/src/index.spec.ts
+++ b/packages/sql/src/index.spec.ts
@@ -176,12 +176,19 @@ it('should handle expression fields with spaces', () => {
   const result = buildWhere({
     'COUNT(DISTINCT user_id) >=': 2,
     'SUM(total_amount) >': 100,
+    'LOWER(status) =': 'paid',
   });
 
   expect(result.sql).toBe(
-    'WHERE COUNT(DISTINCT user_id) >= $1 AND SUM(total_amount) > $2',
+    'WHERE COUNT(DISTINCT user_id) >= $1 AND SUM(total_amount) > $2 AND LOWER(status) = $3',
   );
-  expect(result.values).toEqual([2, 100]);
+  expect(result.values).toEqual([2, 100, 'paid']);
+});
+
+it('should reject unsafe implicit equality keys', () => {
+  expect(() =>
+    buildWhere({ 'tenant_id = tenant_id OR status': 'paid' }),
+  ).toThrow('Invalid SQL identifier');
 });
 
 it('should reject empty IN clauses', () => {

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -209,6 +209,15 @@ export function validateColumnName(column: string): string {
 // Import utilities from shared utils
 import { buildWhere, formatDbError } from './shared/utils';
 
+export {
+  type AggregateBuildResult,
+  type AggregateFunction,
+  type AggregateSelectExpr,
+  type AggregateSpec,
+  type AggregateTimeBucketUnit,
+  bucketExpr,
+  buildAggregate,
+} from './aggregate.js';
 export type { SqlAdapterType } from './shared/utils';
 export { buildWhere, formatDbError };
 

--- a/packages/sql/src/shared/utils.ts
+++ b/packages/sql/src/shared/utils.ts
@@ -53,7 +53,28 @@ const VALID_OPERATORS = {
   '!=': '!=',
   like: 'LIKE',
   in: 'IN',
+  'not in': 'NOT IN',
 } as const;
+
+function parseConditionKey(fullKey: string): {
+  field: string;
+  operator: string;
+} {
+  const trimmed = fullKey.trim();
+  const lower = trimmed.toLowerCase();
+  const operators = ['not in', 'like', 'in', '!=', '>=', '<=', '>', '<', '='];
+
+  for (const operator of operators) {
+    if (lower.endsWith(` ${operator}`)) {
+      return {
+        field: trimmed.slice(0, -(operator.length + 1)).trim(),
+        operator,
+      };
+    }
+  }
+
+  return { field: trimmed, operator: '=' };
+}
 
 /**
  * SQL adapter type for adapter-specific query generation
@@ -70,7 +91,7 @@ const buildCondition = (
   currIndex: { value: number },
   adapterType?: SqlAdapterType,
 ): { sql: string; values: any[] } => {
-  const [field, operator = '='] = fullKey.split(' ');
+  const { field, operator } = parseConditionKey(fullKey);
   const sqlOperator =
     VALID_OPERATORS[operator as keyof typeof VALID_OPERATORS] || '=';
   const values: any[] = [];
@@ -79,9 +100,15 @@ const buildCondition = (
 
   if (value === null) {
     sql = `${field} IS ${sqlOperator === '=' ? 'NULL' : 'NOT NULL'}`;
-  } else if (sqlOperator === 'IN' && Array.isArray(value)) {
+  } else if (
+    (sqlOperator === 'IN' || sqlOperator === 'NOT IN') &&
+    Array.isArray(value)
+  ) {
+    if (value.length === 0) {
+      throw new Error(`${sqlOperator} requires at least one value`);
+    }
     const placeholders = value.map(() => `$${currIndex.value++}`).join(', ');
-    sql = `${field} IN (${placeholders})`;
+    sql = `${field} ${sqlOperator} (${placeholders})`;
     values.push(...value);
   } else if (value instanceof Date) {
     // DuckDB/JSON need CAST to TIMESTAMP to prevent ANY type inference (issue #540)

--- a/packages/sql/src/shared/utils.ts
+++ b/packages/sql/src/shared/utils.ts
@@ -60,7 +60,7 @@ function isSimpleSqlIdentifier(field: string): boolean {
   return /^[a-zA-Z0-9_.]+$/.test(field);
 }
 
-function parseConditionKey(fullKey: string): {
+export function parseConditionKey(fullKey: string): {
   field: string;
   operator: string;
   explicitOperator: boolean;
@@ -147,6 +147,11 @@ const buildCondition = (
  *     prevent DuckDB ANY-type inference issues.
  *   - `'sqlite'` / `'postgres'` / `undefined`: Passes ISO strings directly
  *     (these adapters handle ISO timestamp strings natively).
+ *
+ * Keys with explicit operator suffixes are treated as SQL field/expression
+ * text. Keep those keys developer-controlled; do not pass end-user input as a
+ * condition key.
+ *
  * @returns Object containing the SQL clause and array of values
  *
  * @example Basic Usage (Object format - AND-only):

--- a/packages/sql/src/shared/utils.ts
+++ b/packages/sql/src/shared/utils.ts
@@ -56,9 +56,14 @@ const VALID_OPERATORS = {
   'not in': 'NOT IN',
 } as const;
 
+function isSimpleSqlIdentifier(field: string): boolean {
+  return /^[a-zA-Z0-9_.]+$/.test(field);
+}
+
 function parseConditionKey(fullKey: string): {
   field: string;
   operator: string;
+  explicitOperator: boolean;
 } {
   const trimmed = fullKey.trim();
   const lower = trimmed.toLowerCase();
@@ -69,11 +74,12 @@ function parseConditionKey(fullKey: string): {
       return {
         field: trimmed.slice(0, -(operator.length + 1)).trim(),
         operator,
+        explicitOperator: true,
       };
     }
   }
 
-  return { field: trimmed, operator: '=' };
+  return { field: trimmed, operator: '=', explicitOperator: false };
 }
 
 /**
@@ -91,7 +97,10 @@ const buildCondition = (
   currIndex: { value: number },
   adapterType?: SqlAdapterType,
 ): { sql: string; values: any[] } => {
-  const { field, operator } = parseConditionKey(fullKey);
+  const { field, operator, explicitOperator } = parseConditionKey(fullKey);
+  if (!explicitOperator && !isSimpleSqlIdentifier(field)) {
+    throw new Error(`Invalid SQL identifier: ${field}`);
+  }
   const sqlOperator =
     VALID_OPERATORS[operator as keyof typeof VALID_OPERATORS] || '=';
   const values: any[] = [];


### PR DESCRIPTION
## Summary

- Add `buildAggregate()` and `bucketExpr()` to `@happyvertical/sql` for portable aggregate query generation.
- Support grouped selects, aggregate measures, time buckets, `where`, alias-expanded `having`, ordering, limit, and offset with continuous `$N` placeholders.
- Harden `buildWhere()` parsing so HAVING expressions like `COUNT(DISTINCT user_id) >=` work through the shared builder, add `NOT IN`, and reject empty `IN` clauses.
- Document the new aggregate builder and cover it with pure SQL builder tests plus an in-memory SQLite execution test.

Supports the SDK slice of happyvertical/smrt#1633.

## Validation

- `pnpm exec vitest run src/aggregate.spec.ts src/index.spec.ts` from `packages/sql` — 35 passed, 4 skipped
- `pnpm --filter @happyvertical/sql test` — 337 passed, 4 skipped
- `pnpm --filter @happyvertical/sql build`
- `pnpm exec tsc --noEmit -p packages/sql/tsconfig.json`
- `pnpm exec biome check packages/sql/src/aggregate.ts packages/sql/src/aggregate.spec.ts packages/sql/src/index.ts packages/sql/src/index.spec.ts packages/sql/src/shared/utils.ts packages/sql/README.md`
- Lefthook pre-push `pnpm run typecheck` — passed