### PR TITLE
fix(payments): read refunded amount back from the Stripe refund response

### DIFF
--- a/.changeset/payments-refund-amount-readback.md
+++ b/.changeset/payments-refund-amount-readback.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/payments": patch
+---
+
+Fix `StripeAdapter.refundPayment` to read the refunded amount back from the Stripe refund response. `RefundResult.amount` now comes from `readSafeInteger(refund, 'amount') ?? input.amount` (mirroring `capturePayment`), so a full refund — where the caller supplies no `amount` — surfaces the amount Stripe actually refunded instead of `undefined`. Partial refunds are unaffected, since the response echoes the requested amount.

--- a/packages/payments/src/adapters/stripe.ts
+++ b/packages/payments/src/adapters/stripe.ts
@@ -484,7 +484,10 @@ export class StripeAdapter implements PaymentBackend {
         readProviderString(refund, 'id'),
       ),
       transactionId: paymentReference,
-      amount,
+      // Read the settled amount back from the refund object (mirrors
+      // capturePayment) so a full refund — no `input.amount` supplied — still
+      // surfaces the amount Stripe actually refunded instead of `undefined`.
+      amount: readSafeInteger(refund, 'amount') ?? amount,
       currency: currency.toUpperCase(),
       raw: refund,
     };

--- a/packages/payments/src/stripe.test.ts
+++ b/packages/payments/src/stripe.test.ts
@@ -1520,6 +1520,50 @@ describe('StripeAdapter', () => {
     });
   });
 
+  it('surfaces the refunded amount from the Stripe response for a full refund', async () => {
+    let refundBody = '';
+    const fetch = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        if (String(input).endsWith('/refunds') && init?.method === 'POST') {
+          refundBody = String(init?.body ?? '');
+          // A full refund settles the whole captured charge; Stripe echoes the
+          // amount it actually refunded even though the caller sent none.
+          return jsonResponse({
+            id: 're_full',
+            status: 'succeeded',
+            amount: 5000,
+            currency: 'usd',
+          });
+        }
+
+        return jsonResponse({ error: { message: 'not found' } }, 404);
+      },
+    );
+    const adapter = new StripeAdapter({
+      secretKey: 'sk_test_123',
+      apiBaseUrl: 'https://stripe.example/v1',
+      fetch,
+      successUrl: 'https://app.example/success',
+      cancelUrl: 'https://app.example/cancel',
+    });
+
+    // Omit `amount` — a full refund — so the result's amount can only come from
+    // the Stripe response, not the (absent) request input.
+    const refund = await adapter.refundPayment({
+      paymentId: 'pi_123',
+      currency: 'USD',
+    });
+
+    // No amount is sent to Stripe for a full refund...
+    expect(new URLSearchParams(refundBody).has('amount')).toBe(false);
+    // ...but the result still reports the amount Stripe refunded.
+    expect(refund).toMatchObject({
+      status: 'succeeded',
+      refundId: 're_full',
+      amount: 5000,
+    });
+  });
+
   it('maps Stripe refund response statuses to refund results', async () => {
     for (const [stripeStatus, expectedStatus] of [
       ['succeeded', 'succeeded'],


### PR DESCRIPTION
Fixes `StripeAdapter.refundPayment` so `RefundResult.amount` reflects the amount Stripe actually refunded.

## Problem

`refundPayment` derived `RefundResult.amount` only from the caller's `input.amount`. For a **full refund** (no `input.amount` supplied), that left `amount: undefined`, so downstream consumers couldn't report the refunded amount. `capturePayment` already reads its amount back from the provider response (`readSafeInteger(intent, "amount_received") ?? readSafeInteger(intent, "amount") ?? amount`); refunds didn't follow suit.

## Change

Read the settled amount back from the Stripe refund object, mirroring the capture path:

```ts
amount: readSafeInteger(refund, 'amount') ?? amount,
```

- **Full refund** → surfaces the amount Stripe refunded instead of `undefined`.
- **Partial refund** → unchanged (the response echoes the requested amount).
- Falls back to the normalized request amount if the response somehow lacks a valid `amount`, so there's no regression.

## Validation

- `pnpm --filter @happyvertical/payments test` — 104 passed (includes the new full-refund test)
- New test verified to **fail without the fix** (`amount: undefined`) and pass with it
- `pnpm --filter @happyvertical/payments build` — clean (vite + dts typecheck)
- `tsc --noEmit` on the adapter source — clean
- `biome check` on changed files — clean
- `pnpm run agent:check` (ecosystem manifest freshness) — clean
- Conventional-commit + changeset validated via lefthook

## Context / motivation

Surfaced in anytown.ai's `advertising-payments.ts`, which had to keep a `?? 0` fallback (with a NOTE pointing here) on the refund path. Needed before the anytown "release funds on rejection/cancellation" epic, which refunds captured campaign payments and reverses the ledger prepayment using the real refunded amount. Once released, the `?? 0` + NOTE in anytown's `refundAdvertisingPayment` can be dropped.

## Known follow-up (out of scope)

`refundPayment` still returns `currency` from the requested/defaulted value rather than reading it back from the refund response — the same latent bug class as this `amount` fix, and something `capturePayment`/`voidPayment` already do. Flagged as a separate follow-up to keep this hotfix tightly scoped.

## Checklist

- [x] Run `npm test` (equivalent: `pnpm --filter @happyvertical/payments test` + `build`)
- [x] Run `npm run lint` (equivalent: `biome check` on changed files, incl. pre-commit hook)
- [x] Add changeset (`.changeset/payments-refund-amount-readback.md`, patch)
