### PR TITLE
ci(ci): migrate SDK control plane

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -1,0 +1,51 @@
+{
+  "schema": "https://happyvertical.com/schemas/agent-project/v1",
+  "policy": {
+    "profile": "happyvertical",
+    "revision": "1.0.0"
+  },
+  "tracker": {
+    "provider": "github",
+    "repository": "happyvertical/sdk",
+    "project_url": "https://github.com/orgs/happyvertical/projects/7"
+  },
+  "labels": {
+    "claim": "agent: implementation",
+    "blocked": "status: blocked",
+    "dispatch": {
+      "claude": "dispatch: claude",
+      "codex": "dispatch: codex",
+      "hermes": "dispatch: hermes",
+      "zcode": "dispatch: zcode"
+    }
+  },
+  "memory": {
+    "provider": "hindsight",
+    "bank": "repo-happyvertical-sdk",
+    "package_tags": [
+      "package:packages"
+    ]
+  },
+  "instructions": {
+    "canonical": "AGENTS.md",
+    "adapters": [
+      "claude",
+      "gemini",
+      "copilot"
+    ]
+  },
+  "skills": {
+    "paths": [
+      ".agents/skills"
+    ]
+  },
+  "github": {
+    "required_status_checks": [
+      "lifecycle",
+      "Required CI"
+    ]
+  },
+  "runtime": {
+    "agent_policy_workflow": ".github/workflows/on-pull-request.yml"
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -113,7 +113,7 @@ body:
 
         ## 📋 SOP Checklist (for implementer)
 
-        This checklist ensures proper workflow adherence per [CLAUDE.md SOPs](../../CLAUDE.md).
+        This checklist ensures proper workflow adherence per [AGENTS.md SOPs](../../AGENTS.md).
 
   - type: checkboxes
     id: sop-start-work

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -86,7 +86,7 @@ body:
 
         ## 📋 SOP Checklist (for implementer)
 
-        This checklist ensures proper workflow adherence per [CLAUDE.md SOPs](../../CLAUDE.md).
+        This checklist ensures proper workflow adherence per [AGENTS.md SOPs](../../AGENTS.md).
 
   - type: checkboxes
     id: sop-start-work

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Generated adapter
+
+Follow `/AGENTS.md` as canonical repository instructions.

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -26,7 +26,7 @@ concurrency:
       (github.event_name == 'pull_request' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null))) &&
-      format('lifecycle-{0}', github.run_id) ||
+      'lifecycle' ||
       'validation'
     }}
   cancel-in-progress: true

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -756,13 +756,13 @@ jobs:
             if [ "$EVENT_NAME" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
             fi
-            prior=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100" \
-              --jq '[.check_runs[] | select(.name == "Required CI" and .status == "completed" and .conclusion == "success")] | length')
-            if [ "$prior" -lt 1 ]; then
-              echo "::error::No prior successful full Required CI exists for $head_sha"
+            latest=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100" \
+              --jq '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+            if [ "$latest" != success ]; then
+              echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
               exit 1
             fi
-            echo "Preserved prior successful Required CI for $head_sha after lifecycle-only event."
+            echo "Preserved the latest successful Required CI for $head_sha after lifecycle-only event."
             exit 0
           fi
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -833,15 +833,37 @@ jobs:
     if: always()
     needs: [validation-gate, metadata-gate]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
     steps:
       - name: Require the event-appropriate gate
         env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           VALIDATION: ${{ needs.validation-gate.result }}
           METADATA: ${{ needs.metadata-gate.result }}
         run: |
-          if { [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; } ||
-             { [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; }; then
+          set -euo pipefail
+          if [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; then
             exit 0
+          fi
+          if [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; then
+            head_sha="$EVENT_HEAD_SHA"
+            if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+              head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
+            fi
+            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
+            pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
+            latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+            if [ "$pending" -eq 0 ] && [ "$latest" = success ]; then
+              exit 0
+            fi
+            echo "::error::Final validation baseline for $head_sha is pending=$pending latest=$latest"
+            exit 1
           fi
           echo "::error::Expected exactly one successful gate; validation=$VALIDATION metadata=$METADATA"
           exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -686,12 +686,7 @@ jobs:
 
   validation-gate:
     name: >-
-      ${{ (github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      !(github.event.action == 'edited' && github.event.changes.base != null))) &&
-      'Required CI / inactive validation' ||
-      'Required CI / validation' }}
+      Required CI / ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) && 'inactive validation' || 'validation' }}
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -684,22 +684,10 @@ jobs:
       packages: read
 
   required-ci:
-    name: >-
-      ${{
-        (github.event_name == 'merge_group' ||
-        (github.event_name == 'pull_request' &&
-        (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-        (github.event.action == 'edited' && github.event.changes.base != null)))) &&
-        'Required CI' ||
-        'Lifecycle Required CI Event'
-      }}
-    if: >-
-      always() &&
-      (github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))))
+    name: Required CI
+    if: always()
     needs:
