### PR TITLE
ci(ci): shallow clone exhaustive validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 0
+          # Affected validation compares against the PR base and needs history.
+          # Full validation does not; avoid spending the job timeout fetching it.
+          fetch-depth: ${{ inputs.mode == 'affected' && '0' || '1' }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # Affected validation compares against the PR base and needs history.
-          # Full validation does not; avoid spending the job timeout fetching it.
-          fetch-depth: ${{ inputs.mode == 'affected' && '0' || '1' }}
+          # Affected validation needs the PR merge commit plus its base/head parents.
+          # Neither mode needs every branch and tag from the repository history.
+          fetch-depth: ${{ inputs.mode == 'affected' && '2' || '1' }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment


### PR DESCRIPTION
## Summary

- use a depth-1 checkout for exhaustive/full validation
- use a depth-2 checkout for affected PR validation so the merge commit and base/head parents are available
- prevent repository-wide branch and tag history transfer from consuming the 40-minute job timeout

Closes #1077

## Validation

- `actionlint .github/workflows/test.yml`
- workflow parsing through the pre-commit hook
- `pnpm test:ci-scripts` (13 tests)
- `pnpm agent:check`
- pre-push `pnpm typecheck`
- depth-2 fetch of `refs/pull/1078/merge` retained the exact base SHA in an 11.27 MiB pack
- `git diff --check`

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex:priority-readiness","issue":"https://github.com/happyvertical/sdk/issues/1077","policy_revision":"1.0.0","validation":["actionlint","workflow parsing","13 CI-script tests","agent context check","typecheck","depth-2 PR merge fetch","git diff --check"]}