### PR TITLE
feat(speech): add speech provider package

### DIFF
--- a/.changeset/soft-rocks-speak.md
+++ b/.changeset/soft-rocks-speak.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/speech": minor
+---
+
+Add the speech provider abstraction package with Studio Server STT/TTS and Qwen3/OpenAI-compatible TTS adapters.

--- a/AGENT.md
+++ b/AGENT.md
@@ -6,10 +6,10 @@
 
 ## Workspace Map
 - Package docs standard: `AGENT.md`
-- Local workspace packages: `30`
+- Local workspace packages: `31`
 - External catalog packages: `@happyvertical/ocr`, `@happyvertical/pdf`, `@happyvertical/spider`
 - Generated manifest: `ecosystem-manifest.json`
-- Top-level package order: `accounting`, `ai`, `analytics`, `auth`, `cache`, `comfyui`, `directory`, `documents`, `email`, `encryption`, `files`, `geo`, `github-actions`, `graphql`, `images`, `jobs`, `json`, `logger`, `messages`, `payments`, `projects`, `repos`, `sdk-mcp`, `secrets`, `social`, `sql`, `translator`, `utils`, `video`, `weather`
+- Top-level package order: `accounting`, `ai`, `analytics`, `auth`, `cache`, `comfyui`, `directory`, `documents`, `email`, `encryption`, `files`, `geo`, `github-actions`, `graphql`, `images`, `jobs`, `json`, `logger`, `messages`, `payments`, `projects`, `repos`, `sdk-mcp`, `secrets`, `social`, `speech`, `sql`, `translator`, `utils`, `video`, `weather`
 
 ## Build & Test
 ```bash

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -99,6 +99,7 @@ export default {
         'sdk-mcp',
         'secrets',
         'social',
+        'speech',
         'sql',
         'translator',
         'utils',

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -3,7 +3,7 @@
   "workspace": {
     "name": "@happyvertical/sdk",
     "path": ".",
-    "packageCount": 30,
+    "packageCount": 31,
     "localPackageOrder": [
       "accounting",
       "ai",
@@ -30,6 +30,7 @@
       "sdk-mcp",
       "secrets",
       "social",
+      "speech",
       "sql",
       "translator",
       "utils",
@@ -53,7 +54,7 @@
       },
       "position": {
         "index": 1,
-        "count": 30
+        "count": 31
       },
       "description": "Multi-provider accounting integration for AR/AP sync and audit with QuickBooks, Stripe, and more",
       "commands": {
@@ -98,7 +99,7 @@
       },
       "position": {
         "index": 2,
-        "count": 30
+        "count": 31
       },
       "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
       "commands": {
@@ -148,7 +149,7 @@
       },
       "position": {
         "index": 3,
-        "count": 30
+        "count": 31
       },
       "description": "Unified analytics interface for Google Analytics 4, Plausible, and more",
       "commands": {
@@ -193,7 +194,7 @@
       },
       "position": {
         "index": 4,
-        "count": 30
+        "count": 31
       },
       "description": "Unified authentication interface supporting Keycloak, AWS Cognito, and Nostr with OAuth2/OIDC and public key identity",
       "commands": {
@@ -240,7 +241,7 @@
       },
       "position": {
         "index": 5,
-        "count": 30
+        "count": 31
       },
       "description": "Standardized caching interface supporting Memory, File, and Redis backends",
       "commands": {
@@ -290,7 +291,7 @@
       },
       "position": {
         "index": 6,
-        "count": 30
+        "count": 31
       },
       "description": "ComfyUI API client for workflow orchestration and video generation",
       "commands": {
@@ -334,7 +335,7 @@
       },
       "position": {
         "index": 7,
-        "count": 30
+        "count": 31
       },
       "description": "Unified directory services with adapter-based architecture (Kanidm, Stalwart, PostgreSQL, AWS)",
       "commands": {
@@ -383,7 +384,7 @@
       },
       "position": {
         "index": 8,
-        "count": 30
+        "count": 31
       },
       "description": "Multi-part document processing with support for PDF, HTML, and Markdown",
       "commands": {
@@ -432,7 +433,7 @@
       },
       "position": {
         "index": 9,
-        "count": 30
+        "count": 31
       },
       "description": "Low-level email protocol operations with adapter-based architecture",
       "commands": {
@@ -486,7 +487,7 @@
       },
       "position": {
         "index": 10,
-        "count": 30
+        "count": 31
       },
       "description": "Unified encryption and cryptography operations with adapter-based architecture",
       "commands": {
@@ -535,7 +536,7 @@
       },
       "position": {
         "index": 11,
-        "count": 30
+        "count": 31
       },
       "description": "File system utilities for local and remote file operations",
       "commands": {
@@ -585,7 +586,7 @@
       },
       "position": {
         "index": 12,
-        "count": 30
+        "count": 31
       },
       "description": "Standardized geographical information interface supporting Google Maps and OpenStreetMap",
       "commands": {
@@ -631,7 +632,7 @@
       },
       "position": {
         "index": 13,
-        "count": 30
+        "count": 31
       },
       "description": "Reusable GitHub Actions utilities for issue triage, PR validation, and workflow automation",
       "commands": {
@@ -676,7 +677,7 @@
       },
       "position": {
         "index": 14,
-        "count": 30
+        "count": 31
       },
       "description": "GitHub GraphQL client for SDK packages",
       "commands": {
@@ -720,7 +721,7 @@
       },
       "position": {
         "index": 15,
-        "count": 30
+        "count": 31
       },
       "description": "Image processing utilities with adapter pattern for scaling from static to enterprise",
       "commands": {
@@ -768,7 +769,7 @@
       },
       "position": {
         "index": 16,
-        "count": 30
+        "count": 31
       },
       "description": "Job queue abstraction with multiple backend adapters (SQLite, PostgreSQL, Bull, SQS)",
       "commands": {
@@ -817,7 +818,7 @@
       },
       "position": {
         "index": 17,
-        "count": 30
+        "count": 31
       },
       "description": "High-performance JSON parsing and serialization with Rust SIMD acceleration and automatic fallback",
       "commands": {
@@ -860,7 +861,7 @@
       },
       "position": {
         "index": 18,
-        "count": 30
+        "count": 31
       },
       "description": "Structured logging for HAVE SDK with signal adapter",
       "commands": {
@@ -912,7 +913,7 @@
       },
       "position": {
         "index": 19,
-        "count": 30
+        "count": 31
       },
       "description": "Unified multi-channel messaging with adapter-based architecture (Slack, Twitter, Email)",
       "commands": {
@@ -960,7 +961,7 @@
       },
       "position": {
         "index": 20,
-        "count": 30
+        "count": 31
       },
       "description": "Payment backend abstraction with adapters for Base USDC, BTCPay Server, and Stripe",
       "commands": {
@@ -1005,7 +1006,7 @@
       },
       "position": {
         "index": 21,
-        "count": 30
+        "count": 31
       },
       "description": "Standardized project management interface for GitHub Projects, Jira, ZenHub, and Linear",
       "commands": {
@@ -1051,7 +1052,7 @@
       },
       "position": {
         "index": 22,
-        "count": 30
+        "count": 31
       },
       "description": "Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOps",
       "commands": {
@@ -1099,7 +1100,7 @@
       },
       "position": {
         "index": 23,
-        "count": 30
+        "count": 31
       },
       "description": "MCP server for HAVE SDK - Routes queries to package experts using AGENT.md files",
       "commands": {
@@ -1147,7 +1148,7 @@
       },
       "position": {
         "index": 24,
-        "count": 30
+        "count": 31
       },
       "description": "Envelope encryption for per-tenant secret management with pluggable backends",
       "commands": {
@@ -1191,7 +1192,7 @@
       },
       "position": {
         "index": 25,
-        "count": 30
+        "count": 31
       },
       "description": "Social platform adapters for publishing to YouTube, Threads, X, and Bluesky",
       "commands": {
@@ -1226,6 +1227,53 @@
       ]
     },
     {
+      "name": "@happyvertical/speech",
+      "shortName": "speech",
+      "path": "packages/speech",
+      "docs": {
+        "agent": "packages/speech/AGENT.md",
+        "metadata": "packages/speech/metadata.json"
+      },
+      "position": {
+        "index": 26,
+        "count": 31
+      },
+      "description": "Speech provider abstraction for STT and TTS backends",
+      "commands": {
+        "build": "pnpm --filter @happyvertical/speech build",
+        "test": "pnpm --filter @happyvertical/speech test",
+        "typecheck": "pnpm --filter @happyvertical/speech typecheck",
+        "clean": "pnpm --filter @happyvertical/speech clean"
+      },
+      "correctionLoops": [
+        "If Vite or TypeScript reports missing packages, run `pnpm install` at the repo root and rerun `pnpm --filter @happyvertical/speech build`.",
+        "If tests or exports fail after API, type, or bundle changes, run `pnpm --filter @happyvertical/speech clean` followed by `pnpm --filter @happyvertical/speech build` and `pnpm --filter @happyvertical/speech test`.",
+        "If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands."
+      ],
+      "provides": [
+        "Speech provider abstraction for STT and TTS backends"
+      ],
+      "implements": [
+        "Studio Server STT",
+        "Studio Server TTS",
+        "Qwen3 TTS",
+        "OpenAI-compatible TTS"
+      ],
+      "requires": {
+        "workspace": [],
+        "externalHappyVertical": [],
+        "external": []
+      },
+      "dependents": [],
+      "stability": {
+        "level": "experimental",
+        "reason": "Marked as preview or experimental in package guidance."
+      },
+      "keywords": [
+        "speech"
+      ]
+    },
+    {
       "name": "@happyvertical/sql",
       "shortName": "sql",
       "path": "packages/sql",
@@ -1234,8 +1282,8 @@
         "metadata": "packages/sql/metadata.json"
       },
       "position": {
-        "index": 26,
-        "count": 30
+        "index": 27,
+        "count": 31
       },
       "description": "Database interface with support for SQLite, PostgreSQL, and DuckDB",
       "commands": {
@@ -1287,8 +1335,8 @@
         "metadata": "packages/translator/metadata.json"
       },
       "position": {
-        "index": 27,
-        "count": 30
+        "index": 28,
+        "count": 31
       },
       "description": "Standardized translation interface supporting Google Translate, DeepL, and LibreTranslate",
       "commands": {
@@ -1334,8 +1382,8 @@
         "metadata": "packages/utils/metadata.json"
       },
       "position": {
-        "index": 28,
-        "count": 30
+        "index": 29,
+        "count": 31
       },
       "description": "Foundation utilities for ID generation, date parsing, URL handling, string conversion, error handling, and logging",
       "commands": {
@@ -1403,8 +1451,8 @@
         "metadata": "packages/video/metadata.json"
       },
       "position": {
-        "index": 29,
-        "count": 30
+        "index": 30,
+        "count": 31
       },
       "description": "Video processing utilities with adapter pattern for composition and transcoding",
       "commands": {
@@ -1450,8 +1498,8 @@
         "metadata": "packages/weather/metadata.json"
       },
       "position": {
-        "index": 30,
-        "count": 30
+        "index": 31,
+        "count": 31
       },
       "description": "Weather data provider abstraction for HAppyVertical SDK",
       "commands": {
@@ -1785,6 +1833,31 @@
       "type": "provides",
       "from": "@happyvertical/social",
       "to": "Social platform adapters for publishing to YouTube, Threads, X, and Bluesky"
+    },
+    {
+      "type": "implements",
+      "from": "@happyvertical/speech",
+      "to": "Studio Server STT"
+    },
+    {
+      "type": "implements",
+      "from": "@happyvertical/speech",
+      "to": "Studio Server TTS"
+    },
+    {
+      "type": "implements",
+      "from": "@happyvertical/speech",
+      "to": "Qwen3 TTS"
+    },
+    {
+      "type": "implements",
+      "from": "@happyvertical/speech",
+      "to": "OpenAI-compatible TTS"
+    },
+    {
+      "type": "provides",
+      "from": "@happyvertical/speech",
+      "to": "Speech provider abstraction for STT and TTS backends"
     },
     {
       "type": "requires",

--- a/packages/accounting/AGENT.md
+++ b/packages/accounting/AGENT.md
@@ -7,7 +7,7 @@ Multi-provider accounting integration for AR/AP sync and audit with QuickBooks, 
 ## Package Map
 - Package: `@happyvertical/accounting`
 - Hierarchy path: `@happyvertical/sdk > packages > accounting`
-- Workspace position: `1 of 30` local packages
+- Workspace position: `1 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/accounting/metadata.json
+++ b/packages/accounting/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/accounting",
   "position": {
     "index": 1,
-    "count": 30
+    "count": 31
   },
   "description": "Multi-provider accounting integration for AR/AP sync and audit with QuickBooks, Stripe, and more",
   "provides": [

--- a/packages/ai/AGENT.md
+++ b/packages/ai/AGENT.md
@@ -7,7 +7,7 @@ Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic
 ## Package Map
 - Package: `@happyvertical/ai`
 - Hierarchy path: `@happyvertical/sdk > packages > ai`
-- Workspace position: `2 of 30` local packages
+- Workspace position: `2 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/sdk-mcp`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/ai/metadata.json
+++ b/packages/ai/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/ai",
   "position": {
     "index": 2,
-    "count": 30
+    "count": 31
   },
   "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
   "provides": [

--- a/packages/analytics/AGENT.md
+++ b/packages/analytics/AGENT.md
@@ -7,7 +7,7 @@ Unified analytics interface for Google Analytics 4, Plausible, and more
 ## Package Map
 - Package: `@happyvertical/analytics`
 - Hierarchy path: `@happyvertical/sdk > packages > analytics`
-- Workspace position: `3 of 30` local packages
+- Workspace position: `3 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/analytics/metadata.json
+++ b/packages/analytics/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/analytics",
   "position": {
     "index": 3,
-    "count": 30
+    "count": 31
   },
   "description": "Unified analytics interface for Google Analytics 4, Plausible, and more",
   "provides": [

--- a/packages/auth/AGENT.md
+++ b/packages/auth/AGENT.md
@@ -7,7 +7,7 @@ Unified authentication interface supporting Keycloak, AWS Cognito, and Nostr wit
 ## Package Map
 - Package: `@happyvertical/auth`
 - Hierarchy path: `@happyvertical/sdk > packages > auth`
-- Workspace position: `4 of 30` local packages
+- Workspace position: `4 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/auth/metadata.json
+++ b/packages/auth/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/auth",
   "position": {
     "index": 4,
-    "count": 30
+    "count": 31
   },
   "description": "Unified authentication interface supporting Keycloak, AWS Cognito, and Nostr with OAuth2/OIDC and public key identity",
   "provides": [

--- a/packages/cache/AGENT.md
+++ b/packages/cache/AGENT.md
@@ -7,7 +7,7 @@ Standardized caching interface supporting Memory, File, and Redis backends
 ## Package Map
 - Package: `@happyvertical/cache`
 - Hierarchy path: `@happyvertical/sdk > packages > cache`
-- Workspace position: `5 of 30` local packages
+- Workspace position: `5 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/geo`, `@happyvertical/translator`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/cache/metadata.json
+++ b/packages/cache/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/cache",
   "position": {
     "index": 5,
-    "count": 30
+    "count": 31
   },
   "description": "Standardized caching interface supporting Memory, File, and Redis backends",
   "provides": [

--- a/packages/comfyui/AGENT.md
+++ b/packages/comfyui/AGENT.md
@@ -7,7 +7,7 @@ ComfyUI API client for workflow orchestration and video generation
 ## Package Map
 - Package: `@happyvertical/comfyui`
 - Hierarchy path: `@happyvertical/sdk > packages > comfyui`
-- Workspace position: `6 of 30` local packages
+- Workspace position: `6 of 31` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/comfyui/metadata.json
+++ b/packages/comfyui/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/comfyui",
   "position": {
     "index": 6,
-    "count": 30
+    "count": 31
   },
   "description": "ComfyUI API client for workflow orchestration and video generation",
   "provides": [

--- a/packages/directory/AGENT.md
+++ b/packages/directory/AGENT.md
@@ -7,7 +7,7 @@ Unified directory services with adapter-based architecture (Kanidm, Stalwart, Po
 ## Package Map
 - Package: `@happyvertical/directory`
 - Hierarchy path: `@happyvertical/sdk > packages > directory`
-- Workspace position: `7 of 30` local packages
+- Workspace position: `7 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/directory/metadata.json
+++ b/packages/directory/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/directory",
   "position": {
     "index": 7,
-    "count": 30
+    "count": 31
   },
   "description": "Unified directory services with adapter-based architecture (Kanidm, Stalwart, PostgreSQL, AWS)",
   "provides": [

--- a/packages/documents/AGENT.md
+++ b/packages/documents/AGENT.md
@@ -7,7 +7,7 @@ Multi-part document processing with support for PDF, HTML, and Markdown
 ## Package Map
 - Package: `@happyvertical/documents`
 - Hierarchy path: `@happyvertical/sdk > packages > documents`
-- Workspace position: `8 of 30` local packages
+- Workspace position: `8 of 31` local packages
 - Internal dependencies: `@happyvertical/files`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/documents/metadata.json
+++ b/packages/documents/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/documents",
   "position": {
     "index": 8,
-    "count": 30
+    "count": 31
   },
   "description": "Multi-part document processing with support for PDF, HTML, and Markdown",
   "provides": [

--- a/packages/email/AGENT.md
+++ b/packages/email/AGENT.md
@@ -7,7 +7,7 @@ Low-level email protocol operations with adapter-based architecture
 ## Package Map
 - Package: `@happyvertical/email`
 - Hierarchy path: `@happyvertical/sdk > packages > email`
-- Workspace position: `9 of 30` local packages
+- Workspace position: `9 of 31` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: `@happyvertical/messages`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/email/metadata.json
+++ b/packages/email/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/email",
   "position": {
     "index": 9,
-    "count": 30
+    "count": 31
   },
   "description": "Low-level email protocol operations with adapter-based architecture",
   "provides": [

--- a/packages/encryption/AGENT.md
+++ b/packages/encryption/AGENT.md
@@ -7,7 +7,7 @@ Unified encryption and cryptography operations with adapter-based architecture
 ## Package Map
 - Package: `@happyvertical/encryption`
 - Hierarchy path: `@happyvertical/sdk > packages > encryption`
-- Workspace position: `10 of 30` local packages
+- Workspace position: `10 of 31` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/encryption/metadata.json
+++ b/packages/encryption/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/encryption",
   "position": {
     "index": 10,
-    "count": 30
+    "count": 31
   },
   "description": "Unified encryption and cryptography operations with adapter-based architecture",
   "provides": [

--- a/packages/files/AGENT.md
+++ b/packages/files/AGENT.md
@@ -7,7 +7,7 @@ File system utilities for local and remote file operations
 ## Package Map
 - Package: `@happyvertical/files`
 - Hierarchy path: `@happyvertical/sdk > packages > files`
-- Workspace position: `11 of 30` local packages
+- Workspace position: `11 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/documents`, `@happyvertical/sdk-mcp`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/files/metadata.json
+++ b/packages/files/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/files",
   "position": {
     "index": 11,
-    "count": 30
+    "count": 31
   },
   "description": "File system utilities for local and remote file operations",
   "provides": [

--- a/packages/geo/AGENT.md
+++ b/packages/geo/AGENT.md
@@ -7,7 +7,7 @@ Standardized geographical information interface supporting Google Maps and OpenS
 ## Package Map
 - Package: `@happyvertical/geo`
 - Hierarchy path: `@happyvertical/sdk > packages > geo`
-- Workspace position: `12 of 30` local packages
+- Workspace position: `12 of 31` local packages
 - Internal dependencies: `@happyvertical/cache`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/geo/metadata.json
+++ b/packages/geo/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/geo",
   "position": {
     "index": 12,
-    "count": 30
+    "count": 31
   },
   "description": "Standardized geographical information interface supporting Google Maps and OpenStreetMap",
   "provides": [

--- a/packages/github-actions/AGENT.md
+++ b/packages/github-actions/AGENT.md
@@ -7,7 +7,7 @@ Reusable GitHub Actions utilities for issue triage, PR validation, and workflow 
 ## Package Map
 - Package: `@happyvertical/github-actions`
 - Hierarchy path: `@happyvertical/sdk > packages > github-actions`
-- Workspace position: `13 of 30` local packages
+- Workspace position: `13 of 31` local packages
 - Internal dependencies: `@happyvertical/projects`, `@happyvertical/repos`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/github-actions/metadata.json
+++ b/packages/github-actions/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/github-actions",
   "position": {
     "index": 13,
-    "count": 30
+    "count": 31
   },
   "description": "Reusable GitHub Actions utilities for issue triage, PR validation, and workflow automation",
   "provides": [

--- a/packages/graphql/AGENT.md
+++ b/packages/graphql/AGENT.md
@@ -7,7 +7,7 @@ GitHub GraphQL client for SDK packages
 ## Package Map
 - Package: `@happyvertical/graphql`
 - Hierarchy path: `@happyvertical/sdk > packages > graphql`
-- Workspace position: `14 of 30` local packages
+- Workspace position: `14 of 31` local packages
 - Internal dependencies: none
 - Internal dependents: `@happyvertical/projects`, `@happyvertical/repos`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/graphql/metadata.json
+++ b/packages/graphql/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/graphql",
   "position": {
     "index": 14,
-    "count": 30
+    "count": 31
   },
   "description": "GitHub GraphQL client for SDK packages",
   "provides": [

--- a/packages/images/AGENT.md
+++ b/packages/images/AGENT.md
@@ -7,7 +7,7 @@ Image processing utilities with adapter pattern for scaling from static to enter
 ## Package Map
 - Package: `@happyvertical/images`
 - Hierarchy path: `@happyvertical/sdk > packages > images`
-- Workspace position: `15 of 30` local packages
+- Workspace position: `15 of 31` local packages
 - Internal dependencies: none
 - Internal dependents: `@happyvertical/video`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/images/metadata.json
+++ b/packages/images/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/images",
   "position": {
     "index": 15,
-    "count": 30
+    "count": 31
   },
   "description": "Image processing utilities with adapter pattern for scaling from static to enterprise",
   "provides": [

--- a/packages/jobs/AGENT.md
+++ b/packages/jobs/AGENT.md
@@ -7,7 +7,7 @@ Job queue abstraction with multiple backend adapters (SQLite, PostgreSQL, Bull, 
 ## Package Map
 - Package: `@happyvertical/jobs`
 - Hierarchy path: `@happyvertical/sdk > packages > jobs`
-- Workspace position: `16 of 30` local packages
+- Workspace position: `16 of 31` local packages
 - Internal dependencies: `@happyvertical/sql`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/jobs/metadata.json
+++ b/packages/jobs/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/jobs",
   "position": {
     "index": 16,
-    "count": 30
+    "count": 31
   },
   "description": "Job queue abstraction with multiple backend adapters (SQLite, PostgreSQL, Bull, SQS)",
   "provides": [

--- a/packages/json/AGENT.md
+++ b/packages/json/AGENT.md
@@ -7,7 +7,7 @@ High-performance JSON parsing and serialization with Rust SIMD acceleration and 
 ## Package Map
 - Package: `@happyvertical/json`
 - Hierarchy path: `@happyvertical/sdk > packages > json`
-- Workspace position: `17 of 30` local packages
+- Workspace position: `17 of 31` local packages
 - Internal dependencies: none
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/json/metadata.json
+++ b/packages/json/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/json",
   "position": {
     "index": 17,
-    "count": 30
+    "count": 31
   },
   "description": "High-performance JSON parsing and serialization with Rust SIMD acceleration and automatic fallback",
   "provides": [

--- a/packages/logger/AGENT.md
+++ b/packages/logger/AGENT.md
@@ -7,7 +7,7 @@ Structured logging for HAVE SDK with signal adapter
 ## Package Map
 - Package: `@happyvertical/logger`
 - Hierarchy path: `@happyvertical/sdk > packages > logger`
-- Workspace position: `18 of 30` local packages
+- Workspace position: `18 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/comfyui`, `@happyvertical/email`, `@happyvertical/encryption`, `@happyvertical/messages`, `@happyvertical/social`, `@happyvertical/video`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/logger/metadata.json
+++ b/packages/logger/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/logger",
   "position": {
     "index": 18,
-    "count": 30
+    "count": 31
   },
   "description": "Structured logging for HAVE SDK with signal adapter",
   "provides": [

--- a/packages/messages/AGENT.md
+++ b/packages/messages/AGENT.md
@@ -7,7 +7,7 @@ Unified multi-channel messaging with adapter-based architecture (Slack, Twitter,
 ## Package Map
 - Package: `@happyvertical/messages`
 - Hierarchy path: `@happyvertical/sdk > packages > messages`
-- Workspace position: `19 of 30` local packages
+- Workspace position: `19 of 31` local packages
 - Internal dependencies: `@happyvertical/email`, `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/messages/metadata.json
+++ b/packages/messages/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/messages",
   "position": {
     "index": 19,
-    "count": 30
+    "count": 31
   },
   "description": "Unified multi-channel messaging with adapter-based architecture (Slack, Twitter, Email)",
   "provides": [

--- a/packages/payments/AGENT.md
+++ b/packages/payments/AGENT.md
@@ -7,7 +7,7 @@ Payment backend abstraction with adapters for Base USDC, BTCPay Server, and Stri
 ## Package Map
 - Package: `@happyvertical/payments`
 - Hierarchy path: `@happyvertical/sdk > packages > payments`
-- Workspace position: `20 of 30` local packages
+- Workspace position: `20 of 31` local packages
 - Internal dependencies: none
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/payments/metadata.json
+++ b/packages/payments/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/payments",
   "position": {
     "index": 20,
-    "count": 30
+    "count": 31
   },
   "description": "Payment backend abstraction with adapters for Base USDC, BTCPay Server, and Stripe",
   "provides": [

--- a/packages/projects/AGENT.md
+++ b/packages/projects/AGENT.md
@@ -7,7 +7,7 @@ Standardized project management interface for GitHub Projects, Jira, ZenHub, and
 ## Package Map
 - Package: `@happyvertical/projects`
 - Hierarchy path: `@happyvertical/sdk > packages > projects`
-- Workspace position: `21 of 30` local packages
+- Workspace position: `21 of 31` local packages
 - Internal dependencies: `@happyvertical/graphql`, `@happyvertical/repos`
 - Internal dependents: `@happyvertical/github-actions`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/projects/metadata.json
+++ b/packages/projects/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/projects",
   "position": {
     "index": 21,
-    "count": 30
+    "count": 31
   },
   "description": "Standardized project management interface for GitHub Projects, Jira, ZenHub, and Linear",
   "provides": [

--- a/packages/repos/AGENT.md
+++ b/packages/repos/AGENT.md
@@ -7,7 +7,7 @@ Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOp
 ## Package Map
 - Package: `@happyvertical/repos`
 - Hierarchy path: `@happyvertical/sdk > packages > repos`
-- Workspace position: `22 of 30` local packages
+- Workspace position: `22 of 31` local packages
 - Internal dependencies: `@happyvertical/graphql`
 - Internal dependents: `@happyvertical/github-actions`, `@happyvertical/projects`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/repos/metadata.json
+++ b/packages/repos/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/repos",
   "position": {
     "index": 22,
-    "count": 30
+    "count": 31
   },
   "description": "Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOps",
   "provides": [

--- a/packages/sdk-mcp/AGENT.md
+++ b/packages/sdk-mcp/AGENT.md
@@ -7,7 +7,7 @@ MCP server for HAVE SDK - Routes queries to package experts using AGENT.md files
 ## Package Map
 - Package: `@happyvertical/sdk-mcp`
 - Hierarchy path: `@happyvertical/sdk > packages > sdk-mcp`
-- Workspace position: `23 of 30` local packages
+- Workspace position: `23 of 31` local packages
 - Internal dependencies: `@happyvertical/ai`, `@happyvertical/files`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/sdk-mcp/metadata.json
+++ b/packages/sdk-mcp/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/sdk-mcp",
   "position": {
     "index": 23,
-    "count": 30
+    "count": 31
   },
   "description": "MCP server for HAVE SDK - Routes queries to package experts using AGENT.md files",
   "provides": [

--- a/packages/secrets/AGENT.md
+++ b/packages/secrets/AGENT.md
@@ -7,7 +7,7 @@ Envelope encryption for per-tenant secret management with pluggable backends
 ## Package Map
 - Package: `@happyvertical/secrets`
 - Hierarchy path: `@happyvertical/sdk > packages > secrets`
-- Workspace position: `24 of 30` local packages
+- Workspace position: `24 of 31` local packages
 - Internal dependencies: `@happyvertical/sql`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/secrets/metadata.json
+++ b/packages/secrets/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/secrets",
   "position": {
     "index": 24,
-    "count": 30
+    "count": 31
   },
   "description": "Envelope encryption for per-tenant secret management with pluggable backends",
   "provides": [

--- a/packages/social/AGENT.md
+++ b/packages/social/AGENT.md
@@ -7,7 +7,7 @@ Social platform adapters for publishing to YouTube, Threads, X, and Bluesky
 ## Package Map
 - Package: `@happyvertical/social`
 - Hierarchy path: `@happyvertical/sdk > packages > social`
-- Workspace position: `25 of 30` local packages
+- Workspace position: `25 of 31` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/social/metadata.json
+++ b/packages/social/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/social",
   "position": {
     "index": 25,
-    "count": 30
+    "count": 31
   },
   "description": "Social platform adapters for publishing to YouTube, Threads, X, and Bluesky",
   "provides": [

--- a/packages/speech/AGENT.md
+++ b/packages/speech/AGENT.md
@@ -1,0 +1,51 @@
+# @happyvertical/speech
+
+<!-- BEGIN AGENT:GENERATED -->
+## Purpose
+Speech provider abstraction for STT and TTS backends
+
+## Package Map
+- Package: `@happyvertical/speech`
+- Hierarchy path: `@happyvertical/sdk > packages > speech`
+- Workspace position: `26 of 31` local packages
+- Internal dependencies: none
+- Internal dependents: none
+- Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`
+
+## Build & Test
+```bash
+pnpm --filter @happyvertical/speech build
+pnpm --filter @happyvertical/speech test
+pnpm --filter @happyvertical/speech typecheck
+pnpm --filter @happyvertical/speech clean
+```
+
+## Agent Correction Loops
+- If Vite or TypeScript reports missing packages, run `pnpm install` at the repo root and rerun `pnpm --filter @happyvertical/speech build`.
+- If tests or exports fail after API, type, or bundle changes, run `pnpm --filter @happyvertical/speech clean` followed by `pnpm --filter @happyvertical/speech build` and `pnpm --filter @happyvertical/speech test`.
+- If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands.
+
+## Ecosystem Relationships
+- Provides: Speech provider abstraction for STT and TTS backends
+- Implements: Studio Server STT, Studio Server TTS, Qwen3 TTS, OpenAI-compatible TTS
+- Requires: none
+- Stability: experimental (Marked as preview or experimental in package guidance.)
+<!-- END AGENT:GENERATED -->
+
+
+## SDK Pattern
+
+Use factory functions as the public surface:
+
+- `getSpeech(config)` returns a service with optional STT and TTS providers.
+- `getTranscriber(config)` creates an STT provider.
+- `getSpeechSynthesizer(config)` creates a TTS provider.
+
+Adapter constructors are internal implementation details. Keep new backends behind the `type` option and the factory switch.
+
+## Adapters
+
+- Studio Server STT (`type: 'studio-server'`) posts multipart audio to `/v1/transcribe`.
+- Studio Server TTS (`type: 'studio-server'`) posts Studio-shaped JSON to `/v1/tts/synthesize`.
+- Qwen3 TTS (`type: 'qwen3-tts'`) posts OpenAI-shaped JSON to `/v1/audio/speech`.
+- OpenAI-compatible TTS (`type: 'openai-compatible'`) posts OpenAI-shaped JSON to `/v1/audio/speech`.

--- a/packages/speech/AGENT.md
+++ b/packages/speech/AGENT.md
@@ -46,6 +46,6 @@ Adapter constructors are internal implementation details. Keep new backends behi
 ## Adapters
 
 - Studio Server STT (`type: 'studio-server'`) posts multipart audio to `/v1/transcribe`.
-- Studio Server TTS (`type: 'studio-server'`) posts Studio-shaped JSON to `/v1/tts/synthesize`.
-- Qwen3 TTS (`type: 'qwen3-tts'`) posts OpenAI-shaped JSON to `/v1/audio/speech`.
+- Studio Server TTS (`type: 'studio-server'`) posts multipart form data to `/v1/tts/synthesize`.
+- Qwen3 TTS (`type: 'qwen3-tts'`) posts multipart form data to `/v1/audio/speech`.
 - OpenAI-compatible TTS (`type: 'openai-compatible'`) posts OpenAI-shaped JSON to `/v1/audio/speech`.

--- a/packages/speech/CHANGELOG.md
+++ b/packages/speech/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @happyvertical/speech
+
+## 0.77.0
+
+- Initial speech provider abstraction package.

--- a/packages/speech/README.md
+++ b/packages/speech/README.md
@@ -43,12 +43,14 @@ const spoken = await speech.synthesize({
 
 ## Adapters
 
-| Provider | Type | Method | Path |
-| --- | --- | --- | --- |
-| Studio Server STT | `studio-server` | `POST` | `/v1/transcribe` |
-| Studio Server TTS | `studio-server` | `POST` | `/v1/tts/synthesize` |
-| Qwen3 TTS | `qwen3-tts` | `POST` | `/v1/audio/speech` |
-| OpenAI-compatible TTS | `openai-compatible` | `POST` | `/v1/audio/speech` |
+| Provider | Type | Method | Path | Encoding |
+| --- | --- | --- | --- | --- |
+| Studio Server STT | `studio-server` | `POST` | `/v1/transcribe` | Multipart (`audio`) |
+| Studio Server TTS | `studio-server` | `POST` | `/v1/tts/synthesize` | Multipart |
+| Qwen3 TTS | `qwen3-tts` | `POST` | `/v1/audio/speech` | Multipart |
+| OpenAI-compatible TTS | `openai-compatible` | `POST` | `/v1/audio/speech` | JSON |
+
+Studio Server and Qwen3 accept pre-extracted provider voice prompts through `SpeechVoice.prompt`; the adapters forward these as the multipart `voice_prompt` field.
 
 ## Environment Configuration
 
@@ -76,4 +78,8 @@ Optional overrides include `STT_PATH`, `TTS_PATH`, `STT_API_KEY`, `TTS_API_KEY`,
 
 ## Testing
 
-Default tests use tiny in-process HTTP fixture services that emulate Studio Server and Qwen endpoint shapes. They validate contract differences without downloading or running production-scale models.
+Default tests use tiny in-process HTTP fixture services that mirror the Studio Server, Qwen3, and OpenAI-compatible request shapes. They validate field names, encodings, and response normalization without downloading production-scale models.
+
+Docker or Testcontainers integration suites should run the fixture services or Studio Server with mock backends. Model-backed tests must remain opt-in, for example behind `HV_SPEECH_MODEL_TESTS=1`, so the normal SDK suite never downloads model weights.
+
+On Apple Silicon, run model-backed Qwen tests with a host-native Metal/MLX runtime or against a remote cluster service; Docker contract tests should continue using mock backends because Linux containers do not expose the host Metal runtime.

--- a/packages/speech/README.md
+++ b/packages/speech/README.md
@@ -1,0 +1,79 @@
+# @happyvertical/speech
+
+Speech provider abstraction for HappyVertical STT and TTS backends.
+
+This package owns runtime speech backend contracts. It is intentionally separate from SMRT model packages such as `@happyvertical/smrt-voice`, which persist voice profiles, samples, and generated outputs.
+
+## Install
+
+```bash
+pnpm add @happyvertical/speech
+```
+
+## Usage
+
+```typescript
+import { getSpeech } from '@happyvertical/speech';
+
+const speech = await getSpeech({
+  transcriber: {
+    type: 'studio-server',
+    baseUrl: 'http://studio-server.studio-server.svc.cluster.local',
+  },
+  synthesizer: {
+    type: 'qwen3-tts',
+    baseUrl: 'http://qwen3-tts.qwen3-tts.svc.cluster.local',
+  },
+});
+
+const transcript = await speech.transcribe({
+  audio: {
+    data: audioBytes,
+    contentType: 'audio/wav',
+    filename: 'utterance.wav',
+  },
+  language: 'en',
+});
+
+const spoken = await speech.synthesize({
+  text: transcript.text,
+  outputFormat: 'mp3',
+});
+```
+
+## Adapters
+
+| Provider | Type | Method | Path |
+| --- | --- | --- | --- |
+| Studio Server STT | `studio-server` | `POST` | `/v1/transcribe` |
+| Studio Server TTS | `studio-server` | `POST` | `/v1/tts/synthesize` |
+| Qwen3 TTS | `qwen3-tts` | `POST` | `/v1/audio/speech` |
+| OpenAI-compatible TTS | `openai-compatible` | `POST` | `/v1/audio/speech` |
+
+## Environment Configuration
+
+SDK-style names are preferred:
+
+```bash
+HAVE_SPEECH_STT_TYPE=studio-server
+HAVE_SPEECH_STT_BASE_URL=http://studio-server.studio-server.svc.cluster.local
+HAVE_SPEECH_TTS_TYPE=qwen3-tts
+HAVE_SPEECH_TTS_BASE_URL=http://qwen3-tts.qwen3-tts.svc.cluster.local
+```
+
+STT defaults to `studio-server` when only a base URL is present. TTS requires an explicit type because multiple TTS wire protocols are supported.
+
+For gateway compatibility, the package also accepts:
+
+```bash
+STT_ADAPTER=studio-server
+STT_BASE_URL=http://studio-server.studio-server.svc.cluster.local
+TTS_ADAPTER=qwen3-tts
+TTS_BASE_URL=http://qwen3-tts.qwen3-tts.svc.cluster.local
+```
+
+Optional overrides include `STT_PATH`, `TTS_PATH`, `STT_API_KEY`, `TTS_API_KEY`, `SPEECH_API_KEY`, `STT_TIMEOUT_MS`, and `TTS_TIMEOUT_MS`.
+
+## Testing
+
+Default tests use tiny in-process HTTP fixture services that emulate Studio Server and Qwen endpoint shapes. They validate contract differences without downloading or running production-scale models.

--- a/packages/speech/metadata.json
+++ b/packages/speech/metadata.json
@@ -1,0 +1,31 @@
+{
+  "name": "@happyvertical/speech",
+  "path": "packages/speech",
+  "position": {
+    "index": 26,
+    "count": 31
+  },
+  "description": "Speech provider abstraction for STT and TTS backends",
+  "provides": [
+    "Speech provider abstraction for STT and TTS backends"
+  ],
+  "implements": [
+    "Studio Server STT",
+    "Studio Server TTS",
+    "Qwen3 TTS",
+    "OpenAI-compatible TTS"
+  ],
+  "requires": {
+    "workspace": [],
+    "externalHappyVertical": [],
+    "external": []
+  },
+  "dependents": [],
+  "stability": {
+    "level": "experimental",
+    "reason": "Marked as preview or experimental in package guidance."
+  },
+  "keywords": [
+    "speech"
+  ]
+}

--- a/packages/speech/package.json
+++ b/packages/speech/package.json
@@ -18,10 +18,10 @@
     "build:watch": "vite build --watch",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "dev": "npm run build:watch & npm run test:watch"
+    "dev": "vite build --watch"
   },
   "devDependencies": {
-    "@types/node": "24.12.2",
+    "@types/node": "25.0.10",
     "typescript": "^5.9.3",
     "vite": "7.3.2",
     "vite-plugin-dts": "4.5.4",

--- a/packages/speech/package.json
+++ b/packages/speech/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@happyvertical/speech",
+  "version": "0.77.0",
+  "description": "Speech provider abstraction for STT and TTS backends",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "test": "npx vitest run",
+    "test:watch": "npx vitest",
+    "build": "vite build",
+    "build:watch": "vite build --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "dev": "npm run build:watch & npm run test:watch"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.2",
+    "typescript": "^5.9.3",
+    "vite": "7.3.2",
+    "vite-plugin-dts": "4.5.4",
+    "vitest": "^4.1.5"
+  },
+  "keywords": [
+    "speech",
+    "stt",
+    "tts",
+    "studio-server",
+    "qwen3-tts"
+  ],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "AGENT.md",
+    "metadata.json"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/speech"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/speech#readme",
+  "license": "MIT"
+}

--- a/packages/speech/src/__tests__/http-adapters.test.ts
+++ b/packages/speech/src/__tests__/http-adapters.test.ts
@@ -70,11 +70,14 @@ describe('@happyvertical/speech HTTP adapters', () => {
     });
   });
 
-  it('returns an injectable speech service that fails clearly when no provider is configured', async () => {
+  it('ignores empty env values and fails clearly when no provider is configured', async () => {
     const speech = await getSpeech(
       {},
       {
-        env: {},
+        env: Object.fromEntries([
+          ['STT_BASE_URL', ' '],
+          ['TTS_BASE_URL', ''],
+        ]),
       },
     );
 
@@ -96,9 +99,14 @@ describe('@happyvertical/speech HTTP adapters', () => {
     await expect(
       getTranscriber({
         type: 'qwen3-tts',
-        baseUrl: 'http://speech.example',
       } as never),
     ).rejects.toThrow('Invalid STT speech adapter type: qwen3-tts');
+
+    await expect(
+      getSpeechSynthesizer({
+        type: 'unsupported',
+      } as never),
+    ).rejects.toThrow('Invalid TTS speech adapter type: unsupported');
 
     await expect(
       getSpeech(
@@ -197,6 +205,32 @@ describe('@happyvertical/speech HTTP adapters', () => {
         });
 
         expect(result.text).toBe('blob ok');
+      },
+    );
+  });
+
+  it('preserves the MIME type from Blob audio inputs', async () => {
+    await withFixtureServer(
+      (_req, body, res) => {
+        const multipart = body.toString('utf8');
+        expect(multipart).toContain('Content-Type: audio/wav');
+
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ text: 'typed blob ok' }));
+      },
+      async (baseUrl) => {
+        const transcriber = await getTranscriber({
+          type: 'studio-server',
+          baseUrl,
+        });
+        const result = await transcriber.transcribe({
+          audio: {
+            data: new Blob(['blob audio'], { type: 'audio/wav' }),
+            filename: 'fixture.wav',
+          },
+        });
+
+        expect(result.text).toBe('typed blob ok');
       },
     );
   });
@@ -461,5 +495,43 @@ describe('@happyvertical/speech HTTP adapters', () => {
         },
       }),
     ).rejects.toThrow('request timeout signal fired');
+  });
+
+  it('keeps the timeout active while reading the response body', async () => {
+    let bodyReadAborted = false;
+    const synthesizer = await getSpeechSynthesizer({
+      type: 'qwen3-tts',
+      baseUrl: 'http://speech.example',
+      timeoutMs: 1,
+      fetch: async (_input, init) => {
+        const signal = init?.signal;
+        if (!signal) {
+          throw new Error('Expected a timeout signal');
+        }
+
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              signal.addEventListener(
+                'abort',
+                () => {
+                  bodyReadAborted = true;
+                  controller.error(signal.reason);
+                },
+                { once: true },
+              );
+            },
+          }),
+          {
+            headers: { 'content-type': 'audio/mpeg' },
+          },
+        );
+      },
+    });
+
+    await expect(
+      synthesizer.synthesize({ text: 'timeout while streaming' }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(bodyReadAborted).toBe(true);
   });
 });

--- a/packages/speech/src/__tests__/http-adapters.test.ts
+++ b/packages/speech/src/__tests__/http-adapters.test.ts
@@ -1,0 +1,465 @@
+import { Buffer } from 'node:buffer';
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getAvailableSpeechAdapters,
+  getSpeech,
+  getSpeechSynthesizer,
+  getTranscriber,
+  type SpeechProviderError,
+} from '../index.js';
+
+type FixtureHandler = (
+  req: IncomingMessage,
+  body: Buffer,
+  res: ServerResponse,
+) => void | Promise<void>;
+
+const servers: Array<ReturnType<typeof createServer>> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+});
+
+async function withFixtureServer<T>(
+  handler: FixtureHandler,
+  run: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    req.on('end', async () => {
+      try {
+        await handler(req, Buffer.concat(chunks), res);
+      } catch (error) {
+        res.statusCode = 500;
+        res.end(error instanceof Error ? error.stack : String(error));
+      }
+    });
+  });
+  servers.push(server);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Fixture server did not expose a TCP address');
+  }
+
+  return run(`http://127.0.0.1:${address.port}`);
+}
+
+describe('@happyvertical/speech HTTP adapters', () => {
+  it('reports adapter availability by capability', () => {
+    expect(getAvailableSpeechAdapters()).toEqual({
+      transcribers: ['studio-server'],
+      synthesizers: ['studio-server', 'qwen3-tts', 'openai-compatible'],
+    });
+  });
+
+  it('returns an injectable speech service that fails clearly when no provider is configured', async () => {
+    const speech = await getSpeech(
+      {},
+      {
+        env: {},
+      },
+    );
+
+    await expect(
+      speech.transcribe({
+        audio: {
+          data: new Uint8Array([1]),
+        },
+      }),
+    ).rejects.toThrow('No STT provider configured');
+    await expect(
+      speech.synthesize({
+        text: 'hello',
+      }),
+    ).rejects.toThrow('No TTS provider configured');
+  });
+
+  it('rejects invalid adapter types and empty required env values', async () => {
+    await expect(
+      getTranscriber({
+        type: 'qwen3-tts',
+        baseUrl: 'http://speech.example',
+      } as never),
+    ).rejects.toThrow('Invalid STT speech adapter type: qwen3-tts');
+
+    await expect(
+      getSpeech(
+        {},
+        {
+          env: Object.fromEntries([
+            ['TTS_ADAPTER', 'qwen3-tts'],
+            ['TTS_BASE_URL', ''],
+          ]),
+        },
+      ),
+    ).rejects.toThrow('TTS baseUrl is required');
+
+    await expect(
+      getSpeech(
+        {},
+        {
+          env: Object.fromEntries([['TTS_BASE_URL', 'http://speech.example']]),
+        },
+      ),
+    ).rejects.toThrow('TTS provider type is required');
+  });
+
+  it('posts Studio Server STT audio to /v1/transcribe as multipart form data', async () => {
+    await withFixtureServer(
+      (req, body, res) => {
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/v1/transcribe');
+        expect(req.headers['content-type']).toContain('multipart/form-data');
+
+        const multipart = body.toString('utf8');
+        expect(multipart).toContain('name="file"; filename="fixture.wav"');
+        expect(multipart).toContain('Content-Type: audio/wav');
+        expect(req.headers.authorization).toBe('Bearer test-token');
+        expect(multipart).toContain('name="language"');
+        expect(multipart).toContain('en');
+        expect(multipart).toContain('name="sample_rate"');
+        expect(multipart).toContain('16000');
+
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            text: 'hello from studio',
+            language: 'en',
+            words: [{ word: 'hello', start: 0, end: 0.4 }],
+          }),
+        );
+      },
+      async (baseUrl) => {
+        const transcriber = await getTranscriber({
+          type: 'studio-server',
+          baseUrl,
+          apiKey: 'test-token',
+        });
+        const result = await transcriber.transcribe({
+          audio: {
+            data: new Uint8Array([1, 2, 3, 4]),
+            contentType: 'audio/wav',
+            filename: 'fixture.wav',
+            sampleRate: 16000,
+          },
+          language: 'en',
+        });
+
+        expect(result.text).toBe('hello from studio');
+        expect(result.words).toEqual([
+          { word: 'hello', startSeconds: 0, endSeconds: 0.4 },
+        ]);
+      },
+    );
+  });
+
+  it('uses explicit contentType for Blob audio inputs', async () => {
+    await withFixtureServer(
+      (req, body, res) => {
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/v1/transcribe');
+
+        const multipart = body.toString('utf8');
+        expect(multipart).toContain('Content-Type: audio/custom');
+
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ text: 'blob ok' }));
+      },
+      async (baseUrl) => {
+        const transcriber = await getTranscriber({
+          type: 'studio-server',
+          baseUrl,
+        });
+        const result = await transcriber.transcribe({
+          audio: {
+            data: new Blob(['blob audio']),
+            contentType: 'audio/custom',
+            filename: 'fixture.audio',
+          },
+        });
+
+        expect(result.text).toBe('blob ok');
+      },
+    );
+  });
+
+  it('posts Studio Server TTS to /v1/tts/synthesize with Studio-shaped JSON', async () => {
+    await withFixtureServer(
+      (req, body, res) => {
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/v1/tts/synthesize');
+        expect(req.headers['content-type']).toContain('application/json');
+
+        const payload = JSON.parse(body.toString('utf8')) as Record<
+          string,
+          unknown
+        >;
+        expect(payload).toMatchObject(
+          Object.fromEntries([
+            ['text', 'Speak through Studio Server.'],
+            ['voice', 'narrator'],
+            ['format', 'wav'],
+            ['sample_rate', 24000],
+            ['speed', 1.1],
+          ]),
+        );
+        expect(payload).not.toHaveProperty('input');
+        expect(payload).not.toHaveProperty('response_format');
+
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            audio: Buffer.from('studio-audio').toString('base64'),
+            contentType: 'audio/wav',
+            sampleRate: 24000,
+            wordTimings: [{ word: 'Speak', start: 0, end: 0.25 }],
+          }),
+        );
+      },
+      async (baseUrl) => {
+        const synthesizer = await getSpeechSynthesizer({
+          type: 'studio-server',
+          baseUrl,
+        });
+        const result = await synthesizer.synthesize({
+          text: 'Speak through Studio Server.',
+          voice: 'narrator',
+          outputFormat: 'wav',
+          sampleRate: 24000,
+          speed: 1.1,
+        });
+
+        expect(Buffer.from(result.audio).toString('utf8')).toBe('studio-audio');
+        expect(result.contentType).toBe('audio/wav');
+        expect(result.sampleRate).toBe(24000);
+        expect(result.words).toEqual([
+          { word: 'Speak', startSeconds: 0, endSeconds: 0.25 },
+        ]);
+      },
+    );
+  });
+
+  it('configures Qwen3 TTS through env and posts OpenAI-shaped JSON to /v1/audio/speech', async () => {
+    await withFixtureServer(
+      (req, body, res) => {
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/v1/audio/speech');
+        expect(req.headers['content-type']).toContain('application/json');
+
+        const payload = JSON.parse(body.toString('utf8')) as Record<
+          string,
+          unknown
+        >;
+        expect(payload).toEqual(
+          Object.fromEntries([
+            ['model', 'qwen3-tts'],
+            ['input', 'Speak through Qwen.'],
+            ['voice', 'default'],
+            ['response_format', 'mp3'],
+          ]),
+        );
+
+        res.setHeader('content-type', 'audio/mpeg');
+        res.end(Buffer.from('qwen-audio'));
+      },
+      async (baseUrl) => {
+        const speech = await getSpeech(
+          {},
+          {
+            env: Object.fromEntries([
+              ['TTS_ADAPTER', 'qwen3-tts'],
+              ['TTS_BASE_URL', baseUrl],
+            ]),
+          },
+        );
+        const result = await speech.synthesize({
+          text: 'Speak through Qwen.',
+          outputFormat: 'mp3',
+        });
+
+        expect(Buffer.from(result.audio).toString('utf8')).toBe('qwen-audio');
+        expect(result.contentType).toBe('audio/mpeg');
+        expect(result.provider).toBe('qwen3-tts');
+        expect(result.model).toBe('qwen3-tts');
+      },
+    );
+  });
+
+  it('posts OpenAI-compatible TTS with defaults and custom path', async () => {
+    await withFixtureServer(
+      (req, body, res) => {
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/custom/audio');
+
+        const payload = JSON.parse(body.toString('utf8')) as Record<
+          string,
+          unknown
+        >;
+        expect(payload).toEqual(
+          Object.fromEntries([
+            ['model', 'tts-1'],
+            ['input', 'Use defaults.'],
+            ['voice', 'alloy'],
+            ['response_format', 'opus'],
+          ]),
+        );
+
+        res.setHeader('content-type', 'audio/ogg');
+        res.end(Buffer.from('openai-compatible-audio'));
+      },
+      async (baseUrl) => {
+        const synthesizer = await getSpeechSynthesizer({
+          type: 'openai-compatible',
+          baseUrl,
+          speechPath: '/custom/audio',
+        });
+        const result = await synthesizer.synthesize({
+          text: 'Use defaults.',
+          outputFormat: 'opus',
+        });
+
+        expect(Buffer.from(result.audio).toString('utf8')).toBe(
+          'openai-compatible-audio',
+        );
+        expect(result.format).toBe('ogg');
+        expect(result.model).toBe('tts-1');
+      },
+    );
+  });
+
+  it('wraps provider HTTP errors with status and response body', async () => {
+    await withFixtureServer(
+      (_req, _body, res) => {
+        res.statusCode = 503;
+        res.end('provider unavailable');
+      },
+      async (baseUrl) => {
+        const synthesizer = await getSpeechSynthesizer({
+          type: 'qwen3-tts',
+          baseUrl,
+        });
+
+        await expect(
+          synthesizer.synthesize({
+            text: 'fail',
+          }),
+        ).rejects.toMatchObject({
+          name: 'SpeechProviderError',
+          status: 503,
+          responseBody: 'provider unavailable',
+        } satisfies Partial<SpeechProviderError>);
+      },
+    );
+  });
+
+  it('rejects JSON TTS responses without audio content', async () => {
+    await withFixtureServer(
+      (_req, _body, res) => {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ contentType: 'audio/wav' }));
+      },
+      async (baseUrl) => {
+        const synthesizer = await getSpeechSynthesizer({
+          type: 'studio-server',
+          baseUrl,
+        });
+
+        await expect(
+          synthesizer.synthesize({
+            text: 'missing audio',
+          }),
+        ).rejects.toThrow(
+          'studio-server JSON speech response did not include base64 audio',
+        );
+      },
+    );
+  });
+
+  it('honors caller abort signals when timeoutMs also creates an adapter signal', async () => {
+    const controller = new AbortController();
+    const transcriber = await getTranscriber({
+      type: 'studio-server',
+      baseUrl: 'http://speech.example',
+      timeoutMs: 1000,
+      fetch: async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const fallback = setTimeout(
+            () => reject(new Error('caller signal was not composed')),
+            25,
+          );
+          const signal = init?.signal;
+          signal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(fallback);
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        }),
+    });
+
+    const request = transcriber.transcribe({
+      audio: {
+        data: new Uint8Array([1]),
+      },
+      signal: controller.signal,
+    });
+    controller.abort(new DOMException('caller abort', 'AbortError'));
+
+    await expect(request).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'caller abort',
+    });
+  });
+
+  it('aborts requests when timeoutMs elapses', async () => {
+    const transcriber = await getTranscriber({
+      type: 'studio-server',
+      baseUrl: 'http://speech.example',
+      timeoutMs: 1,
+      fetch: async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const fallback = setTimeout(
+            () => reject(new Error('timeout signal was not fired')),
+            50,
+          );
+          const signal = init?.signal;
+          signal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(fallback);
+              reject(new Error('request timeout signal fired'));
+            },
+            { once: true },
+          );
+        }),
+    });
+
+    await expect(
+      transcriber.transcribe({
+        audio: {
+          data: new Uint8Array([1]),
+        },
+      }),
+    ).rejects.toThrow('request timeout signal fired');
+  });
+});