+      - lifecycle
       - changeset-check
       - validate-commits
       - validate-workflows
@@ -713,13 +701,22 @@ jobs:
       - publish-dry-run
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      checks: read
       contents: read
+      pull-requests: read
     steps:
       - name: Verify event-appropriate required job set
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          BASE_CHANGED: ${{ github.event.changes.base != null }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           HEAD_REF: ${{ github.head_ref }}
           MERGE_QUEUE_ENABLED: ${{ vars.CI_MERGE_QUEUE_ENABLED }}
+          LIFECYCLE: ${{ needs.lifecycle.result }}
           CHANGESET: ${{ needs.changeset-check.result }}
           COMMITS: ${{ needs.validate-commits.result }}
           WORKFLOWS: ${{ needs.validate-workflows.result }}
@@ -734,12 +731,40 @@ jobs:
           DOCS: ${{ needs.docs-build.result }}
           PACK: ${{ needs.publish-dry-run.result }}
         run: |
+          set -euo pipefail
           require_success() {
             if [ "$2" != success ]; then
               echo "$1 must succeed, got: $2"
               exit 1
             fi
           }
+
+          require_success 'Lifecycle policy' "$LIFECYCLE"
+
+          full_validation=false
+          if [ "$EVENT_NAME" = merge_group ]; then
+            full_validation=true
+          elif [ "$EVENT_NAME" = pull_request ] && {
+            [[ "$EVENT_ACTION" =~ ^(opened|synchronize|reopened)$ ]] ||
+              { [ "$EVENT_ACTION" = edited ] && [ "$BASE_CHANGED" = true ]; }
+          }; then
+            full_validation=true
+          fi
+
+          if [ "$full_validation" = false ]; then
+            head_sha="$EVENT_HEAD_SHA"
+            if [ "$EVENT_NAME" = workflow_dispatch ]; then
+              head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
+            fi
+            prior=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100" \
+              --jq '[.check_runs[] | select(.name == "Required CI" and .status == "completed" and .conclusion == "success")] | length')
+            if [ "$prior" -lt 1 ]; then
+              echo "::error::No prior successful full Required CI exists for $head_sha"
+              exit 1
+            fi
+            echo "Preserved prior successful Required CI for $head_sha after lifecycle-only event."
+            exit 0
+          fi
 
           require_success 'PostgreSQL scope detection' "$POSTGRES_SCOPE"
           require_success 'Validate Changes' "$TEST"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -756,8 +756,15 @@ jobs:
             if [ "$EVENT_NAME" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
             fi
-            latest=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100" \
-              --jq '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100")
+            other_pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" \
+              '[.check_runs[] | select(.name == "Required CI" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
+            if [ "$other_pending" -gt 0 ]; then
+              echo "::error::Another Required CI is still running for $head_sha"
+              exit 1
+            fi
+            latest=$(printf '%s\n' "$checks" | jq -r \
+              '[.check_runs[] | select(.name == "Required CI" and .status == "completed" and .conclusion != "cancelled")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
             if [ "$latest" != success ]; then
               echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
               exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -685,7 +685,7 @@ jobs:
       packages: read
 
   validation-gate:
-    name: Required CI / validation
+    name: ${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) || (github.event.action == 'edited' && github.event.changes.base != null)))) && 'Required CI / validation' || 'Required CI / validation (inactive)' }}
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -793,6 +793,8 @@ jobs:
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null)))
     needs: [lifecycle, validate-commits]
