### PR TITLE
fix(files): reject ZIP data descriptors

### DIFF
--- a/.changeset/reject-zip-data-descriptors.md
+++ b/.changeset/reject-zip-data-descriptors.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/files": patch
+---
+
+Reject ZIP data descriptors for stored as well as compressed entries because zero-decompression inspection cannot verify their payload boundary.

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -127,15 +127,12 @@ central-directory work while disambiguating end records in hostile comments.
 Policy is deliberately strict: ZIP64, encrypted, multi-disk, malformed,
 truncated, ambiguous-end-record, and non-UTF-8-name archives are rejected with
 typed errors. Stored entries must also declare identical compressed and
-uncompressed sizes, and each local header, compressed payload, and optional
-classic data descriptor must occupy a distinct range. Those referenced ranges
-must collectively cover every byte before the central directory, so archive
-preambles, padding gaps, and local entries omitted from the central directory
-are rejected. Signed and unsigned 32-bit data descriptors are cross-checked
-against their central-directory entry; missing, truncated, or inconsistent
-descriptors are rejected. Data descriptors on compressed entries are also
-rejected because their payload boundary cannot be verified without
-decompression; classic descriptors remain supported for stored entries. Entry
+uncompressed sizes, and each local header and compressed payload must occupy a
+distinct range. Those referenced ranges must collectively cover every byte
+before the central directory, so archive preambles, padding gaps, and local
+entries omitted from the central directory are rejected. Data descriptors are
+rejected for both stored and compressed entries because their payload boundary
+cannot be verified without decompression or extractor-specific scanning. Entry
 names use strict UTF-8 decoding whether or not the UTF-8 flag is set. Leading
 UTF-8 BOMs are rejected because filename decoders disagree on whether the BOM
 is part of the extracted path; common macOS ZIPs with valid UTF-8 names remain

--- a/packages/files/src/archive.test.ts
+++ b/packages/files/src/archive.test.ts
@@ -709,51 +709,27 @@ describe('inspectZipManifest', () => {
     expect(error.message).toContain('not described by a central-directory');
   });
 
