### PR TITLE
fix(projects): map GitHub board item details

### DIFF
--- a/.changeset/fuzzy-cards-render.md
+++ b/.changeset/fuzzy-cards-render.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/projects": patch
+---
+
+Make `GitHubProject.listItems()` return Projects V2 item types, top-level content metadata, human-readable provider field values, and statuses while preserving the 100-item default limit, paging within GitHub's query limits, and skipping inaccessible content.

--- a/packages/projects/README.md
+++ b/packages/projects/README.md
@@ -130,6 +130,9 @@ Get project details including fields and statuses.
 
 Add an issue or pull request to the project.
 
+The GitHub adapter returns the created item's identity and content type. Use
+`listItems()` when content metadata, status, or provider fields are required.
+
 **Parameters:**
 - `contentId: string` - Node ID of the issue or PR (from @happyvertical/repos)
 
@@ -146,6 +149,9 @@ Remove an item from the project.
 
 Get a specific project item.
 
+The GitHub adapter returns item identity and content type only. Use
+`listItems()` for the enriched content metadata, status, and provider fields.
+
 **Parameters:**
 - `itemId: string` - Project item ID
 
@@ -153,10 +159,18 @@ Get a specific project item.
 
 ##### `listItems(filters?: ItemFilters): Promise<ProjectItem[]>`
 
-List all items in the project.
+List items in the project. The GitHub adapter follows Projects V2 pagination,
+skips deleted or inaccessible content, and returns each item's content type,
+status, provider field values, and top-level `title`, `url`, and `assignees`
+metadata for provider-neutral rendering. Provider fields remain separately
+keyed by their original names, even when a field has the same name as top-level
+metadata. Results default to at most 100 items and are fetched in pages sized to
+stay below GitHub's GraphQL node limit. A `limit` of 0 returns no items.
+The GitHub adapter currently applies only `limit` and `cursor`; callers should
+apply `status`, `assignees`, or `labels` filters to the returned items.
 
 **Parameters:**
-- `filters?: ItemFilters` - Optional filters (limit, cursor, status)
+- `filters?: ItemFilters` - Optional filters (`limit` defaults to 100)
 
 **Returns:** Array of project items
 