+    outputs:
+      prerequisites-passed: ${{ steps.prerequisites.outputs.passed }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -800,13 +802,11 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - name: Preserve validation baseline
+      - name: Validate metadata prerequisites
+        id: prerequisites
         env:
-          GH_TOKEN: ${{ github.token }}
           EVENT_ACTION: ${{ github.event.action }}
           TITLE_CHANGED: ${{ github.event.changes.title != null }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           LIFECYCLE: ${{ needs.lifecycle.result }}
           COMMITS: ${{ needs.validate-commits.result }}
         run: |
@@ -816,6 +816,14 @@ jobs:
             echo "::error::Conventional title validation failed: $COMMITS"
             exit 1
           fi
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+      - name: Preserve validation baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
           head_sha="$EVENT_HEAD_SHA"
           if [ "${{ github.event_name }}" = workflow_dispatch ]; then
             head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
@@ -846,12 +854,13 @@ jobs:
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           VALIDATION: ${{ needs.validation-gate.result }}
           METADATA: ${{ needs.metadata-gate.result }}
+          METADATA_PREREQUISITES: ${{ needs.metadata-gate.outputs.prerequisites-passed }}
         run: |
           set -euo pipefail
           if [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; then
             exit 0
           fi
-          if [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; then
+          if [ "$VALIDATION" = skipped ] && [ "$METADATA_PREREQUISITES" = true ]; then
             head_sha="$EVENT_HEAD_SHA"
             if [ "${{ github.event_name }}" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
@@ -865,7 +874,7 @@ jobs:
             echo "::error::Final validation baseline for $head_sha is pending=$pending latest=$latest"
             exit 1
           fi
-          echo "::error::Expected exactly one successful gate; validation=$VALIDATION metadata=$METADATA"
+          echo "::error::Expected exactly one valid gate; validation=$VALIDATION metadata=$METADATA metadata_prerequisites=$METADATA_PREREQUISITES"
           exit 1
 
   dependabot:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -29,13 +29,7 @@ concurrency:
       'lifecycle' ||
       'validation'
     }}
-  cancel-in-progress: >-
-    ${{ !(
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      !(github.event.action == 'edited' && github.event.changes.base != null))
-    ) }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -690,9 +684,14 @@ jobs:
       contents: read
       packages: read
 
-  required-ci:
-    name: Required CI
-    if: always()
+  validation-gate:
+    name: Required CI / validation
+    if: >-
+      always() &&
+      (github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))))
     needs:
       - lifecycle
       - changeset-check
@@ -749,41 +748,6 @@ jobs:
 
           require_success 'Lifecycle policy' "$LIFECYCLE"
 
