### PR TITLE
feat(files): inspect ZIP manifests safely

### DIFF
--- a/.changeset/secure-zips-wave.md
+++ b/.changeset/secure-zips-wave.md
@@ -2,4 +2,4 @@
 "@happyvertical/files": patch
 ---
 
-Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, ZIP64, encrypted, and multi-disk archives.
+Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, ZIP64, encrypted, and multi-disk archives.

--- a/.changeset/secure-zips-wave.md
+++ b/.changeset/secure-zips-wave.md
@@ -2,4 +2,4 @@
 "@happyvertical/files": patch
 ---
 
-Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, alternate filename encodings, creator-OS metadata conflicts, unverifiable compressed data descriptors, hidden local entries, ZIP64, encrypted, and multi-disk archives while preserving leading UTF-8 BOMs in inspected names.
+Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, alternate filename encodings, leading UTF-8 BOMs, creator-OS metadata conflicts, unverifiable compressed data descriptors, hidden local entries, ZIP64, encrypted, and multi-disk archives.

--- a/.changeset/secure-zips-wave.md
+++ b/.changeset/secure-zips-wave.md
@@ -2,4 +2,4 @@
 "@happyvertical/files": patch
 ---
 
-Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, alternate filename encodings, creator-OS metadata conflicts, hidden local entries, ZIP64, encrypted, and multi-disk archives.
+Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, alternate filename encodings, creator-OS metadata conflicts, unverifiable compressed data descriptors, hidden local entries, ZIP64, encrypted, and multi-disk archives while preserving leading UTF-8 BOMs in inspected names.

--- a/.changeset/secure-zips-wave.md
+++ b/.changeset/secure-zips-wave.md
@@ -2,4 +2,4 @@
 "@happyvertical/files": patch
 ---
 
-Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, ZIP64, encrypted, and multi-disk archives.
+Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, hidden local entries, ZIP64, encrypted, and multi-disk archives.

--- a/.changeset/secure-zips-wave.md
+++ b/.changeset/secure-zips-wave.md
@@ -2,4 +2,4 @@
 "@happyvertical/files": patch
 ---
 
-Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, hidden local entries, ZIP64, encrypted, and multi-disk archives.
+Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, alternate filename encodings, hidden local entries, ZIP64, encrypted, and multi-disk archives.

--- a/.changeset/secure-zips-wave.md
+++ b/.changeset/secure-zips-wave.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/files": patch
+---
+
+Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, ZIP64, encrypted, and multi-disk archives.

--- a/.changeset/secure-zips-wave.md
+++ b/.changeset/secure-zips-wave.md
@@ -2,4 +2,4 @@
 "@happyvertical/files": patch
 ---
 
-Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, alternate filename encodings, hidden local entries, ZIP64, encrypted, and multi-disk archives.
+Add a bounded, zero-decompression `inspectZipManifest()` API with normalized file and directory metadata, typed malformed/unsafe/limit/unsupported-feature failures, configurable entry and size limits, and explicit rejection of traversal paths, symlinks, NUL bytes, non-portable Windows names, path aliases, alternate filename encodings, creator-OS metadata conflicts, hidden local entries, ZIP64, encrypted, and multi-disk archives.

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -140,8 +140,10 @@ so an extractor cannot select a different path or character encoding from the
 one inspected. PKWARE and ASi Unix extra fields are likewise rejected because
 they can supply link targets;
 libarchive's `xl` field is rejected because it can override the inspected file
-type. These alternate-metadata cases, along with contradictory Unix file and
-directory attributes, use
+type. Unix file-type bits are honored only for Unix- or Darwin-origin central
+headers; file-type bits claimed by DOS, NTFS, or other creator systems are
+rejected. These alternate-metadata cases, along with contradictory Unix file
+and directory attributes, use
 `UnsupportedZipFeatureError` with the `ambiguous-metadata` feature. This API is
 a metadata preflight, not an extraction API; consumers that later extract an
 accepted archive must still use an extraction destination and library with

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -129,7 +129,8 @@ Unicode path extra fields are rejected so an extractor cannot select a
 different path from the one inspected. PKWARE and ASi Unix extra fields are
 likewise rejected because they can supply link targets; libarchive's `xl`
 field is rejected because it can override the inspected file type. These
-alternate-metadata cases use
+alternate-metadata cases, along with contradictory Unix file and directory
+attributes, use
 `UnsupportedZipFeatureError` with the `ambiguous-metadata` feature. This API is
 a metadata preflight, not an extraction API; consumers that later extract an
 accepted archive must still use an extraction destination and library with

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -135,9 +135,10 @@ are rejected. Signed and unsigned 32-bit data descriptors are cross-checked
 against their central-directory entry; missing, truncated, or inconsistent
 descriptors are rejected. Entry names use strict UTF-8 decoding whether or not
 the UTF-8 flag is set, so common macOS ZIPs with valid names remain compatible.
-Info-ZIP and Xceed Unicode path extra fields are rejected so an extractor
-cannot select a different path from the one inspected. PKWARE and ASi Unix
-extra fields are likewise rejected because they can supply link targets;
+PKWARE alternate-encoding, Info-ZIP, and Xceed path extra fields are rejected
+so an extractor cannot select a different path or character encoding from the
+one inspected. PKWARE and ASi Unix extra fields are likewise rejected because
+they can supply link targets;
 libarchive's `xl` field is rejected because it can override the inspected file
 type. These alternate-metadata cases, along with contradictory Unix file and
 directory attributes, use

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -136,9 +136,10 @@ against their central-directory entry; missing, truncated, or inconsistent
 descriptors are rejected. Data descriptors on compressed entries are also
 rejected because their payload boundary cannot be verified without
 decompression; classic descriptors remain supported for stored entries. Entry
-names use strict UTF-8 decoding whether or not the UTF-8 flag is set, preserve
-a leading UTF-8 BOM as part of the path, and keep common macOS ZIPs with valid
-names compatible.
+names use strict UTF-8 decoding whether or not the UTF-8 flag is set. Leading
+UTF-8 BOMs are rejected because filename decoders disagree on whether the BOM
+is part of the extracted path; common macOS ZIPs with valid UTF-8 names remain
+compatible.
 PKWARE alternate-encoding, Info-ZIP, and Xceed path extra fields are rejected
 so an extractor cannot select a different path or character encoding from the
 one inspected. PKWARE and ASi Unix extra fields are likewise rejected because

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -112,7 +112,7 @@ metadata only. It does not decompress or materialize file bodies. Paths are
 returned with `/` separators and `.`/empty segments removed; names containing
 ordinary spaces remain valid. The whole archive is rejected for parent
 traversal, absolute/drive-qualified paths, NUL bytes, symlinks, Unix special
-files, or normalized path collisions.
+files, normalized path collisions, or file/descendant path conflicts.
 
 Default limits are 10,000 entries, 200 MiB per entry, 2 GiB aggregate declared
 uncompressed size, and 1,024 encoded path bytes. Entry count includes directory
@@ -121,8 +121,9 @@ with non-negative safe integers. The entry limit also bounds cumulative
 central-directory work while disambiguating end records in hostile comments.
 
 Policy is deliberately strict: ZIP64, encrypted, multi-disk, malformed,
-truncated, and non-UTF-8-name archives are rejected with typed errors. Raw
-entry names use strict UTF-8 decoding whether or not the UTF-8 flag is set, so
+truncated, and non-UTF-8-name archives are rejected with typed errors. Stored
+entries must also declare identical compressed and uncompressed sizes. Entry
+names use strict UTF-8 decoding whether or not the UTF-8 flag is set, so
 common macOS ZIPs with valid names remain compatible. Info-ZIP and Xceed
 Unicode path extra fields are rejected so an extractor cannot select a
 different path from the one inspected. PKWARE and ASi Unix extra fields are

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -113,8 +113,9 @@ returned with `/` separators and `.`/empty segments removed; names containing
 ordinary spaces remain valid. The whole archive is rejected for parent
 traversal, absolute/drive-qualified paths, NTFS alternate data stream paths
 containing colons, NUL bytes, Unix symlinks and special files, Windows reparse
-points, normalized path collisions, file/descendant path conflicts, or
-overlapping local entry ranges.
+points and reserved device names, path segments ending in dots or spaces,
+case-insensitive or Unicode-normalization path collisions, file/descendant path
+conflicts, or overlapping local entry ranges.
 
 Default limits are 10,000 entries, 200 MiB per entry, 2 GiB aggregate declared
 uncompressed size, and 1,024 encoded path bytes. Entry count includes directory

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -77,6 +77,63 @@ const buf = await fetchBuffer('https://example.com/image.png');
 await fetchToFile('https://example.com/file.zip', './downloads/file.zip');
 ```
 
+### Secure ZIP Manifest Inspection
+
+Inspect untrusted ZIP metadata before deciding whether to accept an upload:
+
+```typescript
+import {
+  inspectZipManifest,
+  ZipManifestError,
+  ZipManifestLimitError,
+} from '@happyvertical/files';
+
+try {
+  const manifest = inspectZipManifest(zipBytes, {
+    maxEntries: 2_000,
+    maxEntryUncompressedBytes: 50 * 1024 * 1024,
+    maxTotalUncompressedBytes: 500 * 1024 * 1024,
+  });
+
+  const files = manifest.entries
+    .filter((entry) => entry.type === 'file')
+    .map(({ path, size }) => ({ path, size }));
+} catch (error) {
+  if (error instanceof ZipManifestLimitError) {
+    console.error(error.limit, error.actual, error.maximum);
+  } else if (error instanceof ZipManifestError) {
+    console.error(error.code, error.message);
+  }
+}
+```
+
+`inspectZipManifest()` reads and cross-checks central-directory and local-header
+metadata only. It does not decompress or materialize file bodies. Paths are
+returned with `/` separators and `.`/empty segments removed; names containing
+ordinary spaces remain valid. The whole archive is rejected for parent
+traversal, absolute/drive-qualified paths, NUL bytes, symlinks, Unix special
+files, or normalized path collisions.
+
+Default limits are 10,000 entries, 200 MiB per entry, 2 GiB aggregate declared
+uncompressed size, and 1,024 encoded path bytes. Entry count includes directory
+entries, and aggregate size includes every entry. All limits are configurable
+with non-negative safe integers. The entry limit also bounds cumulative
+central-directory work while disambiguating end records in hostile comments.
+
+Policy is deliberately strict: ZIP64, encrypted, multi-disk, malformed,
+truncated, and non-UTF-8-name archives are rejected with typed errors. Raw
+entry names use strict UTF-8 decoding whether or not the UTF-8 flag is set, so
+common macOS ZIPs with valid names remain compatible. Info-ZIP and Xceed
+Unicode path extra fields are rejected so an extractor cannot select a
+different path from the one inspected. PKWARE and ASi Unix extra fields are
+likewise rejected because they can supply link targets; libarchive's `xl`
+field is rejected because it can override the inspected file type. These
+alternate-metadata cases use
+`UnsupportedZipFeatureError` with the `ambiguous-metadata` feature. This API is
+a metadata preflight, not an extraction API; consumers that later extract an
+accepted archive must still use an extraction destination and library with
+equivalent path and symlink protections.
+
 ### Error Handling
 
 ```typescript
@@ -125,6 +182,8 @@ const files = await listFiles('/path/to/dir', { match: /\.json$/ });
 **Interface methods**: `exists`, `read`, `write`, `delete`, `copy`, `move`, `createDirectory`, `list`, `getStats`, `getMimeType`, `upload`, `download`, `downloadWithCache`, `cache.get/set/clear`, `getCapabilities`
 
 **Fetch**: `fetchText`, `fetchJSON`, `fetchBuffer`, `fetchToFile`, `addRateLimit`, `getRateLimit`
+
+**Archive inspection**: `inspectZipManifest`, `DEFAULT_ZIP_MANIFEST_LIMITS`, `ZipManifestError`, `InvalidZipArchiveError`, `UnsafeZipEntryError`, `ZipManifestLimitError`, `UnsupportedZipFeatureError`
 
 **Errors**: `FilesystemError`, `FileNotFoundError`, `PermissionError`, `DirectoryNotEmptyError`, `InvalidPathError`
 

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -115,7 +115,8 @@ traversal, absolute/drive-qualified paths, NTFS alternate data stream paths
 containing colons, NUL bytes, Unix symlinks and special files, Windows reparse
 points and reserved device names, path segments ending in dots or spaces,
 case-insensitive or Unicode-normalization path collisions, file/descendant path
-conflicts, or overlapping local entry ranges.
+conflicts, overlapping local entry ranges, or unreferenced data before the
+central directory.
 
 Default limits are 10,000 entries, 200 MiB per entry, 2 GiB aggregate declared
 uncompressed size, and 1,024 encoded path bytes. Entry count includes directory
@@ -127,8 +128,10 @@ Policy is deliberately strict: ZIP64, encrypted, multi-disk, malformed,
 truncated, ambiguous-end-record, and non-UTF-8-name archives are rejected with
 typed errors. Stored entries must also declare identical compressed and
 uncompressed sizes, and each local header, compressed payload, and optional