-  it('includes validated data descriptors in overlap detection', () => {
-    const embeddedDescriptor = buildDataDescriptor(0, 56, 56, true);
-    const error = inspectError(
-      buildZip([
-        {
-          name: 'first.bin',
-          compressedSize: 56,
-          flags: 0x0008,
-          uncompressedSize: 56,
-        },
-        {
-          name: 'second.bin',
-          body: embeddedDescriptor,
-        },
-      ]),
-    );
-
-    expect(error).toBeInstanceOf(InvalidZipArchiveError);
-    expect(error.message).toContain('local entry ranges');
-    expect(error.message).toContain('overlap');
-  });
-
   it.each([
-    'signed',
-    'unsigned',
-  ] as const)('accepts and bounds %s classic data descriptors', (dataDescriptor) => {
-    const data = buildZip([
+    [
+      'signed stored',
       {
-        name: 'streamed.bin',
+        name: 'signed-stored.bin',
         body: new Uint8Array([1, 2, 3]),
-        crc32: 0x55bc801d,
-        dataDescriptor,
+        dataDescriptor: 'signed',
         flags: 0x0008,
       },
-      { name: 'next.txt' },
-    ]);
-
-    expect(inspectZipManifest(data).entries.map(({ path }) => path)).toEqual([
-      'streamed.bin',
-      'next.txt',
-    ]);
-  });
-
-  it('accepts an unsigned data descriptor whose CRC equals the optional signature', () => {
-    const data = buildZip([
+    ],
+    [
+      'unsigned stored',
+      {
+        name: 'unsigned-stored.bin',
+        body: new Uint8Array([1, 2, 3]),
+        dataDescriptor: 'unsigned',
+        flags: 0x0008,
+      },
+    ],
+    [
+      'stored CRC/signature collision',
       {
         name: 'crc-collision.bin',
         body: new Uint8Array([1, 2, 3]),
@@ -761,50 +737,50 @@ describe('inspectZipManifest', () => {
         dataDescriptor: 'unsigned',
         flags: 0x0008,
       },
-    ]);
-
-    expect(inspectZipManifest(data).entries[0]?.path).toBe('crc-collision.bin');
-  });
-
-  it('rejects compressed entries whose data-descriptor boundary requires decompression', () => {
-    const error = inspectError(
-      buildZip([
-        {
-          name: 'streamed-deflate.bin',
-          body: new Uint8Array([0x03, 0x00]),
-          compressedSize: 2,
-          compressionMethod: 8,
-          dataDescriptor: 'signed',
-          flags: 0x0008,
-          uncompressedSize: 0,
-        },
-      ]),
-    );
+    ],
+    [
+      'missing stored',
+      {
+        name: 'missing-stored.bin',
+        body: new Uint8Array([1, 2, 3]),
+        dataDescriptor: 'missing',
+        flags: 0x0008,
+      },
+    ],
+    [
+      'signed deflate',
+      {
+        name: 'streamed-deflate.bin',
+        body: new Uint8Array([0x03, 0x00]),
+        compressionMethod: 8,
+        dataDescriptor: 'signed',
+        flags: 0x0008,
+        uncompressedSize: 0,
+      },
+    ],
+    [
+      'stored early-boundary smuggling',
+      {
+        name: 'smuggled-stored.bin',
+        body: concatenate([
+          buildDataDescriptor(0, 0, 0, true),
+          new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+        ]),
+        dataDescriptor: 'signed',
+        flags: 0x0008,
+      },
+    ],
+  ] satisfies Array<
+    [string, ZipFixtureEntry]
+  >)('rejects %s data descriptors as ambiguous metadata', (_label, entry) => {
+    const error = inspectError(buildZip([entry]));
 
     expect(error).toBeInstanceOf(UnsupportedZipFeatureError);
     expect((error as UnsupportedZipFeatureError).feature).toBe(
       'ambiguous-metadata',
     );
-    expect((error as UnsupportedZipFeatureError).entryPath).toBe(
-      'streamed-deflate.bin',
-    );
+    expect((error as UnsupportedZipFeatureError).entryPath).toBe(entry.name);
     expect(error.message).toContain('payload boundary');
-  });
-
-  it('rejects missing data descriptors', () => {
-    const error = inspectError(
-      buildZip([
-        {
-          name: 'streamed.bin',
-          body: new Uint8Array([1, 2, 3]),
-          dataDescriptor: 'missing',
-          flags: 0x0008,
-        },
-      ]),
-    );
-
-    expect(error).toBeInstanceOf(InvalidZipArchiveError);
-    expect(error.message).toContain('data descriptor');
   });
 
   it('enforces the configured central-directory entry-count limit', () => {

--- a/packages/files/src/archive.ts
+++ b/packages/files/src/archive.ts
@@ -7,7 +7,6 @@
  */
 
 const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
-const DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
 const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
 const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 const ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06064b50;
@@ -872,13 +871,10 @@ function validateLocalHeader(
     );
   }
 
-  if (
-    (localFlags & DATA_DESCRIPTOR_FLAG) !== 0 &&
-    entry.compressionMethod !== 0
-  ) {
+  if ((localFlags & DATA_DESCRIPTOR_FLAG) !== 0) {
     throw new UnsupportedZipFeatureError(
       'ambiguous-metadata',
-      `Compressed ZIP entry "${entry.rawPath}" uses a data descriptor whose payload boundary cannot be verified without decompression.`,
+      `ZIP entry "${entry.rawPath}" uses a data descriptor whose payload boundary cannot be verified without decompression or extractor-specific scanning.`,
       entry.rawPath,
     );
   }
@@ -908,25 +904,13 @@ function validateLocalHeader(
 
   assertExtraFields(data, localNameEnd, localExtraEnd, 'local file header');
 
-  if ((localFlags & DATA_DESCRIPTOR_FLAG) === 0) {
-    if (
-      localCrc32 !== entry.centralCrc32 ||
-      localCompressedSize !== entry.compressedSize ||
-      localUncompressedSize !== entry.uncompressedSize
-    ) {
-      throw new InvalidZipArchiveError(
-        'ZIP local file sizes do not match the central-directory entry.',
-      );
-    }
-  } else if (
-    (localCrc32 !== 0 && localCrc32 !== entry.centralCrc32) ||
-    (localCompressedSize !== 0 &&
-      localCompressedSize !== entry.compressedSize) ||
-    (localUncompressedSize !== 0 &&
-      localUncompressedSize !== entry.uncompressedSize)
+  if (
+    localCrc32 !== entry.centralCrc32 ||
+    localCompressedSize !== entry.compressedSize ||
+    localUncompressedSize !== entry.uncompressedSize
   ) {
     throw new InvalidZipArchiveError(
-      'ZIP local file metadata does not match its data descriptor.',
+      'ZIP local file sizes do not match the central-directory entry.',
     );
   }
 
@@ -936,59 +920,7 @@ function validateLocalHeader(
     );
   }
 
-  const localDataEnd = localExtraEnd + entry.compressedSize;
-  if ((localFlags & DATA_DESCRIPTOR_FLAG) !== 0) {
-    return validateDataDescriptor(view, localDataEnd, entry);
-  }
-  return localDataEnd;
-}
-
-function validateDataDescriptor(
-  view: DataView,
-  offset: number,
-  entry: {
-    centralDirectoryOffset: number;
-    centralCrc32: number;
-    compressedSize: number;
-    uncompressedSize: number;
-  },
-): number {
-  assertRange(
-    offset,
-    12,
-    entry.centralDirectoryOffset,
-    'ZIP data descriptor is missing or truncated.',
-  );
-
-  const firstValue = view.getUint32(offset, true);
-  const unsignedMatches =
-    firstValue === entry.centralCrc32 &&
-    view.getUint32(offset + 4, true) === entry.compressedSize &&
-    view.getUint32(offset + 8, true) === entry.uncompressedSize;
-
-  if (firstValue !== DATA_DESCRIPTOR_SIGNATURE) {
-    if (unsignedMatches) {
-      return offset + 12;
-    }
-    throw new InvalidZipArchiveError(
-      'ZIP data descriptor does not match its central-directory entry.',
-    );
-  }
-
-  const hasSignedRange = 16 <= entry.centralDirectoryOffset - offset;
-  const signedMatches =
-    hasSignedRange &&
-    view.getUint32(offset + 4, true) === entry.centralCrc32 &&
-    view.getUint32(offset + 8, true) === entry.compressedSize &&
-    view.getUint32(offset + 12, true) === entry.uncompressedSize;
-
-  if (signedMatches === unsignedMatches) {
-    throw new InvalidZipArchiveError(
-      'ZIP data descriptor is ambiguous or does not match its central-directory entry.',
-    );
-  }
-
-  return signedMatches ? offset + 16 : offset + 12;
+  return localExtraEnd + entry.compressedSize;
 }
 
 function assertExtraFields(


### PR DESCRIPTION
## Summary

- reject ZIP data descriptors for stored entries as well as compressed entries because a zero-decompression inspector cannot prove their payload boundary
- remove the now-unreachable classic descriptor parser while retaining local/central metadata checks and bounded payload-range coverage
- cover signed, unsigned, missing, CRC/signature-collision, deflate, and stored early-boundary smuggling cases with typed `ambiguous-metadata` failures
- update the strict-policy documentation and add a fresh patch changeset for 0.78.3

Closes #1082

Follow-up to the security review on #1083.

## Release recovery

PR #1085 reached `main` first and its release run published immutable 0.78.2 registry artifacts before PR #1086 merged. The later recovery committed and tagged the complete #1076/#1082 source at `a1086d94`, but it cannot overwrite the already-published tarballs; `@happyvertical/files@0.78.2` therefore does not export `inspectZipManifest`.

This PR is based directly on release commit `a1086d94` and supplies the narrow follow-up needed for one coherent 0.78.3 publish. Changesets reports `@happyvertical/files` 0.78.2 → 0.78.3 and the configured fixed group follows at patch.

## Validation

- `@happyvertical/projects`: 10/10 tests passed
- `@happyvertical/files`: 222/222 tests passed, including 80 archive tests
- `@happyvertical/sql`: 341 passed, 4 skipped
- `pnpm test:ci-scripts`: 18/18 passed
- `pnpm agent:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`: 31 packages passed
- generated `@happyvertical/files` API docs
- changeset machine output: `@happyvertical/files` 0.78.2 → 0.78.3
- final full-roster review-cycle at `3d18b5da`: clean across correctness, security, maintainability, product behavior, tests, docs, release behavior, and local consistency

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-019f5c83-6435-7493-bcf3-07149f9de5db",
  "issue": "happyvertical/sdk#1082",
  "policy_revision": "1.0.0",
  "validation": [
    "release base a1086d94 (v0.78.2): verified",
    "@happyvertical/projects tests: 10 passed",
    "@happyvertical/files tests: 222 passed (80 archive tests)",
    "@happyvertical/sql tests: 341 passed, 4 skipped",
    "test:ci-scripts: 18 passed",
    "agent:check: passed",
    "typecheck: passed",
    "lint: passed",
    "build: 31 packages passed",
    "generated Files API docs: passed",
    "changeset status: @happyvertical/files 0.78.2 -> 0.78.3",
    "review-cycle final full roster at 3d18b5da: clean"
  ]
}
```