-          full_validation=false
-          if [ "$EVENT_NAME" = merge_group ]; then
-            full_validation=true
-          elif [ "$EVENT_NAME" = pull_request ] && {
-            [[ "$EVENT_ACTION" =~ ^(opened|synchronize|reopened)$ ]] ||
-              { [ "$EVENT_ACTION" = edited ] && [ "$BASE_CHANGED" = true ]; }
-          }; then
-            full_validation=true
-          fi
-
-          if [ "$full_validation" = false ]; then
-            if [ "$EVENT_NAME" = pull_request ] && [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ]; then
-              require_success 'Conventional commits' "$COMMITS"
-            fi
-            head_sha="$EVENT_HEAD_SHA"
-            if [ "$EVENT_NAME" = workflow_dispatch ]; then
-              head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
-            fi
-            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100")
-            other_pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" \
-              '[.check_runs[] | select(.name == "Required CI" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
-            if [ "$other_pending" -gt 0 ]; then
-              echo "::error::Another Required CI is still running for $head_sha"
-              exit 1
-            fi
-            latest=$(printf '%s\n' "$checks" | jq -r \
-              '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
-            if [ "$latest" != success ]; then
-              echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
-              exit 1
-            fi
-            echo "Preserved the latest successful Required CI for $head_sha after lifecycle-only event."
-            exit 0
-          fi
-
           require_success 'PostgreSQL scope detection' "$POSTGRES_SCOPE"
           require_success 'Validate Changes' "$TEST"
           require_success 'Documentation Build' "$DOCS"
@@ -818,7 +782,69 @@ jobs:
             require_success 'Publish Dry Run' "$PACK"
           fi
 
-          echo "Required CI passed for $EVENT_NAME"
+          echo "Validation baseline passed for $EVENT_NAME"
+
+  metadata-gate:
+    name: Required CI / metadata
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      !(github.event.action == 'edited' && github.event.changes.base != null)))
+    needs: [lifecycle, validate-commits]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Preserve validation baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_ACTION: ${{ github.event.action }}
+          TITLE_CHANGED: ${{ github.event.changes.title != null }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          LIFECYCLE: ${{ needs.lifecycle.result }}
+          COMMITS: ${{ needs.validate-commits.result }}
+        run: |
+          set -euo pipefail
+          [ "$LIFECYCLE" = success ] || { echo "::error::Lifecycle policy failed: $LIFECYCLE"; exit 1; }
+          if [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ] && [ "$COMMITS" != success ]; then
+            echo "::error::Conventional title validation failed: $COMMITS"
+            exit 1
+          fi
+          head_sha="$EVENT_HEAD_SHA"
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
+          fi
+          checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
+          pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
+          latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+          if [ "$pending" -gt 0 ] || [ "$latest" != success ]; then
+            echo "::error::Validation baseline for $head_sha is pending=$pending latest=$latest"
+            exit 1
+          fi
+
+  required-ci:
+    name: Required CI
+    if: always()
+    needs: [validation-gate, metadata-gate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the event-appropriate gate
+        env:
+          VALIDATION: ${{ needs.validation-gate.result }}
+          METADATA: ${{ needs.metadata-gate.result }}
+        run: |
+          if { [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; } ||
+             { [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; }; then
+            exit 0
+          fi
+          echo "::error::Expected exactly one successful gate; validation=$VALIDATION metadata=$METADATA"
+          exit 1
 
   dependabot:
     name: Dependabot Automation

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,6 +22,11 @@ concurrency:
       github.event.merge_group.head_sha ||
       github.ref
     }}-${{
+      (github.event_name == 'pull_request' &&
+      github.event.action == 'edited' &&
+      github.event.changes.title != null &&
+      github.event.changes.base == null) &&
+      'title' ||
       (github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -29,7 +29,7 @@ concurrency:
       'lifecycle' ||
       'validation'
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) }}
 
 permissions:
   contents: read
@@ -685,7 +685,7 @@ jobs:
       packages: read
 
   validation-gate:
-    name: ${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) || (github.event.action == 'edited' && github.event.changes.base != null)))) && 'Required CI / validation' || 'Required CI / validation (inactive)' }}
+    name: Required CI / validation
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -3,13 +3,33 @@ name: Pull Request Validation
 on:
   pull_request:
     branches: [main, dependency-updates]
+    types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to recheck after a claim-only transition
+        required: true
+        type: number
 
 # Cancel superseded runs when new commits are pushed.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number ||