-classic data descriptor must occupy a distinct range before the central
-directory. Signed and unsigned 32-bit data descriptors are cross-checked
+classic data descriptor must occupy a distinct range. Those referenced ranges
+must collectively cover every byte before the central directory, so archive
+preambles, padding gaps, and local entries omitted from the central directory
+are rejected. Signed and unsigned 32-bit data descriptors are cross-checked
 against their central-directory entry; missing, truncated, or inconsistent
 descriptors are rejected. Entry names use strict UTF-8 decoding whether or not
 the UTF-8 flag is set, so common macOS ZIPs with valid names remain compatible.

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -111,8 +111,9 @@ try {
 metadata only. It does not decompress or materialize file bodies. Paths are
 returned with `/` separators and `.`/empty segments removed; names containing
 ordinary spaces remain valid. The whole archive is rejected for parent
-traversal, absolute/drive-qualified paths, NUL bytes, symlinks, Unix special
-files, normalized path collisions, or file/descendant path conflicts.
+traversal, absolute/drive-qualified paths, NTFS alternate data stream paths
+containing colons, NUL bytes, symlinks, Unix special files, normalized path
+collisions, or file/descendant path conflicts.
 
 Default limits are 10,000 entries, 200 MiB per entry, 2 GiB aggregate declared
 uncompressed size, and 1,024 encoded path bytes. Entry count includes directory

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -123,19 +123,20 @@ with non-negative safe integers. The entry limit also bounds cumulative
 central-directory work while disambiguating end records in hostile comments.
 
 Policy is deliberately strict: ZIP64, encrypted, multi-disk, malformed,
-truncated, and non-UTF-8-name archives are rejected with typed errors. Stored
-entries must also declare identical compressed and uncompressed sizes, and
-each local header, compressed payload, and optional classic data descriptor
-must occupy a distinct range before the central directory. Signed and unsigned
-32-bit data descriptors are cross-checked against their central-directory
-entry; missing, truncated, or inconsistent descriptors are rejected. Entry
-names use strict UTF-8 decoding whether or not the UTF-8 flag is set, so common
-macOS ZIPs with valid names remain compatible. Info-ZIP and Xceed Unicode path
-extra fields are rejected so an extractor cannot select a different path from
-the one inspected. PKWARE and ASi Unix extra fields are likewise rejected
-because they can supply link targets; libarchive's `xl` field is rejected
-because it can override the inspected file type. These alternate-metadata
-cases, along with contradictory Unix file and directory attributes, use
+truncated, ambiguous-end-record, and non-UTF-8-name archives are rejected with
+typed errors. Stored entries must also declare identical compressed and
+uncompressed sizes, and each local header, compressed payload, and optional
+classic data descriptor must occupy a distinct range before the central
+directory. Signed and unsigned 32-bit data descriptors are cross-checked
+against their central-directory entry; missing, truncated, or inconsistent
+descriptors are rejected. Entry names use strict UTF-8 decoding whether or not
+the UTF-8 flag is set, so common macOS ZIPs with valid names remain compatible.
+Info-ZIP and Xceed Unicode path extra fields are rejected so an extractor
+cannot select a different path from the one inspected. PKWARE and ASi Unix
+extra fields are likewise rejected because they can supply link targets;
+libarchive's `xl` field is rejected because it can override the inspected file
+type. These alternate-metadata cases, along with contradictory Unix file and
+directory attributes, use
 `UnsupportedZipFeatureError` with the `ambiguous-metadata` feature. This API is
 a metadata preflight, not an extraction API; consumers that later extract an
 accepted archive must still use an extraction destination and library with

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -112,8 +112,9 @@ metadata only. It does not decompress or materialize file bodies. Paths are
 returned with `/` separators and `.`/empty segments removed; names containing
 ordinary spaces remain valid. The whole archive is rejected for parent
 traversal, absolute/drive-qualified paths, NTFS alternate data stream paths
-containing colons, NUL bytes, symlinks, Unix special files, normalized path
-collisions, or file/descendant path conflicts.
+containing colons, NUL bytes, Unix symlinks and special files, Windows reparse
+points, normalized path collisions, file/descendant path conflicts, or
+overlapping local entry ranges.
 
 Default limits are 10,000 entries, 200 MiB per entry, 2 GiB aggregate declared
 uncompressed size, and 1,024 encoded path bytes. Entry count includes directory
@@ -123,15 +124,18 @@ central-directory work while disambiguating end records in hostile comments.
 
 Policy is deliberately strict: ZIP64, encrypted, multi-disk, malformed,
 truncated, and non-UTF-8-name archives are rejected with typed errors. Stored
-entries must also declare identical compressed and uncompressed sizes. Entry
-names use strict UTF-8 decoding whether or not the UTF-8 flag is set, so
-common macOS ZIPs with valid names remain compatible. Info-ZIP and Xceed
-Unicode path extra fields are rejected so an extractor cannot select a
-different path from the one inspected. PKWARE and ASi Unix extra fields are
-likewise rejected because they can supply link targets; libarchive's `xl`
-field is rejected because it can override the inspected file type. These
-alternate-metadata cases, along with contradictory Unix file and directory
-attributes, use
+entries must also declare identical compressed and uncompressed sizes, and
+each local header, compressed payload, and optional classic data descriptor
+must occupy a distinct range before the central directory. Signed and unsigned
+32-bit data descriptors are cross-checked against their central-directory
+entry; missing, truncated, or inconsistent descriptors are rejected. Entry
+names use strict UTF-8 decoding whether or not the UTF-8 flag is set, so common
+macOS ZIPs with valid names remain compatible. Info-ZIP and Xceed Unicode path
+extra fields are rejected so an extractor cannot select a different path from
+the one inspected. PKWARE and ASi Unix extra fields are likewise rejected
+because they can supply link targets; libarchive's `xl` field is rejected
+because it can override the inspected file type. These alternate-metadata
+cases, along with contradictory Unix file and directory attributes, use
 `UnsupportedZipFeatureError` with the `ambiguous-metadata` feature. This API is
 a metadata preflight, not an extraction API; consumers that later extract an
 accepted archive must still use an extraction destination and library with

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -133,8 +133,12 @@ must collectively cover every byte before the central directory, so archive
 preambles, padding gaps, and local entries omitted from the central directory
 are rejected. Signed and unsigned 32-bit data descriptors are cross-checked
 against their central-directory entry; missing, truncated, or inconsistent
-descriptors are rejected. Entry names use strict UTF-8 decoding whether or not
-the UTF-8 flag is set, so common macOS ZIPs with valid names remain compatible.
+descriptors are rejected. Data descriptors on compressed entries are also
+rejected because their payload boundary cannot be verified without
+decompression; classic descriptors remain supported for stored entries. Entry
+names use strict UTF-8 decoding whether or not the UTF-8 flag is set, preserve
+a leading UTF-8 BOM as part of the path, and keep common macOS ZIPs with valid
+names compatible.
 PKWARE alternate-encoding, Info-ZIP, and Xceed path extra fields are rejected
 so an extractor cannot select a different path or character encoding from the
 one inspected. PKWARE and ASi Unix extra fields are likewise rejected because

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -766,6 +766,31 @@ describe('inspectZipManifest', () => {
     expect(inspectZipManifest(data).entries[0]?.path).toBe('crc-collision.bin');
   });
 
+  it('rejects compressed entries whose data-descriptor boundary requires decompression', () => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'streamed-deflate.bin',
+          body: new Uint8Array([0x03, 0x00]),
+          compressedSize: 2,
+          compressionMethod: 8,
+          dataDescriptor: 'signed',
+          flags: 0x0008,
+          uncompressedSize: 0,
+        },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+    expect((error as UnsupportedZipFeatureError).feature).toBe(
+      'ambiguous-metadata',
+    );
+    expect((error as UnsupportedZipFeatureError).entryPath).toBe(
+      'streamed-deflate.bin',
+    );
+    expect(error.message).toContain('payload boundary');
+  });
+
   it('rejects missing data descriptors', () => {
     const error = inspectError(
       buildZip([
@@ -1057,6 +1082,13 @@ describe('inspectZipManifest', () => {
           ?.path,
       ).toBe('café.txt');
     }
+  });
+
+  it('preserves a leading UTF-8 BOM as part of an entry path', () => {
+    expect(
+      inspectZipManifest(buildZip([{ name: '\ufeffsafe.txt' }])).entries[0]
+        ?.path,
+    ).toBe('\ufeffsafe.txt');
   });
 
   it('rejects PKWARE alternate filename encodings in local and central metadata', () => {

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -15,6 +15,8 @@ interface ZipFixtureEntry {
   name: string | Uint8Array;
   body?: Uint8Array;
   compressedSize?: number;
+  crc32?: number;
+  dataDescriptor?: 'signed' | 'unsigned' | 'missing';
   uncompressedSize?: number;
   compressionMethod?: number;
   flags?: number;
@@ -78,6 +80,7 @@ function buildZip(
     const body = entry.body ?? new Uint8Array();
     const compressedSize = entry.compressedSize ?? body.length;
     const uncompressedSize = entry.uncompressedSize ?? body.length;
+    const crc32 = entry.crc32 ?? 0;
     const compressionMethod = entry.compressionMethod ?? 0;
     const flags = entry.flags ?? 0;
     const localFlags = entry.localFlags ?? flags;
@@ -87,17 +90,36 @@ function buildZip(
     localOffsets.push(localOffset);
     const localHeader = new Uint8Array(30);
     const localView = new DataView(localHeader.buffer);
+    const localUsesDataDescriptor = (localFlags & 0x0008) !== 0;
     localView.setUint32(0, 0x04034b50, true);
     localView.setUint16(4, 20, true);
     localView.setUint16(6, localFlags, true);
     localView.setUint16(8, compressionMethod, true);
-    localView.setUint32(18, compressedSize, true);
-    localView.setUint32(22, uncompressedSize, true);
+    localView.setUint32(14, localUsesDataDescriptor ? 0 : crc32, true);
+    localView.setUint32(18, localUsesDataDescriptor ? 0 : compressedSize, true);
+    localView.setUint32(
+      22,
+      localUsesDataDescriptor ? 0 : uncompressedSize,
+      true,
+    );
     localView.setUint16(26, localName.length, true);
     localView.setUint16(28, localExtra.length, true);
-    localParts.push(localHeader, localName, localExtra, body);
+    const dataDescriptor =
+      (flags & 0x0008) !== 0 && entry.dataDescriptor !== 'missing'
+        ? buildDataDescriptor(
+            crc32,
+            compressedSize,
+            uncompressedSize,
+            entry.dataDescriptor !== 'unsigned',
+          )
+        : new Uint8Array();
+    localParts.push(localHeader, localName, localExtra, body, dataDescriptor);
     localOffset +=
-      localHeader.length + localName.length + localExtra.length + body.length;
+      localHeader.length +
+      localName.length +
+      localExtra.length +
+      body.length +
+      dataDescriptor.length;
 
     const centralHeader = new Uint8Array(46);
     const centralView = new DataView(centralHeader.buffer);
@@ -106,6 +128,7 @@ function buildZip(
     centralView.setUint16(6, 20, true);
     centralView.setUint16(8, flags, true);
     centralView.setUint16(10, compressionMethod, true);
+    centralView.setUint32(16, crc32, true);
     centralView.setUint32(20, compressedSize, true);
     centralView.setUint32(24, uncompressedSize, true);
     centralView.setUint16(28, centralName.length, true);
@@ -161,6 +184,24 @@ function buildZip(
     endRecord,
     comment,
   ]);
+}
+
+function buildDataDescriptor(
+  crc32: number,
+  compressedSize: number,
+  uncompressedSize: number,
+  includeSignature: boolean,
+): Uint8Array {
+  const descriptor = new Uint8Array(includeSignature ? 16 : 12);
+  const view = new DataView(descriptor.buffer);
+  const valuesOffset = includeSignature ? 4 : 0;
+  if (includeSignature) {
+    view.setUint32(0, 0x08074b50, true);
+  }
+  view.setUint32(valuesOffset, crc32, true);
+  view.setUint32(valuesOffset + 4, compressedSize, true);
+  view.setUint32(valuesOffset + 8, uncompressedSize, true);
+  return descriptor;
 }
 
 function mutateZip(
@@ -296,6 +337,22 @@ describe('inspectZipManifest', () => {
 
     expect(error).toBeInstanceOf(UnsafeZipEntryError);
     expect((error as UnsafeZipEntryError).reason).toBe('symlink');
+  });
+
+  it('rejects Windows reparse-point entries', () => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'junction',
+          externalAttributes: 0x400,
+          versionMadeBy: 0x0a14,
+        },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('reparse-point');
+    expect(error.entryPath).toBe('junction');
   });
 
   it.each([
@@ -456,6 +513,99 @@ describe('inspectZipManifest', () => {
 
     expect(error).toBeInstanceOf(InvalidZipArchiveError);
     expect(error.message).toContain('different compressed and uncompressed');
+  });
+
+  it('rejects overlapping local entry ranges', () => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'first.bin',
+          compressedSize: 48,
+          uncompressedSize: 48,
+        },
+        {
+          name: 'second.bin',
+          body: new Uint8Array(96),
+        },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+    expect(error.message).toContain('local entry ranges');
+    expect(error.message).toContain('overlap');
+  });
+
+  it('includes validated data descriptors in overlap detection', () => {
+    const embeddedDescriptor = buildDataDescriptor(0, 56, 56, true);
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'first.bin',
+          compressedSize: 56,
+          flags: 0x0008,
+          uncompressedSize: 56,
+        },
+        {
+          name: 'second.bin',
+          body: embeddedDescriptor,
+        },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+    expect(error.message).toContain('local entry ranges');
+    expect(error.message).toContain('overlap');
+  });
+
+  it.each([
+    'signed',
+    'unsigned',
+  ] as const)('accepts and bounds %s classic data descriptors', (dataDescriptor) => {
+    const data = buildZip([
+      {
+        name: 'streamed.bin',
+        body: new Uint8Array([1, 2, 3]),
+        crc32: 0x55bc801d,
+        dataDescriptor,
+        flags: 0x0008,
+      },
+      { name: 'next.txt' },
+    ]);
+
+    expect(inspectZipManifest(data).entries.map(({ path }) => path)).toEqual([
+      'streamed.bin',
+      'next.txt',
+    ]);
+  });
+
+  it('accepts an unsigned data descriptor whose CRC equals the optional signature', () => {
+    const data = buildZip([
+      {
+        name: 'crc-collision.bin',
+        body: new Uint8Array([1, 2, 3]),
+        crc32: 0x08074b50,
+        dataDescriptor: 'unsigned',
+        flags: 0x0008,
+      },
+    ]);
+
+    expect(inspectZipManifest(data).entries[0]?.path).toBe('crc-collision.bin');
+  });
+
+  it('rejects missing data descriptors', () => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'streamed.bin',
+          body: new Uint8Array([1, 2, 3]),
+          dataDescriptor: 'missing',
+          flags: 0x0008,
+        },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+    expect(error.message).toContain('data descriptor');
   });
 
   it('enforces the configured central-directory entry-count limit', () => {

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -1,0 +1,658 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InvalidZipArchiveError,
+  inspectZipManifest,
+  UnsafeZipEntryError,
+  UnsupportedZipFeatureError,
+  ZipManifestError,
+  ZipManifestLimitError,
+  type ZipManifestLimits,
+} from './archive';
+
+const encoder = new TextEncoder();
+
+interface ZipFixtureEntry {
+  name: string | Uint8Array;
+  body?: Uint8Array;
+  compressedSize?: number;
+  uncompressedSize?: number;
+  compressionMethod?: number;
+  flags?: number;
+  localFlags?: number;
+  localName?: string | Uint8Array;
+  localExtra?: Uint8Array;
+  centralExtra?: Uint8Array;
+  externalAttributes?: number;
+  versionMadeBy?: number;
+  startingDisk?: number;
+}
+
+interface ZipFixtureOptions {
+  comment?: Uint8Array;
+  diskNumber?: number;
+  centralDirectoryDisk?: number;
+  entriesOnDisk?: number;
+  totalEntries?: number;
+  centralDirectorySize?: number;
+  centralDirectoryOffset?: number;
+  zip64Locator?: boolean;
+}
+
+function bytes(value: string | Uint8Array): Uint8Array {
+  return typeof value === 'string' ? encoder.encode(value) : value;
+}
+
+function extraField(id: number, payload = new Uint8Array()): Uint8Array {
+  const field = new Uint8Array(4 + payload.length);
+  const view = new DataView(field.buffer);
+  view.setUint16(0, id, true);
+  view.setUint16(2, payload.length, true);
+  field.set(payload, 4);
+  return field;
+}
+
+function concatenate(parts: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(
+    parts.reduce((total, part) => total + part.length, 0),
+  );
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+function buildZip(
+  entries: ZipFixtureEntry[],
+  options: ZipFixtureOptions = {},
+): Uint8Array {
+  const localParts: Uint8Array[] = [];
+  const centralParts: Uint8Array[] = [];
+  const localOffsets: number[] = [];
+  let localOffset = 0;
+
+  for (const entry of entries) {
+    const centralName = bytes(entry.name);
+    const localName = bytes(entry.localName ?? entry.name);
+    const body = entry.body ?? new Uint8Array();
+    const compressedSize = entry.compressedSize ?? body.length;
+    const uncompressedSize = entry.uncompressedSize ?? body.length;
+    const compressionMethod = entry.compressionMethod ?? 0;
+    const flags = entry.flags ?? 0;
+    const localFlags = entry.localFlags ?? flags;
+    const localExtra = entry.localExtra ?? new Uint8Array();
+    const centralExtra = entry.centralExtra ?? new Uint8Array();
+
+    localOffsets.push(localOffset);
+    const localHeader = new Uint8Array(30);
+    const localView = new DataView(localHeader.buffer);
+    localView.setUint32(0, 0x04034b50, true);
+    localView.setUint16(4, 20, true);
+    localView.setUint16(6, localFlags, true);
+    localView.setUint16(8, compressionMethod, true);
+    localView.setUint32(18, compressedSize, true);
+    localView.setUint32(22, uncompressedSize, true);
+    localView.setUint16(26, localName.length, true);
+    localView.setUint16(28, localExtra.length, true);
+    localParts.push(localHeader, localName, localExtra, body);
+    localOffset +=
+      localHeader.length + localName.length + localExtra.length + body.length;
+
+    const centralHeader = new Uint8Array(46);
+    const centralView = new DataView(centralHeader.buffer);
+    centralView.setUint32(0, 0x02014b50, true);
+    centralView.setUint16(4, entry.versionMadeBy ?? 0x0314, true);
+    centralView.setUint16(6, 20, true);
+    centralView.setUint16(8, flags, true);
+    centralView.setUint16(10, compressionMethod, true);
+    centralView.setUint32(20, compressedSize, true);
+    centralView.setUint32(24, uncompressedSize, true);
+    centralView.setUint16(28, centralName.length, true);
+    centralView.setUint16(30, centralExtra.length, true);
+    centralView.setUint16(34, entry.startingDisk ?? 0, true);
+    centralView.setUint32(38, entry.externalAttributes ?? 0, true);
+    centralView.setUint32(42, localOffsets.at(-1) ?? 0, true);
+    centralParts.push(centralHeader, centralName, centralExtra);
+  }
+
+  const localData = concatenate(localParts);
+  const centralDirectory = concatenate(centralParts);
+  const zip64EndRecord = options.zip64Locator
+    ? new Uint8Array(56)
+    : new Uint8Array();
+  const locator = options.zip64Locator ? new Uint8Array(20) : new Uint8Array();
+  if (options.zip64Locator) {
+    const zip64View = new DataView(zip64EndRecord.buffer);
+    zip64View.setUint32(0, 0x06064b50, true);
+    zip64View.setUint32(4, 44, true);
+
+    const locatorView = new DataView(locator.buffer);
+    locatorView.setUint32(0, 0x07064b50, true);
+    locatorView.setUint32(8, localData.length + centralDirectory.length, true);
+    locatorView.setUint32(16, 1, true);
+  }
+
+  const comment = options.comment ?? new Uint8Array();
+  const endRecord = new Uint8Array(22);
+  const endView = new DataView(endRecord.buffer);
+  endView.setUint32(0, 0x06054b50, true);
+  endView.setUint16(4, options.diskNumber ?? 0, true);
+  endView.setUint16(6, options.centralDirectoryDisk ?? 0, true);
+  endView.setUint16(8, options.entriesOnDisk ?? entries.length, true);
+  endView.setUint16(10, options.totalEntries ?? entries.length, true);
+  endView.setUint32(
+    12,
+    options.centralDirectorySize ?? centralDirectory.length,
+    true,
+  );
+  endView.setUint32(
+    16,
+    options.centralDirectoryOffset ?? localData.length,
+    true,
+  );
+  endView.setUint16(20, comment.length, true);
+
+  return concatenate([
+    localData,
+    centralDirectory,
+    zip64EndRecord,
+    locator,
+    endRecord,
+    comment,
+  ]);
+}
+
+function mutateZip(
+  data: Uint8Array,
+  mutate: (
+    view: DataView,
+    offsets: { centralDirectory: number; endRecord: number },
+  ) => void,
+): Uint8Array {
+  const result = data.slice();
+  const view = new DataView(result.buffer);
+  const endRecord = result.length - 22;
+  const centralDirectory = view.getUint32(endRecord + 16, true);
+  mutate(view, { centralDirectory, endRecord });
+  return result;
+}
+
+function inspectError(
+  data: Uint8Array,
+  limits?: ZipManifestLimits,
+): ZipManifestError {
+  try {
+    inspectZipManifest(data, limits);
+  } catch (error) {
+    if (error instanceof ZipManifestError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error('Expected ZIP inspection to fail');
+}
+
+describe('inspectZipManifest', () => {
+  it('returns normalized file and directory metadata without rejecting spaces', () => {
+    const data = buildZip([
+      { name: 'project folder/' },
+      {
+        name: 'project folder/read me.txt',
+        body: new Uint8Array([1, 2, 3, 4]),
+      },
+      {
+        name: 'project folder\\nested\\.\\data.json',
+        body: new Uint8Array([5, 6]),
+        compressionMethod: 8,
+      },
+    ]);
+
+    expect(inspectZipManifest(data)).toEqual({
+      entries: [
+        {
+          path: 'project folder',
+          type: 'directory',
+          size: 0,
+          compressedSize: 0,
+          compressionMethod: 0,
+        },
+        {
+          path: 'project folder/read me.txt',
+          type: 'file',
+          size: 4,
+          compressedSize: 4,
+          compressionMethod: 0,
+        },
+        {
+          path: 'project folder/nested/data.json',
+          type: 'file',
+          size: 2,
+          compressedSize: 2,
+          compressionMethod: 8,
+        },
+      ],
+      entryCount: 3,
+      fileCount: 2,
+      directoryCount: 1,
+      totalUncompressedBytes: 6,
+    });
+  });
+
+  it.each([
+    '../outside.txt',
+    'folder/../../outside.txt',
+    'folder\\..\\outside.txt',
+  ])('rejects traversal path %s', (name) => {
+    const error = inspectError(buildZip([{ name }]));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('path-traversal');
+    expect(error.code).toBe('ZIP_UNSAFE_ENTRY');
+  });
+
+  it.each([
+    ['/etc/passwd', 'absolute-path'],
+    ['\\\\server\\share\\file.txt', 'absolute-path'],
+    ['C:\\temp\\file.txt', 'drive-qualified-path'],
+    ['d:relative.txt', 'drive-qualified-path'],
+  ] as const)('rejects unsafe absolute or drive path %s', (name, reason) => {
+    const error = inspectError(buildZip([{ name }]));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe(reason);
+  });
+
+  it('rejects an actual NUL byte while allowing ordinary spaces', () => {
+    const error = inspectError(buildZip([{ name: 'safe name\0hidden.txt' }]));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('nul-byte');
+  });
+
+  it('rejects Unix symbolic-link entries', () => {
+    const symlinkMode = (0o120777 << 16) >>> 0;
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'link',
+          externalAttributes: symlinkMode,
+          versionMadeBy: 0x0314,
+        },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('symlink');
+  });
+
+  it.each([
+    { fileType: 0o010000, label: 'FIFO' },
+    { fileType: 0o020000, label: 'character device' },
+    { fileType: 0o060000, label: 'block device' },
+    { fileType: 0o140000, label: 'socket' },
+  ] as const)('rejects Unix $label entries', ({ fileType }) => {
+    const externalAttributes = ((fileType | 0o644) << 16) >>> 0;
+    const error = inspectError(
+      buildZip([{ name: 'special', externalAttributes }]),
+    );
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('special-file');
+  });
+
+  it('rejects ASi Unix metadata that could override the entry file type', () => {
+    const asiUnixExtra = extraField(0x756e, new Uint8Array(10));
+
+    for (const data of [
+      buildZip([{ name: 'link', centralExtra: asiUnixExtra }]),
+      buildZip([{ name: 'link', localExtra: asiUnixExtra }]),
+    ]) {
+      const error = inspectError(data);
+      expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+      expect((error as UnsupportedZipFeatureError).feature).toBe(
+        'ambiguous-metadata',
+      );
+    }
+  });
+
+  it('rejects PKWARE Unix metadata that could supply a link target', () => {
+    const linkTarget = encoder.encode('../../outside');
+    const pkwareUnixExtra = extraField(
+      0x000d,
+      concatenate([new Uint8Array(12), linkTarget]),
+    );
+
+    for (const data of [
+      buildZip([{ name: 'safe.txt', centralExtra: pkwareUnixExtra }]),
+      buildZip([{ name: 'safe.txt', localExtra: pkwareUnixExtra }]),
+    ]) {
+      const error = inspectError(data);
+      expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+      expect((error as UnsupportedZipFeatureError).feature).toBe(
+        'ambiguous-metadata',
+      );
+    }
+  });
+
+  it('rejects libarchive metadata that could override the file type', () => {
+    const attributes = new Uint8Array(7);
+    const attributesView = new DataView(attributes.buffer);
+    attributesView.setUint8(0, 0x05);
+    attributesView.setUint16(1, 0x0314, true);
+    attributesView.setUint32(3, (0o120777 << 16) >>> 0, true);
+    const libarchiveExtra = extraField(0x6c78, attributes);
+
+    for (const data of [
+      buildZip([{ name: 'safe.txt', centralExtra: libarchiveExtra }]),
+      buildZip([{ name: 'safe.txt', localExtra: libarchiveExtra }]),
+    ]) {
+      const error = inspectError(data);
+      expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+      expect((error as UnsupportedZipFeatureError).feature).toBe(
+        'ambiguous-metadata',
+      );
+    }
+  });
+
+  it('rejects paths that collide after normalization', () => {
+    const error = inspectError(
+      buildZip([{ name: 'folder//file.txt' }, { name: 'folder/file.txt' }]),
+    );
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('duplicate-path');
+  });
+
+  it('enforces the configured central-directory entry-count limit', () => {
+    const error = inspectError(buildZip([{ name: 'one' }, { name: 'two' }]), {
+      maxEntries: 1,
+    });
+
+    expect(error).toBeInstanceOf(ZipManifestLimitError);
+    expect((error as ZipManifestLimitError).limit).toBe('entry-count');
+    expect((error as ZipManifestLimitError).actual).toBe(2);
+  });
+
+  it('enforces the configured per-entry uncompressed-size limit', () => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'large.bin',
+          compressedSize: 0,
+          uncompressedSize: 6,
+          compressionMethod: 8,
+        },
+      ]),
+      { maxEntryUncompressedBytes: 5 },
+    );
+
+    expect(error).toBeInstanceOf(ZipManifestLimitError);
+    expect((error as ZipManifestLimitError).limit).toBe(
+      'entry-uncompressed-size',
+    );
+    expect(error.entryPath).toBe('large.bin');
+  });
+
+  it('enforces the configured aggregate uncompressed-size limit', () => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'one.bin',
+          compressedSize: 0,
+          uncompressedSize: 3,
+          compressionMethod: 8,
+        },
+        {
+          name: 'two.bin',
+          compressedSize: 0,
+          uncompressedSize: 3,
+          compressionMethod: 8,
+        },
+      ]),
+      { maxTotalUncompressedBytes: 5 },
+    );
+
+    expect(error).toBeInstanceOf(ZipManifestLimitError);
+    expect((error as ZipManifestLimitError).limit).toBe(
+      'total-uncompressed-size',
+    );
+    expect((error as ZipManifestLimitError).actual).toBe(6);
+  });
+
+  it('rejects invalid configured limits', () => {
+    const data = buildZip([]);
+
+    expect(() => inspectZipManifest(data, { maxEntries: -1 })).toThrow(
+      RangeError,
+    );
+    expect(() =>
+      inspectZipManifest(data, { maxTotalUncompressedBytes: 1.5 }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects missing and truncated central-directory metadata', () => {
+    expect(inspectError(new Uint8Array([1, 2, 3]))).toBeInstanceOf(
+      InvalidZipArchiveError,
+    );
+
+    const truncatedEntry = mutateZip(
+      buildZip([{ name: 'file.txt' }]),
+      (view, { centralDirectory }) => {
+        view.setUint16(centralDirectory + 28, 0xffff, true);
+      },
+    );
+    expect(inspectError(truncatedEntry)).toBeInstanceOf(InvalidZipArchiveError);
+  });
+
+  it('rejects corrupt central-directory signatures and size/count mismatches', () => {
+    const invalidSignature = mutateZip(
+      buildZip([{ name: 'file.txt' }]),
+      (view, { centralDirectory }) => {
+        view.setUint32(centralDirectory, 0x11111111, true);
+      },
+    );
+    expect(inspectError(invalidSignature)).toBeInstanceOf(
+      InvalidZipArchiveError,
+    );
+
+    const invalidSize = mutateZip(
+      buildZip([{ name: 'file.txt' }]),
+      (view, { endRecord }) => {
+        const size = view.getUint32(endRecord + 12, true);
+        view.setUint32(endRecord + 12, size - 1, true);
+      },
+    );
+    expect(inspectError(invalidSize)).toBeInstanceOf(InvalidZipArchiveError);
+
+    const invalidCount = mutateZip(
+      buildZip([{ name: 'file.txt' }]),
+      (view, { endRecord }) => {
+        view.setUint16(endRecord + 8, 2, true);
+        view.setUint16(endRecord + 10, 2, true);
+      },
+    );
+    expect(inspectError(invalidCount)).toBeInstanceOf(InvalidZipArchiveError);
+  });
+
+  it('rejects mismatched local and central-directory paths', () => {
+    const error = inspectError(
+      buildZip([{ name: 'safe.txt', localName: 'evil.txt' }]),
+    );
+
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+  });
+
+  it('ignores forged EOCD signatures inside a valid ZIP comment', () => {
+    const comment = new Uint8Array(30);
+    new DataView(comment.buffer).setUint32(0, 0x06054b50, true);
+    const data = buildZip([{ name: 'valid.txt' }], { comment });
+
+    expect(inspectZipManifest(data).entries[0]?.path).toBe('valid.txt');
+  });
+
+  it('falls back from an EOF-aligned forged EOCD in a valid ZIP comment', () => {
+    const forgedEndRecord = new Uint8Array(22);
+    new DataView(forgedEndRecord.buffer).setUint32(0, 0x06054b50, true);
+    const data = buildZip([{ name: 'valid.txt' }], {
+      comment: forgedEndRecord,
+    });
+
+    expect(inspectZipManifest(data).entries[0]?.path).toBe('valid.txt');
+  });
+
+  it('falls back from forged ZIP64 markers at the end of a valid comment', () => {
+    const baseLength = buildZip([{ name: 'valid.txt' }]).length;
+    const forgedSentinel = new Uint8Array(22);
+    const sentinelView = new DataView(forgedSentinel.buffer);
+    sentinelView.setUint32(0, 0x06054b50, true);
+    sentinelView.setUint16(8, 0xffff, true);
+    sentinelView.setUint16(10, 0xffff, true);
+    sentinelView.setUint32(16, baseLength, true);
+
+    const orphanLocator = new Uint8Array(42);
+    const orphanView = new DataView(orphanLocator.buffer);
+    orphanView.setUint32(0, 0x07064b50, true);
+    orphanView.setUint32(20, 0x06054b50, true);
+    orphanView.setUint16(28, 0xffff, true);
+    orphanView.setUint16(30, 0xffff, true);
+    orphanView.setUint32(32, 0xffffffff, true);
+    orphanView.setUint32(36, 0xffffffff, true);
+
+    for (const comment of [forgedSentinel, orphanLocator]) {
+      expect(
+        inspectZipManifest(buildZip([{ name: 'valid.txt' }], { comment }))
+          .entries[0]?.path,
+      ).toBe('valid.txt');
+    }
+  });
+
+  it('bounds cumulative EOCD candidate validation by maxEntries', () => {
+    const base = buildZip([{ name: 'valid.txt' }]);
+    const baseView = new DataView(base.buffer);
+    const realEndRecord = base.length - 22;
+    const centralDirectory = baseView.getUint32(realEndRecord + 16, true);
+    const comment = new Uint8Array(64);
+    const commentView = new DataView(comment.buffer);
+
+    for (const offset of [0, 32]) {
+      const candidateOffset = base.length + offset;
+      commentView.setUint32(offset, 0x06054b50, true);
+      commentView.setUint16(offset + 8, 2, true);
+      commentView.setUint16(offset + 10, 2, true);
+      commentView.setUint32(
+        offset + 12,
+        candidateOffset - centralDirectory,
+        true,
+      );
+      commentView.setUint32(offset + 16, centralDirectory, true);
+      commentView.setUint16(offset + 20, comment.length - offset - 22, true);
+    }
+
+    const error = inspectError(buildZip([{ name: 'valid.txt' }], { comment }), {
+      maxEntries: 2,
+    });
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+    expect(error.message).toContain('entry-check budget');
+  });
+
+  it.each([
+    { flags: 0x0001, label: 'traditional encryption' },
+    { flags: 0x0040, label: 'strong encryption' },
+    { flags: 0x2000, label: 'masked local-header encryption' },
+  ])('rejects $label explicitly', ({ flags }) => {
+    const error = inspectError(buildZip([{ name: 'secret.txt', flags }]));
+
+    expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+    expect((error as UnsupportedZipFeatureError).feature).toBe('encryption');
+    expect(error.code).toBe('ZIP_UNSUPPORTED_FEATURE');
+  });
+
+  it('rejects encryption markers in local flags and extra fields', () => {
+    const strongEncryptionExtra = extraField(0x0017);
+
+    for (const data of [
+      buildZip([{ name: 'secret.txt', flags: 0, localFlags: 0x2000 }]),
+      buildZip([{ name: 'secret.txt', centralExtra: strongEncryptionExtra }]),
+      buildZip([{ name: 'secret.txt', localExtra: strongEncryptionExtra }]),
+    ]) {
+      const error = inspectError(data);
+      expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+      expect((error as UnsupportedZipFeatureError).feature).toBe('encryption');
+    }
+  });
+
+  it('rejects WinZip AES metadata even when encryption flags are malformed', () => {
+    const aesExtra = extraField(0x9901);
+
+    for (const data of [
+      buildZip([{ name: 'secret.txt', compressionMethod: 99 }]),
+      buildZip([{ name: 'secret.txt', centralExtra: aesExtra }]),
+    ]) {
+      const error = inspectError(data);
+      expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+      expect((error as UnsupportedZipFeatureError).feature).toBe('encryption');
+    }
+  });
+
+  it('rejects alternate Unicode paths but accepts strict UTF-8 raw names', () => {
+    const traversalPath = encoder.encode('../outside.txt');
+    const unicodePathExtras = [
+      extraField(
+        0x7075,
+        concatenate([new Uint8Array([1, 0, 0, 0, 0]), traversalPath]),
+      ),
+      extraField(0x554e, traversalPath),
+    ];
+
+    for (const unicodePathExtra of unicodePathExtras) {
+      for (const data of [
+        buildZip([{ name: 'safe.txt', centralExtra: unicodePathExtra }]),
+        buildZip([{ name: 'safe.txt', localExtra: unicodePathExtra }]),
+      ]) {
+        const error = inspectError(data);
+        expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+        expect((error as UnsupportedZipFeatureError).feature).toBe(
+          'ambiguous-metadata',
+        );
+      }
+    }
+
+    for (const flags of [0, 0x0800]) {
+      expect(
+        inspectZipManifest(buildZip([{ name: 'café.txt', flags }])).entries[0]
+          ?.path,
+      ).toBe('café.txt');
+    }
+  });
+
+  it('rejects ZIP64 chains and extra fields explicitly', () => {
+    const sentinel = mutateZip(buildZip([]), (view, { endRecord }) => {
+      view.setUint16(endRecord + 8, 0xffff, true);
+      view.setUint16(endRecord + 10, 0xffff, true);
+    });
+    const locator = buildZip([], { zip64Locator: true });
+    const zip64Extra = extraField(0x0001);
+    const extra = buildZip([{ name: 'file.txt', centralExtra: zip64Extra }]);
+
+    expect(inspectError(sentinel)).toBeInstanceOf(InvalidZipArchiveError);
+
+    for (const data of [locator, extra]) {
+      const error = inspectError(data);
+      expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+      expect((error as UnsupportedZipFeatureError).feature).toBe('zip64');
+    }
+  });
+
+  it('rejects multi-disk archives explicitly', () => {
+    const error = inspectError(
+      buildZip([{ name: 'file.txt' }], {
+        diskNumber: 1,
+        centralDirectoryDisk: 1,
+      }),
+    );
+
+    expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+    expect((error as UnsupportedZipFeatureError).feature).toBe('multi-disk');
+  });
+});

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -219,6 +219,47 @@ function mutateZip(
   return result;
 }
 
