### PR TITLE
fix(ci): ignore private package version drift

### DIFF
--- a/scripts/validate-workspace-consistency.js
+++ b/scripts/validate-workspace-consistency.js
@@ -88,7 +88,8 @@ function validateWorkspacePackages(errors) {
   for (const { manifestPath, manifest } of manifests) {
     if (
       typeof manifest.name === 'string' &&
-      manifest.name.startsWith(INTERNAL_SCOPE)
+      manifest.name.startsWith(INTERNAL_SCOPE) &&
+      manifest.private !== true
     ) {
       internalVersions.set(manifest.name, {
         manifestPath,
@@ -153,7 +154,7 @@ function main() {
   }
 
   console.log(
-    '✅ Workspace consistency validated: internal package versions are aligned and in-repo dependencies use workspace:*',
+    '✅ Workspace consistency validated: published internal package versions are aligned and in-repo dependencies use workspace:*',
   );
 }
 

--- a/scripts/validate-workspace-consistency.test.mjs
+++ b/scripts/validate-workspace-consistency.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'validate-workspace-consistency.js',
+);
+
+function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createWorkspace({ docs, packages }) {
+  const root = mkdtempSync(join(tmpdir(), 'sdk-workspace-consistency-'));
+  mkdirSync(join(root, '.changeset'));
+  writeJson(join(root, '.changeset', 'config.json'), {
+    fixed: [['@happyvertical/*']],
+    updateInternalDependencies: 'patch',
+  });
+  writeJson(join(root, 'package.json'), {
+    name: 'sdk-workspace',
+    private: true,
+  });
+
+  if (docs) {
+    mkdirSync(join(root, 'docs'));
+    writeJson(join(root, 'docs', 'package.json'), docs);
+  }
+
+  for (const [directory, manifest] of Object.entries(packages)) {
+    const packageDirectory = join(root, 'packages', directory);
+    mkdirSync(packageDirectory, { recursive: true });
+    writeJson(join(packageDirectory, 'package.json'), manifest);
+  }
+
+  return root;
+}
+
+function validateWorkspace(root) {
+  return spawnSync(process.execPath, [scriptPath], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
+
+test('published version alignment ignores private workspaces', () => {
+  const root = createWorkspace({
+    docs: {
+      name: '@happyvertical/docs',
+      version: '0.78.0',
+      private: true,
+    },
+    packages: {
+      files: {
+        name: '@happyvertical/files',
+        version: '0.78.1',
+      },
+    },
+  });
+
+  try {
+    const result = validateWorkspace(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /published internal package versions are aligned/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('private workspaces still enforce internal workspace dependency specs', () => {
+  const root = createWorkspace({
+    docs: {
+      name: '@happyvertical/docs',
+      version: '0.78.0',
+      private: true,
+      dependencies: {
+        '@happyvertical/files': '^0.78.1',
+      },
+    },
+    packages: {
+      files: {
+        name: '@happyvertical/files',
+        version: '0.78.1',
+      },
+    },
+  });
+
+  try {
+    const result = validateWorkspace(root);
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /docs\/package\.json: dependencies\.@happyvertical\/files must use "workspace:\*"/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('published version alignment still rejects public workspace drift', () => {
+  const root = createWorkspace({
+    packages: {
+      files: {
+        name: '@happyvertical/files',
+        version: '0.78.1',
+      },
+      sql: {
+        name: '@happyvertical/sql',
+        version: '0.78.0',
+      },
+    },
+  });
+
+  try {
+    const result = validateWorkspace(root);
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /Published @happyvertical workspace packages must share one version/,
+    );
+    assert.match(result.stderr, /@happyvertical\/files -> 0\.78\.1/);
+    assert.match(result.stderr, /@happyvertical\/sql -> 0\.78\.0/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- exclude explicitly private workspaces from published SDK version alignment
- keep private workspaces in internal dependency discovery and `workspace:*` enforcement
- cover real top-level docs drift, private dependency drift, and public version drift

Closes #1084

## Validation

- `fnm exec --using=24.18.0 pnpm test:ci-scripts` — 18 tests passed
- `node scripts/validate-workspace-consistency.js`
- `pnpm agent:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` — 31 packages passed
- review-cycle — accepted fixture-topology finding fixed; clean final full-roster review

## Release note

CI-only validator repair; no package changeset or published release content.

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-019f5c83-6435-7493-bcf3-07149f9de5db",
  "issue": "happyvertical/sdk#1084",
  "policy_revision": "1.0.0",
  "validation": [
    "Node 24.18.0 CI scripts: 18 passed",
    "workspace consistency validator: passed",
    "agent:check: passed",
    "typecheck: passed",
    "lint: passed",
    "build: 31 packages passed",
    "review-cycle final full roster: clean"
  ]
}
```