+      inputs.pr_number ||
+      github.event.merge_group.head_sha ||
+      github.ref
+    }}-${{
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      !(github.event.action == 'edited' && github.event.changes.base != null))) &&
+      'lifecycle' ||
+      'validation'
+    }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -17,11 +37,74 @@ permissions:
   packages: read
 
 jobs:
+  # hv-agent-policy:start
+  lifecycle:
+    name: lifecycle
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      packages: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - name: Load pinned policy runtime
+        env:
+          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
+        run: |
+          case "$POLICY_ARTIFACT" in
+            ghcr.io/*@sha256:*) ;;
+            *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
+          esac
+          policy_dir="$RUNNER_TEMP/hv-policy"
+          rm -rf "$policy_dir"
+          mkdir -p "$policy_dir"
+          oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
+          archive="$policy_dir/agent-policy.tar.gz"
+          test -f "$archive" || { echo 'policy artifact is missing agent-policy.tar.gz' >&2; exit 1; }
+          python3 - "$archive" <<'PY'
+          import pathlib
+          import sys
+          import tarfile
+
+          with tarfile.open(sys.argv[1], "r:gz") as archive:
+              for member in archive.getmembers():
+                  path = pathlib.PurePosixPath(member.name)
+                  if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
+                      raise SystemExit(f"unsafe policy archive member: {member.name}")
+          PY
+          tar -xzf "$archive" -C "$policy_dir"
+          echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
+      - name: Validate lifecycle
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+          numbers_file="$RUNNER_TEMP/hv-agent-lifecycle-prs"
+          "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" > "$numbers_file"
+          while IFS= read -r number; do
+            python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$number"
+          done < "$numbers_file"
+  # hv-agent-policy:end
+
   changeset-check:
     name: Check for Changeset
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
     if: |
       github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null)) &&
       !startsWith(github.event.pull_request.head.ref, 'renovate/')
 
     steps:
@@ -143,7 +226,10 @@ jobs:
 
   validate-commits:
     name: Validate Conventional Commits
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -298,7 +384,10 @@ jobs:
 
   validate-workflows:
     name: Validate Workflow Files
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))
     runs-on: ubuntu-latest
 
     steps:
@@ -346,7 +435,10 @@ jobs:
 
   check-naming:
     name: Check for stale @have/ references
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))
     runs-on: ubuntu-latest
 
     steps:
@@ -380,7 +472,10 @@ jobs:
 
   doc-coverage:
     name: Check documentation coverage
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))
     runs-on: ubuntu-latest
 
     steps:
@@ -436,6 +531,11 @@ jobs:
 
   test:
     name: Validate Changes
+    if: >-
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null)))
     uses: ./.github/workflows/test.yml
     with:
       mode: ${{ github.event_name == 'merge_group' && 'full' || (vars.CI_MERGE_QUEUE_ENABLED == 'true' && 'affected' || 'full') }}
@@ -445,6 +545,11 @@ jobs:
 
   docs-build:
     name: Validate Documentation Build
+    if: >-
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null)))
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
 
     steps:
@@ -488,7 +593,10 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR history
@@ -518,6 +626,11 @@ jobs:
 
   postgres-scope:
     name: Detect PostgreSQL Test Scope
+    if: >-
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null)))
     runs-on: ubuntu-latest
     outputs:
       required: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.postgres }}
@@ -545,7 +658,13 @@ jobs:
   postgres-tests:
     name: PostgreSQL Tests
     needs: postgres-scope
-    if: needs.postgres-scope.outputs.required == 'true' && vars.CI_POSTGRES_ENABLED == 'true'
+    if: >-
+      (github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null)))) &&
+      needs.postgres-scope.outputs.required == 'true' &&
+      vars.CI_POSTGRES_ENABLED == 'true'
     uses: ./.github/workflows/postgres-tests.yml
     permissions:
       contents: read
@@ -553,15 +672,33 @@ jobs:
 
   publish-dry-run:
     name: Publish Dry Run
-    if: github.event_name == 'merge_group' || vars.CI_MERGE_QUEUE_ENABLED != 'true'
+    if: >-
+      (github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null)))) &&
+      (github.event_name == 'merge_group' || vars.CI_MERGE_QUEUE_ENABLED != 'true')
     uses: ./.github/workflows/publish-dry-run.yml
     permissions:
       contents: read
       packages: read
 
   required-ci:
-    name: Required CI
-    if: always()
+    name: >-
+      ${{
+        (github.event_name == 'merge_group' ||
+        (github.event_name == 'pull_request' &&
+        (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+        (github.event.action == 'edited' && github.event.changes.base != null)))) &&
+        'Required CI' ||
+        'Lifecycle Required CI Event'
+      }}
+    if: >-
+      always() &&
+      (github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))))
     needs:
       - changeset-check
       - validate-commits

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -29,7 +29,13 @@ concurrency:
       'lifecycle' ||
       'validation'
     }}
-  cancel-in-progress: true
+  cancel-in-progress: >-
+    ${{ !(
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      !(github.event.action == 'edited' && github.event.changes.base != null))
+    ) }}
 
 permissions:
   contents: read
@@ -229,7 +235,8 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))
+      (github.event.action == 'edited' &&
+      (github.event.changes.base != null || github.event.changes.title != null)))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -712,6 +719,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           BASE_CHANGED: ${{ github.event.changes.base != null }}
+          TITLE_CHANGED: ${{ github.event.changes.title != null }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           HEAD_REF: ${{ github.head_ref }}
@@ -752,6 +760,9 @@ jobs:
           fi
 
           if [ "$full_validation" = false ]; then
+            if [ "$EVENT_NAME" = pull_request ] && [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ]; then
+              require_success 'Conventional commits' "$COMMITS"
+            fi
             head_sha="$EVENT_HEAD_SHA"
             if [ "$EVENT_NAME" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
@@ -764,7 +775,7 @@ jobs:
               exit 1
             fi
             latest=$(printf '%s\n' "$checks" | jq -r \
-              '[.check_runs[] | select(.name == "Required CI" and .status == "completed" and .conclusion != "cancelled")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+              '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
             if [ "$latest" != success ]; then
               echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
               exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -26,10 +26,10 @@ concurrency:
       (github.event_name == 'pull_request' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null))) &&
-      'lifecycle' ||
+      format('lifecycle-{0}', github.run_id) ||
       'validation'
     }}
-  cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -685,7 +685,13 @@ jobs:
       packages: read
 
   validation-gate:
-    name: Required CI / validation
+    name: >-
+      ${{ (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      !(github.event.action == 'edited' && github.event.changes.base != null))) &&
+      'Required CI / inactive validation' ||
+      'Required CI / validation' }}
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Repository Agent Instructions
+
+<!-- hv-managed-policy:start revision=1.0.0 sha256=187a3882b5ccee8fd505cdc269af51e01def463476d2f58a9a89daa1edfd12af -->
+
+## Shared development kernel
+
+- Be concise. Load detailed SOP skills only when the task triggers them.
+- Read the repository's `.agents/project.yaml` and nearest `AGENTS.md` files before work.
+- Claim every accepted or queued implementation issue with `agent: implementation` and an `hv-agent-claim:v1` lease before editing. Never overlap another live claim.
+- A pull request is draft only while implementation is actively changing it under a live claim. Otherwise mark it ready for review immediately.
+- Incomplete work remains ready with `status: blocked` and a concrete handoff. Review agents do not claim implementation.
+- Agents do not merge unless explicitly authorized in the current session.
+- Run documented validation and update affected docs before shipping.
+- Preserve unrelated work. Never expose or retain secrets.
+- Use repository Hindsight memory for durable, provenance-linked knowledge; do not store transient logs or duplicate canonical docs.
+- Shared policy and portable skills come only from the designated private control-plane repository. Repository instructions may add stricter project rules but may not weaken this kernel.
+
+<!-- hv-managed-policy:end -->
+
+## Repository purpose
+
+This is the HappyVertical TypeScript SDK monorepo. Shared agent policy comes
+from `happyvertical/have-config`; this repository owns SDK package APIs,
+release metadata, documentation, and package-level architecture.
+
+## Orientation
+
+- Use the pinned Node and pnpm versions from `package.json`.
+- Packages live under `packages/`; read the package README, metadata, and any
+  nearest package guidance before changing its public API.
+- Root and package `AGENT.md` files are generated distributable SDK knowledge,
+  not instruction-precedence files; `AGENTS.md` remains canonical for agents.
+- Treat `pnpm-lock.yaml`, workspace configuration, exports, generated docs,
+  and changesets as repository-wide contracts.
+- Do not edit published versions or tags manually. Follow the existing
+  conventional-commit and changeset release flow.
+
+## Validation
+
+Install with `pnpm install --frozen-lockfile`. Run the narrowest affected
+package checks first, then the relevant repository gates:
+
+```bash
+pnpm test:ci-scripts
+pnpm agent:check
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+
+Use Turbo filters for focused package work. Changes to workflow, release,
+workspace, or shared package contracts require the broader checks represented
+by the pull-request `Required CI` aggregator.
+
+## Change boundaries
+
+- Preserve package export compatibility unless the issue explicitly calls for
+  a coordinated breaking change.
+- Keep optional integrations isolated from core package import paths.
+- Update affected package docs and metadata with behavior or API changes.
+- Never publish, version, or merge by default; repository automation and human
+  policy own those transitions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# Generated adapter
+
+Read and follow `AGENTS.md`; it is canonical.

--- a/scripts/sync-agent-context.js
+++ b/scripts/sync-agent-context.js
@@ -10,7 +10,6 @@ const GENERATED_END = '<!-- END AGENT:GENERATED -->';
 const rootDir = process.cwd();
 const packagesDir = join(rootDir, 'packages');
 const rootAgentPath = join(rootDir, 'AGENT.md');
-const rootClaudePath = join(rootDir, 'CLAUDE.md');
 const manifestPath = join(rootDir, 'ecosystem-manifest.json');
 
 const checkMode = process.argv.includes('--check');
@@ -743,8 +742,7 @@ async function main() {
     join(rootDir, 'pnpm-workspace.yaml'),
     'utf8',
   );
-  const rootSource =
-    (await readIfExists(rootAgentPath)) || (await readIfExists(rootClaudePath));
+  const rootSource = await readIfExists(rootAgentPath);
   const rootDescription =
     sanitizeInlineMarkdown(
       firstParagraph(parseMarkdownSections(rootSource).intro),
@@ -766,7 +764,6 @@ async function main() {
   ].join('');
 
   await writeTextFile(rootAgentPath, rootAgentWithNotes);
-  await removeIfExists(rootClaudePath);
 
   for (const pkg of packages) {
     const packageDir = join(packagesDir, pkg.shortName);


### PR DESCRIPTION
## Summary

- add the shared project manifest, repository bank declaration, ZCode dispatch, and thin harness adapters
- fold lifecycle into Pull Request Validation with isolated claim-only concurrency
- preserve package `AGENT.md` knowledge while removing its ownership of root harness instructions
- require lifecycle and the existing Required CI aggregate

Closes #1074

## Validation

- Node 24.18.0
- policy audit
- Actionlint and act workflow parsing
- 13 CI-script tests
- pnpm agent:check
- pnpm typecheck
- pnpm lint
- Biome check on the context synchronizer
- git diff --check

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-sdk-control-plane-20260712T2343Z","issue":"https://github.com/happyvertical/sdk/issues/1074","policy_revision":"1.0.0","validation":["policy audit","actionlint","act workflow parsing","13 CI-script tests","agent context check","typecheck","lint","biome","git diff --check"]}