--- a/packages/speech/src/__tests__/http-adapters.test.ts
+++ b/packages/speech/src/__tests__/http-adapters.test.ts
@@ -130,6 +130,22 @@ describe('@happyvertical/speech HTTP adapters', () => {
     ).rejects.toThrow('TTS provider type is required');
   });
 
+  it('falls back past blank preferred environment aliases', async () => {
+    const speech = await getSpeech(
+      {},
+      {
+        env: Object.fromEntries([
+          ['HAVE_SPEECH_TTS_TYPE', ' '],
+          ['HAVE_SPEECH_TTS_BASE_URL', ''],
+          ['TTS_ADAPTER', 'qwen3-tts'],
+          ['TTS_BASE_URL', 'http://speech.example'],
+        ]),
+      },
+    );
+
+    expect(speech.synthesizer?.type).toBe('qwen3-tts');
+  });
+
   it('posts Studio Server STT audio to /v1/transcribe as multipart form data', async () => {
     await withFixtureServer(
       (req, body, res) => {
@@ -138,20 +154,28 @@ describe('@happyvertical/speech HTTP adapters', () => {
         expect(req.headers['content-type']).toContain('multipart/form-data');
 
         const multipart = body.toString('utf8');
-        expect(multipart).toContain('name="file"; filename="fixture.wav"');
+        expect(multipart).toContain('name="audio"; filename="fixture.wav"');
         expect(multipart).toContain('Content-Type: audio/wav');
         expect(req.headers.authorization).toBe('Bearer test-token');
         expect(multipart).toContain('name="language"');
         expect(multipart).toContain('en');
-        expect(multipart).toContain('name="sample_rate"');
-        expect(multipart).toContain('16000');
 
         res.setHeader('content-type', 'application/json');
         res.end(
           JSON.stringify({
             text: 'hello from studio',
             language: 'en',
-            words: [{ word: 'hello', start: 0, end: 0.4 }],
+            // biome-ignore lint/style/useNamingConvention: Studio Server response uses snake_case.
+            word_timings: [{ word: 'hello', start: 0, end: 0.4 }],
+            segments: [
+              {
+                text: 'hello from studio',
+                start: 0,
+                end: 0.4,
+                confidence: 0.98,
+                speaker: 'speaker-1',
+              },
+            ],
           }),
         );
       },
@@ -174,6 +198,15 @@ describe('@happyvertical/speech HTTP adapters', () => {
         expect(result.text).toBe('hello from studio');
         expect(result.words).toEqual([
           { word: 'hello', startSeconds: 0, endSeconds: 0.4 },
+        ]);
+        expect(result.segments).toEqual([
+          {
+            text: 'hello from studio',
+            startSeconds: 0,
+            endSeconds: 0.4,
+            confidence: 0.98,
+            speakerId: 'speaker-1',
+          },
         ]);
       },
     );
@@ -235,38 +268,28 @@ describe('@happyvertical/speech HTTP adapters', () => {
     );
   });
 
-  it('posts Studio Server TTS to /v1/tts/synthesize with Studio-shaped JSON', async () => {
+  it('posts Studio Server TTS to /v1/tts/synthesize as multipart form data', async () => {
     await withFixtureServer(
       (req, body, res) => {
         expect(req.method).toBe('POST');
         expect(req.url).toBe('/v1/tts/synthesize');
-        expect(req.headers['content-type']).toContain('application/json');
+        expect(req.headers['content-type']).toContain('multipart/form-data');
 
-        const payload = JSON.parse(body.toString('utf8')) as Record<
-          string,
-          unknown
-        >;
-        expect(payload).toMatchObject(
-          Object.fromEntries([
-            ['text', 'Speak through Studio Server.'],
-            ['voice', 'narrator'],
-            ['format', 'wav'],
-            ['sample_rate', 24000],
-            ['speed', 1.1],
-          ]),
-        );
-        expect(payload).not.toHaveProperty('input');
-        expect(payload).not.toHaveProperty('response_format');
+        const multipart = body.toString('utf8');
+        expect(multipart).toContain('name="text"');
+        expect(multipart).toContain('Speak through Studio Server.');
+        expect(multipart).toContain('name="language"');
+        expect(multipart).toContain('English');
+        expect(multipart).toContain('name="speaker"');
+        expect(multipart).toContain('narrator');
+        expect(multipart).toContain('name="voice_prompt"');
+        expect(multipart).toContain('studio-voice-prompt');
+        expect(multipart).toContain('name="speed"');
+        expect(multipart).toContain('1.1');
 
-        res.setHeader('content-type', 'application/json');
-        res.end(
-          JSON.stringify({
-            audio: Buffer.from('studio-audio').toString('base64'),
-            contentType: 'audio/wav',
-            sampleRate: 24000,
-            wordTimings: [{ word: 'Speak', start: 0, end: 0.25 }],
-          }),
-        );
+        res.setHeader('content-type', 'audio/wav');
+        res.setHeader('x-sample-rate', '24000');
+        res.end(Buffer.from('studio-audio'));
       },
       async (baseUrl) => {
         const synthesizer = await getSpeechSynthesizer({
@@ -275,43 +298,41 @@ describe('@happyvertical/speech HTTP adapters', () => {
         });
         const result = await synthesizer.synthesize({
           text: 'Speak through Studio Server.',
-          voice: 'narrator',
-          outputFormat: 'wav',
-          sampleRate: 24000,
+          language: 'English',
+          voice: {
+            speakerId: 'narrator',
+            prompt: 'studio-voice-prompt',
+          },
           speed: 1.1,
         });
 
         expect(Buffer.from(result.audio).toString('utf8')).toBe('studio-audio');
         expect(result.contentType).toBe('audio/wav');
+        expect(result.format).toBe('wav');
         expect(result.sampleRate).toBe(24000);
-        expect(result.words).toEqual([
-          { word: 'Speak', startSeconds: 0, endSeconds: 0.25 },
-        ]);
       },
     );
   });
 
-  it('configures Qwen3 TTS through env and posts OpenAI-shaped JSON to /v1/audio/speech', async () => {
+  it('configures Qwen3 TTS through env and posts multipart form data to /v1/audio/speech', async () => {
     await withFixtureServer(
       (req, body, res) => {
         expect(req.method).toBe('POST');
         expect(req.url).toBe('/v1/audio/speech');
-        expect(req.headers['content-type']).toContain('application/json');
+        expect(req.headers['content-type']).toContain('multipart/form-data');
 
-        const payload = JSON.parse(body.toString('utf8')) as Record<
-          string,
-          unknown
-        >;
-        expect(payload).toEqual(
-          Object.fromEntries([
-            ['model', 'qwen3-tts'],
-            ['input', 'Speak through Qwen.'],
-            ['voice', 'default'],
-            ['response_format', 'mp3'],
-          ]),
-        );
+        const multipart = body.toString('utf8');
+        expect(multipart).toContain('name="text"');
+        expect(multipart).toContain('Speak through Qwen.');
+        expect(multipart).toContain('name="language"');
+        expect(multipart).toContain('English');
+        expect(multipart).toContain('name="speaker"');
+        expect(multipart).toContain('Ryan');
+        expect(multipart).toContain('name="voice_prompt"');
+        expect(multipart).toContain('qwen-voice-prompt');
 
-        res.setHeader('content-type', 'audio/mpeg');
+        res.setHeader('content-type', 'audio/wav');
+        res.setHeader('x-sample-rate', '24000');
         res.end(Buffer.from('qwen-audio'));
       },
       async (baseUrl) => {
@@ -326,11 +347,17 @@ describe('@happyvertical/speech HTTP adapters', () => {
         );
         const result = await speech.synthesize({
           text: 'Speak through Qwen.',
-          outputFormat: 'mp3',
+          language: 'English',
+          voice: {
+            speakerId: 'Ryan',
+            prompt: 'qwen-voice-prompt',
+          },
         });
 
         expect(Buffer.from(result.audio).toString('utf8')).toBe('qwen-audio');
-        expect(result.contentType).toBe('audio/mpeg');
+        expect(result.contentType).toBe('audio/wav');
+        expect(result.format).toBe('wav');
+        expect(result.sampleRate).toBe(24000);
         expect(result.provider).toBe('qwen3-tts');
         expect(result.model).toBe('qwen3-tts');
       },

--- a/packages/speech/src/adapters/openai-compatible.ts
+++ b/packages/speech/src/adapters/openai-compatible.ts
@@ -1,0 +1,78 @@
+import {
+  compactJson,
+  HttpSpeechAdapter,
+  readSynthesizedSpeechResponse,
+  voiceToString,
+} from '../shared/http.js';
+import type {
+  OpenAICompatibleSpeechSynthesizerOptions,
+  Qwen3SpeechSynthesizerOptions,
+  SpeechSynthesizer,
+  SpeechSynthesizerType,
+  SynthesisRequest,
+  SynthesizedSpeech,
+} from '../shared/types.js';
+
+type OpenAICompatibleSpeechOptions =
+  | OpenAICompatibleSpeechSynthesizerOptions
+  | Qwen3SpeechSynthesizerOptions;
+
+export class OpenAICompatibleSpeechSynthesizer
+  extends HttpSpeechAdapter
+  implements SpeechSynthesizer
+{
+  readonly type: Extract<
+    SpeechSynthesizerType,
+    'openai-compatible' | 'qwen3-tts'
+  >;
+
+  private readonly speechPath: string;
+  private readonly defaultModel: string;
+  private readonly defaultVoice: string;
+
+  constructor(options: OpenAICompatibleSpeechOptions) {
+    super(options);
+    this.type = options.type;
+    this.speechPath = options.speechPath ?? '/v1/audio/speech';
+    this.defaultModel = options.defaultModel ?? 'tts-1';
+    this.defaultVoice = options.defaultVoice ?? 'alloy';
+  }
+
+  async synthesize(request: SynthesisRequest): Promise<SynthesizedSpeech> {
+    const outputFormat = request.outputFormat ?? 'mp3';
+    const payload = compactJson({
+      model: request.model ?? this.defaultModel,
+      input: request.text,
+      voice: voiceToString(request.voice, this.defaultVoice),
+      // biome-ignore lint/style/useNamingConvention: OpenAI-compatible API uses snake_case.
+      response_format: outputFormat,
+      speed: request.speed,
+    });
+
+    const response = await this.post(this.type, this.speechPath, {
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: request.signal,
+    });
+    const speech = await readSynthesizedSpeechResponse(response, this.type);
+
+    return {
+      ...speech,
+      format: speech.format ?? outputFormat,
+      model: speech.model ?? String(payload.model),
+    };
+  }
+}
+
+export class Qwen3SpeechSynthesizer extends OpenAICompatibleSpeechSynthesizer {
+  constructor(options: Qwen3SpeechSynthesizerOptions) {
+    super({
+      ...options,
+      type: 'qwen3-tts',
+      defaultModel: options.defaultModel ?? 'qwen3-tts',
+      defaultVoice: options.defaultVoice ?? 'default',
+    });
+  }
+}

--- a/packages/speech/src/adapters/openai-compatible.ts
+++ b/packages/speech/src/adapters/openai-compatible.ts
@@ -49,14 +49,18 @@ export class OpenAICompatibleSpeechSynthesizer
       speed: request.speed,
     });
 
-    const response = await this.post(this.type, this.speechPath, {
-      headers: {
-        'content-type': 'application/json',
+    const speech = await this.post(
+      this.type,
+      this.speechPath,
+      {
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: request.signal,
       },
-      body: JSON.stringify(payload),
-      signal: request.signal,
-    });
-    const speech = await readSynthesizedSpeechResponse(response, this.type);
+      (response) => readSynthesizedSpeechResponse(response, this.type),
+    );
 
     return {
       ...speech,

--- a/packages/speech/src/adapters/openai-compatible.ts
+++ b/packages/speech/src/adapters/openai-compatible.ts
@@ -6,33 +6,23 @@ import {
 } from '../shared/http.js';
 import type {
   OpenAICompatibleSpeechSynthesizerOptions,
-  Qwen3SpeechSynthesizerOptions,
   SpeechSynthesizer,
-  SpeechSynthesizerType,
   SynthesisRequest,
   SynthesizedSpeech,
 } from '../shared/types.js';
-
-type OpenAICompatibleSpeechOptions =
-  | OpenAICompatibleSpeechSynthesizerOptions
-  | Qwen3SpeechSynthesizerOptions;
 
 export class OpenAICompatibleSpeechSynthesizer
   extends HttpSpeechAdapter
   implements SpeechSynthesizer
 {
-  readonly type: Extract<
-    SpeechSynthesizerType,
-    'openai-compatible' | 'qwen3-tts'
-  >;
+  readonly type = 'openai-compatible' as const;
 
   private readonly speechPath: string;
   private readonly defaultModel: string;
   private readonly defaultVoice: string;
 
-  constructor(options: OpenAICompatibleSpeechOptions) {
+  constructor(options: OpenAICompatibleSpeechSynthesizerOptions) {
     super(options);
-    this.type = options.type;
     this.speechPath = options.speechPath ?? '/v1/audio/speech';
     this.defaultModel = options.defaultModel ?? 'tts-1';
     this.defaultVoice = options.defaultVoice ?? 'alloy';
@@ -67,16 +57,5 @@ export class OpenAICompatibleSpeechSynthesizer
       format: speech.format ?? outputFormat,
       model: speech.model ?? String(payload.model),
     };
-  }
-}
-
-export class Qwen3SpeechSynthesizer extends OpenAICompatibleSpeechSynthesizer {
-  constructor(options: Qwen3SpeechSynthesizerOptions) {
-    super({
-      ...options,
-      type: 'qwen3-tts',
-      defaultModel: options.defaultModel ?? 'qwen3-tts',
-      defaultVoice: options.defaultVoice ?? 'default',
-    });
   }
 }

--- a/packages/speech/src/adapters/qwen3.ts
+++ b/packages/speech/src/adapters/qwen3.ts
@@ -1,0 +1,48 @@
+import {
+  createHappyVerticalSynthesisForm,
+  HttpSpeechAdapter,
+  readSynthesizedSpeechResponse,
+} from '../shared/http.js';
+import type {
+  Qwen3SpeechSynthesizerOptions,
+  SpeechSynthesizer,
+  SynthesisRequest,
+  SynthesizedSpeech,
+} from '../shared/types.js';
+
+export class Qwen3SpeechSynthesizer
+  extends HttpSpeechAdapter
+  implements SpeechSynthesizer
+{
+  readonly type = 'qwen3-tts' as const;
+
+  private readonly speechPath: string;
+  private readonly defaultModel: string;
+  private readonly defaultVoice?: string;
+
+  constructor(options: Qwen3SpeechSynthesizerOptions) {
+    super(options);
+    this.speechPath = options.speechPath ?? '/v1/audio/speech';
+    this.defaultModel = options.defaultModel ?? 'qwen3-tts';
+    this.defaultVoice = options.defaultVoice;
+  }
+
+  async synthesize(request: SynthesisRequest): Promise<SynthesizedSpeech> {
+    const form = createHappyVerticalSynthesisForm(request, this.defaultVoice);
+    const speech = await this.post(
+      this.type,
+      this.speechPath,
+      {
+        body: form,
+        signal: request.signal,
+      },
+      (response) => readSynthesizedSpeechResponse(response, this.type),
+    );
+
+    return {
+      ...speech,
+      format: speech.format ?? request.outputFormat,
+      model: speech.model ?? request.model ?? this.defaultModel,
+    };
+  }
+}

--- a/packages/speech/src/adapters/studio-server.ts
+++ b/packages/speech/src/adapters/studio-server.ts
@@ -1,0 +1,91 @@
+import {
+  appendAudioInput,
+  appendOptionalFormValue,
+  compactJson,
+  HttpSpeechAdapter,
+  readSynthesizedSpeechResponse,
+  readTranscriptResponse,
+  voiceToString,
+} from '../shared/http.js';
+import type {
+  SpeechSynthesizer,
+  StudioServerSpeechSynthesizerOptions,
+  StudioServerTranscriberOptions,
+  SynthesisRequest,
+  SynthesizedSpeech,
+  Transcriber,
+  TranscriptionRequest,
+  TranscriptResult,
+} from '../shared/types.js';
+
+export class StudioServerTranscriber
+  extends HttpSpeechAdapter
+  implements Transcriber
+{
+  readonly type = 'studio-server' as const;
+  private readonly transcribePath: string;
+
+  constructor(options: StudioServerTranscriberOptions) {
+    super(options);
+    this.transcribePath = options.transcribePath ?? '/v1/transcribe';
+  }
+
+  async transcribe(request: TranscriptionRequest): Promise<TranscriptResult> {
+    const form = new FormData();
+    appendAudioInput(form, request.audio);
+    appendOptionalFormValue(form, 'language', request.language);
+    appendOptionalFormValue(form, 'model', request.model);
+    appendOptionalFormValue(form, 'prompt', request.prompt);
+    appendOptionalFormValue(form, 'temperature', request.temperature);
+    appendOptionalFormValue(form, 'response_format', request.responseFormat);
+    appendOptionalFormValue(form, 'sample_rate', request.audio.sampleRate);
+    appendOptionalFormValue(form, 'channels', request.audio.channels);
+
+    const response = await this.post(this.type, this.transcribePath, {
+      body: form,
+      signal: request.signal,
+    });
+    return readTranscriptResponse(response, this.type);
+  }
+}
+
+export class StudioServerSpeechSynthesizer
+  extends HttpSpeechAdapter
+  implements SpeechSynthesizer
+{
+  readonly type = 'studio-server' as const;
+  private readonly synthesizePath: string;
+  private readonly defaultVoice: string;
+
+  constructor(options: StudioServerSpeechSynthesizerOptions) {
+    super(options);
+    this.synthesizePath = options.synthesizePath ?? '/v1/tts/synthesize';
+    this.defaultVoice = options.defaultVoice ?? 'default';
+  }
+
+  async synthesize(request: SynthesisRequest): Promise<SynthesizedSpeech> {
+    const payload = compactJson({
+      text: request.text,
+      voice: voiceToString(request.voice, this.defaultVoice),
+      model: request.model,
+      language: request.language,
+      format: request.outputFormat,
+      // biome-ignore lint/style/useNamingConvention: Studio Server API uses snake_case.
+      sample_rate: request.sampleRate,
+      speed: request.speed,
+      pitch: request.pitch,
+      // biome-ignore lint/style/useNamingConvention: Studio Server API uses snake_case.
+      response_format: request.responseFormat,
+      metadata: request.metadata,
+    });
+
+    const response = await this.post(this.type, this.synthesizePath, {
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: request.signal,
+    });
+    return readSynthesizedSpeechResponse(response, this.type);
+  }
+}

--- a/packages/speech/src/adapters/studio-server.ts
+++ b/packages/speech/src/adapters/studio-server.ts
@@ -1,11 +1,10 @@
 import {
   appendAudioInput,
   appendOptionalFormValue,
-  compactJson,
+  createHappyVerticalSynthesisForm,
   HttpSpeechAdapter,
   readSynthesizedSpeechResponse,
   readTranscriptResponse,
-  voiceToString,
 } from '../shared/http.js';
 import type {
   SpeechSynthesizer,
@@ -34,12 +33,6 @@ export class StudioServerTranscriber
     const form = new FormData();
     appendAudioInput(form, request.audio);
     appendOptionalFormValue(form, 'language', request.language);
-    appendOptionalFormValue(form, 'model', request.model);
-    appendOptionalFormValue(form, 'prompt', request.prompt);
-    appendOptionalFormValue(form, 'temperature', request.temperature);
-    appendOptionalFormValue(form, 'response_format', request.responseFormat);
-    appendOptionalFormValue(form, 'sample_rate', request.audio.sampleRate);
-    appendOptionalFormValue(form, 'channels', request.audio.channels);
 
     return this.post(
       this.type,
@@ -59,38 +52,22 @@ export class StudioServerSpeechSynthesizer
 {
   readonly type = 'studio-server' as const;
   private readonly synthesizePath: string;
-  private readonly defaultVoice: string;
+  private readonly defaultVoice?: string;
 
   constructor(options: StudioServerSpeechSynthesizerOptions) {
     super(options);
     this.synthesizePath = options.synthesizePath ?? '/v1/tts/synthesize';
-    this.defaultVoice = options.defaultVoice ?? 'default';
+    this.defaultVoice = options.defaultVoice;
   }
 
   async synthesize(request: SynthesisRequest): Promise<SynthesizedSpeech> {
-    const payload = compactJson({
-      text: request.text,
-      voice: voiceToString(request.voice, this.defaultVoice),
-      model: request.model,
-      language: request.language,
-      format: request.outputFormat,
-      // biome-ignore lint/style/useNamingConvention: Studio Server API uses snake_case.
-      sample_rate: request.sampleRate,
-      speed: request.speed,
-      pitch: request.pitch,
-      // biome-ignore lint/style/useNamingConvention: Studio Server API uses snake_case.
-      response_format: request.responseFormat,
-      metadata: request.metadata,
-    });
+    const form = createHappyVerticalSynthesisForm(request, this.defaultVoice);
 
     return this.post(
       this.type,
       this.synthesizePath,
       {
-        headers: {
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify(payload),
+        body: form,
         signal: request.signal,
       },
       (response) => readSynthesizedSpeechResponse(response, this.type),

--- a/packages/speech/src/adapters/studio-server.ts
+++ b/packages/speech/src/adapters/studio-server.ts
@@ -41,11 +41,15 @@ export class StudioServerTranscriber
     appendOptionalFormValue(form, 'sample_rate', request.audio.sampleRate);
     appendOptionalFormValue(form, 'channels', request.audio.channels);
 
-    const response = await this.post(this.type, this.transcribePath, {
-      body: form,
-      signal: request.signal,
-    });
-    return readTranscriptResponse(response, this.type);
+    return this.post(
+      this.type,
+      this.transcribePath,
+      {
+        body: form,
+        signal: request.signal,
+      },
+      (response) => readTranscriptResponse(response, this.type),
+    );
   }
 }
 
@@ -79,13 +83,17 @@ export class StudioServerSpeechSynthesizer
       metadata: request.metadata,
     });
 
-    const response = await this.post(this.type, this.synthesizePath, {
-      headers: {
-        'content-type': 'application/json',
+    return this.post(
+      this.type,
+      this.synthesizePath,
+      {
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: request.signal,
       },
-      body: JSON.stringify(payload),
-      signal: request.signal,
-    });
-    return readSynthesizedSpeechResponse(response, this.type);
+      (response) => readSynthesizedSpeechResponse(response, this.type),
+    );
   }
 }

--- a/packages/speech/src/index.ts
+++ b/packages/speech/src/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @happyvertical/speech
+ *
+ * Speech provider abstraction for STT and TTS backends.
+ *
+ * @example
+ * ```typescript
+ * import { getSpeech } from '@happyvertical/speech';
+ *
+ * const speech = await getSpeech({
+ *   transcriber: {
+ *     type: 'studio-server',
+ *     baseUrl: 'http://studio-server.studio-server.svc.cluster.local',
+ *   },
+ *   synthesizer: {
+ *     type: 'qwen3-tts',
+ *     baseUrl: 'http://qwen3-tts.qwen3-tts.svc.cluster.local',
+ *   },
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export * from './shared/errors.js';
+export {
+  getAvailableSpeechAdapters,
+  getSpeech,
+  getSpeechSynthesizer,
+  getTranscriber,
+  type SpeechFactoryContext,
+} from './shared/factory.js';
+export type {
+  AudioBytes,
+  AudioInput,
+  GetSpeechOptions,
+  GetSpeechSynthesizerOptions,
+  GetTranscriberOptions,
+  OpenAICompatibleSpeechSynthesizerOptions,
+  Qwen3SpeechSynthesizerOptions,
+  Speech,
+  SpeechAdapterAvailability,
+  SpeechAdapterType,
+  SpeechFetch,
+  SpeechSynthesizer,
+  SpeechSynthesizerType,
+  SpeechVoice,
+  SpeechVoiceInput,
+  StudioServerSpeechSynthesizerOptions,
+  StudioServerTranscriberOptions,
+  SynthesisRequest,
+  SynthesizedSpeech,
+  Transcriber,
+  TranscriberType,
+  TranscriptionRequest,
+  TranscriptResult,
+  TranscriptSegment,
+  WordTiming,
+} from './shared/types.js';

--- a/packages/speech/src/shared/errors.ts
+++ b/packages/speech/src/shared/errors.ts
@@ -1,0 +1,43 @@
+export class SpeechError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public adapter?: string,
+  ) {
+    super(message);
+    this.name = 'SpeechError';
+  }
+}
+
+export class SpeechConfigurationError extends SpeechError {
+  constructor(message: string, adapter?: string) {
+    super(message, 'SPEECH_CONFIGURATION_ERROR', adapter);
+    this.name = 'SpeechConfigurationError';
+  }
+}
+
+export class InvalidSpeechAdapterError extends SpeechError {
+  constructor(type: string, kind: string) {
+    super(`Invalid ${kind} speech adapter type: ${type}`, 'INVALID_ADAPTER');
+    this.name = 'InvalidSpeechAdapterError';
+  }
+}
+
+export class SpeechProviderError extends SpeechError {
+  readonly status?: number;
+  readonly responseBody?: string;
+
+  constructor(
+    adapter: string,
+    message: string,
+    options: { status?: number; responseBody?: string; cause?: unknown } = {},
+  ) {
+    super(message, 'SPEECH_PROVIDER_ERROR', adapter);
+    this.name = 'SpeechProviderError';
+    this.status = options.status;
+    this.responseBody = options.responseBody;
+    if (options.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+}

--- a/packages/speech/src/shared/factory.ts
+++ b/packages/speech/src/shared/factory.ts
@@ -161,12 +161,12 @@ function normalizeTranscriberOptions(
   const baseUrl =
     options.baseUrl ?? readEnv(env, 'HAVE_SPEECH_STT_BASE_URL', 'STT_BASE_URL');
 
-  if (!baseUrl?.trim()) {
-    throw new SpeechConfigurationError('STT baseUrl is required', type);
-  }
-
   if (type !== 'studio-server') {
     throw new InvalidSpeechAdapterError(type, 'STT');
+  }
+
+  if (!baseUrl?.trim()) {
+    throw new SpeechConfigurationError('STT baseUrl is required', type);
   }
 
   return {
@@ -211,6 +211,14 @@ function normalizeSpeechSynthesizerOptions(
 
   if (!type) {
     throw new SpeechConfigurationError('TTS provider type is required');
+  }
+
+  if (
+    type !== 'studio-server' &&
+    type !== 'qwen3-tts' &&
+    type !== 'openai-compatible'
+  ) {
+    throw new InvalidSpeechAdapterError(type, 'TTS');
   }
 
   if (!baseUrl?.trim()) {
@@ -312,7 +320,7 @@ function readEnv(env: SpeechEnv, ...keys: string[]): string | undefined {
 }
 
 function hasAnyEnv(env: SpeechEnv, ...keys: string[]): boolean {
-  return keys.some((key) => env[key] !== undefined);
+  return keys.some((key) => Boolean(env[key]?.trim()));
 }
 
 function parseOptionalInteger(value: string | undefined): number | undefined {

--- a/packages/speech/src/shared/factory.ts
+++ b/packages/speech/src/shared/factory.ts
@@ -1,7 +1,5 @@
-import {
-  OpenAICompatibleSpeechSynthesizer,
-  Qwen3SpeechSynthesizer,
-} from '../adapters/openai-compatible.js';
+import { OpenAICompatibleSpeechSynthesizer } from '../adapters/openai-compatible.js';
+import { Qwen3SpeechSynthesizer } from '../adapters/qwen3.js';
 import {
   StudioServerSpeechSynthesizer,
   StudioServerTranscriber,
@@ -311,8 +309,8 @@ function hasSynthesizerEnv(env: SpeechEnv): boolean {
 function readEnv(env: SpeechEnv, ...keys: string[]): string | undefined {
   for (const key of keys) {
     const value = env[key];
-    if (value !== undefined) {
-      return value;
+    if (value?.trim()) {
+      return value.trim();
     }
   }
 

--- a/packages/speech/src/shared/factory.ts
+++ b/packages/speech/src/shared/factory.ts
@@ -1,0 +1,329 @@
+import {
+  OpenAICompatibleSpeechSynthesizer,
+  Qwen3SpeechSynthesizer,
+} from '../adapters/openai-compatible.js';
+import {
+  StudioServerSpeechSynthesizer,
+  StudioServerTranscriber,
+} from '../adapters/studio-server.js';
+import {
+  InvalidSpeechAdapterError,
+  SpeechConfigurationError,
+} from './errors.js';
+import type {
+  GetSpeechOptions,
+  GetSpeechSynthesizerOptions,
+  GetTranscriberOptions,
+  OpenAICompatibleSpeechSynthesizerOptions,
+  Qwen3SpeechSynthesizerOptions,
+  Speech,
+  SpeechAdapterAvailability,
+  SpeechFetch,
+  SpeechSynthesizer,
+  StudioServerSpeechSynthesizerOptions,
+  StudioServerTranscriberOptions,
+  SynthesisRequest,
+  SynthesizedSpeech,
+  Transcriber,
+  TranscriptionRequest,
+  TranscriptResult,
+} from './types.js';
+
+interface SpeechEnv {
+  [key: string]: string | undefined;
+}
+
+export interface SpeechFactoryContext {
+  env?: SpeechEnv;
+  fetch?: SpeechFetch;
+  headers?: HeadersInit;
+}
+
+/**
+ * Creates a speech service from explicit options and/or environment variables.
+ *
+ * Explicit options win over environment defaults. If no STT or TTS config is
+ * available, the returned service is still usable for dependency injection, but
+ * calling the missing operation throws a configuration error.
+ */
+export async function getSpeech(
+  options: GetSpeechOptions = {},
+  context: SpeechFactoryContext = {},
+): Promise<Speech> {
+  const transcriber =
+    options.transcriber === false
+      ? undefined
+      : await getOptionalTranscriber(options.transcriber, context);
+  const synthesizer =
+    options.synthesizer === false
+      ? undefined
+      : await getOptionalSpeechSynthesizer(options.synthesizer, context);
+
+  return {
+    transcriber,
+    synthesizer,
+    async transcribe(request: TranscriptionRequest): Promise<TranscriptResult> {
+      if (!transcriber) {
+        throw new SpeechConfigurationError('No STT provider configured');
+      }
+      return transcriber.transcribe(request);
+    },
+    async synthesize(request: SynthesisRequest): Promise<SynthesizedSpeech> {
+      if (!synthesizer) {
+        throw new SpeechConfigurationError('No TTS provider configured');
+      }
+      return synthesizer.synthesize(request);
+    },
+  };
+}
+
+export async function getTranscriber(
+  options: GetTranscriberOptions = {},
+  context: SpeechFactoryContext = {},
+): Promise<Transcriber> {
+  const resolved = normalizeTranscriberOptions(options, context);
+
+  switch (resolved.type) {
+    case 'studio-server':
+      return new StudioServerTranscriber(resolved);
+    default:
+      throw new InvalidSpeechAdapterError(
+        (resolved as { type?: string }).type ?? 'unknown',
+        'STT',
+      );
+  }
+}
+
+export async function getSpeechSynthesizer(
+  options?: GetSpeechSynthesizerOptions,
+  context: SpeechFactoryContext = {},
+): Promise<SpeechSynthesizer> {
+  const resolved = normalizeSpeechSynthesizerOptions(options, context);
+
+  switch (resolved.type) {
+    case 'studio-server':
+      return new StudioServerSpeechSynthesizer(resolved);
+    case 'qwen3-tts':
+      return new Qwen3SpeechSynthesizer(resolved);
+    case 'openai-compatible':
+      return new OpenAICompatibleSpeechSynthesizer(resolved);
+    default:
+      throw new InvalidSpeechAdapterError(
+        (resolved as { type?: string }).type ?? 'unknown',
+        'TTS',
+      );
+  }
+}
+
+export function getAvailableSpeechAdapters(): SpeechAdapterAvailability {
+  return {
+    transcribers: ['studio-server'],
+    synthesizers: ['studio-server', 'qwen3-tts', 'openai-compatible'],
+  };
+}
+
+async function getOptionalTranscriber(
+  options: GetTranscriberOptions | undefined,
+  context: SpeechFactoryContext,
+): Promise<Transcriber | undefined> {
+  if (!options && !hasTranscriberEnv(context.env ?? defaultEnv())) {
+    return undefined;
+  }
+
+  return getTranscriber(options, context);
+}
+
+async function getOptionalSpeechSynthesizer(
+  options: GetSpeechSynthesizerOptions | undefined,
+  context: SpeechFactoryContext,
+): Promise<SpeechSynthesizer | undefined> {
+  if (!options && !hasSynthesizerEnv(context.env ?? defaultEnv())) {
+    return undefined;
+  }
+
+  return getSpeechSynthesizer(options, context);
+}
+
+function normalizeTranscriberOptions(
+  options: GetTranscriberOptions = {},
+  context: SpeechFactoryContext,
+): StudioServerTranscriberOptions {
+  const env = context.env ?? defaultEnv();
+  const type =
+    options.type ??
+    readEnv(
+      env,
+      'HAVE_SPEECH_STT_TYPE',
+      'HAVE_SPEECH_STT_ADAPTER',
+      'STT_ADAPTER',
+    ) ??
+    'studio-server';
+  const baseUrl =
+    options.baseUrl ?? readEnv(env, 'HAVE_SPEECH_STT_BASE_URL', 'STT_BASE_URL');
+
+  if (!baseUrl?.trim()) {
+    throw new SpeechConfigurationError('STT baseUrl is required', type);
+  }
+
+  if (type !== 'studio-server') {
+    throw new InvalidSpeechAdapterError(type, 'STT');
+  }
+
+  return {
+    ...options,
+    type,
+    baseUrl: baseUrl.trim(),
+    fetch: options.fetch ?? context.fetch,
+    headers: options.headers ?? context.headers,
+    apiKey:
+      options.apiKey ??
+      readEnv(env, 'HAVE_SPEECH_STT_API_KEY', 'STT_API_KEY', 'SPEECH_API_KEY'),
+    timeoutMs:
+      options.timeoutMs ??
+      parseOptionalInteger(
+        readEnv(env, 'HAVE_SPEECH_STT_TIMEOUT_MS', 'STT_TIMEOUT_MS'),
+      ),
+    transcribePath:
+      options.transcribePath ??
+      readEnv(env, 'HAVE_SPEECH_STT_PATH', 'STT_PATH'),
+  };
+}
+
+function normalizeSpeechSynthesizerOptions(
+  options: GetSpeechSynthesizerOptions | undefined,
+  context: SpeechFactoryContext,
+):
+  | StudioServerSpeechSynthesizerOptions
+  | Qwen3SpeechSynthesizerOptions
+  | OpenAICompatibleSpeechSynthesizerOptions {
+  const env = context.env ?? defaultEnv();
+  const type =
+    options?.type ??
+    (readEnv(
+      env,
+      'HAVE_SPEECH_TTS_TYPE',
+      'HAVE_SPEECH_TTS_ADAPTER',
+      'TTS_ADAPTER',
+    ) as GetSpeechSynthesizerOptions['type'] | undefined);
+  const baseUrl =
+    options?.baseUrl ??
+    readEnv(env, 'HAVE_SPEECH_TTS_BASE_URL', 'TTS_BASE_URL');
+
+  if (!type) {
+    throw new SpeechConfigurationError('TTS provider type is required');
+  }
+
+  if (!baseUrl?.trim()) {
+    throw new SpeechConfigurationError('TTS baseUrl is required', type);
+  }
+
+  const shared = {
+    type,
+    baseUrl: baseUrl.trim(),
+    fetch: options?.fetch ?? context.fetch,
+    headers: options?.headers ?? context.headers,
+    apiKey:
+      options?.apiKey ??
+      readEnv(env, 'HAVE_SPEECH_TTS_API_KEY', 'TTS_API_KEY', 'SPEECH_API_KEY'),
+    timeoutMs:
+      options?.timeoutMs ??
+      parseOptionalInteger(
+        readEnv(env, 'HAVE_SPEECH_TTS_TIMEOUT_MS', 'TTS_TIMEOUT_MS'),
+      ),
+  };
+
+  if (type === 'studio-server') {
+    return {
+      ...shared,
+      type,
+      synthesizePath:
+        options?.synthesizePath ??
+        readEnv(env, 'HAVE_SPEECH_TTS_PATH', 'TTS_PATH'),
+      defaultVoice:
+        options?.defaultVoice ??
+        readEnv(env, 'HAVE_SPEECH_TTS_VOICE', 'TTS_VOICE'),
+    };
+  }
+
+  if (type === 'qwen3-tts') {
+    return {
+      ...shared,
+      type,
+      speechPath:
+        options?.speechPath ?? readEnv(env, 'HAVE_SPEECH_TTS_PATH', 'TTS_PATH'),
+      defaultModel:
+        options?.defaultModel ??
+        readEnv(env, 'HAVE_SPEECH_TTS_MODEL', 'TTS_MODEL'),
+      defaultVoice:
+        options?.defaultVoice ??
+        readEnv(env, 'HAVE_SPEECH_TTS_VOICE', 'TTS_VOICE'),
+    };
+  }
+
+  if (type === 'openai-compatible') {
+    return {
+      ...shared,
+      type,
+      speechPath:
+        options?.speechPath ?? readEnv(env, 'HAVE_SPEECH_TTS_PATH', 'TTS_PATH'),
+      defaultModel:
+        options?.defaultModel ??
+        readEnv(env, 'HAVE_SPEECH_TTS_MODEL', 'TTS_MODEL'),
+      defaultVoice:
+        options?.defaultVoice ??
+        readEnv(env, 'HAVE_SPEECH_TTS_VOICE', 'TTS_VOICE'),
+    };
+  }
+
+  throw new InvalidSpeechAdapterError(type, 'TTS');
+}
+
+function hasTranscriberEnv(env: SpeechEnv): boolean {
+  return hasAnyEnv(
+    env,
+    'HAVE_SPEECH_STT_TYPE',
+    'HAVE_SPEECH_STT_ADAPTER',
+    'HAVE_SPEECH_STT_BASE_URL',
+    'STT_ADAPTER',
+    'STT_BASE_URL',
+  );
+}
+
+function hasSynthesizerEnv(env: SpeechEnv): boolean {
+  return hasAnyEnv(
+    env,
+    'HAVE_SPEECH_TTS_TYPE',
+    'HAVE_SPEECH_TTS_ADAPTER',
+    'HAVE_SPEECH_TTS_BASE_URL',
+    'TTS_ADAPTER',
+    'TTS_BASE_URL',
+  );
+}
+
+function readEnv(env: SpeechEnv, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = env[key];
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function hasAnyEnv(env: SpeechEnv, ...keys: string[]): boolean {
+  return keys.some((key) => env[key] !== undefined);
+}
+
+function parseOptionalInteger(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function defaultEnv(): SpeechEnv {
+  return globalThis.process?.env ?? {};
+}

--- a/packages/speech/src/shared/http.ts
+++ b/packages/speech/src/shared/http.ts
@@ -3,8 +3,10 @@ import type {
   AudioInput,
   HttpSpeechOptions,
   SpeechFetch,
+  SynthesisRequest,
   SynthesizedSpeech,
   TranscriptResult,
+  TranscriptSegment,
   WordTiming,
 } from './types.js';
 
@@ -178,7 +180,11 @@ async function assertOk(
   );
 }
 
-export function appendAudioInput(form: FormData, audio: AudioInput): void {
+export function appendAudioInput(
+  form: FormData,
+  audio: AudioInput,
+  fieldName = 'audio',
+): void {
   const filename = audio.filename ?? 'audio';
   const data = audio.data;
 
@@ -189,14 +195,14 @@ export function appendAudioInput(form: FormData, audio: AudioInput): void {
       data.type === contentType
         ? data
         : new Blob([data], { type: contentType });
-    form.append('file', blob, filename);
+    form.append(fieldName, blob, filename);
     return;
   }
 
   const contentType = audio.contentType ?? 'application/octet-stream';
   const blobPart =
     data instanceof Uint8Array ? arrayBufferFromBytes(data) : data;
-  form.append('file', new Blob([blobPart], { type: contentType }), filename);
+  form.append(fieldName, new Blob([blobPart], { type: contentType }), filename);
 }
 
 export function appendOptionalFormValue(
@@ -211,13 +217,40 @@ export function appendOptionalFormValue(
   form.append(name, String(value));
 }
 
+export function createHappyVerticalSynthesisForm(
+  request: SynthesisRequest,
+  defaultVoice?: string,
+): FormData {
+  const form = new FormData();
+  const voice =
+    request.voice && typeof request.voice !== 'string'
+      ? request.voice
+      : undefined;
+  form.set('text', request.text);
+  appendOptionalFormValue(
+    form,
+    'language',
+    request.language ?? voice?.language,
+  );
+  appendOptionalFormValue(
+    form,
+    'speaker',
+    voiceToString(request.voice, defaultVoice),
+  );
+  appendOptionalFormValue(form, 'speed', request.speed);
+
+  appendOptionalFormValue(form, 'voice_prompt', voice?.prompt);
+
+  return form;
+}
+
 export function voiceToString(
   voice:
     | string
     | { id?: string; name?: string; speakerId?: string }
     | undefined,
-  fallback: string,
-): string {
+  fallback?: string,
+): string | undefined {
   if (!voice) {
     return fallback;
   }
@@ -325,6 +358,36 @@ export function normalizeWordTimings(value: unknown): WordTiming[] | undefined {
   });
 }
 
+export function normalizeTranscriptSegments(
+  value: unknown,
+): TranscriptSegment[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.flatMap((entry): TranscriptSegment[] => {
+    if (!entry || typeof entry !== 'object') {
+      return [];
+    }
+
+    const record = entry as Record<string, unknown>;
+    const text = getString(record, 'text', 'transcript');
+    if (!text) {
+      return [];
+    }
+
+    return [
+      {
+        text,
+        startSeconds: getNumber(record, 'startSeconds', 'start', 'start_time'),
+        endSeconds: getNumber(record, 'endSeconds', 'end', 'end_time'),
+        confidence: getNumber(record, 'confidence'),
+        speakerId: getString(record, 'speakerId', 'speaker', 'speaker_id'),
+      },
+    ];
+  });
+}
+
 export async function readTranscriptResponse(
   response: Response,
   adapterName: string,
@@ -349,6 +412,7 @@ export async function readTranscriptResponse(
     words: normalizeWordTimings(
       json.words ?? json.wordTimings ?? json.word_timings,
     ),
+    segments: normalizeTranscriptSegments(json.segments),
     provider: getString(json, 'provider') ?? adapterName,
     model: getString(json, 'model'),
     raw: json,
@@ -364,10 +428,12 @@ export async function readSynthesizedSpeechResponse(
 
   if (!responseContentType.includes('application/json')) {
     const audio = await response.arrayBuffer();
+    const sampleRate = parseHeaderNumber(response, 'x-sample-rate');
     return {
       audio,
       contentType: responseContentType,
       format: contentTypeToFormat(responseContentType),
+      sampleRate,
       provider: adapterName,
     };
   }
@@ -406,4 +472,17 @@ export async function readSynthesizedSpeechResponse(
     model: getString(json, 'model'),
     raw: json,
   };
+}
+
+function parseHeaderNumber(
+  response: Response,
+  headerName: string,
+): number | undefined {
+  const value = response.headers.get(headerName);
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/packages/speech/src/shared/http.ts
+++ b/packages/speech/src/shared/http.ts
@@ -21,14 +21,18 @@ export function resolveSpeechUrl(baseUrl: string, path: string): string {
 }
 
 export function resolveFetch(fetchOverride?: SpeechFetch): SpeechFetch {
-  const resolved = fetchOverride ?? globalThis.fetch;
-  if (!resolved) {
+  if (fetchOverride) {
+    return fetchOverride;
+  }
+
+  const globalFetch = globalThis.fetch;
+  if (!globalFetch) {
     throw new SpeechConfigurationError(
       'No fetch implementation available for speech adapter',
     );
   }
 
-  return resolved.bind(globalThis);
+  return globalFetch.bind(globalThis);
 }
 
 export function mergeHeaders(
@@ -65,11 +69,12 @@ export abstract class HttpSpeechAdapter {
     this.timeoutMs = options.timeoutMs;
   }
 
-  protected async post(
+  protected async post<T>(
     adapterName: string,
     path: string,
     init: Omit<RequestInit, 'method'>,
-  ): Promise<Response> {
+    readResponse: (response: Response) => Promise<T>,
+  ): Promise<T> {
     const timeoutController =
       this.timeoutMs && this.timeoutMs > 0 ? new AbortController() : undefined;
     const timeout =
@@ -95,7 +100,7 @@ export abstract class HttpSpeechAdapter {
         },
       );
       await assertOk(response, adapterName);
-      return response;
+      return await readResponse(response);
     } finally {
       if (timeout) {
         clearTimeout(timeout);
@@ -174,11 +179,12 @@ async function assertOk(
 }
 
 export function appendAudioInput(form: FormData, audio: AudioInput): void {
-  const contentType = audio.contentType ?? 'application/octet-stream';
   const filename = audio.filename ?? 'audio';
   const data = audio.data;
 
   if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    const contentType =
+      audio.contentType ?? (data.type || 'application/octet-stream');
     const blob =
       data.type === contentType
         ? data
@@ -187,6 +193,7 @@ export function appendAudioInput(form: FormData, audio: AudioInput): void {
     return;
   }
 
+  const contentType = audio.contentType ?? 'application/octet-stream';
   const blobPart =
     data instanceof Uint8Array ? arrayBufferFromBytes(data) : data;
   form.append('file', new Blob([blobPart], { type: contentType }), filename);

--- a/packages/speech/src/shared/http.ts
+++ b/packages/speech/src/shared/http.ts
@@ -1,0 +1,402 @@
+import { SpeechConfigurationError, SpeechProviderError } from './errors.js';
+import type {
+  AudioInput,
+  HttpSpeechOptions,
+  SpeechFetch,
+  SynthesizedSpeech,
+  TranscriptResult,
+  WordTiming,
+} from './types.js';
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  if (!baseUrl.trim()) {
+    throw new SpeechConfigurationError('Speech adapter baseUrl is required');
+  }
+
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+}
+
+export function resolveSpeechUrl(baseUrl: string, path: string): string {
+  return new URL(path.replace(/^\//, ''), normalizeBaseUrl(baseUrl)).toString();
+}
+
+export function resolveFetch(fetchOverride?: SpeechFetch): SpeechFetch {
+  const resolved = fetchOverride ?? globalThis.fetch;
+  if (!resolved) {
+    throw new SpeechConfigurationError(
+      'No fetch implementation available for speech adapter',
+    );
+  }
+
+  return resolved.bind(globalThis);
+}
+
+export function mergeHeaders(
+  options: Pick<HttpSpeechOptions, 'apiKey' | 'headers'>,
+  extra?: HeadersInit,
+): Headers {
+  const headers = new Headers(options.headers);
+
+  if (options.apiKey && !headers.has('authorization')) {
+    headers.set('authorization', `Bearer ${options.apiKey}`);
+  }
+
+  if (extra) {
+    new Headers(extra).forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+
+  return headers;
+}
+
+export abstract class HttpSpeechAdapter {
+  protected readonly baseUrl: string;
+  protected readonly fetchImpl: SpeechFetch;
+  protected readonly apiKey?: string;
+  protected readonly headers?: HeadersInit;
+  protected readonly timeoutMs?: number;
+
+  constructor(options: HttpSpeechOptions) {
+    this.baseUrl = options.baseUrl;
+    this.fetchImpl = resolveFetch(options.fetch);
+    this.apiKey = options.apiKey;
+    this.headers = options.headers;
+    this.timeoutMs = options.timeoutMs;
+  }
+
+  protected async post(
+    adapterName: string,
+    path: string,
+    init: Omit<RequestInit, 'method'>,
+  ): Promise<Response> {
+    const timeoutController =
+      this.timeoutMs && this.timeoutMs > 0 ? new AbortController() : undefined;
+    const timeout =
+      timeoutController && this.timeoutMs
+        ? setTimeout(() => timeoutController.abort(), this.timeoutMs)
+        : undefined;
+    const requestSignal = composeAbortSignals(
+      init.signal,
+      timeoutController?.signal,
+    );
+
+    try {
+      const response = await this.fetchImpl(
+        resolveSpeechUrl(this.baseUrl, path),
+        {
+          ...init,
+          method: 'POST',
+          headers: mergeHeaders(
+            { apiKey: this.apiKey, headers: this.headers },
+            init.headers,
+          ),
+          signal: requestSignal.signal,
+        },
+      );
+      await assertOk(response, adapterName);
+      return response;
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      requestSignal.cleanup();
+    }
+  }
+}
+
+function composeAbortSignals(
+  ...signals: Array<AbortSignal | undefined | null>
+): { signal?: AbortSignal; cleanup: () => void } {
+  const activeSignals = signals.filter((signal): signal is AbortSignal =>
+    Boolean(signal),
+  );
+
+  if (activeSignals.length === 0) {
+    return { cleanup: () => undefined };
+  }
+
+  if (activeSignals.length === 1) {
+    return { signal: activeSignals[0], cleanup: () => undefined };
+  }
+
+  const controller = new AbortController();
+  let cleanup = () => undefined;
+
+  const abortFrom = (signal: AbortSignal) => {
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason);
+    }
+    cleanup();
+  };
+
+  const onAbort = (event: Event) => {
+    abortFrom(event.target as AbortSignal);
+  };
+
+  cleanup = () => {
+    for (const signal of activeSignals) {
+      signal.removeEventListener('abort', onAbort);
+    }
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      return { signal: controller.signal, cleanup: () => undefined };
+    }
+  }
+
+  for (const signal of activeSignals) {
+    signal.addEventListener('abort', onAbort, { once: true });
+  }
+
+  return { signal: controller.signal, cleanup };
+}
+
+async function assertOk(
+  response: Response,
+  adapterName: string,
+): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+
+  const responseBody = await response.text().catch(() => undefined);
+  throw new SpeechProviderError(
+    adapterName,
+    `${adapterName} speech request failed with HTTP ${response.status}`,
+    {
+      status: response.status,
+      responseBody,
+    },
+  );
+}
+
+export function appendAudioInput(form: FormData, audio: AudioInput): void {
+  const contentType = audio.contentType ?? 'application/octet-stream';
+  const filename = audio.filename ?? 'audio';
+  const data = audio.data;
+
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    const blob =
+      data.type === contentType
+        ? data
+        : new Blob([data], { type: contentType });
+    form.append('file', blob, filename);
+    return;
+  }
+
+  const blobPart =
+    data instanceof Uint8Array ? arrayBufferFromBytes(data) : data;
+  form.append('file', new Blob([blobPart], { type: contentType }), filename);
+}
+
+export function appendOptionalFormValue(
+  form: FormData,
+  name: string,
+  value: unknown,
+): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  form.append(name, String(value));
+}
+
+export function voiceToString(
+  voice:
+    | string
+    | { id?: string; name?: string; speakerId?: string }
+    | undefined,
+  fallback: string,
+): string {
+  if (!voice) {
+    return fallback;
+  }
+
+  if (typeof voice === 'string') {
+    return voice;
+  }
+
+  return voice.id ?? voice.name ?? voice.speakerId ?? fallback;
+}
+
+export function compactJson(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  );
+}
+
+export function contentTypeToFormat(contentType: string): string | undefined {
+  const match = /^audio\/([^;]+)/.exec(contentType);
+  return match?.[1];
+}
+
+export function arrayBufferFromBytes(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+export function decodeBase64(base64: string): ArrayBuffer {
+  if (typeof Buffer !== 'undefined') {
+    return arrayBufferFromBytes(Buffer.from(base64, 'base64'));
+  }
+
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+function getNumber(
+  value: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'number') {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function getString(
+  value: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string') {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export function normalizeWordTimings(value: unknown): WordTiming[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.flatMap((entry): WordTiming[] => {
+    if (!entry || typeof entry !== 'object') {
+      return [];
+    }
+
+    const record = entry as Record<string, unknown>;
+    const word = getString(record, 'word', 'text', 'token');
+    const startSeconds = getNumber(
+      record,
+      'startSeconds',
+      'start',
+      'start_time',
+    );
+    const endSeconds = getNumber(record, 'endSeconds', 'end', 'end_time');
+
+    if (!word || startSeconds === undefined || endSeconds === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        word,
+        startSeconds,
+        endSeconds,
+        confidence: getNumber(record, 'confidence'),
+        speakerId: getString(record, 'speakerId', 'speaker', 'speaker_id'),
+      },
+    ];
+  });
+}
+
+export async function readTranscriptResponse(
+  response: Response,
+  adapterName: string,
+): Promise<TranscriptResult> {
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (!contentType.includes('application/json')) {
+    const text = await response.text();
+    return {
+      text,
+      provider: adapterName,
+    };
+  }
+
+  const json = (await response.json()) as Record<string, unknown>;
+  const text = getString(json, 'text', 'transcript', 'transcription') ?? '';
+
+  return {
+    text,
+    language: getString(json, 'language', 'lang'),
+    durationSeconds: getNumber(json, 'durationSeconds', 'duration'),
+    words: normalizeWordTimings(
+      json.words ?? json.wordTimings ?? json.word_timings,
+    ),
+    provider: getString(json, 'provider') ?? adapterName,
+    model: getString(json, 'model'),
+    raw: json,
+  };
+}
+
+export async function readSynthesizedSpeechResponse(
+  response: Response,
+  adapterName: string,
+): Promise<SynthesizedSpeech> {
+  const responseContentType =
+    response.headers.get('content-type') ?? 'application/octet-stream';
+
+  if (!responseContentType.includes('application/json')) {
+    const audio = await response.arrayBuffer();
+    return {
+      audio,
+      contentType: responseContentType,
+      format: contentTypeToFormat(responseContentType),
+      provider: adapterName,
+    };
+  }
+
+  const json = (await response.json()) as Record<string, unknown>;
+  const contentType =
+    getString(json, 'contentType', 'content_type', 'mimeType', 'mime_type') ??
+    'application/octet-stream';
+  const encodedAudio = getString(
+    json,
+    'audio',
+    'audioContent',
+    'audio_content',
+  );
+
+  if (!encodedAudio) {
+    throw new SpeechProviderError(
+      adapterName,
+      `${adapterName} JSON speech response did not include base64 audio`,
+    );
+  }
+
+  return {
+    audio: decodeBase64(encodedAudio),
+    contentType,
+    format:
+      getString(json, 'format', 'response_format') ??
+      contentTypeToFormat(contentType),
+    sampleRate: getNumber(json, 'sampleRate', 'sample_rate'),
+    channels: getNumber(json, 'channels'),
+    durationSeconds: getNumber(json, 'durationSeconds', 'duration'),
+    words: normalizeWordTimings(
+      json.words ?? json.wordTimings ?? json.word_timings,
+    ),
+    provider: getString(json, 'provider') ?? adapterName,
+    model: getString(json, 'model'),
+    raw: json,
+  };
+}

--- a/packages/speech/src/shared/types.ts
+++ b/packages/speech/src/shared/types.ts
@@ -69,6 +69,7 @@ export interface SpeechVoice {
   name?: string;
   language?: string;
   speakerId?: string;
+  /** Opaque pre-extracted prompt for providers that support voice cloning. */
   prompt?: string;
   metadata?: Record<string, unknown>;
 }

--- a/packages/speech/src/shared/types.ts
+++ b/packages/speech/src/shared/types.ts
@@ -1,0 +1,179 @@
+export type SpeechAdapterType =
+  | 'studio-server'
+  | 'qwen3-tts'
+  | 'openai-compatible';
+
+export type TranscriberType = 'studio-server';
+
+export type SpeechSynthesizerType =
+  | 'studio-server'
+  | 'qwen3-tts'
+  | 'openai-compatible';
+
+export interface SpeechAdapterAvailability {
+  transcribers: TranscriberType[];
+  synthesizers: SpeechSynthesizerType[];
+}
+
+export type AudioBytes = ArrayBuffer | Uint8Array | Blob;
+
+export interface AudioInput {
+  data: AudioBytes;
+  contentType?: string;
+  filename?: string;
+  sampleRate?: number;
+  channels?: number;
+  durationSeconds?: number;
+}
+
+export interface WordTiming {
+  word: string;
+  startSeconds: number;
+  endSeconds: number;
+  confidence?: number;
+  speakerId?: string;
+}
+
+export interface TranscriptSegment {
+  text: string;
+  startSeconds?: number;
+  endSeconds?: number;
+  confidence?: number;
+  speakerId?: string;
+}
+
+export interface TranscriptResult {
+  text: string;
+  language?: string;
+  durationSeconds?: number;
+  words?: WordTiming[];
+  segments?: TranscriptSegment[];
+  provider?: string;
+  model?: string;
+  raw?: unknown;
+}
+
+export interface TranscriptionRequest {
+  audio: AudioInput;
+  signal?: AbortSignal;
+  language?: string;
+  model?: string;
+  prompt?: string;
+  temperature?: number;
+  responseFormat?: 'json' | 'text' | 'verbose_json';
+  metadata?: Record<string, unknown>;
+}
+
+export interface SpeechVoice {
+  id?: string;
+  name?: string;
+  language?: string;
+  speakerId?: string;
+  prompt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type SpeechVoiceInput = string | SpeechVoice;
+
+export interface SynthesisRequest {
+  text: string;
+  signal?: AbortSignal;
+  voice?: SpeechVoiceInput;
+  model?: string;
+  language?: string;
+  outputFormat?: string;
+  sampleRate?: number;
+  speed?: number;
+  pitch?: number;
+  responseFormat?: 'audio' | 'json';
+  metadata?: Record<string, unknown>;
+}
+
+export interface SynthesizedSpeech {
+  audio: ArrayBuffer;
+  contentType: string;
+  format?: string;
+  sampleRate?: number;
+  channels?: number;
+  durationSeconds?: number;
+  words?: WordTiming[];
+  provider?: string;
+  model?: string;
+  raw?: unknown;
+}
+
+export interface Transcriber {
+  readonly type: TranscriberType;
+  transcribe(request: TranscriptionRequest): Promise<TranscriptResult>;
+}
+
+export interface SpeechSynthesizer {
+  readonly type: SpeechSynthesizerType;
+  synthesize(request: SynthesisRequest): Promise<SynthesizedSpeech>;
+}
+
+export interface Speech {
+  readonly transcriber?: Transcriber;
+  readonly synthesizer?: SpeechSynthesizer;
+  transcribe(request: TranscriptionRequest): Promise<TranscriptResult>;
+  synthesize(request: SynthesisRequest): Promise<SynthesizedSpeech>;
+}
+
+export type SpeechFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface HttpSpeechOptions {
+  baseUrl: string;
+  fetch?: SpeechFetch;
+  apiKey?: string;
+  headers?: HeadersInit;
+  timeoutMs?: number;
+}
+
+export interface StudioServerTranscriberOptions extends HttpSpeechOptions {
+  type?: 'studio-server';
+  transcribePath?: string;
+}
+
+export interface StudioServerSpeechSynthesizerOptions
+  extends HttpSpeechOptions {
+  type: 'studio-server';
+  synthesizePath?: string;
+  defaultVoice?: string;
+}
+
+export interface Qwen3SpeechSynthesizerOptions extends HttpSpeechOptions {
+  type: 'qwen3-tts';
+  speechPath?: string;
+  defaultModel?: string;
+  defaultVoice?: string;
+}
+
+export interface OpenAICompatibleSpeechSynthesizerOptions
+  extends HttpSpeechOptions {
+  type: 'openai-compatible';
+  speechPath?: string;
+  defaultModel?: string;
+  defaultVoice?: string;
+}
+
+export interface GetTranscriberOptions
+  extends Partial<StudioServerTranscriberOptions> {
+  type?: TranscriberType;
+}
+
+export interface GetSpeechSynthesizerOptions
+  extends Partial<HttpSpeechOptions> {
+  type?: SpeechSynthesizerType;
+  synthesizePath?: string;
+  speechPath?: string;
+  defaultModel?: string;
+  defaultVoice?: string;
+}
+
+export interface GetSpeechOptions {
+  transcriber?: GetTranscriberOptions | false;
+  synthesizer?: GetSpeechSynthesizerOptions | false;
+}

--- a/packages/speech/tsconfig.json
+++ b/packages/speech/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/speech/vite.config.ts
+++ b/packages/speech/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('speech');

--- a/packages/sql/AGENT.md
+++ b/packages/sql/AGENT.md
@@ -7,7 +7,7 @@ Database interface with support for SQLite, PostgreSQL, and DuckDB
 ## Package Map
 - Package: `@happyvertical/sql`
 - Hierarchy path: `@happyvertical/sdk > packages > sql`
-- Workspace position: `26 of 30` local packages
+- Workspace position: `27 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/jobs`, `@happyvertical/secrets`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/sql/metadata.json
+++ b/packages/sql/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/sql",
   "path": "packages/sql",
   "position": {
-    "index": 26,
-    "count": 30
+    "index": 27,
+    "count": 31
   },
   "description": "Database interface with support for SQLite, PostgreSQL, and DuckDB",
   "provides": [

--- a/packages/translator/AGENT.md
+++ b/packages/translator/AGENT.md
@@ -7,7 +7,7 @@ Standardized translation interface supporting Google Translate, DeepL, and Libre
 ## Package Map
 - Package: `@happyvertical/translator`
 - Hierarchy path: `@happyvertical/sdk > packages > translator`
-- Workspace position: `27 of 30` local packages
+- Workspace position: `28 of 31` local packages
 - Internal dependencies: `@happyvertical/cache`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/translator/metadata.json
+++ b/packages/translator/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/translator",
   "path": "packages/translator",
   "position": {
-    "index": 27,
-    "count": 30
+    "index": 28,
+    "count": 31
   },
   "description": "Standardized translation interface supporting Google Translate, DeepL, and LibreTranslate",
   "provides": [

--- a/packages/utils/AGENT.md
+++ b/packages/utils/AGENT.md
@@ -7,7 +7,7 @@ Foundation utilities for ID generation, date parsing, URL handling, string conve
 ## Package Map
 - Package: `@happyvertical/utils`
 - Hierarchy path: `@happyvertical/sdk > packages > utils`
-- Workspace position: `28 of 30` local packages
+- Workspace position: `29 of 31` local packages
 - Internal dependencies: none
 - Internal dependents: `@happyvertical/accounting`, `@happyvertical/ai`, `@happyvertical/analytics`, `@happyvertical/auth`, `@happyvertical/cache`, `@happyvertical/comfyui`, `@happyvertical/directory`, `@happyvertical/documents`, `@happyvertical/email`, `@happyvertical/encryption`, `@happyvertical/files`, `@happyvertical/geo`, `@happyvertical/jobs`, `@happyvertical/logger`, `@happyvertical/messages`, `@happyvertical/sdk-mcp`, `@happyvertical/secrets`, `@happyvertical/social`, `@happyvertical/sql`, `@happyvertical/translator`, `@happyvertical/video`, `@happyvertical/weather`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/utils/metadata.json
+++ b/packages/utils/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/utils",
   "path": "packages/utils",
   "position": {
-    "index": 28,
-    "count": 30
+    "index": 29,
+    "count": 31
   },
   "description": "Foundation utilities for ID generation, date parsing, URL handling, string conversion, error handling, and logging",
   "provides": [

--- a/packages/video/AGENT.md
+++ b/packages/video/AGENT.md
@@ -7,7 +7,7 @@ Video processing utilities with adapter pattern for composition and transcoding
 ## Package Map
 - Package: `@happyvertical/video`
 - Hierarchy path: `@happyvertical/sdk > packages > video`
-- Workspace position: `29 of 30` local packages
+- Workspace position: `30 of 31` local packages
 - Internal dependencies: `@happyvertical/images`, `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/video/metadata.json
+++ b/packages/video/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/video",
   "path": "packages/video",
   "position": {
-    "index": 29,
-    "count": 30
+    "index": 30,
+    "count": 31
   },
   "description": "Video processing utilities with adapter pattern for composition and transcoding",
   "provides": [

--- a/packages/weather/AGENT.md
+++ b/packages/weather/AGENT.md
@@ -7,7 +7,7 @@ Weather data provider abstraction for HAppyVertical SDK
 ## Package Map
 - Package: `@happyvertical/weather`
 - Hierarchy path: `@happyvertical/sdk > packages > weather`
-- Workspace position: `30 of 30` local packages
+- Workspace position: `31 of 31` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/weather/metadata.json
+++ b/packages/weather/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/weather",
   "path": "packages/weather",
   "position": {
-    "index": 30,
-    "count": 30
+    "index": 31,
+    "count": 31
   },
   "description": "Weather data provider abstraction for HAppyVertical SDK",
   "provides": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -906,6 +906,24 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
+  packages/speech:
+    devDependencies:
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 7.3.2
+        version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: 4.5.4
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+
   packages/sql:
     dependencies:
       '@duckdb/node-api':
@@ -20397,7 +20415,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.29':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@vue/shared': 3.5.29
       entities: 7.0.1
       estree-walker: 2.0.2


### PR DESCRIPTION
## Summary

- Adds `@happyvertical/speech`, a new SDK package for runtime STT/TTS provider contracts.
- Implements factory-first public APIs for Studio Server STT/TTS plus Qwen3/OpenAI-compatible TTS adapters.
- Adds fixture HTTP tests for provider wire shapes, error handling, abort/timeout behavior, env config, auth headers, and capability discovery.
- Syncs SDK agent metadata, package manifest, lockfile, and commitlint scope for the new package.

## Review Follow-Up

- Addressed Grok review findings before publishing: removed unimplemented voice-clone public surface, made adapter discovery capability-aware, composed caller abort signals with timeout aborts, aligned `@types/node` with the lockfile, tightened empty env handling, fixed Blob content type handling, and marked the package experimental.

## Validation

- `pnpm exec biome check packages/speech commitlint.config.mjs`
- `pnpm --filter @happyvertical/speech test`
- `pnpm --filter @happyvertical/speech typecheck`
- `pnpm --filter @happyvertical/speech build`
- `pnpm agent:check`
- `git diff --check`
- pre-push hook: `pnpm typecheck` / `turbo run typecheck`

Note: local commands pass with the repo engine warning because this shell is on Node `v22.22.3` while the SDK asks for `>=24`.