+function removeCentralDirectoryEntry(
+  data: Uint8Array,
+  entryIndex: number,
+): Uint8Array {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const endRecord = data.length - 22;
+  const centralDirectoryOffset = view.getUint32(endRecord + 16, true);
+  const entryCount = view.getUint16(endRecord + 10, true);
+  if (entryIndex < 0 || entryIndex >= entryCount) {
+    throw new RangeError('Central-directory entry index is out of range');
+  }
+
+  let entryStart = centralDirectoryOffset;
+  for (let index = 0; index < entryIndex; index += 1) {
+    entryStart +=
+      46 +
+      view.getUint16(entryStart + 28, true) +
+      view.getUint16(entryStart + 30, true) +
+      view.getUint16(entryStart + 32, true);
+  }
+  const entryLength =
+    46 +
+    view.getUint16(entryStart + 28, true) +
+    view.getUint16(entryStart + 30, true) +
+    view.getUint16(entryStart + 32, true);
+  const result = concatenate([
+    data.subarray(0, entryStart),
+    data.subarray(entryStart + entryLength),
+  ]);
+  const resultView = new DataView(result.buffer);
+  const resultEndRecord = endRecord - entryLength;
+  resultView.setUint16(resultEndRecord + 8, entryCount - 1, true);
+  resultView.setUint16(resultEndRecord + 10, entryCount - 1, true);
+  resultView.setUint32(
+    resultEndRecord + 12,
+    view.getUint32(endRecord + 12, true) - entryLength,
+    true,
+  );
+  return result;
+}
+
 function inspectError(
   data: Uint8Array,
   limits?: ZipManifestLimits,
@@ -235,6 +276,13 @@ function inspectError(
 }
 
 describe('inspectZipManifest', () => {
+  it('accepts an empty archive with no local entry data', () => {
+    const manifest = inspectZipManifest(buildZip([]));
+
+    expect(manifest.entries).toEqual([]);
+    expect(manifest.entryCount).toBe(0);
+  });
+
   it('returns normalized file and directory metadata without rejecting spaces', () => {
     const data = buildZip([
       { name: 'project folder/' },
@@ -589,6 +637,38 @@ describe('inspectZipManifest', () => {
     expect(error).toBeInstanceOf(InvalidZipArchiveError);
     expect(error.message).toContain('local entry ranges');
     expect(error.message).toContain('overlap');
+  });
+
+  it.each([
+    {
+      label: 'before the referenced entry',
+      entries: [{ name: '../hidden.txt' }, { name: 'safe.txt' }],
+      hiddenIndex: 0,
+    },
+    {
+      label: 'between referenced entries',
+      entries: [
+        { name: 'first.txt' },
+        { name: '../hidden.txt' },
+        { name: 'last.txt' },
+      ],
+      hiddenIndex: 1,
+    },
+    {
+      label: 'after the referenced entry',
+      entries: [{ name: 'safe.txt' }, { name: '../hidden.txt' }],
+      hiddenIndex: 1,
+    },
+  ])('rejects an unreferenced local entry $label', ({
+    entries,
+    hiddenIndex,
+  }) => {
+    const error = inspectError(
+      removeCentralDirectoryEntry(buildZip(entries), hiddenIndex),
+    );
+
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+    expect(error.message).toContain('not described by a central-directory');
   });
 
   it('includes validated data descriptors in overlap detection', () => {

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -481,6 +481,44 @@ describe('inspectZipManifest', () => {
     expect(error.entryPath).toBe(name);
   });
 
+  it.each([
+    { creator: 'DOS', versionMadeBy: 0x0014 },
+    { creator: 'NTFS', versionMadeBy: 0x0a14 },
+  ])('rejects spoofed Unix file-type bits from a $creator creator', ({
+    versionMadeBy,
+  }) => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'folder',
+          externalAttributes: (0o040755 << 16) >>> 0,
+          versionMadeBy,
+        },
+        { name: 'folder/file.txt' },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+    expect((error as UnsupportedZipFeatureError).feature).toBe(
+      'ambiguous-metadata',
+    );
+    expect(error.entryPath).toBe('folder');
+  });
+
+  it('honors Unix file-type bits from a Darwin creator', () => {
+    const manifest = inspectZipManifest(
+      buildZip([
+        {
+          name: 'folder',
+          externalAttributes: (0o040755 << 16) >>> 0,
+          versionMadeBy: 0x1314,
+        },
+      ]),
+    );
+
+    expect(manifest.entries[0]?.type).toBe('directory');
+  });
+
   it('rejects ASi Unix metadata that could override the entry file type', () => {
     const asiUnixExtra = extraField(0x756e, new Uint8Array(10));
 

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -364,6 +364,59 @@ describe('inspectZipManifest', () => {
     expect((error as UnsafeZipEntryError).reason).toBe('duplicate-path');
   });
 
+  it.each([
+    [
+      'file before descendant',
+      [{ name: 'folder' }, { name: 'folder/file.txt' }],
+    ],
+    [
+      'descendant before file',
+      [{ name: 'folder/file.txt' }, { name: 'folder' }],
+    ],
+  ])('rejects file and descendant path conflicts: %s', (_label, entries) => {
+    const error = inspectError(buildZip(entries));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('path-conflict');
+  });
+
+  it('accepts an explicit directory that follows its descendant', () => {
+    const manifest = inspectZipManifest(
+      buildZip([{ name: 'folder/file.txt' }, { name: 'folder/' }]),
+    );
+
+    expect(manifest.entries.map(({ path, type }) => ({ path, type }))).toEqual([
+      { path: 'folder/file.txt', type: 'file' },
+      { path: 'folder', type: 'directory' },
+    ]);
+  });
+
+  it('bounds conflict inspection for many deep slash-heavy paths', () => {
+    const entries = Array.from({ length: 250 }, (_, index) => ({
+      name: `root-${index}/${Array.from({ length: 200 }, () => 'd').join('/')}/file.txt`,
+    }));
+
+    const manifest = inspectZipManifest(buildZip(entries));
+
+    expect(manifest.entryCount).toBe(entries.length);
+  });
+
+  it('rejects stored entries whose declared sizes differ', () => {
+    const error = inspectError(
+      buildZip([
+        {
+          name: 'impossible.bin',
+          compressedSize: 0,
+          uncompressedSize: 10,
+          compressionMethod: 0,
+        },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+    expect(error.message).toContain('different compressed and uncompressed');
+  });
+
   it('enforces the configured central-directory entry-count limit', () => {
     const error = inspectError(buildZip([{ name: 'one' }, { name: 'two' }]), {
       maxEntries: 1,

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -263,6 +263,18 @@ describe('inspectZipManifest', () => {
     expect((error as UnsafeZipEntryError).reason).toBe(reason);
   });
 
+  it.each([
+    'safe.txt:payload',
+    'dir/file.txt:payload',
+    'dir/C:payload',
+  ])('rejects NTFS alternate data stream path %s', (name) => {
+    const error = inspectError(buildZip([{ name }]));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('alternate-data-stream');
+    expect(error.entryPath).toBe(name);
+  });
+
   it('rejects an actual NUL byte while allowing ordinary spaces', () => {
     const error = inspectError(buildZip([{ name: 'safe name\0hidden.txt' }]));
 

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -301,6 +301,35 @@ describe('inspectZipManifest', () => {
     expect((error as UnsafeZipEntryError).reason).toBe('special-file');
   });
 
+  it.each([
+    {
+      label: 'DOS directory attribute',
+      name: 'folder',
+      externalAttributes: (((0o100644 << 16) >>> 0) | 0x10) >>> 0,
+    },
+    {
+      label: 'directory path marker',
+      name: 'folder/',
+      externalAttributes: (0o100644 << 16) >>> 0,
+    },
+  ])('rejects Unix regular files with a conflicting $label', ({
+    name,
+    externalAttributes,
+  }) => {
+    const error = inspectError(
+      buildZip([
+        { name, externalAttributes, versionMadeBy: 0x0314 },
+        { name: 'folder/file.txt' },
+      ]),
+    );
+
+    expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+    expect((error as UnsupportedZipFeatureError).feature).toBe(
+      'ambiguous-metadata',
+    );
+    expect(error.entryPath).toBe(name);
+  });
+
   it('rejects ASi Unix metadata that could override the entry file type', () => {
     const asiUnixExtra = extraField(0x756e, new Uint8Array(10));
 

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -745,6 +745,21 @@ describe('inspectZipManifest', () => {
     expect(inspectZipManifest(data).entries[0]?.path).toBe('valid.txt');
   });
 
+  it('rejects a plausible empty EOCD smuggled in a valid ZIP comment', () => {
+    const forgedEndRecord = new Uint8Array(22);
+    const forgedView = new DataView(forgedEndRecord.buffer);
+    const forgedOffset = buildZip([{ name: 'hidden.txt' }]).length;
+    forgedView.setUint32(0, 0x06054b50, true);
+    forgedView.setUint32(16, forgedOffset, true);
+
+    const error = inspectError(
+      buildZip([{ name: 'hidden.txt' }], { comment: forgedEndRecord }),
+    );
+
+    expect(error).toBeInstanceOf(InvalidZipArchiveError);
+    expect(error.message).toContain('multiple structurally valid');
+  });
+
   it('falls back from forged ZIP64 markers at the end of a valid comment', () => {
     const baseLength = buildZip([{ name: 'valid.txt' }]).length;
     const forgedSentinel = new Uint8Array(22);

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -1021,6 +1021,21 @@ describe('inspectZipManifest', () => {
     }
   });
 
+  it('rejects PKWARE alternate filename encodings in local and central metadata', () => {
+    const alternateEncodingExtra = extraField(0x0008, encoder.encode('IBM037'));
+
+    for (const data of [
+      buildZip([{ name: 'safe.txt', centralExtra: alternateEncodingExtra }]),
+      buildZip([{ name: 'safe.txt', localExtra: alternateEncodingExtra }]),
+    ]) {
+      const error = inspectError(data);
+      expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+      expect((error as UnsupportedZipFeatureError).feature).toBe(
+        'ambiguous-metadata',
+      );
+    }
+  });
+
   it('rejects ZIP64 chains and extra fields explicitly', () => {
     const sentinel = mutateZip(buildZip([]), (view, { endRecord }) => {
       view.setUint16(endRecord + 8, 0xffff, true);

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -316,6 +316,40 @@ describe('inspectZipManifest', () => {
     expect(error.entryPath).toBe(name);
   });
 
+  it.each([
+    'CON',
+    'con.txt',
+    'dir/NUL.txt',
+    'AUX.md',
+    'COM1',
+    'LPT9.log',
+    'CONIN$',
+    'dir/file.',
+    'dir/file ',
+  ])('rejects Windows-reserved path %s', (name) => {
+    const error = inspectError(buildZip([{ name }]));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('windows-reserved-path');
+    expect(error.entryPath).toBe(name);
+  });
+
+  it('allows names that only resemble Windows device names', () => {
+    const manifest = inspectZipManifest(
+      buildZip([
+        { name: 'COM10.txt' },
+        { name: 'computer.txt' },
+        { name: 'null.txt' },
+      ]),
+    );
+
+    expect(manifest.entries.map((entry) => entry.path)).toEqual([
+      'COM10.txt',
+      'computer.txt',
+      'null.txt',
+    ]);
+  });
+
   it('rejects an actual NUL byte while allowing ordinary spaces', () => {
     const error = inspectError(buildZip([{ name: 'safe name\0hidden.txt' }]));
 
@@ -463,6 +497,19 @@ describe('inspectZipManifest', () => {
   });
 
   it.each([
+    ['case-only aliases', 'Readme.md', 'readme.md'],
+    ['Unicode-normalization aliases', 'caf\u00e9.txt', 'cafe\u0301.txt'],
+  ])('rejects portable path collisions: %s', (_label, first, second) => {
+    const error = inspectError(buildZip([{ name: first }, { name: second }]));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe(
+      'portable-path-collision',
+    );
+    expect(error.entryPath).toBe(second);
+  });
+
+  it.each([
     [
       'file before descendant',
       [{ name: 'folder' }, { name: 'folder/file.txt' }],
@@ -473,6 +520,15 @@ describe('inspectZipManifest', () => {
     ],
   ])('rejects file and descendant path conflicts: %s', (_label, entries) => {
     const error = inspectError(buildZip(entries));
+
+    expect(error).toBeInstanceOf(UnsafeZipEntryError);
+    expect((error as UnsafeZipEntryError).reason).toBe('path-conflict');
+  });
+
+  it('rejects case-insensitive file and descendant path conflicts', () => {
+    const error = inspectError(
+      buildZip([{ name: 'Folder' }, { name: 'folder/file.txt' }]),
+    );
 
     expect(error).toBeInstanceOf(UnsafeZipEntryError);
     expect((error as UnsafeZipEntryError).reason).toBe('path-conflict');

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -1084,11 +1084,18 @@ describe('inspectZipManifest', () => {
     }
   });
 
-  it('preserves a leading UTF-8 BOM as part of an entry path', () => {
-    expect(
-      inspectZipManifest(buildZip([{ name: '\ufeffsafe.txt' }])).entries[0]
-        ?.path,
-    ).toBe('\ufeffsafe.txt');
+  it.each([
+    '\ufeffsafe.txt',
+    '\ufeff../outside.txt',
+    '\ufeff/etc/passwd',
+  ])('rejects a leading UTF-8 BOM as ambiguous filename metadata: %s', (name) => {
+    const error = inspectError(buildZip([{ name }]));
+
+    expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
+    expect((error as UnsupportedZipFeatureError).feature).toBe(
+      'ambiguous-metadata',
+    );
+    expect(error.message).toContain('UTF-8 BOM');
   });
 
   it('rejects PKWARE alternate filename encodings in local and central metadata', () => {

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -44,7 +44,10 @@ const DARWIN_CREATOR_SYSTEM = 19;
 const WINDOWS_RESERVED_DEVICE_BASENAME =
   /^(?:aux|con|conin\$|conout\$|nul|prn|com[1-9\u00b9\u00b2\u00b3]|lpt[1-9\u00b9\u00b2\u00b3])$/iu;
 
-const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+const utf8Decoder = new TextDecoder('utf-8', {
+  fatal: true,
+  ignoreBOM: true,
+});
 
 /** Limits applied while inspecting ZIP metadata. */
 export interface ZipManifestLimits {
@@ -423,6 +426,7 @@ export function inspectZipManifest(
       compressedSize,
       compressionMethod,
       localHeaderOffset,
+      rawPath,
       uncompressedSize,
     });
     localEntryRanges.push({
@@ -814,6 +818,7 @@ function validateLocalHeader(
     compressedSize: number;
     compressionMethod: number;
     localHeaderOffset: number;
+    rawPath: string;
     uncompressedSize: number;
   },
 ): number {
@@ -864,6 +869,17 @@ function validateLocalHeader(
   ) {
     throw new InvalidZipArchiveError(
       'ZIP local file header does not match its central-directory entry.',
+    );
+  }
+
+  if (
+    (localFlags & DATA_DESCRIPTOR_FLAG) !== 0 &&
+    entry.compressionMethod !== 0
+  ) {
+    throw new UnsupportedZipFeatureError(
+      'ambiguous-metadata',
+      `Compressed ZIP entry "${entry.rawPath}" uses a data descriptor whose payload boundary cannot be verified without decompression.`,
+      entry.rawPath,
     );
   }
 

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -112,6 +112,7 @@ export class InvalidZipArchiveError extends ZipManifestError {
 
 export type ZipUnsafeEntryReason =
   | 'absolute-path'
+  | 'alternate-data-stream'
   | 'drive-qualified-path'
   | 'duplicate-path'
   | 'empty-path'
@@ -192,10 +193,10 @@ interface ResolvedZipManifestLimits {
  * Inspect a ZIP archive without decompressing entry bodies.
  *
  * ZIP64, encrypted, and multi-disk archives are rejected. Entry paths are
- * normalized and checked for traversal, absolute/drive-qualified forms, NUL
- * bytes, symlinks, Unix special files, and post-normalization collisions. The
- * declared entry sizes and end-record validation work are bounded before a
- * manifest is returned.
+ * normalized and checked for traversal, absolute/drive-qualified forms, NTFS
+ * alternate data streams, NUL bytes, symlinks, Unix special files, and
+ * post-normalization collisions. The declared entry sizes and end-record
+ * validation work are bounded before a manifest is returned.
  */
 export function inspectZipManifest(
   data: Uint8Array,
@@ -904,6 +905,13 @@ function normalizeEntryPath(rawPath: string): string {
       'drive-qualified-path',
       rawPath,
       `ZIP entry "${rawPath}" uses a drive-qualified path.`,
+    );
+  }
+  if (unifiedPath.includes(':')) {
+    throw new UnsafeZipEntryError(
+      'alternate-data-stream',
+      rawPath,
+      `ZIP entry "${rawPath}" contains a colon that can select an NTFS alternate data stream.`,
     );
   }
   if (unifiedPath.startsWith('/')) {

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -458,7 +458,10 @@ export function inspectZipManifest(
     );
   }
 
-  assertNoOverlappingLocalEntryRanges(localEntryRanges);
+  assertLocalEntryRangesCoverArchiveData(
+    localEntryRanges,
+    endRecord.centralDirectoryOffset,
+  );
   assertNoFileDescendantConflicts(entries);
 
   return {
@@ -476,21 +479,33 @@ interface LocalEntryRange {
   path: string;
 }
 
-function assertNoOverlappingLocalEntryRanges(
+function assertLocalEntryRangesCoverArchiveData(
   ranges: readonly LocalEntryRange[],
+  centralDirectoryOffset: number,
 ): void {
   const sortedRanges = [...ranges].sort(
     (left, right) => left.start - right.start || left.end - right.end,
   );
+  let expectedStart = 0;
 
-  for (let index = 1; index < sortedRanges.length; index += 1) {
-    const previous = sortedRanges[index - 1];
-    const current = sortedRanges[index];
-    if (current.start < previous.end) {
+  for (const range of sortedRanges) {
+    if (range.start < expectedStart) {
       throw new InvalidZipArchiveError(
-        `ZIP local entry ranges for "${previous.path}" and "${current.path}" overlap.`,
+        `ZIP local entry ranges overlap at "${range.path}".`,
       );
     }
+    if (range.start > expectedStart) {
+      throw new InvalidZipArchiveError(
+        'ZIP contains data before the central directory that is not described by a central-directory entry.',
+      );
+    }
+    expectedStart = range.end;
+  }
+
+  if (expectedStart !== centralDirectoryOffset) {
+    throw new InvalidZipArchiveError(
+      'ZIP contains data before the central directory that is not described by a central-directory entry.',
+    );
   }
 }
 

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -116,6 +116,7 @@ export type ZipUnsafeEntryReason =
   | 'duplicate-path'
   | 'empty-path'
   | 'nul-byte'
+  | 'path-conflict'
   | 'path-traversal'
   | 'special-file'
   | 'symlink';
@@ -329,6 +330,20 @@ export function inspectZipManifest(
       );
     }
 
+    if (compressionMethod === 0 && compressedSize !== uncompressedSize) {
+      throw new InvalidZipArchiveError(
+        `Stored ZIP entry "${path}" declares different compressed and uncompressed sizes.`,
+      );
+    }
+
+    const type: ZipManifestEntry['type'] =
+      rawPath.endsWith('/') ||
+      rawPath.endsWith('\\') ||
+      (unixMode & UNIX_FILE_TYPE_MASK) === UNIX_DIRECTORY_TYPE ||
+      (externalAttributes & DOS_DIRECTORY_ATTRIBUTE) !== 0
+        ? 'directory'
+        : 'file';
+
     if (normalizedPaths.has(path)) {
       throw new UnsafeZipEntryError(
         'duplicate-path',
@@ -336,6 +351,7 @@ export function inspectZipManifest(
         `ZIP entry "${rawPath}" collides with another normalized path ("${path}").`,
       );
     }
+
     normalizedPaths.add(path);
 
     validateLocalHeader(data, view, {
@@ -370,14 +386,6 @@ export function inspectZipManifest(
       );
     }
 
-    const type =
-      rawPath.endsWith('/') ||
-      rawPath.endsWith('\\') ||
-      (unixMode & UNIX_FILE_TYPE_MASK) === UNIX_DIRECTORY_TYPE ||
-      (externalAttributes & DOS_DIRECTORY_ATTRIBUTE) !== 0
-        ? 'directory'
-        : 'file';
-
     if (type === 'directory') {
       directoryCount += 1;
     } else {
@@ -400,6 +408,8 @@ export function inspectZipManifest(
     );
   }
 
+  assertNoFileDescendantConflicts(entries);
+
   return {
     entries,
     entryCount: entries.length,
@@ -407,6 +417,41 @@ export function inspectZipManifest(
     directoryCount,
     totalUncompressedBytes,
   };
+}
+
+function assertNoFileDescendantConflicts(
+  entries: readonly ZipManifestEntry[],
+): void {
+  const sortedEntries = [...entries].sort((left, right) =>
+    left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
+  );
+
+  for (const entry of sortedEntries) {
+    if (entry.type !== 'file') {
+      continue;
+    }
+
+    const descendantPrefix = `${entry.path}/`;
+    let low = 0;
+    let high = sortedEntries.length;
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2);
+      if (sortedEntries[middle].path < descendantPrefix) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+
+    const descendant = sortedEntries[low];
+    if (descendant?.path.startsWith(descendantPrefix)) {
+      throw new UnsafeZipEntryError(
+        'path-conflict',
+        entry.path,
+        `ZIP file entry "${entry.path}" conflicts with descendant entry "${descendant.path}".`,
+      );
+    }
+  }
 }
 
 function resolveLimits(limits: ZipManifestLimits): ResolvedZipManifestLimits {

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -39,6 +39,8 @@ const UNIX_REGULAR_FILE_TYPE = 0o100000;
 const UNIX_SYMLINK_TYPE = 0o120000;
 const DOS_DIRECTORY_ATTRIBUTE = 0x10;
 const WINDOWS_REPARSE_POINT_ATTRIBUTE = 0x400;
+const UNIX_CREATOR_SYSTEM = 3;
+const DARWIN_CREATOR_SYSTEM = 19;
 const WINDOWS_RESERVED_DEVICE_BASENAME =
   /^(?:aux|con|conin\$|conout\$|nul|prn|com[1-9\u00b9\u00b2\u00b3]|lpt[1-9\u00b9\u00b2\u00b3])$/iu;
 
@@ -271,6 +273,7 @@ export function inspectZipManifest(
       );
     }
 
+    const versionMadeBy = view.getUint16(offset + 4, true);
     const flags = view.getUint16(offset + 8, true);
     const compressionMethod = view.getUint16(offset + 10, true);
     const crc32 = view.getUint32(offset + 16, true);
@@ -324,11 +327,23 @@ export function inspectZipManifest(
 
     const unixMode = (externalAttributes >>> 16) & 0xffff;
     const unixFileType = unixMode & UNIX_FILE_TYPE_MASK;
+    const creatorSystem = versionMadeBy >>> 8;
     if ((externalAttributes & WINDOWS_REPARSE_POINT_ATTRIBUTE) !== 0) {
       throw new UnsafeZipEntryError(
         'reparse-point',
         rawPath,
         `ZIP entry "${rawPath}" is a Windows reparse point, which is not allowed.`,
+      );
+    }
+    if (
+      unixFileType !== 0 &&
+      creatorSystem !== UNIX_CREATOR_SYSTEM &&
+      creatorSystem !== DARWIN_CREATOR_SYSTEM
+    ) {
+      throw new UnsupportedZipFeatureError(
+        'ambiguous-metadata',
+        `ZIP entry "${rawPath}" declares Unix file-type metadata from a non-Unix creator system.`,
+        rawPath,
       );
     }
     if (unixFileType === UNIX_SYMLINK_TYPE) {

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -336,11 +336,25 @@ export function inspectZipManifest(
       );
     }
 
+    const hasDirectoryPathMarker =
+      rawPath.endsWith('/') || rawPath.endsWith('\\');
+    const hasDosDirectoryAttribute =
+      (externalAttributes & DOS_DIRECTORY_ATTRIBUTE) !== 0;
+    if (
+      unixFileType === UNIX_REGULAR_FILE_TYPE &&
+      (hasDirectoryPathMarker || hasDosDirectoryAttribute)
+    ) {
+      throw new UnsupportedZipFeatureError(
+        'ambiguous-metadata',
+        `ZIP entry "${rawPath}" has contradictory Unix file and directory metadata.`,
+        rawPath,
+      );
+    }
+
     const type: ZipManifestEntry['type'] =
-      rawPath.endsWith('/') ||
-      rawPath.endsWith('\\') ||
-      (unixMode & UNIX_FILE_TYPE_MASK) === UNIX_DIRECTORY_TYPE ||
-      (externalAttributes & DOS_DIRECTORY_ATTRIBUTE) !== 0
+      hasDirectoryPathMarker ||
+      unixFileType === UNIX_DIRECTORY_TYPE ||
+      hasDosDirectoryAttribute
         ? 'directory'
         : 'file';
 

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -13,6 +13,7 @@ const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 const ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06064b50;
 const ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIGNATURE = 0x07064b50;
 const ZIP64_EXTRA_FIELD_ID = 0x0001;
+const PKWARE_EXTENDED_LANGUAGE_ENCODING_EXTRA_FIELD_ID = 0x0008;
 const PKWARE_UNIX_EXTRA_FIELD_ID = 0x000d;
 const STRONG_ENCRYPTION_EXTRA_FIELD_ID = 0x0017;
 const XCEED_UNICODE_PATH_EXTRA_FIELD_ID = 0x554e;
@@ -993,12 +994,13 @@ function assertExtraFields(
       throw encryptionError();
     }
     if (
+      headerId === PKWARE_EXTENDED_LANGUAGE_ENCODING_EXTRA_FIELD_ID ||
       headerId === XCEED_UNICODE_PATH_EXTRA_FIELD_ID ||
       headerId === UNICODE_PATH_EXTRA_FIELD_ID
     ) {
       throw new UnsupportedZipFeatureError(
         'ambiguous-metadata',
-        'ZIP Unicode path extra fields are not supported because entry names must have one unambiguous representation.',
+        'ZIP alternate path-encoding extra fields are not supported because entry names must have one unambiguous representation.',
       );
     }
     if (

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -38,6 +38,8 @@ const UNIX_REGULAR_FILE_TYPE = 0o100000;
 const UNIX_SYMLINK_TYPE = 0o120000;
 const DOS_DIRECTORY_ATTRIBUTE = 0x10;
 const WINDOWS_REPARSE_POINT_ATTRIBUTE = 0x400;
+const WINDOWS_RESERVED_DEVICE_BASENAME =
+  /^(?:aux|con|conin\$|conout\$|nul|prn|com[1-9\u00b9\u00b2\u00b3]|lpt[1-9\u00b9\u00b2\u00b3])$/iu;
 
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
@@ -121,9 +123,11 @@ export type ZipUnsafeEntryReason =
   | 'nul-byte'
   | 'path-conflict'
   | 'path-traversal'
+  | 'portable-path-collision'
   | 'reparse-point'
   | 'special-file'
-  | 'symlink';
+  | 'symlink'
+  | 'windows-reserved-path';
 
 /** An entry is unsafe to expose to an extraction workflow. */
 export class UnsafeZipEntryError extends ZipManifestError {
@@ -198,9 +202,9 @@ interface ResolvedZipManifestLimits {
  * ZIP64, encrypted, and multi-disk archives are rejected. Entry paths are
  * normalized and checked for traversal, absolute/drive-qualified forms, NTFS
  * alternate data streams, NUL bytes, Unix symlinks and special files, Windows
- * reparse points, and post-normalization collisions. Local entry ranges,
- * declared entry sizes, and end-record validation work are bounded and
- * cross-checked before a manifest is returned.
+ * reparse points and reserved names, and portable case/normalization
+ * collisions. Local entry ranges, declared entry sizes, and end-record
+ * validation work are bounded and cross-checked before a manifest is returned.
  */
 export function inspectZipManifest(
   data: Uint8Array,
@@ -246,6 +250,7 @@ export function inspectZipManifest(
   const entries: ZipManifestEntry[] = [];
   const localEntryRanges: LocalEntryRange[] = [];
   const normalizedPaths = new Set<string>();
+  const portablePaths = new Map<string, string>();
   let totalUncompressedBytes = 0;
   let fileCount = 0;
   let directoryCount = 0;
@@ -380,7 +385,18 @@ export function inspectZipManifest(
       );
     }
 
+    const portableKey = portablePathKey(path);
+    const existingPortablePath = portablePaths.get(portableKey);
+    if (existingPortablePath !== undefined) {
+      throw new UnsafeZipEntryError(
+        'portable-path-collision',
+        rawPath,
+        `ZIP entry "${rawPath}" collides with "${existingPortablePath}" on a case-insensitive or Unicode-normalizing filesystem.`,
+      );
+    }
+
     normalizedPaths.add(path);
+    portablePaths.set(portableKey, path);
 
     const localDataEnd = validateLocalHeader(data, view, {
       centralDirectoryOffset: endRecord.centralDirectoryOffset,
@@ -481,21 +497,27 @@ function assertNoOverlappingLocalEntryRanges(
 function assertNoFileDescendantConflicts(
   entries: readonly ZipManifestEntry[],
 ): void {
-  const sortedEntries = [...entries].sort((left, right) =>
-    left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
-  );
+  const sortedEntries = entries
+    .map((entry) => ({ entry, portableKey: portablePathKey(entry.path) }))
+    .sort((left, right) =>
+      left.portableKey < right.portableKey
+        ? -1
+        : left.portableKey > right.portableKey
+          ? 1
+          : 0,
+    );
 
-  for (const entry of sortedEntries) {
+  for (const { entry, portableKey } of sortedEntries) {
     if (entry.type !== 'file') {
       continue;
     }
 
-    const descendantPrefix = `${entry.path}/`;
+    const descendantPrefix = `${portableKey}/`;
     let low = 0;
     let high = sortedEntries.length;
     while (low < high) {
       const middle = low + Math.floor((high - low) / 2);
-      if (sortedEntries[middle].path < descendantPrefix) {
+      if (sortedEntries[middle].portableKey < descendantPrefix) {
         low = middle + 1;
       } else {
         high = middle;
@@ -503,11 +525,11 @@ function assertNoFileDescendantConflicts(
     }
 
     const descendant = sortedEntries[low];
-    if (descendant?.path.startsWith(descendantPrefix)) {
+    if (descendant?.portableKey.startsWith(descendantPrefix)) {
       throw new UnsafeZipEntryError(
         'path-conflict',
         entry.path,
-        `ZIP file entry "${entry.path}" conflicts with descendant entry "${descendant.path}".`,
+        `ZIP file entry "${entry.path}" conflicts with descendant entry "${descendant.entry.path}".`,
       );
     }
   }
@@ -1052,6 +1074,28 @@ function normalizeEntryPath(rawPath: string): string {
     );
   }
 
+  for (const segment of segments) {
+    if (segment === '' || segment === '.') {
+      continue;
+    }
+    if (/[. ]$/u.test(segment)) {
+      throw new UnsafeZipEntryError(
+        'windows-reserved-path',
+        rawPath,
+        `ZIP entry "${rawPath}" contains a path segment ending in a dot or space, which is not portable to Windows.`,
+      );
+    }
+
+    const basename = segment.split('.', 1)[0].replace(/[. ]+$/u, '');
+    if (WINDOWS_RESERVED_DEVICE_BASENAME.test(basename)) {
+      throw new UnsafeZipEntryError(
+        'windows-reserved-path',
+        rawPath,
+        `ZIP entry "${rawPath}" contains the Windows-reserved device name "${segment}".`,
+      );
+    }
+  }
+
   const normalizedPath = segments
     .filter((segment) => segment !== '' && segment !== '.')
     .join('/');
@@ -1063,6 +1107,10 @@ function normalizeEntryPath(rawPath: string): string {
     );
   }
   return normalizedPath;
+}
+
+function portablePathKey(path: string): string {
+  return path.normalize('NFC').toUpperCase().toLowerCase().normalize('NFC');
 }
 
 function assertRange(

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -566,6 +566,7 @@ function findEndOfCentralDirectory(
     maxEntries,
     remainingEntryChecks: Math.min(maxEntries, 0xfffe) + 1,
   };
+  let endRecord: EndOfCentralDirectory | undefined;
 
   for (
     let offset = view.byteLength - END_OF_CENTRAL_DIRECTORY_SIZE;
@@ -594,8 +595,17 @@ function findEndOfCentralDirectory(
       centralDirectoryOffset: view.getUint32(offset + 16, true),
     };
     if (isStructurallyPlausibleEndRecord(view, candidate, validationBudget)) {
-      return candidate;
+      if (endRecord) {
+        throw new InvalidZipArchiveError(
+          'ZIP archive contains multiple structurally valid end-of-central-directory records.',
+        );
+      }
+      endRecord = candidate;
     }
+  }
+
+  if (endRecord) {
+    return endRecord;
   }
 
   throw new InvalidZipArchiveError(

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -7,6 +7,7 @@
  */
 
 const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
 const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
 const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 const ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06064b50;
@@ -36,6 +37,7 @@ const UNIX_DIRECTORY_TYPE = 0o040000;
 const UNIX_REGULAR_FILE_TYPE = 0o100000;
 const UNIX_SYMLINK_TYPE = 0o120000;
 const DOS_DIRECTORY_ATTRIBUTE = 0x10;
+const WINDOWS_REPARSE_POINT_ATTRIBUTE = 0x400;
 
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
@@ -119,6 +121,7 @@ export type ZipUnsafeEntryReason =
   | 'nul-byte'
   | 'path-conflict'
   | 'path-traversal'
+  | 'reparse-point'
   | 'special-file'
   | 'symlink';
 
@@ -194,9 +197,10 @@ interface ResolvedZipManifestLimits {
  *
  * ZIP64, encrypted, and multi-disk archives are rejected. Entry paths are
  * normalized and checked for traversal, absolute/drive-qualified forms, NTFS
- * alternate data streams, NUL bytes, symlinks, Unix special files, and
- * post-normalization collisions. The declared entry sizes and end-record
- * validation work are bounded before a manifest is returned.
+ * alternate data streams, NUL bytes, Unix symlinks and special files, Windows
+ * reparse points, and post-normalization collisions. Local entry ranges,
+ * declared entry sizes, and end-record validation work are bounded and
+ * cross-checked before a manifest is returned.
  */
 export function inspectZipManifest(
   data: Uint8Array,
@@ -240,6 +244,7 @@ export function inspectZipManifest(
   }
 
   const entries: ZipManifestEntry[] = [];
+  const localEntryRanges: LocalEntryRange[] = [];
   const normalizedPaths = new Set<string>();
   let totalUncompressedBytes = 0;
   let fileCount = 0;
@@ -262,6 +267,7 @@ export function inspectZipManifest(
 
     const flags = view.getUint16(offset + 8, true);
     const compressionMethod = view.getUint16(offset + 10, true);
+    const crc32 = view.getUint32(offset + 16, true);
     const compressedSize = view.getUint32(offset + 20, true);
     const uncompressedSize = view.getUint32(offset + 24, true);
     const fileNameLength = view.getUint16(offset + 28, true);
@@ -312,6 +318,13 @@ export function inspectZipManifest(
 
     const unixMode = (externalAttributes >>> 16) & 0xffff;
     const unixFileType = unixMode & UNIX_FILE_TYPE_MASK;
+    if ((externalAttributes & WINDOWS_REPARSE_POINT_ATTRIBUTE) !== 0) {
+      throw new UnsafeZipEntryError(
+        'reparse-point',
+        rawPath,
+        `ZIP entry "${rawPath}" is a Windows reparse point, which is not allowed.`,
+      );
+    }
     if (unixFileType === UNIX_SYMLINK_TYPE) {
       throw new UnsafeZipEntryError(
         'symlink',
@@ -369,8 +382,9 @@ export function inspectZipManifest(
 
     normalizedPaths.add(path);
 
-    validateLocalHeader(data, view, {
+    const localDataEnd = validateLocalHeader(data, view, {
       centralDirectoryOffset: endRecord.centralDirectoryOffset,
+      centralCrc32: crc32,
       centralFlags: flags,
       centralNameStart: nameStart,
       centralNameEnd: nameEnd,
@@ -378,6 +392,11 @@ export function inspectZipManifest(
       compressionMethod,
       localHeaderOffset,
       uncompressedSize,
+    });
+    localEntryRanges.push({
+      end: localDataEnd,
+      path,
+      start: localHeaderOffset,
     });
 
     if (uncompressedSize > resolvedLimits.maxEntryUncompressedBytes) {
@@ -423,6 +442,7 @@ export function inspectZipManifest(
     );
   }
 
+  assertNoOverlappingLocalEntryRanges(localEntryRanges);
   assertNoFileDescendantConflicts(entries);
 
   return {
@@ -432,6 +452,30 @@ export function inspectZipManifest(
     directoryCount,
     totalUncompressedBytes,
   };
+}
+
+interface LocalEntryRange {
+  start: number;
+  end: number;
+  path: string;
+}
+
+function assertNoOverlappingLocalEntryRanges(
+  ranges: readonly LocalEntryRange[],
+): void {
+  const sortedRanges = [...ranges].sort(
+    (left, right) => left.start - right.start || left.end - right.end,
+  );
+
+  for (let index = 1; index < sortedRanges.length; index += 1) {
+    const previous = sortedRanges[index - 1];
+    const current = sortedRanges[index];
+    if (current.start < previous.end) {
+      throw new InvalidZipArchiveError(
+        `ZIP local entry ranges for "${previous.path}" and "${current.path}" overlap.`,
+      );
+    }
+  }
 }
 
 function assertNoFileDescendantConflicts(
@@ -700,6 +744,7 @@ function validateLocalHeader(
   view: DataView,
   entry: {
     centralDirectoryOffset: number;
+    centralCrc32: number;
     centralFlags: number;
     centralNameStart: number;
     centralNameEnd: number;
@@ -708,7 +753,7 @@ function validateLocalHeader(
     localHeaderOffset: number;
     uncompressedSize: number;
   },
-): void {
+): number {
   assertRange(
     entry.localHeaderOffset,
     LOCAL_FILE_HEADER_SIZE,
@@ -730,6 +775,7 @@ function validateLocalHeader(
     entry.localHeaderOffset + 8,
     true,
   );
+  const localCrc32 = view.getUint32(entry.localHeaderOffset + 14, true);
   const localCompressedSize = view.getUint32(
     entry.localHeaderOffset + 18,
     true,
@@ -785,6 +831,7 @@ function validateLocalHeader(
 
   if ((localFlags & DATA_DESCRIPTOR_FLAG) === 0) {
     if (
+      localCrc32 !== entry.centralCrc32 ||
       localCompressedSize !== entry.compressedSize ||
       localUncompressedSize !== entry.uncompressedSize
     ) {
@@ -792,6 +839,16 @@ function validateLocalHeader(
         'ZIP local file sizes do not match the central-directory entry.',
       );
     }
+  } else if (
+    (localCrc32 !== 0 && localCrc32 !== entry.centralCrc32) ||
+    (localCompressedSize !== 0 &&
+      localCompressedSize !== entry.compressedSize) ||
+    (localUncompressedSize !== 0 &&
+      localUncompressedSize !== entry.uncompressedSize)
+  ) {
+    throw new InvalidZipArchiveError(
+      'ZIP local file metadata does not match its data descriptor.',
+    );
   }
 
   if (entry.compressedSize > entry.centralDirectoryOffset - localExtraEnd) {
@@ -799,6 +856,60 @@ function validateLocalHeader(
       'ZIP entry body is truncated or overlaps the central directory.',
     );
   }
+
+  const localDataEnd = localExtraEnd + entry.compressedSize;
+  if ((localFlags & DATA_DESCRIPTOR_FLAG) !== 0) {
+    return validateDataDescriptor(view, localDataEnd, entry);
+  }
+  return localDataEnd;
+}
+
+function validateDataDescriptor(
+  view: DataView,
+  offset: number,
+  entry: {
+    centralDirectoryOffset: number;
+    centralCrc32: number;
+    compressedSize: number;
+    uncompressedSize: number;
+  },
+): number {
+  assertRange(
+    offset,
+    12,
+    entry.centralDirectoryOffset,
+    'ZIP data descriptor is missing or truncated.',
+  );
+
+  const firstValue = view.getUint32(offset, true);
+  const unsignedMatches =
+    firstValue === entry.centralCrc32 &&
+    view.getUint32(offset + 4, true) === entry.compressedSize &&
+    view.getUint32(offset + 8, true) === entry.uncompressedSize;
+
+  if (firstValue !== DATA_DESCRIPTOR_SIGNATURE) {
+    if (unsignedMatches) {
+      return offset + 12;
+    }
+    throw new InvalidZipArchiveError(
+      'ZIP data descriptor does not match its central-directory entry.',
+    );
+  }
+
+  const hasSignedRange = 16 <= entry.centralDirectoryOffset - offset;
+  const signedMatches =
+    hasSignedRange &&
+    view.getUint32(offset + 4, true) === entry.centralCrc32 &&
+    view.getUint32(offset + 8, true) === entry.compressedSize &&
+    view.getUint32(offset + 12, true) === entry.uncompressedSize;
+
+  if (signedMatches === unsignedMatches) {
+    throw new InvalidZipArchiveError(
+      'ZIP data descriptor is ambiguous or does not match its central-directory entry.',
+    );
+  }
+
+  return signedMatches ? offset + 16 : offset + 12;
 }
 
 function assertExtraFields(

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -1065,13 +1065,22 @@ function assertNotAesCompression(compressionMethod: number): void {
 }
 
 function decodeEntryPath(bytes: Uint8Array): string {
+  let path: string;
   try {
-    return utf8Decoder.decode(bytes);
+    path = utf8Decoder.decode(bytes);
   } catch {
     throw new InvalidZipArchiveError(
       'ZIP entry path is not valid UTF-8. Legacy non-UTF-8 names are not supported.',
     );
   }
+  if (path.startsWith('\ufeff')) {
+    throw new UnsupportedZipFeatureError(
+      'ambiguous-metadata',
+      'ZIP entry path starts with a UTF-8 BOM, which filename decoders interpret inconsistently.',
+      path,
+    );
+  }
+  return path;
 }
 
 function normalizeEntryPath(rawPath: string): string {

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -1,0 +1,927 @@
+/**
+ * Bounded, zero-decompression ZIP manifest inspection.
+ *
+ * The inspector reads ZIP metadata only. It never inflates or materializes an
+ * entry body, and it rejects archive features that would make the classic ZIP
+ * metadata ambiguous (ZIP64, encryption, and multi-disk archives).
+ */
+
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06064b50;
+const ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIGNATURE = 0x07064b50;
+const ZIP64_EXTRA_FIELD_ID = 0x0001;
+const PKWARE_UNIX_EXTRA_FIELD_ID = 0x000d;
+const STRONG_ENCRYPTION_EXTRA_FIELD_ID = 0x0017;
+const XCEED_UNICODE_PATH_EXTRA_FIELD_ID = 0x554e;
+const LIBARCHIVE_EXTRA_FIELD_ID = 0x6c78;
+const UNICODE_PATH_EXTRA_FIELD_ID = 0x7075;
+const ASI_UNIX_EXTRA_FIELD_ID = 0x756e;
+const WINZIP_AES_EXTRA_FIELD_ID = 0x9901;
+const WINZIP_AES_COMPRESSION_METHOD = 99;
+
+const END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+const MAX_ZIP_COMMENT_BYTES = 0xffff;
+const CENTRAL_DIRECTORY_ENTRY_SIZE = 46;
+const LOCAL_FILE_HEADER_SIZE = 30;
+
+const ENCRYPTED_FLAG = 0x0001;
+const STRONG_ENCRYPTION_FLAG = 0x0040;
+const DATA_DESCRIPTOR_FLAG = 0x0008;
+const MASKED_LOCAL_HEADER_FLAG = 0x2000;
+
+const UNIX_FILE_TYPE_MASK = 0o170000;
+const UNIX_DIRECTORY_TYPE = 0o040000;
+const UNIX_REGULAR_FILE_TYPE = 0o100000;
+const UNIX_SYMLINK_TYPE = 0o120000;
+const DOS_DIRECTORY_ATTRIBUTE = 0x10;
+
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+/** Limits applied while inspecting ZIP metadata. */
+export interface ZipManifestLimits {
+  /** Maximum number of central-directory entries, including directories. */
+  maxEntries?: number;
+  /** Maximum declared uncompressed size of one entry. */
+  maxEntryUncompressedBytes?: number;
+  /** Maximum aggregate declared uncompressed size across all entries. */
+  maxTotalUncompressedBytes?: number;
+  /** Maximum encoded byte length of one entry path. */
+  maxPathBytes?: number;
+}
+
+/** Conservative defaults suitable for rejecting untrusted uploads. */
+export const DEFAULT_ZIP_MANIFEST_LIMITS: Readonly<
+  Required<ZipManifestLimits>
+> = Object.freeze({
+  maxEntries: 10_000,
+  maxEntryUncompressedBytes: 200 * 1024 * 1024,
+  maxTotalUncompressedBytes: 2 * 1024 * 1024 * 1024,
+  maxPathBytes: 1024,
+});
+
+/** One normalized entry from a ZIP archive. */
+export interface ZipManifestEntry {
+  /** Normalized relative path using `/` separators and no `.` segments. */
+  path: string;
+  /** Whether the entry represents a file or directory. */
+  type: 'file' | 'directory';
+  /** Declared uncompressed size in bytes. */
+  size: number;
+  /** Declared compressed size in bytes. */
+  compressedSize: number;
+  /** ZIP compression method identifier. Entry bodies are not decompressed. */
+  compressionMethod: number;
+}
+
+/** A bounded metadata-only view of a ZIP archive. */
+export interface ZipManifest {
+  entries: ZipManifestEntry[];
+  entryCount: number;
+  fileCount: number;
+  directoryCount: number;
+  totalUncompressedBytes: number;
+}
+
+export type ZipManifestErrorCode =
+  | 'ZIP_INVALID'
+  | 'ZIP_LIMIT_EXCEEDED'
+  | 'ZIP_UNSAFE_ENTRY'
+  | 'ZIP_UNSUPPORTED_FEATURE';
+
+/** Base class for failures caused by untrusted ZIP input. */
+export class ZipManifestError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ZipManifestErrorCode,
+    public readonly entryPath?: string,
+  ) {
+    super(message);
+    this.name = 'ZipManifestError';
+  }
+}
+
+/** The archive metadata is malformed, truncated, or internally inconsistent. */
+export class InvalidZipArchiveError extends ZipManifestError {
+  constructor(message: string) {
+    super(message, 'ZIP_INVALID');
+    this.name = 'InvalidZipArchiveError';
+  }
+}
+
+export type ZipUnsafeEntryReason =
+  | 'absolute-path'
+  | 'drive-qualified-path'
+  | 'duplicate-path'
+  | 'empty-path'
+  | 'nul-byte'
+  | 'path-traversal'
+  | 'special-file'
+  | 'symlink';
+
+/** An entry is unsafe to expose to an extraction workflow. */
+export class UnsafeZipEntryError extends ZipManifestError {
+  constructor(
+    public readonly reason: ZipUnsafeEntryReason,
+    entryPath: string,
+    message: string,
+  ) {
+    super(message, 'ZIP_UNSAFE_ENTRY', entryPath);
+    this.name = 'UnsafeZipEntryError';
+  }
+}
+
+export type ZipLimitName =
+  | 'entry-count'
+  | 'entry-uncompressed-size'
+  | 'path-bytes'
+  | 'total-uncompressed-size';
+
+/** A configured inspection limit was exceeded. */
+export class ZipManifestLimitError extends ZipManifestError {
+  constructor(
+    public readonly limit: ZipLimitName,
+    public readonly actual: number,
+    public readonly maximum: number,
+    message: string,
+    entryPath?: string,
+  ) {
+    super(message, 'ZIP_LIMIT_EXCEEDED', entryPath);
+    this.name = 'ZipManifestLimitError';
+  }
+}
+
+export type UnsupportedZipFeature =
+  | 'ambiguous-metadata'
+  | 'encryption'
+  | 'multi-disk'
+  | 'zip64';
+
+/** The archive uses a feature deliberately outside this inspector's policy. */
+export class UnsupportedZipFeatureError extends ZipManifestError {
+  constructor(
+    public readonly feature: UnsupportedZipFeature,
+    message: string,
+    entryPath?: string,
+  ) {
+    super(message, 'ZIP_UNSUPPORTED_FEATURE', entryPath);
+    this.name = 'UnsupportedZipFeatureError';
+  }
+}
+
+interface EndOfCentralDirectory {
+  offset: number;
+  diskNumber: number;
+  centralDirectoryDisk: number;
+  entriesOnDisk: number;
+  totalEntries: number;
+  centralDirectorySize: number;
+  centralDirectoryOffset: number;
+}
+
+interface ResolvedZipManifestLimits {
+  maxEntries: number;
+  maxEntryUncompressedBytes: number;
+  maxTotalUncompressedBytes: number;
+  maxPathBytes: number;
+}
+
+/**
+ * Inspect a ZIP archive without decompressing entry bodies.
+ *
+ * ZIP64, encrypted, and multi-disk archives are rejected. Entry paths are
+ * normalized and checked for traversal, absolute/drive-qualified forms, NUL
+ * bytes, symlinks, Unix special files, and post-normalization collisions. The
+ * declared entry sizes and end-record validation work are bounded before a
+ * manifest is returned.
+ */
+export function inspectZipManifest(
+  data: Uint8Array,
+  limits: ZipManifestLimits = {},
+): ZipManifest {
+  if (!(data instanceof Uint8Array)) {
+    throw new TypeError('inspectZipManifest data must be a Uint8Array');
+  }
+
+  const resolvedLimits = resolveLimits(limits);
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const endRecord = findEndOfCentralDirectory(view, resolvedLimits.maxEntries);
+
+  assertClassicZip(endRecord, view);
+
+  if (endRecord.totalEntries > resolvedLimits.maxEntries) {
+    throw new ZipManifestLimitError(
+      'entry-count',
+      endRecord.totalEntries,
+      resolvedLimits.maxEntries,
+      `ZIP archive contains ${endRecord.totalEntries} entries; the limit is ${resolvedLimits.maxEntries}.`,
+    );
+  }
+
+  if (
+    endRecord.centralDirectoryOffset > endRecord.offset ||
+    endRecord.centralDirectorySize >
+      endRecord.offset - endRecord.centralDirectoryOffset
+  ) {
+    throw new InvalidZipArchiveError(
+      'ZIP central directory points outside the archive metadata bounds.',
+    );
+  }
+
+  const centralDirectoryEnd =
+    endRecord.centralDirectoryOffset + endRecord.centralDirectorySize;
+  if (centralDirectoryEnd !== endRecord.offset) {
+    throw new InvalidZipArchiveError(
+      'ZIP central directory size or offset does not match the end record.',
+    );
+  }
+
+  const entries: ZipManifestEntry[] = [];
+  const normalizedPaths = new Set<string>();
+  let totalUncompressedBytes = 0;
+  let fileCount = 0;
+  let directoryCount = 0;
+  let offset = endRecord.centralDirectoryOffset;
+
+  for (let index = 0; index < endRecord.totalEntries; index += 1) {
+    assertRange(
+      offset,
+      CENTRAL_DIRECTORY_ENTRY_SIZE,
+      centralDirectoryEnd,
+      'ZIP central directory is truncated.',
+    );
+
+    if (view.getUint32(offset, true) !== CENTRAL_DIRECTORY_SIGNATURE) {
+      throw new InvalidZipArchiveError(
+        `ZIP central directory entry ${index + 1} has an invalid signature.`,
+      );
+    }
+
+    const flags = view.getUint16(offset + 8, true);
+    const compressionMethod = view.getUint16(offset + 10, true);
+    const compressedSize = view.getUint32(offset + 20, true);
+    const uncompressedSize = view.getUint32(offset + 24, true);
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraFieldLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const startingDisk = view.getUint16(offset + 34, true);
+    const externalAttributes = view.getUint32(offset + 38, true);
+    const localHeaderOffset = view.getUint32(offset + 42, true);
+
+    if (
+      compressedSize === 0xffffffff ||
+      uncompressedSize === 0xffffffff ||
+      localHeaderOffset === 0xffffffff ||
+      startingDisk === 0xffff
+    ) {
+      throw zip64Error();
+    }
+    if (startingDisk !== 0) {
+      throw multiDiskError();
+    }
+    assertNotEncrypted(flags);
+    assertNotAesCompression(compressionMethod);
+
+    const nameStart = offset + CENTRAL_DIRECTORY_ENTRY_SIZE;
+    const nameEnd = nameStart + fileNameLength;
+    const extraEnd = nameEnd + extraFieldLength;
+    const entryEnd = extraEnd + commentLength;
+    assertRange(
+      offset,
+      entryEnd - offset,
+      centralDirectoryEnd,
+      'ZIP central directory entry metadata is truncated.',
+    );
+
+    if (fileNameLength > resolvedLimits.maxPathBytes) {
+      throw new ZipManifestLimitError(
+        'path-bytes',
+        fileNameLength,
+        resolvedLimits.maxPathBytes,
+        `ZIP entry path is ${fileNameLength} bytes; the limit is ${resolvedLimits.maxPathBytes}.`,
+      );
+    }
+
+    assertExtraFields(data, nameEnd, extraEnd, 'central directory');
+    const rawPathBytes = data.subarray(nameStart, nameEnd);
+    const rawPath = decodeEntryPath(rawPathBytes);
+    const path = normalizeEntryPath(rawPath);
+
+    const unixMode = (externalAttributes >>> 16) & 0xffff;
+    const unixFileType = unixMode & UNIX_FILE_TYPE_MASK;
+    if (unixFileType === UNIX_SYMLINK_TYPE) {
+      throw new UnsafeZipEntryError(
+        'symlink',
+        rawPath,
+        `ZIP entry "${rawPath}" is a symbolic link, which is not allowed.`,
+      );
+    }
+    if (
+      unixFileType !== 0 &&
+      unixFileType !== UNIX_DIRECTORY_TYPE &&
+      unixFileType !== UNIX_REGULAR_FILE_TYPE
+    ) {
+      throw new UnsafeZipEntryError(
+        'special-file',
+        rawPath,
+        `ZIP entry "${rawPath}" uses an unsupported Unix special file type.`,
+      );
+    }
+
+    if (normalizedPaths.has(path)) {
+      throw new UnsafeZipEntryError(
+        'duplicate-path',
+        rawPath,
+        `ZIP entry "${rawPath}" collides with another normalized path ("${path}").`,
+      );
+    }
+    normalizedPaths.add(path);
+
+    validateLocalHeader(data, view, {
+      centralDirectoryOffset: endRecord.centralDirectoryOffset,
+      centralFlags: flags,
+      centralNameStart: nameStart,
+      centralNameEnd: nameEnd,
+      compressedSize,
+      compressionMethod,
+      localHeaderOffset,
+      uncompressedSize,
+    });
+
+    if (uncompressedSize > resolvedLimits.maxEntryUncompressedBytes) {
+      throw new ZipManifestLimitError(
+        'entry-uncompressed-size',
+        uncompressedSize,
+        resolvedLimits.maxEntryUncompressedBytes,
+        `ZIP entry "${path}" declares ${uncompressedSize} uncompressed bytes; the per-entry limit is ${resolvedLimits.maxEntryUncompressedBytes}.`,
+        path,
+      );
+    }
+
+    totalUncompressedBytes += uncompressedSize;
+    if (totalUncompressedBytes > resolvedLimits.maxTotalUncompressedBytes) {
+      throw new ZipManifestLimitError(
+        'total-uncompressed-size',
+        totalUncompressedBytes,
+        resolvedLimits.maxTotalUncompressedBytes,
+        `ZIP archive declares ${totalUncompressedBytes} uncompressed bytes; the aggregate limit is ${resolvedLimits.maxTotalUncompressedBytes}.`,
+        path,
+      );
+    }
+
+    const type =
+      rawPath.endsWith('/') ||
+      rawPath.endsWith('\\') ||
+      (unixMode & UNIX_FILE_TYPE_MASK) === UNIX_DIRECTORY_TYPE ||
+      (externalAttributes & DOS_DIRECTORY_ATTRIBUTE) !== 0
+        ? 'directory'
+        : 'file';
+
+    if (type === 'directory') {
+      directoryCount += 1;
+    } else {
+      fileCount += 1;
+    }
+
+    entries.push({
+      path,
+      type,
+      size: uncompressedSize,
+      compressedSize,
+      compressionMethod,
+    });
+    offset = entryEnd;
+  }
+
+  if (offset !== centralDirectoryEnd) {
+    throw new InvalidZipArchiveError(
+      'ZIP central directory entry count does not match its declared size.',
+    );
+  }
+
+  return {
+    entries,
+    entryCount: entries.length,
+    fileCount,
+    directoryCount,
+    totalUncompressedBytes,
+  };
+}
+
+function resolveLimits(limits: ZipManifestLimits): ResolvedZipManifestLimits {
+  return {
+    maxEntries: validateLimit(
+      'maxEntries',
+      limits.maxEntries ?? DEFAULT_ZIP_MANIFEST_LIMITS.maxEntries,
+    ),
+    maxEntryUncompressedBytes: validateLimit(
+      'maxEntryUncompressedBytes',
+      limits.maxEntryUncompressedBytes ??
+        DEFAULT_ZIP_MANIFEST_LIMITS.maxEntryUncompressedBytes,
+    ),
+    maxTotalUncompressedBytes: validateLimit(
+      'maxTotalUncompressedBytes',
+      limits.maxTotalUncompressedBytes ??
+        DEFAULT_ZIP_MANIFEST_LIMITS.maxTotalUncompressedBytes,
+    ),
+    maxPathBytes: validateLimit(
+      'maxPathBytes',
+      limits.maxPathBytes ?? DEFAULT_ZIP_MANIFEST_LIMITS.maxPathBytes,
+    ),
+  };
+}
+
+function validateLimit(name: string, value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+interface EndRecordValidationBudget {
+  maxEntries: number;
+  remainingEntryChecks: number;
+}
+
+function findEndOfCentralDirectory(
+  view: DataView,
+  maxEntries: number,
+): EndOfCentralDirectory {
+  if (view.byteLength < END_OF_CENTRAL_DIRECTORY_SIZE) {
+    throw new InvalidZipArchiveError(
+      'Data is too small to contain a ZIP end-of-central-directory record.',
+    );
+  }
+
+  const earliestOffset = Math.max(
+    0,
+    view.byteLength - END_OF_CENTRAL_DIRECTORY_SIZE - MAX_ZIP_COMMENT_BYTES,
+  );
+  const validationBudget: EndRecordValidationBudget = {
+    maxEntries,
+    remainingEntryChecks: Math.min(maxEntries, 0xfffe) + 1,
+  };
+
+  for (
+    let offset = view.byteLength - END_OF_CENTRAL_DIRECTORY_SIZE;
+    offset >= earliestOffset;
+    offset -= 1
+  ) {
+    if (view.getUint32(offset, true) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+      continue;
+    }
+
+    const commentLength = view.getUint16(offset + 20, true);
+    if (
+      offset + END_OF_CENTRAL_DIRECTORY_SIZE + commentLength !==
+      view.byteLength
+    ) {
+      continue;
+    }
+
+    const candidate = {
+      offset,
+      diskNumber: view.getUint16(offset + 4, true),
+      centralDirectoryDisk: view.getUint16(offset + 6, true),
+      entriesOnDisk: view.getUint16(offset + 8, true),
+      totalEntries: view.getUint16(offset + 10, true),
+      centralDirectorySize: view.getUint32(offset + 12, true),
+      centralDirectoryOffset: view.getUint32(offset + 16, true),
+    };
+    if (isStructurallyPlausibleEndRecord(view, candidate, validationBudget)) {
+      return candidate;
+    }
+  }
+
+  throw new InvalidZipArchiveError(
+    'ZIP end-of-central-directory record is missing or truncated.',
+  );
+}
+
+function isStructurallyPlausibleEndRecord(
+  view: DataView,
+  endRecord: EndOfCentralDirectory,
+  budget: EndRecordValidationBudget,
+): boolean {
+  if (hasStructurallyValidZip64Chain(view, endRecord)) {
+    return true;
+  }
+
+  if (
+    endRecord.centralDirectoryOffset === 0xffffffff ||
+    endRecord.centralDirectorySize === 0xffffffff
+  ) {
+    return false;
+  }
+
+  const centralDirectoryEnd =
+    endRecord.centralDirectoryOffset + endRecord.centralDirectorySize;
+  if (
+    endRecord.centralDirectoryOffset > endRecord.offset ||
+    centralDirectoryEnd !== endRecord.offset
+  ) {
+    return false;
+  }
+
+  if (endRecord.entriesOnDisk === 0xffff || endRecord.totalEntries === 0xffff) {
+    return false;
+  }
+
+  if (endRecord.totalEntries > budget.maxEntries) {
+    return (
+      endRecord.centralDirectorySize >=
+        endRecord.totalEntries * CENTRAL_DIRECTORY_ENTRY_SIZE &&
+      endRecord.centralDirectoryOffset <=
+        endRecord.offset - CENTRAL_DIRECTORY_ENTRY_SIZE &&
+      view.getUint32(endRecord.centralDirectoryOffset, true) ===
+        CENTRAL_DIRECTORY_SIGNATURE
+    );
+  }
+
+  let offset = endRecord.centralDirectoryOffset;
+  for (let index = 0; index < endRecord.totalEntries; index += 1) {
+    if (budget.remainingEntryChecks === 0) {
+      throw new InvalidZipArchiveError(
+        'ZIP end-record candidate validation exceeded the configured entry-check budget.',
+      );
+    }
+    budget.remainingEntryChecks -= 1;
+
+    if (
+      offset > endRecord.offset - CENTRAL_DIRECTORY_ENTRY_SIZE ||
+      view.getUint32(offset, true) !== CENTRAL_DIRECTORY_SIGNATURE
+    ) {
+      return false;
+    }
+
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraFieldLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const entryLength =
+      CENTRAL_DIRECTORY_ENTRY_SIZE +
+      fileNameLength +
+      extraFieldLength +
+      commentLength;
+    if (entryLength > endRecord.offset - offset) {
+      return false;
+    }
+    offset += entryLength;
+  }
+
+  return offset === endRecord.offset;
+}
+
+function hasStructurallyValidZip64Chain(
+  view: DataView,
+  endRecord: EndOfCentralDirectory,
+): boolean {
+  const locatorOffset = endRecord.offset - 20;
+  if (
+    locatorOffset < 0 ||
+    view.getUint32(locatorOffset, true) !==
+      ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIGNATURE
+  ) {
+    return false;
+  }
+
+  const zip64Offset = readSafeUint64(view, locatorOffset + 8);
+  if (
+    zip64Offset === undefined ||
+    zip64Offset > locatorOffset - 56 ||
+    view.getUint32(zip64Offset, true) !==
+      ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE
+  ) {
+    return false;
+  }
+
+  const recordSize = readSafeUint64(view, zip64Offset + 4);
+  return (
+    recordSize !== undefined &&
+    recordSize >= 44 &&
+    zip64Offset + 12 + recordSize === locatorOffset
+  );
+}
+
+function readSafeUint64(view: DataView, offset: number): number | undefined {
+  const low = view.getUint32(offset, true);
+  const high = view.getUint32(offset + 4, true);
+  const value = high * 0x1_0000_0000 + low;
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function assertClassicZip(
+  endRecord: EndOfCentralDirectory,
+  view: DataView,
+): void {
+  const hasZip64Locator = hasStructurallyValidZip64Chain(view, endRecord);
+
+  if (
+    endRecord.entriesOnDisk === 0xffff ||
+    endRecord.totalEntries === 0xffff ||
+    endRecord.centralDirectorySize === 0xffffffff ||
+    endRecord.centralDirectoryOffset === 0xffffffff ||
+    hasZip64Locator
+  ) {
+    throw zip64Error();
+  }
+
+  if (
+    endRecord.diskNumber !== 0 ||
+    endRecord.centralDirectoryDisk !== 0 ||
+    endRecord.entriesOnDisk !== endRecord.totalEntries
+  ) {
+    throw multiDiskError();
+  }
+}
+
+function validateLocalHeader(
+  data: Uint8Array,
+  view: DataView,
+  entry: {
+    centralDirectoryOffset: number;
+    centralFlags: number;
+    centralNameStart: number;
+    centralNameEnd: number;
+    compressedSize: number;
+    compressionMethod: number;
+    localHeaderOffset: number;
+    uncompressedSize: number;
+  },
+): void {
+  assertRange(
+    entry.localHeaderOffset,
+    LOCAL_FILE_HEADER_SIZE,
+    entry.centralDirectoryOffset,
+    'ZIP local file header is missing or truncated.',
+  );
+
+  if (
+    view.getUint32(entry.localHeaderOffset, true) !==
+    LOCAL_FILE_HEADER_SIGNATURE
+  ) {
+    throw new InvalidZipArchiveError(
+      'ZIP central directory points to an invalid local file header.',
+    );
+  }
+
+  const localFlags = view.getUint16(entry.localHeaderOffset + 6, true);
+  const localCompressionMethod = view.getUint16(
+    entry.localHeaderOffset + 8,
+    true,
+  );
+  const localCompressedSize = view.getUint32(
+    entry.localHeaderOffset + 18,
+    true,
+  );
+  const localUncompressedSize = view.getUint32(
+    entry.localHeaderOffset + 22,
+    true,
+  );
+  const localNameLength = view.getUint16(entry.localHeaderOffset + 26, true);
+  const localExtraLength = view.getUint16(entry.localHeaderOffset + 28, true);
+
+  if (
+    localCompressedSize === 0xffffffff ||
+    localUncompressedSize === 0xffffffff
+  ) {
+    throw zip64Error();
+  }
+  assertNotEncrypted(localFlags);
+
+  if (
+    localFlags !== entry.centralFlags ||
+    localCompressionMethod !== entry.compressionMethod
+  ) {
+    throw new InvalidZipArchiveError(
+      'ZIP local file header does not match its central-directory entry.',
+    );
+  }
+
+  const localNameStart = entry.localHeaderOffset + LOCAL_FILE_HEADER_SIZE;
+  const localNameEnd = localNameStart + localNameLength;
+  const localExtraEnd = localNameEnd + localExtraLength;
+  assertRange(
+    entry.localHeaderOffset,
+    localExtraEnd - entry.localHeaderOffset,
+    entry.centralDirectoryOffset,
+    'ZIP local file header metadata is truncated.',
+  );
+
+  const centralNameLength = entry.centralNameEnd - entry.centralNameStart;
+  if (
+    localNameLength !== centralNameLength ||
+    !equalBytes(
+      data.subarray(localNameStart, localNameEnd),
+      data.subarray(entry.centralNameStart, entry.centralNameEnd),
+    )
+  ) {
+    throw new InvalidZipArchiveError(
+      'ZIP local and central-directory entry paths do not match.',
+    );
+  }
+
+  assertExtraFields(data, localNameEnd, localExtraEnd, 'local file header');
+
+  if ((localFlags & DATA_DESCRIPTOR_FLAG) === 0) {
+    if (
+      localCompressedSize !== entry.compressedSize ||
+      localUncompressedSize !== entry.uncompressedSize
+    ) {
+      throw new InvalidZipArchiveError(
+        'ZIP local file sizes do not match the central-directory entry.',
+      );
+    }
+  }
+
+  if (entry.compressedSize > entry.centralDirectoryOffset - localExtraEnd) {
+    throw new InvalidZipArchiveError(
+      'ZIP entry body is truncated or overlaps the central directory.',
+    );
+  }
+}
+
+function assertExtraFields(
+  data: Uint8Array,
+  start: number,
+  end: number,
+  location: string,
+): void {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  let offset = start;
+
+  while (offset < end) {
+    if (end - offset < 4) {
+      throw new InvalidZipArchiveError(
+        `ZIP ${location} contains a truncated extra field.`,
+      );
+    }
+
+    const headerId = view.getUint16(offset, true);
+    const dataSize = view.getUint16(offset + 2, true);
+    const nextOffset = offset + 4 + dataSize;
+    if (nextOffset > end) {
+      throw new InvalidZipArchiveError(
+        `ZIP ${location} contains a truncated extra field.`,
+      );
+    }
+    if (headerId === ZIP64_EXTRA_FIELD_ID) {
+      throw zip64Error();
+    }
+    if (
+      headerId === STRONG_ENCRYPTION_EXTRA_FIELD_ID ||
+      headerId === WINZIP_AES_EXTRA_FIELD_ID
+    ) {
+      throw encryptionError();
+    }
+    if (
+      headerId === XCEED_UNICODE_PATH_EXTRA_FIELD_ID ||
+      headerId === UNICODE_PATH_EXTRA_FIELD_ID
+    ) {
+      throw new UnsupportedZipFeatureError(
+        'ambiguous-metadata',
+        'ZIP Unicode path extra fields are not supported because entry names must have one unambiguous representation.',
+      );
+    }
+    if (
+      headerId === PKWARE_UNIX_EXTRA_FIELD_ID ||
+      headerId === ASI_UNIX_EXTRA_FIELD_ID ||
+      headerId === LIBARCHIVE_EXTRA_FIELD_ID
+    ) {
+      throw new UnsupportedZipFeatureError(
+        'ambiguous-metadata',
+        'ZIP Unix link and file-type extra fields are not supported because entry type must have one unambiguous representation.',
+      );
+    }
+    offset = nextOffset;
+  }
+}
+
+function assertNotEncrypted(flags: number): void {
+  if (
+    (flags &
+      (ENCRYPTED_FLAG | STRONG_ENCRYPTION_FLAG | MASKED_LOCAL_HEADER_FLAG)) !==
+    0
+  ) {
+    throw encryptionError();
+  }
+}
+
+function assertNotAesCompression(compressionMethod: number): void {
+  if (compressionMethod === WINZIP_AES_COMPRESSION_METHOD) {
+    throw encryptionError();
+  }
+}
+
+function decodeEntryPath(bytes: Uint8Array): string {
+  try {
+    return utf8Decoder.decode(bytes);
+  } catch {
+    throw new InvalidZipArchiveError(
+      'ZIP entry path is not valid UTF-8. Legacy non-UTF-8 names are not supported.',
+    );
+  }
+}
+
+function normalizeEntryPath(rawPath: string): string {
+  if (rawPath.length === 0) {
+    throw new UnsafeZipEntryError(
+      'empty-path',
+      rawPath,
+      'ZIP entry path is empty.',
+    );
+  }
+  if (rawPath.includes('\0')) {
+    throw new UnsafeZipEntryError(
+      'nul-byte',
+      rawPath,
+      'ZIP entry path contains a NUL byte.',
+    );
+  }
+
+  const unifiedPath = rawPath.replace(/\\/g, '/');
+  if (/^[a-zA-Z]:/.test(unifiedPath)) {
+    throw new UnsafeZipEntryError(
+      'drive-qualified-path',
+      rawPath,
+      `ZIP entry "${rawPath}" uses a drive-qualified path.`,
+    );
+  }
+  if (unifiedPath.startsWith('/')) {
+    throw new UnsafeZipEntryError(
+      'absolute-path',
+      rawPath,
+      `ZIP entry "${rawPath}" uses an absolute path.`,
+    );
+  }
+
+  const segments = unifiedPath.split('/');
+  if (segments.includes('..')) {
+    throw new UnsafeZipEntryError(
+      'path-traversal',
+      rawPath,
+      `ZIP entry "${rawPath}" contains a parent-directory traversal segment.`,
+    );
+  }
+
+  const normalizedPath = segments
+    .filter((segment) => segment !== '' && segment !== '.')
+    .join('/');
+  if (normalizedPath.length === 0) {
+    throw new UnsafeZipEntryError(
+      'empty-path',
+      rawPath,
+      `ZIP entry "${rawPath}" normalizes to an empty path.`,
+    );
+  }
+  return normalizedPath;
+}
+
+function assertRange(
+  offset: number,
+  length: number,
+  boundary: number,
+  message: string,
+): void {
+  if (
+    offset < 0 ||
+    length < 0 ||
+    offset > boundary ||
+    length > boundary - offset
+  ) {
+    throw new InvalidZipArchiveError(message);
+  }
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function zip64Error(): UnsupportedZipFeatureError {
+  return new UnsupportedZipFeatureError(
+    'zip64',
+    'ZIP64 archives are not supported; use a classic ZIP archive within the configured limits.',
+  );
+}
+
+function multiDiskError(): UnsupportedZipFeatureError {
+  return new UnsupportedZipFeatureError(
+    'multi-disk',
+    'Multi-disk ZIP archives are not supported.',
+  );
+}
+
+function encryptionError(): UnsupportedZipFeatureError {
+  return new UnsupportedZipFeatureError(
+    'encryption',
+    'Encrypted ZIP entries are not supported because their metadata cannot be safely inspected without decryption.',
+  );
+}

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -24,6 +24,7 @@
  * @packageDocumentation
  */
 
+export * from './archive';
 export type {
   FetchToFileOptions,
   WriteResponseToFileOptions,


### PR DESCRIPTION
## Summary

- add a bounded, zero-decompression ZIP manifest inspector with normalized file and directory metadata
- reject traversal, absolute and drive paths, NTFS alternate data streams, NULs, Unix links/special files, Windows reparse points and reserved names, portable path aliases, hidden local entries, alternate filename encodings, creator-OS mode conflicts, unverifiable compressed data descriptors, leading BOM ambiguity, path/layout conflicts, encryption, ZIP64, multi-disk archives, and ambiguous end records
- validate local/central metadata, classic signed and unsigned data descriptors, entry ranges, limits, and unique EOCD selection before returning a manifest
- document the API, strict policy, defaults, and typed failures, with a patch changeset

Closes #1082

## Validation

- Node 24.18.0
- `pnpm --filter @happyvertical/files test` — 222/222 tests passed, including 80 archive tests
- `pnpm --filter @happyvertical/files build`
- component pre-push full typecheck
- integration revision `7d757ea3`: Projects 10/10, SQL 341 passed with 4 skipped, and `pnpm test:ci-scripts` 18/18
- integration full `agent:check`, typecheck, lint, build (31 packages), and generated Files API docs
- 20,000-buffer typed-failure fuzz probe
- independent EOCD-smuggling reproduction fails closed
- all substantive review threads addressed and resolved
- final full-roster review-cycle at `7d757ea3` — clean across correctness, security, maintainability, product behavior, tests, docs, release behavior, and local consistency

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-019f5c83-6435-7493-bcf3-07149f9de5db",
  "issue": "happyvertical/sdk#1082",
  "policy_revision": "1.0.0",
  "validation": [
    "@happyvertical/files tests: 222 passed (80 archive tests)",
    "@happyvertical/files build: passed",
    "component pre-push full typecheck: passed",
    "integration Projects tests: 10 passed",
    "integration SQL tests: 341 passed, 4 skipped",
    "integration test:ci-scripts: 18 passed",
    "integration agent:check/typecheck/lint/build: passed",
    "generated Files API docs: passed",
    "20,000-buffer typed-failure fuzz probe: passed",
    "EOCD-smuggling reproduction: rejected",
    "review-cycle final full roster at 7d757ea3: clean"
  ]
}
```