--- a/packages/projects/src/github/index.test.ts
+++ b/packages/projects/src/github/index.test.ts
@@ -1,0 +1,436 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitHubProject } from './index.js';
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock('@happyvertical/graphql', () => ({
+  // biome-ignore lint/style/useNamingConvention: Mock export must match the module export.
+  GraphQLClient: class {
+    query = mocks.query;
+    mutate = mocks.mutate;
+  },
+}));
+
+function createProject(statusFieldId?: string): GitHubProject {
+  return new GitHubProject({
+    type: 'github',
+    projectId: 'PVT_project',
+    token: 'test-token',
+    statusFieldId,
+  });
+}
+
+function content(
+  typename: 'Issue' | 'PullRequest' | 'DraftIssue',
+  id: string,
+  title = `${typename} title`,
+) {
+  return {
+    typename,
+    id,
+    title,
+    ...(typename === 'DraftIssue'
+      ? {}
+      : { url: `https://github.test/items/${id}` }),
+    assignees: {
+      nodes: [{ login: `${id}-owner` }],
+    },
+  };
+}
+
+function field(id: string, name: string) {
+  return { id, name };
+}
+
+function item(
+  id: string,
+  itemContent: ReturnType<typeof content> | null,
+  fieldValues: unknown[] = [],
+) {
+  return {
+    id,
+    content: itemContent,
+    fieldValues: { nodes: fieldValues },
+  };
+}
+
+function page(
+  nodes: unknown[],
+  pageInfo = { hasNextPage: false, endCursor: null as string | null },
+) {
+  return {
+    node: {
+      items: {
+        nodes,
+        pageInfo,
+      },
+    },
+  };
+}
+
+describe('GitHubProject item writes and reads', () => {
+  beforeEach(() => {
+    mocks.mutate.mockReset();
+    mocks.query.mockReset();
+  });
+
+  it('returns the added content type', async () => {
+    mocks.mutate.mockResolvedValue({
+      addProjectV2ItemById: {
+        item: {
+          id: 'PVTI_pr',
+          content: { id: 'PR_pr', typename: 'PullRequest' },
+        },
+      },
+    });
+
+    const result = await createProject().addItem('PR_pr');
+
+    expect(result).toEqual({
+      id: 'PVTI_pr',
+      contentId: 'PR_pr',
+      fields: {},
+      type: 'PullRequest',
+    });
+    expect(mocks.mutate.mock.calls[0]?.[0]).toContain('typename: __typename');
+  });
+
+  it('returns draft issues with their real type', async () => {
+    mocks.query.mockResolvedValue({
+      node: {
+        id: 'PVTI_draft',
+        content: { id: 'DI_draft', typename: 'DraftIssue' },
+      },
+    });
+
+    const result = await createProject().getItem('PVTI_draft');
+
+    expect(result).toEqual({
+      id: 'PVTI_draft',
+      contentId: 'DI_draft',
+      fields: {},
+      type: 'DraftIssue',
+    });
+    expect(mocks.query.mock.calls[0]?.[0]).toContain('... on DraftIssue');
+  });
+
+  it('returns null when an item or its content is inaccessible', async () => {
+    mocks.query.mockResolvedValue({
+      node: { id: 'PVTI_redacted', content: null },
+    });
+
+    await expect(createProject().getItem('PVTI_redacted')).resolves.toBeNull();
+  });
+});
+
+describe('GitHubProject.listItems', () => {
+  beforeEach(() => {
+    mocks.mutate.mockReset();
+    mocks.query.mockReset();
+  });
+
+  it('maps issues, pull requests, draft issues, content metadata, and provider fields', async () => {
+    mocks.query.mockResolvedValue(
+      page([
+        item('PVTI_issue', content('Issue', 'I_issue'), [
+          {
+            typename: 'ProjectV2ItemFieldSingleSelectValue',
+            field: field('status', 'Status'),
+            name: 'In Progress',
+          },
+          {
+            typename: 'ProjectV2ItemFieldNumberValue',
+            field: field('estimate', 'Estimate'),
+            number: 5,
+          },
+          {
+            typename: 'ProjectV2ItemFieldDateValue',
+            field: field('target-date', 'Target date'),
+            date: '2026-07-20',
+          },
+          {
+            typename: 'ProjectV2ItemFieldIterationValue',
+            field: field('iteration', 'Iteration'),
+            title: 'Sprint 1',
+          },
+          {
+            typename: 'ProjectV2ItemFieldLabelValue',
+            field: field('labels', 'Labels'),
+            labels: { nodes: [{ name: 'bug' }, null] },
+          },
+          {
+            typename: 'ProjectV2ItemFieldMilestoneValue',
+            field: field('milestone', 'Milestone'),
+            milestone: { title: 'MVP' },
+          },
+          {
+            typename: 'ProjectV2ItemFieldPullRequestValue',
+            field: field('linked-prs', 'Linked pull requests'),
+            pullRequests: {
+              nodes: [{ url: 'https://github.test/pulls/1' }, null],
+            },
+          },
+          {
+            typename: 'ProjectV2ItemFieldRepositoryValue',
+            field: field('repository', 'Repository'),
+            repository: { nameWithOwner: 'happyvertical/sdk' },
+          },
+          {
+            typename: 'ProjectV2ItemFieldReviewerValue',
+            field: field('reviewers', 'Reviewers'),
+            reviewers: {
+              nodes: [{ login: 'octocat' }, { slug: 'sdk-team' }, null],
+            },
+          },
+          {
+            typename: 'ProjectV2ItemFieldTextValue',
+            field: field('notes', 'Notes'),
+            text: 'Ready for review',
+          },
+          {
+            typename: 'ProjectV2ItemFieldTextValue',
+            field: field('custom-title', 'title'),
+            text: 'Custom title field',
+          },
+          {
+            typename: 'ProjectV2ItemFieldTextValue',
+            field: field('custom-url', 'url'),
+            text: 'Custom URL field',
+          },
+          {
+            typename: 'ProjectV2ItemFieldTextValue',
+            field: field('custom-assignees', 'assignees'),
+            text: 'Custom assignees field',
+          },
+          {
+            typename: 'ProjectV2ItemFieldTextValue',
+            field: field('prototype-name', '__proto__'),
+            text: 'Prototype-safe field',
+          },
+          {
+            typename: 'ProjectV2ItemFieldUserValue',
+            field: field('owners', 'Owners'),
+            users: { nodes: [{ login: 'willgriffin' }, null] },
+          },
+          {
+            typename: 'ProjectV2ItemIssueFieldValue',
+            field: field('roadmap', 'Roadmap'),
+            issueFieldValue: {
+              typename: 'IssueFieldSingleSelectValue',
+              name: 'Committed',
+              singleSelectValue: 'committed',
+            },
+          },
+          {
+            typename: 'ProjectV2ItemIssueFieldValue',
+            field: field('teams', 'Teams'),
+            issueFieldValue: {
+              typename: 'IssueFieldMultiSelectValue',
+              multiSelectOptions: [{ name: 'Platform' }, { name: 'SDK' }],
+            },
+          },
+        ]),
+        item('PVTI_pr', content('PullRequest', 'PR_pr')),
+        item('PVTI_draft', content('DraftIssue', 'DI_draft')),
+      ]),
+    );
+
+    const result = await createProject().listItems();
+    const expectedProviderFields = Object.fromEntries([
+      ['Status', 'In Progress'],
+      ['Estimate', 5],
+      ['Target date', '2026-07-20'],
+      ['Iteration', 'Sprint 1'],
+      ['Labels', ['bug']],
+      ['Milestone', 'MVP'],
+      ['Linked pull requests', ['https://github.test/pulls/1']],
+      ['Repository', 'happyvertical/sdk'],
+      ['Reviewers', ['octocat', 'sdk-team']],
+      ['Notes', 'Ready for review'],
+      ['title', 'Custom title field'],
+      ['url', 'Custom URL field'],
+      ['assignees', 'Custom assignees field'],
+      ['__proto__', 'Prototype-safe field'],
+      ['Owners', ['willgriffin']],
+      ['Roadmap', 'Committed'],
+      ['Teams', ['Platform', 'SDK']],
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      id: 'PVTI_issue',
+      contentId: 'I_issue',
+      type: 'Issue',
+      title: 'Issue title',
+      url: 'https://github.test/items/I_issue',
+      assignees: ['I_issue-owner'],
+      status: 'In Progress',
+      fields: expectedProviderFields,
+    });
+    expect(Object.getPrototypeOf(result[0]?.fields)).toBe(Object.prototype);
+    expect(Object.hasOwn(result[0]?.fields ?? {}, '__proto__')).toBe(true);
+    expect(result[1]).toMatchObject({
+      id: 'PVTI_pr',
+      contentId: 'PR_pr',
+      type: 'PullRequest',
+      title: 'PullRequest title',
+      url: 'https://github.test/items/PR_pr',
+      assignees: ['PR_pr-owner'],
+      fields: {},
+    });
+    expect(result[2]).toMatchObject({
+      id: 'PVTI_draft',
+      contentId: 'DI_draft',
+      type: 'DraftIssue',
+      title: 'DraftIssue title',
+      url: null,
+      assignees: ['DI_draft-owner'],
+      fields: {},
+    });
+
+    const [query] = mocks.query.mock.calls[0] ?? [];
+    expect(query).toContain('fieldValues(first: 50)');
+    expect(query).toContain('labels(first: 100)');
+    expect(query).toContain('pullRequests(first: 100)');
+    expect(query).toContain('reviewers(first: 100)');
+    expect(query).toContain('users(first: 100)');
+  });
+
+  it('uses a configured status field instead of the canonical Status field', async () => {
+    mocks.query.mockResolvedValue(
+      page([
+        item('PVTI_issue', content('Issue', 'I_issue'), [
+          {
+            typename: 'ProjectV2ItemFieldSingleSelectValue',
+            field: field('canonical-status', 'Status'),
+            name: 'Todo',
+          },
+          {
+            typename: 'ProjectV2ItemFieldSingleSelectValue',
+            field: field('custom-phase', 'Phase'),
+            name: 'Building',
+          },
+        ]),
+      ]),
+    );
+
+    const [result] = await createProject('custom-phase').listItems();
+
+    expect(result.status).toBe('Building');
+    expect(result.fields).toMatchObject(
+      Object.fromEntries([
+        ['Status', 'Todo'],
+        ['Phase', 'Building'],
+      ]),
+    );
+  });
+
+  it('skips deleted or inaccessible item content', async () => {
+    mocks.query.mockResolvedValueOnce(
+      page([
+        null,
+        item('PVTI_redacted', null),
+        item('PVTI_issue', content('Issue', 'I_issue')),
+      ]),
+    );
+
+    const result = await createProject().listItems();
+
+    expect(result.map((projectItem) => projectItem.id)).toEqual(['PVTI_issue']);
+  });
+
+  it('reports a missing or inaccessible project', async () => {
+    mocks.query.mockResolvedValue({ node: null });
+
+    await expect(createProject().listItems()).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('follows pagination from the requested cursor and honors the accessible-item limit', async () => {
+    mocks.query
+      .mockResolvedValueOnce(
+        page(
+          [
+            item('PVTI_issue', content('Issue', 'I_issue')),
+            item('PVTI_redacted', null),
+          ],
+          { hasNextPage: true, endCursor: 'cursor-1' },
+        ),
+      )
+      .mockResolvedValueOnce(
+        page([item('PVTI_pr', content('PullRequest', 'PR_pr'))]),
+      );
+
+    const result = await createProject().listItems({
+      cursor: 'starting-cursor',
+      limit: 2,
+    });
+
+    expect(result.map((projectItem) => projectItem.id)).toEqual([
+      'PVTI_issue',
+      'PVTI_pr',
+    ]);
+    expect(mocks.query).toHaveBeenCalledTimes(2);
+    expect(mocks.query.mock.calls[0]?.[1]).toEqual({
+      projectId: 'PVT_project',
+      first: 2,
+      after: 'starting-cursor',
+    });
+    expect(mocks.query.mock.calls[1]?.[1]).toEqual({
+      projectId: 'PVT_project',
+      first: 20,
+      after: 'cursor-1',
+    });
+  });
+
+  it('only requests the remaining count when prior content was accessible', async () => {
+    mocks.query
+      .mockResolvedValueOnce(
+        page(
+          Array.from({ length: 20 }, (_, index) =>
+            item(`PVTI_${index}`, content('Issue', `I_${index}`)),
+          ),
+          { hasNextPage: true, endCursor: 'cursor-1' },
+        ),
+      )
+      .mockResolvedValueOnce(
+        page(
+          Array.from({ length: 5 }, (_, index) =>
+            item(`PVTI_${index + 20}`, content('Issue', `I_${index + 20}`)),
+          ),
+        ),
+      );
+
+    const result = await createProject().listItems({ limit: 25 });
+
+    expect(result).toHaveLength(25);
+    expect(mocks.query.mock.calls[0]?.[1].first).toBe(20);
+    expect(mocks.query.mock.calls[1]?.[1].first).toBe(5);
+  });
+
+  it('preserves the historical 100-item default limit', async () => {
+    for (let pageIndex = 0; pageIndex < 5; pageIndex += 1) {
+      mocks.query.mockResolvedValueOnce(
+        page(
+          Array.from({ length: 20 }, (_, itemIndex) => {
+            const id = `${pageIndex}-${itemIndex}`;
+            return item(`PVTI_${id}`, content('Issue', `I_${id}`));
+          }),
+          { hasNextPage: true, endCursor: `cursor-${pageIndex}` },
+        ),
+      );
+    }
+
+    const result = await createProject().listItems();
+
+    expect(result).toHaveLength(100);
+    expect(mocks.query).toHaveBeenCalledTimes(5);
+    for (const [, variables] of mocks.query.mock.calls) {
+      expect(variables.first).toBe(20);
+    }
+  });
+});

--- a/packages/projects/src/github/index.ts
+++ b/packages/projects/src/github/index.ts
@@ -14,6 +14,85 @@ import type {
   Status,
 } from '../types.js';
 
+const GITHUB_DEFAULT_ITEMS_LIMIT = 100;
+const GITHUB_ITEMS_PAGE_SIZE = 20;
+
+interface GitHubProjectItemReference {
+  typename: ProjectItem['type'];
+  id: string;
+}
+
+interface GitHubProjectItemContent extends GitHubProjectItemReference {
+  title: string;
+  url?: string;
+  assignees: {
+    nodes: Array<{ login: string } | null>;
+  };
+}
+
+interface GitHubProjectFieldValue {
+  typename: string;
+  field?: {
+    id: string;
+    name: string;
+  };
+  date?: string | null;
+  title?: string;
+  labels?: {
+    nodes: Array<{ name: string } | null>;
+  } | null;
+  milestone?: {
+    title: string;
+  } | null;
+  number?: number | null;
+  pullRequests?: {
+    nodes: Array<{ url: string } | null>;
+  } | null;
+  repository?: {
+    nameWithOwner: string;
+  } | null;
+  reviewers?: {
+    nodes: Array<{
+      login?: string;
+      slug?: string;
+    } | null>;
+  } | null;
+  name?: string | null;
+  text?: string | null;
+  users?: {
+    nodes: Array<{ login: string } | null>;
+  } | null;
+  issueFieldValue?: {
+    typename: string;
+    name?: string;
+    dateValue?: string;
+    multiSelectOptions?: Array<{ name: string }>;
+    numberValue?: number;
+    singleSelectValue?: string;
+    textValue?: string;
+  } | null;
+}
+
+interface GitHubProjectItemNode {
+  id: string;
+  content: GitHubProjectItemContent | null;
+  fieldValues: {
+    nodes: Array<GitHubProjectFieldValue | null>;
+  };
+}
+
+interface GitHubProjectItemsPage {
+  node: {
+    items: {
+      nodes: Array<GitHubProjectItemNode | null>;
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string | null;
+      };
+    };
+  } | null;
+}
+
 /**
  * GitHub Projects V2 implementation
  */
@@ -143,6 +222,15 @@ export class GitHubProject implements IProject {
   }
 
   // Items
+  /**
+   * Add an issue or pull request to the configured GitHub project.
+   *
+   * The mutation result contains item identity and content type only. Use
+   * {@link listItems} when content metadata, status, or fields are required.
+   *
+   * @param contentId - GitHub node ID for the issue or pull request
+   * @returns The created provider-neutral project item
+   */
   async addItem(contentId: string): Promise<ProjectItem> {
     const mutation = `
       mutation($projectId: ID!, $contentId: ID!) {
@@ -155,9 +243,11 @@ export class GitHubProject implements IProject {
             content {
               ... on Issue {
                 id
+                typename: __typename
               }
               ... on PullRequest {
                 id
+                typename: __typename
               }
             }
           }
@@ -172,9 +262,7 @@ export class GitHubProject implements IProject {
       addProjectV2ItemById: {
         item: {
           id: string;
-          content: {
-            id: string;
-          };
+          content: GitHubProjectItemReference;
         };
       };
     };
@@ -183,7 +271,7 @@ export class GitHubProject implements IProject {
       id: data.addProjectV2ItemById.item.id,
       contentId: data.addProjectV2ItemById.item.content.id,
       fields: {},
-      type: 'Issue',
+      type: data.addProjectV2ItemById.item.content.typename,
     };
   }
 
@@ -205,6 +293,15 @@ export class GitHubProject implements IProject {
     });
   }
 
+  /**
+   * Get one GitHub Projects V2 item by its project-item ID.
+   *
+   * This identity lookup does not hydrate content metadata, status, or fields.
+   * Use {@link listItems} for the enriched board-item representation.
+   *
+   * @param itemId - GitHub project-item node ID
+   * @returns The item, or `null` when it or its content is inaccessible
+   */
   async getItem(itemId: string): Promise<ProjectItem | null> {
     const query = `
       query($itemId: ID!) {
@@ -214,9 +311,15 @@ export class GitHubProject implements IProject {
             content {
               ... on Issue {
                 id
+                typename: __typename
               }
               ... on PullRequest {
                 id
+                typename: __typename
+              }
+              ... on DraftIssue {
+                id
+                typename: __typename
               }
             }
           }
@@ -227,13 +330,11 @@ export class GitHubProject implements IProject {
     const data = (await this.graphql.query(query, { itemId })) as {
       node: {
         id: string;
-        content: {
-          id: string;
-        };
+        content: Partial<GitHubProjectItemReference> | null;
       } | null;
     };
 
-    if (!data.node) {
+    if (!data.node?.content?.id || !data.node.content.typename) {
       return null;
     }
 
@@ -241,10 +342,19 @@ export class GitHubProject implements IProject {
       id: data.node.id,
       contentId: data.node.content.id,
       fields: {},
-      type: 'Issue',
+      type: data.node.content.typename,
     };
   }
 
+  /**
+   * List GitHub Projects V2 items after an optional cursor.
+   *
+   * Deleted or inaccessible content is skipped, and the result defaults to at
+   * most 100 accessible items to preserve the adapter's historical limit.
+   *
+   * @param filters - Optional cursor and maximum result count
+   * @returns Provider-neutral project items with content metadata and fields
+   */
   async listItems(filters?: ItemFilters): Promise<ProjectItem[]> {
     const query = `
       query($projectId: ID!, $first: Int!, $after: String) {
@@ -256,9 +366,169 @@ export class GitHubProject implements IProject {
                 content {
                   ... on Issue {
                     id
+                    typename: __typename
+                    title
+                    url
+                    assignees(first: 100) {
+                      nodes {
+                        login
+                      }
+                    }
                   }
                   ... on PullRequest {
                     id
+                    typename: __typename
+                    title
+                    url
+                    assignees(first: 100) {
+                      nodes {
+                        login
+                      }
+                    }
+                  }
+                  ... on DraftIssue {
+                    id
+                    typename: __typename
+                    title
+                    assignees(first: 100) {
+                      nodes {
+                        login
+                      }
+                    }
+                  }
+                }
+                fieldValues(first: 50) {
+                  nodes {
+                    typename: __typename
+                    # GitHub Projects have at most 50 fields. A 20-item page and
+                    # four 100-node nested connections stay below GitHub's
+                    # 500,000-node query limit while avoiding partial values.
+                    ... on ProjectV2ItemFieldDateValue {
+                      field {
+                        ...ProjectField
+                      }
+                      date
+                    }
+                    ... on ProjectV2ItemFieldIterationValue {
+                      field {
+                        ...ProjectField
+                      }
+                      title
+                    }
+                    ... on ProjectV2ItemFieldLabelValue {
+                      field {
+                        ...ProjectField
+                      }
+                      labels(first: 100) {
+                        nodes {
+                          name
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldMilestoneValue {
+                      field {
+                        ...ProjectField
+                      }
+                      milestone {
+                        title
+                      }
+                    }
+                    ... on ProjectV2ItemFieldNumberValue {
+                      field {
+                        ...ProjectField
+                      }
+                      number
+                    }
+                    ... on ProjectV2ItemFieldPullRequestValue {
+                      field {
+                        ...ProjectField
+                      }
+                      pullRequests(first: 100) {
+                        nodes {
+                          url
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldRepositoryValue {
+                      field {
+                        ...ProjectField
+                      }
+                      repository {
+                        nameWithOwner
+                      }
+                    }
+                    ... on ProjectV2ItemFieldReviewerValue {
+                      field {
+                        ...ProjectField
+                      }
+                      reviewers(first: 100) {
+                        nodes {
+                          ... on Bot {
+                            login
+                          }
+                          ... on EnterpriseTeam {
+                            slug
+                          }
+                          ... on Mannequin {
+                            login
+                          }
+                          ... on Team {
+                            slug
+                          }
+                          ... on User {
+                            login
+                          }
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      field {
+                        ...ProjectField
+                      }
+                      name
+                    }
+                    ... on ProjectV2ItemFieldTextValue {
+                      field {
+                        ...ProjectField
+                      }
+                      text
+                    }
+                    ... on ProjectV2ItemFieldUserValue {
+                      field {
+                        ...ProjectField
+                      }
+                      users(first: 100) {
+                        nodes {
+                          login
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemIssueFieldValue {
+                      field {
+                        ...ProjectField
+                      }
+                      issueFieldValue {
+                        typename: __typename
+                        ... on IssueFieldDateValue {
+                          dateValue: value
+                        }
+                        ... on IssueFieldMultiSelectValue {
+                          multiSelectOptions: options {
+                            name
+                          }
+                        }
+                        ... on IssueFieldNumberValue {
+                          numberValue: value
+                        }
+                        ... on IssueFieldSingleSelectValue {
+                          name
+                          singleSelectValue: value
+                        }
+                        ... on IssueFieldTextValue {
+                          textValue: value
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -270,31 +540,175 @@ export class GitHubProject implements IProject {
           }
         }
       }
+
+      fragment ProjectField on ProjectV2FieldCommon {
+        id
+        name
+      }
     `;
 
-    const data = (await this.graphql.query(query, {
-      projectId: this.projectId,
-      first: filters?.limit || 100,
-      after: filters?.cursor,
-    })) as {
-      node: {
-        items: {
-          nodes: Array<{
-            id: string;
-            content: {
-              id: string;
-            };
-          }>;
-        };
-      };
-    };
+    const requestedLimit = filters?.limit ?? GITHUB_DEFAULT_ITEMS_LIMIT;
+    const limit = Number.isFinite(requestedLimit)
+      ? Math.max(0, Math.floor(requestedLimit))
+      : GITHUB_DEFAULT_ITEMS_LIMIT;
+    if (limit === 0) {
+      return [];
+    }
 
-    return data.node.items.nodes.map((item) => ({
+    const items: ProjectItem[] = [];
+    let after = filters?.cursor;
+    let fillPage = false;
+    const seenCursors = new Set<string>();
+
+    while (items.length < limit) {
+      const remaining = limit - items.length;
+      const first = fillPage
+        ? GITHUB_ITEMS_PAGE_SIZE
+        : Math.min(GITHUB_ITEMS_PAGE_SIZE, remaining);
+      const data = await this.graphql.query<GitHubProjectItemsPage>(query, {
+        projectId: this.projectId,
+        first,
+        after,
+      });
+      if (!data.node) {
+        throw new ProjectError(
+          `GitHub project ${this.projectId} was not found or is inaccessible`,
+          ProjectErrorCode.NOT_FOUND,
+        );
+      }
+      const connection = data.node.items;
+      let skippedContent = false;
+
+      for (const node of connection.nodes) {
+        if (!node) {
+          skippedContent = true;
+          continue;
+        }
+        const item = this.mapProjectItem(node);
+        if (item) {
+          items.push(item);
+        } else {
+          skippedContent = true;
+        }
+        if (items.length >= limit) {
+          break;
+        }
+      }
+      fillPage = skippedContent;
+
+      const { endCursor, hasNextPage } = connection.pageInfo;
+      if (
+        !hasNextPage ||
+        !endCursor ||
+        endCursor === after ||
+        seenCursors.has(endCursor)
+      ) {
+        break;
+      }
+      seenCursors.add(endCursor);
+      after = endCursor;
+    }
+
+    return items;
+  }
+
+  /**
+   * Convert one GitHub Projects V2 item into the provider-neutral item shape.
+   */
+  private mapProjectItem(item: GitHubProjectItemNode): ProjectItem | null {
+    const { content } = item;
+    if (!content) {
+      return null;
+    }
+
+    const fieldEntries: Array<[string, unknown]> = [];
+    let status: string | undefined;
+
+    for (const fieldValue of item.fieldValues.nodes) {
+      if (!fieldValue?.field) {
+        continue;
+      }
+      const value = this.mapProjectFieldValue(fieldValue);
+      if (value !== undefined) {
+        fieldEntries.push([fieldValue.field.name, value]);
+      }
+
+      const isStatusField = this.statusFieldId
+        ? fieldValue.field.id === this.statusFieldId
+        : fieldValue.field.name.toLowerCase() === 'status';
+      if (isStatusField && typeof value === 'string') {
+        status = value;
+      }
+    }
+
+    return {
       id: item.id,
-      contentId: item.content.id,
-      fields: {},
-      type: 'Issue' as const,
-    }));
+      contentId: content.id,
+      title: content.title,
+      url: content.url ?? null,
+      assignees: content.assignees.nodes.flatMap((assignee) =>
+        assignee ? [assignee.login] : [],
+      ),
+      status,
+      fields: Object.fromEntries(fieldEntries),
+      type: content.typename,
+    };
+  }
+
+  /**
+   * Convert GitHub's field-value union into stable scalar or string-array values.
+   */
+  private mapProjectFieldValue(value: GitHubProjectFieldValue): unknown {
+    switch (value.typename) {
+      case 'ProjectV2ItemFieldDateValue':
+        return value.date;
+      case 'ProjectV2ItemFieldIterationValue':
+        return value.title;
+      case 'ProjectV2ItemFieldLabelValue':
+        return value.labels?.nodes.flatMap((label) =>
+          label ? [label.name] : [],
+        );
+      case 'ProjectV2ItemFieldMilestoneValue':
+        return value.milestone?.title;
+      case 'ProjectV2ItemFieldNumberValue':
+        return value.number;
+      case 'ProjectV2ItemFieldPullRequestValue':
+        return value.pullRequests?.nodes.flatMap((pullRequest) =>
+          pullRequest ? [pullRequest.url] : [],
+        );
+      case 'ProjectV2ItemFieldRepositoryValue':
+        return value.repository?.nameWithOwner;
+      case 'ProjectV2ItemFieldReviewerValue':
+        return value.reviewers?.nodes.flatMap((reviewer) => {
+          const name = reviewer?.login ?? reviewer?.slug;
+          return name ? [name] : [];
+        });
+      case 'ProjectV2ItemFieldSingleSelectValue':
+        return value.name;
+      case 'ProjectV2ItemFieldTextValue':
+        return value.text;
+      case 'ProjectV2ItemFieldUserValue':
+        return value.users?.nodes.flatMap((user) => (user ? [user.login] : []));
+      case 'ProjectV2ItemIssueFieldValue': {
+        const issueValue = value.issueFieldValue;
+        switch (issueValue?.typename) {
+          case 'IssueFieldDateValue':
+            return issueValue.dateValue;
+          case 'IssueFieldMultiSelectValue':
+            return issueValue.multiSelectOptions?.map((option) => option.name);
+          case 'IssueFieldNumberValue':
+            return issueValue.numberValue;
+          case 'IssueFieldSingleSelectValue':
+            return issueValue.name ?? issueValue.singleSelectValue;
+          case 'IssueFieldTextValue':
+            return issueValue.textValue;
+          default:
+            return undefined;
+        }
+      }
+      default:
+        return undefined;
+    }
   }
 
   // Status Management

--- a/packages/projects/src/types.ts
+++ b/packages/projects/src/types.ts
@@ -12,11 +12,25 @@ export interface Project {
   fields: Field[];
 }
 
+/**
+ * A provider-neutral item on a project board.
+ */
 export interface ProjectItem {
-  id: string; // Project item ID
-  contentId: string; // Issue/PR node ID
+  /** Provider project-item ID. */
+  id: string;
+  /** Provider content-node ID for the issue, pull request, or draft issue. */
+  contentId: string;
+  /** Content title when returned by the provider. */
+  title?: string;
+  /** Content URL, or `null` when the content has no provider URL. */
+  url?: string | null;
+  /** Provider usernames assigned to the content. */
+  assignees?: string[];
+  /** Selected status name from the configured or canonical status field. */
   status?: string;
+  /** Provider field values keyed by field name. */
   fields: Record<string, unknown>;
+  /** Kind of content represented by the project item. */
   type: 'Issue' | 'PullRequest' | 'DraftIssue';
 }
 
@@ -42,12 +56,20 @@ export interface FieldOption {
   color?: string;
 }
 
+/**
+ * Options for reading project items.
+ */
 export interface ItemFilters {
+  /** Return items in this status when supported by the provider. */
   status?: string;
+  /** Return items assigned to these provider usernames when supported. */
   assignees?: string[];
+  /** Return items with these labels when supported. */
   labels?: string[];
+  /** Maximum number of items to return. Defaults to 100; zero returns none. */
   limit?: number;
-  cursor?: string; // For pagination
+  /** Provider cursor after which item pagination begins. */
+  cursor?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- map GitHub Projects V2 issues, pull requests, and draft issues to their real `ProjectItem.type`
- return top-level title, URL, assignees, canonical/configured status, and human-readable provider field values from `listItems()`
- preserve the 100-item default with bounded pagination, skip inaccessible content, and safely handle arbitrary provider field names
- normalize issue multi-select values and align `addItem()` / `getItem()` identity types
- document the enriched listing contract and GitHub filter support

## Validation

- `pnpm --filter @happyvertical/projects test` (10 tests)
- live execution of the exact `listItems` and `getItem` queries against the GitHub GraphQL API
- `pnpm test:ci-scripts`
- `pnpm agent:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- final Codex, Claude, Copilot, and orchestrator review: no unresolved material findings

Closes #1076

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-019f5a1c-528a-7850-8c78-29e020180914","issue":"happyvertical/sdk#1076","policy_revision":"1.0.0","validation":["pnpm --filter @happyvertical/projects test (10 tests)","live GitHub GraphQL listItems/getItem query execution","pnpm test:ci-scripts","pnpm agent:check","pnpm typecheck","pnpm lint","pnpm build","four-perspective final review clean"]}
```