### PR TITLE
feat(ai): add runaway spend guardrails

### DIFF
--- a/.changeset/safe-ai-spend-guardrails.md
+++ b/.changeset/safe-ai-spend-guardrails.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/ai': minor
+---
+
+Add provider-wide generation ceilings, single-attempt defaults, composed request cancellation, bounded reasoning controls, and prompt-free request lifecycle events.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -158,6 +158,9 @@ instances created directly instead of through `getAI()`:
 - zero provider retries (one total upstream attempt)
 - local rejection with `AI_LIMIT_EXCEEDED` before transport when a ceiling is exceeded
 
+Reasoning is opt-in. The 1,024-token default is a ceiling for explicitly
+requested reasoning, not an automatically enabled thinking budget.
+
 An approved workload can raise a client-level ceiling explicitly. Prefer a
 workload-specific client so the wider limit is not shared accidentally.
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -146,6 +146,61 @@ console.log(key.key);
 
 LiteLLM uses the same SDK surface, mapping projects to LiteLLM teams and virtual keys to `/key/generate`.
 
+## Generation Safety
+
+Every generative provider constructor applies the same safe defaults, including
+instances created directly instead of through `getAI()`:
+
+- 4,096 output tokens per request
+- 1,024 reasoning tokens per request
+- one generated image per request
+- a 120-second provider timeout
+- zero provider retries (one total upstream attempt)
+- local rejection with `AI_LIMIT_EXCEEDED` before transport when a ceiling is exceeded
+
+An approved workload can raise a client-level ceiling explicitly. Prefer a
+workload-specific client so the wider limit is not shared accidentally.
+
+```typescript
+const ai = await getAI({
+  type: 'bifrost',
+  apiKey: process.env.BIFROST_API_KEY!,
+  baseUrl: process.env.BIFROST_BASE_URL!,
+  defaultModel: 'gemini-2.5-flash',
+  timeout: 105_000,
+  maxRetries: 0,
+  generationLimits: {
+    maxOutputTokens: 8192,
+    maxReasoningTokens: 1024,
+  },
+  usageTags: {
+    app: 'writer',
+    environment: 'production',
+    feature: 'long-form',
+  },
+  onRequest: (event) => telemetry.record(event),
+});
+
+const controller = new AbortController();
+const result = await ai.message('Write the approved long-form response', {
+  maxTokens: 8192,
+  timeout: 105_000,
+  signal: controller.signal,
+  reasoning: { effort: 'low', maxTokens: 1024 },
+});
+```
+
+`signal` and the SDK timeout are composed and propagated to the provider. A
+client abort is useful for correctness, but it does not guarantee that a remote
+provider stops work or billing. Token ceilings and single attempts are the
+primary cost controls.
+
+`onRequest` receives one prompt-free terminal event for success, failure,
+timeout, caller abort, or local rejection. Events include requested and
+effective token ceilings plus sanitized `usageTags`; prompts, responses, and
+credentials are never included. Legacy `thinkingLevel` options remain available
+as deprecated aliases and are normalized through the reasoning ceiling.
+
 ## Opt-In Rate-Limit Pacing
 
 Use `rateLimit` when multiple calls share the same provider budget and you want
@@ -166,7 +221,7 @@ const ai = await getAI({
     key: 'gemini:shared-batch-key',
     cooldownMs: 2000,
     initialDelayMs: 15000,
-    maxAttempts: 3,
+    maxAttempts: 2,
   },
 });
 ```
@@ -176,8 +231,8 @@ const ai = await getAI({
 - `initialDelayMs` is the fallback retry delay when the provider omits `Retry-After`
 - `maxAttempts` counts the first call plus any rate-limit retries
 
-When `rateLimit` is omitted, or `enabled: false` is set explicitly, `getAI()`
-behaves exactly as it did before.
+When `rateLimit` is omitted, or `enabled: false` is set explicitly, no
+in-process retry wrapper is applied. Provider retries still default to zero.
 
 ### `rateLimit` Options
 
@@ -187,7 +242,7 @@ behaves exactly as it did before.
 | `key` | `string` | derived | Shared budget key; clients with the same key coordinate with each other |
 | `cooldownMs` | `number` | `0` | Minimum delay after a successful call before the next call with the same key |
 | `initialDelayMs` | `number` | `5000` | Fallback retry delay when the provider does not return `Retry-After` |
-| `maxAttempts` | `number` | `3` | Total attempts, including the initial call |
+| `maxAttempts` | `number` | `1` | Total attempts, including the initial call; increase explicitly only for an approved workload |
 | `requestsPerMinute` | `number` | provider-specific | Used by `qwen3-tts` local token-bucket limiting |
 | `maxConcurrent` | `number` | provider-specific | Used by `qwen3-tts` local concurrency limiting |
 
@@ -208,7 +263,7 @@ const ai = await getAI({
     key: 'praeco:multi-site-analysis',
     cooldownMs: 2000,
     initialDelayMs: 15000,
-    maxAttempts: 3,
+    maxAttempts: 2,
   },
 });
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -15,6 +15,11 @@
 export * from './shared/client';
 export * from './shared/factory';
 export { AIMessage as AIMessageClass } from './shared/message';
+export {
+  DEFAULT_AI_GENERATION_LIMITS,
+  DEFAULT_AI_MAX_RETRIES,
+  DEFAULT_AI_TIMEOUT_MS,
+} from './shared/safety';
 export * from './shared/thread';
 export * from './shared/types';
 

--- a/packages/ai/src/providers.test.ts
+++ b/packages/ai/src/providers.test.ts
@@ -215,12 +215,14 @@ describe('LiteLLM Provider', () => {
       expect.objectContaining({
         model: 'claude-3-5-sonnet',
         max_tokens: 4096,
-        reasoning: expect.objectContaining({ max_tokens: 1024 }),
       }),
       expect.objectContaining({
         signal: expect.any(AbortSignal),
         timeout: 120_000,
       }),
+    );
+    expect(createChatCompletion.mock.calls[0][0]).not.toHaveProperty(
+      'reasoning',
     );
   });
 
@@ -1371,15 +1373,15 @@ describe('Bedrock Provider', () => {
       expect.objectContaining({
         modelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
         inferenceConfig: expect.objectContaining({ maxTokens: 4096 }),
-        additionalModelRequestFields: {
-          thinking: { type: 'enabled', budget_tokens: 1024 },
-        },
         toolConfig: expect.objectContaining({
           tools: [expect.any(Object)],
           toolChoice: { auto: {} },
         }),
       }),
       expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+    );
+    expect(converse.mock.calls[0][0]).not.toHaveProperty(
+      'additionalModelRequestFields',
     );
     expect(response.finishReason).toBe('tool_calls');
     expect(response.toolCalls?.[0]).toEqual({

--- a/packages/ai/src/providers.test.ts
+++ b/packages/ai/src/providers.test.ts
@@ -212,7 +212,15 @@ describe('LiteLLM Provider', () => {
     await provider.chat([{ role: 'user', content: 'Hello' }]);
 
     expect(createChatCompletion).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'claude-3-5-sonnet' }),
+      expect.objectContaining({
+        model: 'claude-3-5-sonnet',
+        max_tokens: 4096,
+        reasoning: expect.objectContaining({ max_tokens: 1024 }),
+      }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        timeout: 120_000,
+      }),
     );
   });
 
@@ -318,6 +326,10 @@ describe('LiteLLM Provider', () => {
 
     expect(generateImage).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'gpt-image-1' }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        timeout: 120_000,
+      }),
     );
   });
 
@@ -1358,11 +1370,16 @@ describe('Bedrock Provider', () => {
     expect(converse).toHaveBeenCalledWith(
       expect.objectContaining({
         modelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        inferenceConfig: expect.objectContaining({ maxTokens: 4096 }),
+        additionalModelRequestFields: {
+          thinking: { type: 'enabled', budget_tokens: 1024 },
+        },
         toolConfig: expect.objectContaining({
           tools: [expect.any(Object)],
           toolChoice: { auto: {} },
         }),
       }),
+      expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
     );
     expect(response.finishReason).toBe('tool_calls');
     expect(response.toolCalls?.[0]).toEqual({
@@ -1469,6 +1486,7 @@ describe('Bedrock Provider', () => {
       expect.objectContaining({
         modelId: 'amazon.titan-image-generator-v2:0',
       }),
+      expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
     );
     expect(response.images[0]?.data).toBeTypeOf('string');
   });

--- a/packages/ai/src/rate-limit.test.ts
+++ b/packages/ai/src/rate-limit.test.ts
@@ -163,6 +163,22 @@ describe('shared AI rate limiting', () => {
     expect(chat).toHaveBeenCalledTimes(1);
   });
 
+  it('uses one in-process attempt when maxAttempts is omitted', async () => {
+    const chat = vi.fn(async () => {
+      throw new RateLimitError('gemini');
+    });
+    const ai = createRateLimitedAI(createTestAI({ chat }), {
+      type: 'gemini',
+      apiKey: 'test-key',
+      rateLimit: { enabled: true },
+    });
+
+    await expect(
+      ai.chat([{ role: 'user', content: 'hello' }]),
+    ).rejects.toBeInstanceOf(RateLimitError);
+    expect(chat).toHaveBeenCalledTimes(1);
+  });
+
   it('serializes successful calls that share the same budget key', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/packages/ai/src/safety.test.ts
+++ b/packages/ai/src/safety.test.ts
@@ -39,6 +39,13 @@ describe('AI generation safety defaults', () => {
     });
   });
 
+  it('keeps reasoning disabled until the caller explicitly opts in', () => {
+    expect(normalizeChatOptions({}, {}).reasoning.maxTokens).toBe(0);
+    expect(
+      normalizeChatOptions({}, { reasoning: {} }).reasoning.maxTokens,
+    ).toBe(1024);
+  });
+
   it('rejects excessive output and reasoning before transport', () => {
     expect(() =>
       normalizeChatOptions({}, { maxTokens: 4097 }, 'openai', 'gpt-4o'),
@@ -79,7 +86,9 @@ describe('provider contracts', () => {
     });
     (provider as any).client = { chat: { completions: { create } } };
 
-    await provider.chat([{ role: 'user', content: 'hello' }]);
+    await provider.chat([{ role: 'user', content: 'hello' }], {
+      reasoning: { maxTokens: 1024 },
+    });
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({ max_tokens: 4096 }),
       expect.objectContaining({
@@ -108,12 +117,36 @@ describe('provider contracts', () => {
     });
     (provider as any).client = { chat: { completions: { create } } };
 
-    await provider.chat([{ role: 'user', content: 'hello' }]);
+    await provider.chat([{ role: 'user', content: 'hello' }], {
+      reasoning: { maxTokens: 1024 },
+    });
 
     expect(create.mock.calls[0][0]).toMatchObject({
       max_tokens: 4096,
       reasoning: { max_tokens: 1024 },
     });
+  });
+
+  it('does not enable Anthropic thinking when reasoning is omitted', async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      model: 'claude-test',
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    const provider = new AnthropicProvider({
+      type: 'anthropic',
+      apiKey: 'test',
+      defaultModel: 'claude-test',
+    });
+    (provider as any).client = { messages: { create } };
+
+    await provider.chat([{ role: 'user', content: 'hello' }], {
+      maxTokens: 500,
+      temperature: 0.2,
+    });
+
+    expect(create.mock.calls[0][0]).not.toHaveProperty('thinking');
   });
 
   it('maps bounded output and reasoning into Anthropic native fields', async () => {
@@ -130,7 +163,9 @@ describe('provider contracts', () => {
     });
     (provider as any).client = { messages: { create } };
 
-    await provider.chat([{ role: 'user', content: 'hello' }]);
+    await provider.chat([{ role: 'user', content: 'hello' }], {
+      reasoning: { maxTokens: 1024 },
+    });
 
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -154,7 +189,9 @@ describe('provider contracts', () => {
     });
     (provider as any).client = { models: { generateContent } };
 
-    await provider.chat([{ role: 'user', content: 'hello' }]);
+    await provider.chat([{ role: 'user', content: 'hello' }], {
+      reasoning: { maxTokens: 1024 },
+    });
 
     expect(generateContent.mock.calls[0][0].config).toMatchObject({
       maxOutputTokens: 4096,
@@ -270,6 +307,45 @@ describe('attempt and cancellation controls', () => {
     expect(receivedSignal?.aborted).toBe(true);
     expect(active).toBe(false);
     expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the SDK timeout while fetching a remote image', async () => {
+    let active = false;
+    let receivedSignal: AbortSignal | undefined;
+    global.fetch = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          active = true;
+          receivedSignal = init?.signal as AbortSignal;
+          receivedSignal.addEventListener(
+            'abort',
+            () => {
+              active = false;
+              reject(new DOMException('aborted', 'AbortError'));
+            },
+            { once: true },
+          );
+        }),
+    ) as typeof fetch;
+    const events: AIRequestEvent[] = [];
+    const providerOptions = {
+      type: 'openai' as const,
+      apiKey: 'test',
+      defaultModel: 'gpt-4o',
+      timeout: 10,
+      onRequest: (event: AIRequestEvent) => events.push(event),
+    };
+    const provider = new OpenAIProvider(providerOptions);
+    const observed = createObservedAI(provider, providerOptions);
+
+    await expect(
+      observed.describeImage('https://images.example.test/slow.png'),
+    ).rejects.toMatchObject({ code: 'AI_TIMEOUT' });
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(active).toBe(false);
+    expect(events).toMatchObject([
+      { operation: 'describeImage', status: 'timed_out' },
+    ]);
   });
 });
 

--- a/packages/ai/src/safety.test.ts
+++ b/packages/ai/src/safety.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AnthropicProvider } from './shared/providers/anthropic';
+import { BifrostProvider } from './shared/providers/bifrost';
+import { GeminiProvider } from './shared/providers/gemini';
+import { HuggingFaceProvider } from './shared/providers/huggingface';
+import { OpenAIProvider } from './shared/providers/openai';
+import {
+  createObservedAI,
+  DEFAULT_AI_GENERATION_LIMITS,
+  DEFAULT_AI_MAX_RETRIES,
+  DEFAULT_AI_TIMEOUT_MS,
+  normalizeBaseAIOptions,
+  normalizeChatOptions,
+} from './shared/safety';
+import type { AIInterface, AIRequestEvent } from './shared/types';
+import { AIError } from './shared/types';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function successfulChatResponse(model: string) {
+  return {
+    choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+    model,
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe('AI generation safety defaults', () => {
+  it('normalizes safe provider defaults', () => {
+    expect(normalizeBaseAIOptions({})).toMatchObject({
+      timeout: DEFAULT_AI_TIMEOUT_MS,
+      maxRetries: DEFAULT_AI_MAX_RETRIES,
+      generationLimits: DEFAULT_AI_GENERATION_LIMITS,
+    });
+  });
+
+  it('rejects excessive output and reasoning before transport', () => {
+    expect(() =>
+      normalizeChatOptions({}, { maxTokens: 4097 }, 'openai', 'gpt-4o'),
+    ).toThrowError(expect.objectContaining({ code: 'AI_LIMIT_EXCEEDED' }));
+    expect(() =>
+      normalizeChatOptions(
+        {},
+        { reasoning: { maxTokens: 1025 } },
+        'gemini',
+        'gemini-2.5-flash',
+      ),
+    ).toThrowError(expect.objectContaining({ code: 'AI_LIMIT_EXCEEDED' }));
+  });
+
+  it('clamps only when the provider explicitly opts in', () => {
+    const normalized = normalizeChatOptions(
+      {
+        generationLimits: {
+          maxOutputTokens: 100,
+          maxReasoningTokens: 50,
+          onExceeded: 'clamp',
+        },
+      },
+      { maxTokens: 200, reasoning: { maxTokens: 75 } },
+    );
+
+    expect(normalized.maxTokens).toBe(100);
+    expect(normalized.reasoning.maxTokens).toBe(50);
+  });
+});
+
+describe('provider contracts', () => {
+  it('sends OpenAI defaults and rejects an oversized request before transport', async () => {
+    const create = vi.fn().mockResolvedValue(successfulChatResponse('gpt-4o'));
+    const provider = new OpenAIProvider({
+      apiKey: 'test',
+      defaultModel: 'gpt-4o',
+    });
+    (provider as any).client = { chat: { completions: { create } } };
+
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ max_tokens: 4096 }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        timeout: 120_000,
+      }),
+    );
+
+    await expect(
+      provider.chat([{ role: 'user', content: 'blocked' }], {
+        maxTokens: 4097,
+      }),
+    ).rejects.toMatchObject({ code: 'AI_LIMIT_EXCEEDED' });
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends bounded reasoning through Bifrost OpenAI compatibility', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValue(successfulChatResponse('gemini-2.5-flash'));
+    const provider = new BifrostProvider({
+      type: 'bifrost',
+      apiKey: 'test',
+      baseUrl: 'https://bifrost.example.com/v1',
+      defaultModel: 'gemini-2.5-flash',
+    });
+    (provider as any).client = { chat: { completions: { create } } };
+
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    expect(create.mock.calls[0][0]).toMatchObject({
+      max_tokens: 4096,
+      reasoning: { max_tokens: 1024 },
+    });
+  });
+
+  it('maps bounded output and reasoning into Anthropic native fields', async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      model: 'claude-test',
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    const provider = new AnthropicProvider({
+      type: 'anthropic',
+      apiKey: 'test',
+      defaultModel: 'claude-test',
+    });
+    (provider as any).client = { messages: { create } };
+
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max_tokens: 4096,
+        thinking: { type: 'enabled', budget_tokens: 1024 },
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('maps bounded output and reasoning into Gemini native fields', async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: 'ok',
+      candidates: [],
+      usageMetadata: {},
+    });
+    const provider = new GeminiProvider({
+      type: 'gemini',
+      apiKey: 'test',
+      defaultModel: 'gemini-2.5-flash',
+    });
+    (provider as any).client = { models: { generateContent } };
+
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    expect(generateContent.mock.calls[0][0].config).toMatchObject({
+      maxOutputTokens: 4096,
+      thinkingConfig: { thinkingBudget: 1024 },
+      abortSignal: expect.any(AbortSignal),
+      httpOptions: {
+        timeout: 120_000,
+        retryOptions: { attempts: 1 },
+      },
+    });
+  });
+
+  it('maps the output ceiling into Hugging Face max_new_tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([{ generated_text: 'Human: hello\nok' }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    global.fetch = fetchMock;
+    const provider = new HuggingFaceProvider({
+      type: 'huggingface',
+      apiToken: 'test',
+      defaultModel: 'test-model',
+    });
+
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body)).parameters.max_new_tokens).toBe(4096);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('maps the default output ceiling into Ollama num_predict', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          model: 'llama-test',
+          message: { content: 'ok' },
+          done: true,
+          done_reason: 'stop',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    global.fetch = fetchMock;
+    const { OllamaProvider } = await import('./shared/providers/ollama');
+    const provider = new OllamaProvider({
+      type: 'ollama',
+      baseUrl: 'http://ollama.example.test',
+      defaultModel: 'llama-test',
+    });
+
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body)).options.num_predict).toBe(4096);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('attempt and cancellation controls', () => {
+  it.each([
+    429, 500, 504,
+  ])('makes one upstream attempt for HTTP %s by default', async (status) => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'failed' } }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    global.fetch = fetchMock;
+    const provider = new OpenAIProvider({
+      apiKey: 'test',
+      baseUrl: 'https://openai.example.test/v1',
+      defaultModel: 'gpt-4o',
+    });
+
+    await expect(
+      provider.chat([{ role: 'user', content: 'hello' }]),
+    ).rejects.toBeInstanceOf(AIError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the provider request at the SDK timeout without detached work', async () => {
+    let active = false;
+    let receivedSignal: AbortSignal | undefined;
+    const create = vi.fn(
+      (_request: unknown, requestOptions: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          active = true;
+          receivedSignal = requestOptions.signal;
+          requestOptions.signal.addEventListener(
+            'abort',
+            () => {
+              active = false;
+              reject(new DOMException('aborted', 'AbortError'));
+            },
+            { once: true },
+          );
+        }),
+    );
+    const provider = new OpenAIProvider({
+      apiKey: 'test',
+      defaultModel: 'gpt-4o',
+      timeout: 10,
+    });
+    (provider as any).client = { chat: { completions: { create } } };
+
+    await expect(
+      provider.chat([{ role: 'user', content: 'hello' }]),
+    ).rejects.toMatchObject({ code: 'AI_TIMEOUT' });
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(active).toBe(false);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('request lifecycle events', () => {
+  it('emits prompt-free terminal events for success, failure, timeout, abort, and rejection', async () => {
+    const events: AIRequestEvent[] = [];
+    const target = {
+      chat: vi.fn(async (_messages: unknown, options?: { mode?: string }) => {
+        if (options?.mode === 'failure') {
+          throw new AIError('provider failed', 'API_ERROR');
+        }
+        if (options?.mode === 'timeout') {
+          throw new AIError('provider timed out', 'AI_TIMEOUT');
+        }
+        if (options?.mode === 'abort') {
+          throw new AIError('caller aborted', 'AI_ABORTED');
+        }
+        return { content: 'secret response' };
+      }),
+    } as unknown as AIInterface;
+    const ai = createObservedAI(target, {
+      type: 'bifrost',
+      apiKey: 'secret-key',
+      defaultModel: 'gemini-2.5-flash',
+      usageTags: { app: 'test' },
+      onRequest: (event) => events.push(event),
+    } as any);
+
+    await ai.chat([{ role: 'user', content: 'secret prompt' }]);
+    await expect(ai.chat([], { mode: 'failure' } as any)).rejects.toMatchObject(
+      { code: 'API_ERROR' },
+    );
+    await expect(ai.chat([], { mode: 'timeout' } as any)).rejects.toMatchObject(
+      { code: 'AI_TIMEOUT' },
+    );
+    await expect(ai.chat([], { mode: 'abort' } as any)).rejects.toMatchObject({
+      code: 'AI_ABORTED',
+    });
+    await expect(ai.chat([], { maxTokens: 4097 })).rejects.toMatchObject({
+      code: 'AI_LIMIT_EXCEEDED',
+    });
+
+    expect(events.map((event) => event.status)).toEqual([
+      'succeeded',
+      'failed',
+      'timed_out',
+      'aborted',
+      'rejected',
+    ]);
+    expect(target.chat).toHaveBeenCalledTimes(4);
+    expect(events[0]).toMatchObject({
+      attempts: 1,
+      effectiveMaxOutputTokens: 4096,
+      tags: { app: 'test' },
+    });
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain('secret prompt');
+    expect(serialized).not.toContain('secret response');
+    expect(serialized).not.toContain('secret-key');
+  });
+});

--- a/packages/ai/src/shared/factory.ts
+++ b/packages/ai/src/shared/factory.ts
@@ -7,6 +7,7 @@ import { loadEnvConfig, ValidationError } from '@happyvertical/utils';
 
 import type { AIClientOptions } from './client';
 import { createRateLimitedAI } from './rate-limit';
+import { createObservedAI, normalizeBaseAIOptions } from './safety';
 import type {
   AIInterface,
   AIProviderType,
@@ -218,6 +219,8 @@ export async function getAI(
     (options as any).defaultModel = (options as any).model;
   }
 
+  options = normalizeBaseAIOptions(options as GetAIOptions);
+
   let client: AIInterface;
 
   if (isOpenAIOptions(options)) {
@@ -257,7 +260,7 @@ export async function getAI(
     });
   }
 
-  return createRateLimitedAI(client, options);
+  return createObservedAI(createRateLimitedAI(client, options), options);
 }
 
 /**

--- a/packages/ai/src/shared/providers/anthropic.ts
+++ b/packages/ai/src/shared/providers/anthropic.ts
@@ -7,6 +7,12 @@
  */
 
 import { extractRetryAfterSeconds } from '../rate-limit';
+import {
+  normalizeBaseAIOptions,
+  normalizeChatOptions,
+  type PreparedRequestControls,
+  prepareRequestControls,
+} from '../safety';
 import type {
   AICapabilities,
   AIInterface,
@@ -58,11 +64,11 @@ export class AnthropicProvider implements AIInterface {
    * @param options - Configuration options for the Anthropic provider
    */
   constructor(options: AnthropicOptions) {
-    this.options = {
+    this.options = normalizeBaseAIOptions({
       defaultModel: 'claude-3-5-sonnet-20241022',
       anthropicVersion: '2023-06-01',
       ...options,
-    };
+    });
 
     // Initialize Anthropic client
     this.initializeClientSync();
@@ -144,6 +150,7 @@ export class AnthropicProvider implements AIInterface {
     options: ChatOptions = {},
   ): Promise<AIResponse> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
@@ -151,12 +158,14 @@ export class AnthropicProvider implements AIInterface {
         this.mapMessagesToAnthropic(messages);
 
       const model = options.model || this.options.defaultModel;
+      options = normalizeChatOptions(this.options, options, 'anthropic', model);
+      controls = prepareRequestControls(this.options, options);
 
       // Build request parameters
       const requestParams: Record<string, any> = {
         model,
         messages: anthropicMessages,
-        max_tokens: options.maxTokens || 4096,
+        max_tokens: options.maxTokens,
         temperature: options.temperature,
         top_p: options.topP,
         stop_sequences: Array.isArray(options.stop)
@@ -176,6 +185,12 @@ export class AnthropicProvider implements AIInterface {
         tool_choice: this.mapToolChoice(options.toolChoice),
         stream: false,
       };
+      if ((options.reasoning?.maxTokens || 0) > 0) {
+        requestParams.thinking = {
+          type: 'enabled',
+          budget_tokens: options.reasoning?.maxTokens,
+        };
+      }
 
       // Add response format if specified
       if (options.responseFormat?.type === 'json_object') {
@@ -186,7 +201,10 @@ export class AnthropicProvider implements AIInterface {
           : jsonInstruction.trim();
       }
 
-      const response = await this.client.messages.create(requestParams);
+      const response = await this.client.messages.create(requestParams, {
+        signal: controls.signal,
+        timeout: controls.timeout,
+      });
 
       // Extract text content and tool calls from response
       const textContent = response.content
@@ -228,7 +246,25 @@ export class AnthropicProvider implements AIInterface {
         toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'anthropic',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'anthropic',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -245,6 +281,9 @@ export class AnthropicProvider implements AIInterface {
       stop: options.stop,
       stream: options.stream,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
   }
@@ -291,6 +330,9 @@ export class AnthropicProvider implements AIInterface {
       tools: options.tools,
       toolChoice: options.toolChoice,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
 
@@ -350,6 +392,7 @@ export class AnthropicProvider implements AIInterface {
     options: ChatOptions = {},
   ): AsyncIterable<string> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
@@ -357,11 +400,13 @@ export class AnthropicProvider implements AIInterface {
         this.mapMessagesToAnthropic(messages);
 
       const model = options.model || this.options.defaultModel;
+      options = normalizeChatOptions(this.options, options, 'anthropic', model);
+      controls = prepareRequestControls(this.options, options);
 
-      const stream = await this.client.messages.create({
+      const requestParams: Record<string, any> = {
         model,
         messages: anthropicMessages,
-        max_tokens: options.maxTokens || 4096,
+        max_tokens: options.maxTokens,
         temperature: options.temperature,
         top_p: options.topP,
         stop_sequences: Array.isArray(options.stop)
@@ -371,6 +416,16 @@ export class AnthropicProvider implements AIInterface {
             : undefined,
         system: system || undefined,
         stream: true,
+      };
+      if ((options.reasoning?.maxTokens || 0) > 0) {
+        requestParams.thinking = {
+          type: 'enabled',
+          budget_tokens: options.reasoning?.maxTokens,
+        };
+      }
+      const stream = await this.client.messages.create(requestParams, {
+        signal: controls.signal,
+        timeout: controls.timeout,
       });
 
       for await (const chunk of stream) {
@@ -395,7 +450,25 @@ export class AnthropicProvider implements AIInterface {
         options.usageTags,
       );
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'anthropic',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'anthropic',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 

--- a/packages/ai/src/shared/providers/bedrock.ts
+++ b/packages/ai/src/shared/providers/bedrock.ts
@@ -2,6 +2,13 @@
  * AWS Bedrock provider implementation
  */
 
+import {
+  normalizeBaseAIOptions,
+  normalizeChatOptions,
+  normalizeImageGenerationOptions,
+  type PreparedRequestControls,
+  prepareRequestControls,
+} from '../safety';
 import type {
   AICapabilities,
   AIInterface,
@@ -46,10 +53,10 @@ export class BedrockProvider implements AIInterface {
   private client: any; // Will be BedrockRuntimeClient instance from @aws-sdk/client-bedrock-runtime
 
   constructor(options: BedrockOptions) {
-    this.options = {
+    this.options = normalizeBaseAIOptions({
       defaultModel: BEDROCK_DEFAULT_CHAT_MODEL,
       ...options,
-    };
+    });
 
     // Initialize AWS Bedrock client
     this.initializeClientSync();
@@ -64,6 +71,7 @@ export class BedrockProvider implements AIInterface {
             region: this.options.region,
             credentials: this.options.credentials,
             endpoint: this.options.endpoint,
+            maxAttempts: (this.options.maxRetries || 0) + 1,
           });
         })
         .catch(() => {
@@ -84,6 +92,7 @@ export class BedrockProvider implements AIInterface {
           region: this.options.region,
           credentials: this.options.credentials,
           endpoint: this.options.endpoint,
+          maxAttempts: (this.options.maxRetries || 0) + 1,
         });
       } catch (_error) {
         throw new AIError(
@@ -100,13 +109,22 @@ export class BedrockProvider implements AIInterface {
     options: ChatOptions = {},
   ): Promise<AIResponse> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
       const modelId = options.model || this.options.defaultModel;
+      options = normalizeChatOptions(this.options, options, 'bedrock', modelId);
+      controls = prepareRequestControls(this.options, options);
       const response = this.mapConverseResponse(
         await this.client.converse(
-          await this.buildConverseRequest(messages, options, modelId!),
+          await this.buildConverseRequest(
+            messages,
+            options,
+            modelId!,
+            controls.signal,
+          ),
+          { abortSignal: controls.signal },
         ),
         modelId!,
       );
@@ -122,7 +140,25 @@ export class BedrockProvider implements AIInterface {
       );
       return response;
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'bedrock',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'bedrock',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -139,6 +175,9 @@ export class BedrockProvider implements AIInterface {
       stop: options.stop,
       stream: options.stream,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
   }
@@ -171,6 +210,9 @@ export class BedrockProvider implements AIInterface {
       tools: options.tools,
       toolChoice: options.toolChoice,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
 
@@ -293,7 +335,7 @@ export class BedrockProvider implements AIInterface {
     prompt?: string,
     options: ImageDescriptionOptions = {},
   ): Promise<string> {
-    const imageUrl = await this.imageToDataUrl(image);
+    const imageUrl = await this.imageToDataUrl(image, options.signal);
     const response = await this.chat(
       [
         {
@@ -314,7 +356,11 @@ export class BedrockProvider implements AIInterface {
       ],
       {
         model: options.model || this.options.defaultModel,
-        maxTokens: options.maxTokens || 500,
+        maxTokens: options.maxTokens ?? 500,
+        signal: options.signal,
+        timeout: options.timeout,
+        reasoning: options.reasoning,
+        usageTags: options.usageTags,
       },
     );
 
@@ -325,30 +371,44 @@ export class BedrockProvider implements AIInterface {
     prompt: string,
     options: ImageGenerationOptions = {},
   ): Promise<ImageGenerationResponse> {
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
       const model = options.model || BEDROCK_IMAGE_GENERATION_MODEL;
+      options = normalizeImageGenerationOptions(
+        this.options,
+        options,
+        'bedrock',
+        model,
+      );
+      controls = prepareRequestControls(this.options, options);
       const size = this.resolveImageSize(options);
-      const response = await this.client.invokeModel({
-        modelId: model,
-        contentType: 'application/json',
-        accept: 'application/json',
-        body: JSON.stringify({
-          taskType: 'TEXT_IMAGE',
-          textToImageParams: {
-            text: prompt,
-            ...(options.imageInput && {
-              conditionImage: await this.imageToBase64(options.imageInput),
-            }),
-          },
-          imageGenerationConfig: {
-            numberOfImages: options.n || 1,
-            quality: this.mapImageQuality(options.quality),
-            ...size,
-          },
-        }),
-      });
+      const response = await this.client.invokeModel(
+        {
+          modelId: model,
+          contentType: 'application/json',
+          accept: 'application/json',
+          body: JSON.stringify({
+            taskType: 'TEXT_IMAGE',
+            textToImageParams: {
+              text: prompt,
+              ...(options.imageInput && {
+                conditionImage: await this.imageToBase64(
+                  options.imageInput,
+                  controls.signal,
+                ),
+              }),
+            },
+            imageGenerationConfig: {
+              numberOfImages: options.n,
+              quality: this.mapImageQuality(options.quality),
+              ...size,
+            },
+          }),
+        },
+        { abortSignal: controls.signal },
+      );
 
       const payload = await this.parseInvokeModelBody(response.body);
       if (payload.error) {
@@ -374,7 +434,25 @@ export class BedrockProvider implements AIInterface {
         model,
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'bedrock',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'bedrock',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -383,12 +461,21 @@ export class BedrockProvider implements AIInterface {
     options: ChatOptions = {},
   ): AsyncIterable<string> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
       const modelId = options.model || this.options.defaultModel;
+      options = normalizeChatOptions(this.options, options, 'bedrock', modelId);
+      controls = prepareRequestControls(this.options, options);
       const response = await this.client.converseStream(
-        await this.buildConverseRequest(messages, options, modelId!),
+        await this.buildConverseRequest(
+          messages,
+          options,
+          modelId!,
+          controls.signal,
+        ),
+        { abortSignal: controls.signal },
       );
 
       let usage: TokenUsage | undefined;
@@ -421,7 +508,25 @@ export class BedrockProvider implements AIInterface {
         options.usageTags,
       );
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'bedrock',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'bedrock',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -626,9 +731,12 @@ export class BedrockProvider implements AIInterface {
     messages: AIMessage[],
     options: ChatOptions,
     modelId: string,
+    signal?: AbortSignal,
   ): Promise<Record<string, any>> {
-    const { system, bedrockMessages } =
-      await this.mapMessagesToBedrock(messages);
+    const { system, bedrockMessages } = await this.mapMessagesToBedrock(
+      messages,
+      signal,
+    );
     const systemPrompt =
       options.responseFormat?.type === 'json_object'
         ? [
@@ -641,7 +749,7 @@ export class BedrockProvider implements AIInterface {
 
     const inferenceConfig = Object.fromEntries(
       Object.entries({
-        maxTokens: options.maxTokens || 4096,
+        maxTokens: options.maxTokens,
         temperature: options.temperature,
         topP: options.topP,
         stopSequences: Array.isArray(options.stop)
@@ -658,6 +766,14 @@ export class BedrockProvider implements AIInterface {
       ...(Object.keys(inferenceConfig).length > 0 && { inferenceConfig }),
       ...(systemPrompt && { system: [{ text: systemPrompt }] }),
     };
+    if ((options.reasoning?.maxTokens || 0) > 0) {
+      request.additionalModelRequestFields = {
+        thinking: {
+          type: 'enabled',
+          budget_tokens: options.reasoning?.maxTokens,
+        },
+      };
+    }
 
     const toolConfig = this.mapToolConfig(options);
     if (toolConfig) {
@@ -667,7 +783,10 @@ export class BedrockProvider implements AIInterface {
     return request;
   }
 
-  private async mapMessagesToBedrock(messages: AIMessage[]): Promise<{
+  private async mapMessagesToBedrock(
+    messages: AIMessage[],
+    signal?: AbortSignal,
+  ): Promise<{
     system?: string;
     bedrockMessages: Array<{ role: 'user' | 'assistant'; content: any[] }>;
   }> {
@@ -694,7 +813,10 @@ export class BedrockProvider implements AIInterface {
             continue;
           }
 
-          const image = await this.imageUrlToBedrockImage(part.image_url.url);
+          const image = await this.imageUrlToBedrockImage(
+            part.image_url.url,
+            signal,
+          );
           content.push({ image });
         }
       }
@@ -854,15 +976,21 @@ export class BedrockProvider implements AIInterface {
     return undefined;
   }
 
-  private async imageUrlToBedrockImage(imageUrl: string): Promise<any> {
-    const { bytes, mimeType } = await this.imageToBytes(imageUrl);
+  private async imageUrlToBedrockImage(
+    imageUrl: string,
+    signal?: AbortSignal,
+  ): Promise<any> {
+    const { bytes, mimeType } = await this.imageToBytes(imageUrl, signal);
     return {
       format: this.mimeTypeToBedrockImageFormat(mimeType),
       source: { bytes },
     };
   }
 
-  private async imageToDataUrl(image: string | Buffer): Promise<string> {
+  private async imageToDataUrl(
+    image: string | Buffer,
+    signal?: AbortSignal,
+  ): Promise<string> {
     if (Buffer.isBuffer(image)) {
       return `data:image/png;base64,${image.toString('base64')}`;
     }
@@ -870,11 +998,14 @@ export class BedrockProvider implements AIInterface {
       return image;
     }
 
-    const { bytes, mimeType } = await this.imageToBytes(image);
+    const { bytes, mimeType } = await this.imageToBytes(image, signal);
     return `data:${mimeType};base64,${Buffer.from(bytes).toString('base64')}`;
   }
 
-  private async imageToBase64(image: string | Buffer): Promise<string> {
+  private async imageToBase64(
+    image: string | Buffer,
+    signal?: AbortSignal,
+  ): Promise<string> {
     if (Buffer.isBuffer(image)) {
       return image.toString('base64');
     }
@@ -890,12 +1021,13 @@ export class BedrockProvider implements AIInterface {
       return match[2];
     }
 
-    const { bytes } = await this.imageToBytes(image);
+    const { bytes } = await this.imageToBytes(image, signal);
     return Buffer.from(bytes).toString('base64');
   }
 
   private async imageToBytes(
     image: string,
+    signal?: AbortSignal,
   ): Promise<{ bytes: Uint8Array; mimeType: string }> {
     if (image.startsWith('data:')) {
       const match = image.match(/^data:([^;]+);base64,(.+)$/);
@@ -913,7 +1045,7 @@ export class BedrockProvider implements AIInterface {
       };
     }
 
-    const response = await fetch(image);
+    const response = await fetch(image, { signal });
     if (!response.ok) {
       throw new AIError(
         `Failed to fetch image: ${response.status} ${response.statusText}`,

--- a/packages/ai/src/shared/providers/bifrost.ts
+++ b/packages/ai/src/shared/providers/bifrost.ts
@@ -1,5 +1,9 @@
 import { ValidationError } from '@happyvertical/utils';
 
+import {
+  normalizeChatOptions,
+  normalizeImageGenerationOptions,
+} from '../safety';
 import type {
   AICapabilities,
   AIMessage,
@@ -282,9 +286,15 @@ export class BifrostProvider extends OpenAIProvider {
     messages: AIMessage[],
     options: ChatOptions = {},
   ): Promise<AIResponse> {
+    const safe = normalizeChatOptions(
+      this.options,
+      options,
+      'bifrost',
+      options.model || this.options.defaultModel,
+    );
     return super.chat(messages, {
-      ...options,
-      model: await this.resolveModel('chat', options.model),
+      ...safe,
+      model: await this.resolveModel('chat', safe.model),
     });
   }
 
@@ -292,9 +302,15 @@ export class BifrostProvider extends OpenAIProvider {
     messages: AIMessage[],
     options: ChatOptions = {},
   ): AsyncIterable<string> {
+    const safe = normalizeChatOptions(
+      this.options,
+      options,
+      'bifrost',
+      options.model || this.options.defaultModel,
+    );
     yield* super.stream(messages, {
-      ...options,
-      model: await this.resolveModel('chat', options.model),
+      ...safe,
+      model: await this.resolveModel('chat', safe.model),
     });
   }
 
@@ -303,9 +319,15 @@ export class BifrostProvider extends OpenAIProvider {
     prompt?: string,
     options: ImageDescriptionOptions = {},
   ): Promise<string> {
+    const safe = normalizeChatOptions(
+      this.options,
+      options,
+      'bifrost',
+      options.model || this.options.defaultModel,
+    );
     return super.describeImage(image, prompt, {
-      ...options,
-      model: await this.resolveModel('vision', options.model),
+      ...safe,
+      model: await this.resolveModel('vision', safe.model),
     });
   }
 
@@ -333,9 +355,15 @@ export class BifrostProvider extends OpenAIProvider {
     prompt: string,
     options: ImageGenerationOptions = {},
   ): Promise<ImageGenerationResponse> {
+    const safe = normalizeImageGenerationOptions(
+      this.options,
+      options,
+      'bifrost',
+      options.model,
+    );
     return super.generateImage(prompt, {
-      ...options,
-      model: await this.resolveModel('image_generation', options.model),
+      ...safe,
+      model: await this.resolveModel('image_generation', safe.model),
     });
   }
 }

--- a/packages/ai/src/shared/providers/gemini.ts
+++ b/packages/ai/src/shared/providers/gemini.ts
@@ -4,6 +4,13 @@
 
 import crypto from 'node:crypto';
 import { extractRetryAfterSeconds } from '../rate-limit';
+import {
+  normalizeBaseAIOptions,
+  normalizeChatOptions,
+  normalizeImageGenerationOptions,
+  type PreparedRequestControls,
+  prepareRequestControls,
+} from '../safety';
 import type {
   AICapabilities,
   AIInterface,
@@ -15,7 +22,6 @@ import type {
   EmbeddingOptions,
   EmbeddingResponse,
   GeminiOptions,
-  GeminiThinkingLevel,
   ImageDescriptionOptions,
   ImageEmbeddingOptions,
   ImageGenerationOptions,
@@ -46,10 +52,10 @@ export class GeminiProvider implements AIInterface {
   private client: any; // GoogleGenAI instance from @google/genai
 
   constructor(options: GeminiOptions) {
-    this.options = {
+    this.options = normalizeBaseAIOptions({
       defaultModel: 'gemini-2.5-flash',
       ...options,
-    };
+    });
 
     // Initialize Google Generative AI client
     this.initializeClientSync();
@@ -97,12 +103,20 @@ export class GeminiProvider implements AIInterface {
         project: this.options.projectId,
         location: this.options.location,
         apiKey: this.options.apiKey, // Optional for Vertex AI with ADC
+        httpOptions: {
+          timeout: this.options.timeout,
+          retryOptions: { attempts: (this.options.maxRetries || 0) + 1 },
+        },
       };
     }
 
     // Default to Google AI Studio mode with API key
     return {
       apiKey: this.options.apiKey,
+      httpOptions: {
+        timeout: this.options.timeout,
+        retryOptions: { attempts: (this.options.maxRetries || 0) + 1 },
+      },
     };
   }
 
@@ -111,14 +125,17 @@ export class GeminiProvider implements AIInterface {
     options: ChatOptions = {},
   ): Promise<AIResponse> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
       const model = options.model || this.options.defaultModel;
+      options = normalizeChatOptions(this.options, options, 'gemini', model);
+      controls = prepareRequestControls(this.options, options);
       const requestConfig: Record<string, any> = {
         model,
         contents: this.messagesToGeminiFormat(messages),
-        config: this.buildGenerateContentConfig(options),
+        config: this.buildGenerateContentConfig(options, controls),
       };
 
       // Call new SDK API: ai.models.generateContent()
@@ -172,7 +189,25 @@ export class GeminiProvider implements AIInterface {
         toolCalls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'gemini',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'gemini',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -189,6 +224,9 @@ export class GeminiProvider implements AIInterface {
       stop: options.stop,
       stream: options.stream,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
   }
@@ -235,6 +273,9 @@ export class GeminiProvider implements AIInterface {
       tools: options.tools,
       toolChoice: options.toolChoice,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
 
@@ -323,6 +364,7 @@ export class GeminiProvider implements AIInterface {
    */
   private async imageToGeminiFormat(
     image: string | Buffer,
+    signal?: AbortSignal,
   ): Promise<{ inlineData: { mimeType: string; data: string } }> {
     let mimeType = 'image/png';
     let base64Data: string;
@@ -344,7 +386,7 @@ export class GeminiProvider implements AIInterface {
       }
     } else {
       // Fetch from URL
-      const response = await fetch(image);
+      const response = await fetch(image, { signal });
       if (!response.ok) {
         throw new AIError(
           `Failed to fetch image: ${response.status} ${response.statusText}`,
@@ -379,25 +421,51 @@ export class GeminiProvider implements AIInterface {
     prompt?: string,
     options: ImageDescriptionOptions = {},
   ): Promise<string> {
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
       const defaultPrompt =
         'Describe this image for a search index. Include objects, mood, lighting, and any visible text.';
 
-      const imageData = await this.imageToGeminiFormat(image);
+      const model =
+        options.model || this.options.defaultModel || 'gemini-2.5-flash';
+      const normalized = normalizeChatOptions(
+        this.options,
+        { ...options, maxTokens: options.maxTokens ?? 500 },
+        'gemini',
+        model,
+      );
+      controls = prepareRequestControls(this.options, normalized);
+      const imageData = await this.imageToGeminiFormat(image, controls.signal);
 
       const response = await this.client.models.generateContent({
-        model: options.model || this.options.defaultModel || 'gemini-2.5-flash',
+        model,
         contents: [{ text: prompt || defaultPrompt }, imageData],
-        config: {
-          maxOutputTokens: options.maxTokens || 500,
-        },
+        config: this.buildGenerateContentConfig(normalized, controls),
       });
 
       return response.text || '';
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'gemini',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'gemini',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -461,13 +529,26 @@ export class GeminiProvider implements AIInterface {
     prompt: string,
     options: ImageGenerationOptions = {},
   ): Promise<ImageGenerationResponse> {
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
       const model = options.model || 'imagen-3.0-generate-002';
+      options = normalizeImageGenerationOptions(
+        this.options,
+        options,
+        'gemini',
+        model,
+      );
+      controls = prepareRequestControls(this.options, options);
 
       const config: Record<string, any> = {
-        numberOfImages: options.n || 1,
+        numberOfImages: options.n,
+        abortSignal: controls.signal,
+        httpOptions: {
+          timeout: controls.timeout,
+          retryOptions: { attempts: (this.options.maxRetries || 0) + 1 },
+        },
       };
 
       if (options.aspectRatio) {
@@ -516,7 +597,25 @@ export class GeminiProvider implements AIInterface {
         model,
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'gemini',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'gemini',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -525,14 +624,17 @@ export class GeminiProvider implements AIInterface {
     options: ChatOptions = {},
   ): AsyncIterable<string> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       await this.ensureClient();
 
       const model = options.model || this.options.defaultModel;
+      options = normalizeChatOptions(this.options, options, 'gemini', model);
+      controls = prepareRequestControls(this.options, options);
       const stream = await this.client.models.generateContentStream({
         model,
         contents: this.messagesToGeminiFormat(messages),
-        config: this.buildGenerateContentConfig(options),
+        config: this.buildGenerateContentConfig(options, controls),
       });
 
       let usage: TokenUsage | undefined;
@@ -567,7 +669,25 @@ export class GeminiProvider implements AIInterface {
         options.usageTags,
       );
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'gemini',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'gemini',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -737,18 +857,16 @@ export class GeminiProvider implements AIInterface {
     return { functionCallingConfig: { mode: 'AUTO' } };
   }
 
-  /**
-   * Map thinking level from our type to SDK's expected format
-   * The SDK expects uppercase values: MINIMAL, LOW, MEDIUM, HIGH
-   */
-  private mapThinkingLevel(level: GeminiThinkingLevel): string {
-    return level.toUpperCase();
-  }
-
   private buildGenerateContentConfig(
     options: ChatOptions,
+    controls: PreparedRequestControls,
   ): Record<string, any> {
     const config: Record<string, any> = {
+      abortSignal: controls.signal,
+      httpOptions: {
+        timeout: controls.timeout,
+        retryOptions: { attempts: (this.options.maxRetries || 0) + 1 },
+      },
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
       topP: options.topP,
@@ -779,15 +897,10 @@ export class GeminiProvider implements AIInterface {
       config.toolConfig = this.mapToolChoice(options.toolChoice);
     }
 
-    const thinkingLevel = options.thinkingLevel || this.options.thinkingLevel;
-    if (thinkingLevel || options.includeThoughts !== undefined) {
+    if (options.reasoning) {
       config.thinkingConfig = {
-        ...(thinkingLevel && {
-          thinkingLevel: this.mapThinkingLevel(thinkingLevel),
-        }),
-        ...(options.includeThoughts !== undefined && {
-          includeThoughts: options.includeThoughts,
-        }),
+        thinkingBudget: options.reasoning.maxTokens,
+        includeThoughts: options.reasoning.includeThoughts,
       };
     }
 

--- a/packages/ai/src/shared/providers/gemini.ts
+++ b/packages/ai/src/shared/providers/gemini.ts
@@ -897,10 +897,11 @@ export class GeminiProvider implements AIInterface {
       config.toolConfig = this.mapToolChoice(options.toolChoice);
     }
 
-    if (options.reasoning) {
+    const reasoning = options.reasoning;
+    if (reasoning?.maxTokens !== undefined && reasoning.maxTokens > 0) {
       config.thinkingConfig = {
-        thinkingBudget: options.reasoning.maxTokens,
-        includeThoughts: options.reasoning.includeThoughts,
+        thinkingBudget: reasoning.maxTokens,
+        includeThoughts: reasoning.includeThoughts,
       };
     }
 

--- a/packages/ai/src/shared/providers/huggingface.ts
+++ b/packages/ai/src/shared/providers/huggingface.ts
@@ -2,6 +2,12 @@
  * Hugging Face provider implementation
  */
 
+import {
+  normalizeBaseAIOptions,
+  normalizeChatOptions,
+  type PreparedRequestControls,
+  prepareRequestControls,
+} from '../safety';
 import type {
   AICapabilities,
   AIInterface,
@@ -41,12 +47,12 @@ export class HuggingFaceProvider implements AIInterface {
   private baseUrl: string;
 
   constructor(options: HuggingFaceOptions) {
-    this.options = {
+    this.options = normalizeBaseAIOptions({
       defaultModel: 'microsoft/DialoGPT-medium',
       useCache: true,
       waitForModel: true,
       ...options,
-    };
+    });
 
     this.baseUrl =
       this.options.endpoint || 'https://api-inference.huggingface.co';
@@ -57,30 +63,43 @@ export class HuggingFaceProvider implements AIInterface {
     options: ChatOptions = {},
   ): Promise<AIResponse> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       // Convert messages to a single prompt for text generation models
       const prompt = this.messagesToPrompt(messages);
       const model =
         options.model || this.options.model || this.options.defaultModel;
+      options = normalizeChatOptions(
+        this.options,
+        options,
+        'huggingface',
+        model,
+      );
+      controls = prepareRequestControls(this.options, options);
 
-      const response = await this.makeRequest(`/models/${model}`, {
-        inputs: prompt,
-        parameters: {
-          max_new_tokens: options.maxTokens || 512,
-          temperature: options.temperature || 1.0,
-          top_p: options.topP || 1.0,
-          do_sample: (options.temperature && options.temperature > 0) || false,
-          stop_sequences: Array.isArray(options.stop)
-            ? options.stop
-            : options.stop
-              ? [options.stop]
-              : undefined,
+      const response = await this.makeRequest(
+        `/models/${model}`,
+        {
+          inputs: prompt,
+          parameters: {
+            max_new_tokens: options.maxTokens,
+            temperature: options.temperature ?? 1.0,
+            top_p: options.topP ?? 1.0,
+            do_sample:
+              (options.temperature && options.temperature > 0) || false,
+            stop_sequences: Array.isArray(options.stop)
+              ? options.stop
+              : options.stop
+                ? [options.stop]
+                : undefined,
+          },
+          options: {
+            use_cache: this.options.useCache,
+            wait_for_model: this.options.waitForModel,
+          },
         },
-        options: {
-          use_cache: this.options.useCache,
-          wait_for_model: this.options.waitForModel,
-        },
-      });
+        controls.signal,
+      );
 
       if (Array.isArray(response) && response[0]?.generated_text) {
         const generatedText = response[0].generated_text;
@@ -110,7 +129,25 @@ export class HuggingFaceProvider implements AIInterface {
         'huggingface',
       );
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'huggingface',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'huggingface',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -127,6 +164,9 @@ export class HuggingFaceProvider implements AIInterface {
       stop: options.stop,
       stream: options.stream,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
   }
@@ -159,6 +199,9 @@ export class HuggingFaceProvider implements AIInterface {
       tools: options.tools,
       toolChoice: options.toolChoice,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
 
@@ -273,6 +316,14 @@ export class HuggingFaceProvider implements AIInterface {
     const chunkSize = 10;
 
     for (let i = 0; i < content.length; i += chunkSize) {
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'huggingface',
+          options.model,
+        );
+      }
       const chunk = content.slice(i, i + chunkSize);
       if (options.onProgress) {
         options.onProgress(chunk);
@@ -441,7 +492,11 @@ export class HuggingFaceProvider implements AIInterface {
       .join('\n')}\nAssistant:`;
   }
 
-  private async makeRequest(endpoint: string, data: any): Promise<any> {
+  private async makeRequest(
+    endpoint: string,
+    data: any,
+    signal?: AbortSignal,
+  ): Promise<any> {
     const url = `${this.baseUrl}${endpoint}`;
 
     const response = await fetch(url, {
@@ -452,6 +507,7 @@ export class HuggingFaceProvider implements AIInterface {
         ...this.options.headers,
       },
       body: JSON.stringify(data),
+      signal,
     });
 
     if (!response.ok) {

--- a/packages/ai/src/shared/providers/litellm.ts
+++ b/packages/ai/src/shared/providers/litellm.ts
@@ -1,5 +1,9 @@
 import { ValidationError } from '@happyvertical/utils';
 
+import {
+  normalizeChatOptions,
+  normalizeImageGenerationOptions,
+} from '../safety';
 import type {
   AICapabilities,
   AIMessage,
@@ -258,9 +262,15 @@ export class LiteLLMProvider extends OpenAIProvider {
     messages: AIMessage[],
     options: ChatOptions = {},
   ): Promise<AIResponse> {
+    const safe = normalizeChatOptions(
+      this.options,
+      options,
+      'litellm',
+      options.model || this.options.defaultModel,
+    );
     return super.chat(messages, {
-      ...options,
-      model: await this.resolveModel('chat', options.model),
+      ...safe,
+      model: await this.resolveModel('chat', safe.model),
     });
   }
 
@@ -268,9 +278,15 @@ export class LiteLLMProvider extends OpenAIProvider {
     messages: AIMessage[],
     options: ChatOptions = {},
   ): AsyncIterable<string> {
+    const safe = normalizeChatOptions(
+      this.options,
+      options,
+      'litellm',
+      options.model || this.options.defaultModel,
+    );
     yield* super.stream(messages, {
-      ...options,
-      model: await this.resolveModel('chat', options.model),
+      ...safe,
+      model: await this.resolveModel('chat', safe.model),
     });
   }
 
@@ -279,9 +295,15 @@ export class LiteLLMProvider extends OpenAIProvider {
     prompt?: string,
     options: ImageDescriptionOptions = {},
   ): Promise<string> {
+    const safe = normalizeChatOptions(
+      this.options,
+      options,
+      'litellm',
+      options.model || this.options.defaultModel,
+    );
     return super.describeImage(image, prompt, {
-      ...options,
-      model: await this.resolveModel('vision', options.model),
+      ...safe,
+      model: await this.resolveModel('vision', safe.model),
     });
   }
 
@@ -309,9 +331,15 @@ export class LiteLLMProvider extends OpenAIProvider {
     prompt: string,
     options: ImageGenerationOptions = {},
   ): Promise<ImageGenerationResponse> {
+    const safe = normalizeImageGenerationOptions(
+      this.options,
+      options,
+      'litellm',
+      options.model,
+    );
     return super.generateImage(prompt, {
-      ...options,
-      model: await this.resolveModel('image_generation', options.model),
+      ...safe,
+      model: await this.resolveModel('image_generation', safe.model),
     });
   }
 }

--- a/packages/ai/src/shared/providers/ollama.ts
+++ b/packages/ai/src/shared/providers/ollama.ts
@@ -8,6 +8,13 @@
 
 import { ValidationError } from '@happyvertical/utils';
 
+import {
+  normalizeBaseAIOptions,
+  normalizeChatOptions,
+  normalizeImageGenerationOptions,
+  type PreparedRequestControls,
+  prepareRequestControls,
+} from '../safety';
 import type {
   AICapabilities,
   AIInterface,
@@ -363,10 +370,10 @@ export class OllamaProvider implements AIInterface {
 
   constructor(options: OllamaOptions) {
     this.host = normalizeHost(options.baseUrl);
-    this.options = {
+    this.options = normalizeBaseAIOptions({
       ...options,
       baseUrl: this.host,
-    };
+    });
     this.configuredDefaultModel = options.defaultModel;
   }
 
@@ -389,27 +396,6 @@ export class OllamaProvider implements AIInterface {
       headers.set('Authorization', `Bearer ${this.options.apiKey}`);
     }
     return headers;
-  }
-
-  private async fetchWithTimeout(
-    url: string,
-    init: RequestInit,
-  ): Promise<Response> {
-    const controller = new AbortController();
-    const timeout =
-      typeof this.options.timeout === 'number' ? this.options.timeout : 0;
-    const timer = timeout
-      ? setTimeout(() => controller.abort(), timeout)
-      : undefined;
-
-    try {
-      return await fetch(url, {
-        ...init,
-        signal: controller.signal,
-      });
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
   }
 
   private async buildHttpError(response: Response): Promise<AIError> {
@@ -457,15 +443,16 @@ export class OllamaProvider implements AIInterface {
   private async requestJson<T>(
     path: string,
     body?: Record<string, unknown>,
-    options: { compatibility?: boolean } = {},
+    options: { compatibility?: boolean; signal?: AbortSignal } = {},
   ): Promise<T> {
     const baseUrl = options.compatibility
       ? this.compatibilityBaseUrl
       : this.nativeBaseUrl;
-    const response = await this.fetchWithTimeout(`${baseUrl}${path}`, {
+    const response = await fetch(`${baseUrl}${path}`, {
       method: body ? 'POST' : 'GET',
       headers: this.buildHeaders(),
       body: body ? JSON.stringify(body) : undefined,
+      signal: options.signal,
     });
 
     if (!response.ok) {
@@ -478,15 +465,14 @@ export class OllamaProvider implements AIInterface {
   private async requestStream(
     path: string,
     body: Record<string, unknown>,
+    signal: AbortSignal,
   ): Promise<Response> {
-    const response = await this.fetchWithTimeout(
-      `${this.nativeBaseUrl}${path}`,
-      {
-        method: 'POST',
-        headers: this.buildHeaders(true),
-        body: JSON.stringify(body),
-      },
-    );
+    const response = await fetch(`${this.nativeBaseUrl}${path}`, {
+      method: 'POST',
+      headers: this.buildHeaders(true),
+      body: JSON.stringify(body),
+      signal,
+    });
 
     if (!response.ok) {
       throw await this.buildHttpError(response);
@@ -620,7 +606,10 @@ export class OllamaProvider implements AIInterface {
     );
   }
 
-  private async imageToBase64Payload(image: string | Buffer): Promise<string> {
+  private async imageToBase64Payload(
+    image: string | Buffer,
+    signal?: AbortSignal,
+  ): Promise<string> {
     if (Buffer.isBuffer(image)) {
       return image.toString('base64');
     }
@@ -630,7 +619,7 @@ export class OllamaProvider implements AIInterface {
       return commaIndex === -1 ? image : image.slice(commaIndex + 1);
     }
 
-    const response = await fetch(image);
+    const response = await fetch(image, { signal });
     if (!response.ok) {
       throw new AIError(
         `Failed to fetch image: ${response.status} ${response.statusText}`,
@@ -643,7 +632,10 @@ export class OllamaProvider implements AIInterface {
     return Buffer.from(arrayBuffer).toString('base64');
   }
 
-  private async imageToDataUrl(image: string | Buffer): Promise<string> {
+  private async imageToDataUrl(
+    image: string | Buffer,
+    signal?: AbortSignal,
+  ): Promise<string> {
     if (Buffer.isBuffer(image)) {
       return `data:image/png;base64,${image.toString('base64')}`;
     }
@@ -652,7 +644,7 @@ export class OllamaProvider implements AIInterface {
       return image;
     }
 
-    const response = await fetch(image);
+    const response = await fetch(image, { signal });
     if (!response.ok) {
       throw new AIError(
         `Failed to fetch image: ${response.status} ${response.statusText}`,
@@ -681,6 +673,7 @@ export class OllamaProvider implements AIInterface {
 
   private async mapMessagesToOllama(
     messages: AIMessage[],
+    signal?: AbortSignal,
   ): Promise<OllamaMessage[]> {
     const mappedMessages = await Promise.all(
       messages.map(async (message) => {
@@ -700,7 +693,7 @@ export class OllamaProvider implements AIInterface {
           if (imageParts.length > 0) {
             mapped.images = await Promise.all(
               imageParts.map((part) =>
-                this.imageToBase64Payload(part.image_url.url),
+                this.imageToBase64Payload(part.image_url.url, signal),
               ),
             );
           }
@@ -792,8 +785,16 @@ export class OllamaProvider implements AIInterface {
   }
 
   private mapThink(
-    options: Pick<ChatOptions, 'thinkingLevel'>,
+    options: Pick<ChatOptions, 'thinkingLevel' | 'reasoning'>,
   ): boolean | string | undefined {
+    if (options.reasoning?.maxTokens === 0) {
+      return false;
+    }
+    if (options.reasoning?.effort) {
+      return options.reasoning.effort === 'none'
+        ? false
+        : options.reasoning.effort;
+    }
     if (!Object.hasOwn(options, 'thinkingLevel')) {
       return undefined;
     }
@@ -806,23 +807,35 @@ export class OllamaProvider implements AIInterface {
     options: ChatOptions = {},
   ): Promise<AIResponse> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
+      options = normalizeChatOptions(
+        this.options,
+        options,
+        'ollama',
+        options.model || this.options.defaultModel,
+      );
+      controls = prepareRequestControls(this.options, options);
       const model = await this.resolveModel(
         this.isVisionRequest(messages) ? 'vision' : 'chat',
         options.model,
       );
 
-      const response = await this.requestJson<OllamaChatResponse>('/chat', {
-        model,
-        messages: await this.mapMessagesToOllama(messages),
-        stream: false,
-        format:
-          options.responseFormat?.type === 'json_object' ? 'json' : undefined,
-        tools: this.mapTools(options.tools, options.toolChoice),
-        think: this.mapThink(options),
-        keep_alive: this.options.keepAlive,
-        options: this.buildRuntimeOptions(options),
-      });
+      const response = await this.requestJson<OllamaChatResponse>(
+        '/chat',
+        {
+          model,
+          messages: await this.mapMessagesToOllama(messages, controls.signal),
+          stream: false,
+          format:
+            options.responseFormat?.type === 'json_object' ? 'json' : undefined,
+          tools: this.mapTools(options.tools, options.toolChoice),
+          think: this.mapThink(options),
+          keep_alive: this.options.keepAlive,
+          options: this.buildRuntimeOptions(options),
+        },
+        { signal: controls.signal },
+      );
 
       const usage = mapUsage(response.prompt_eval_count, response.eval_count);
 
@@ -859,7 +872,25 @@ export class OllamaProvider implements AIInterface {
         toolCalls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'ollama',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'ollama',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -868,7 +899,15 @@ export class OllamaProvider implements AIInterface {
     options: CompletionOptions = {},
   ): Promise<AIResponse> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
+      options = normalizeChatOptions(
+        this.options,
+        options,
+        'ollama',
+        options.model || this.options.defaultModel,
+      );
+      controls = prepareRequestControls(this.options, options);
       const model = await this.resolveModel('chat', options.model);
       const response = await this.requestJson<OllamaGenerateResponse>(
         '/generate',
@@ -879,6 +918,7 @@ export class OllamaProvider implements AIInterface {
           keep_alive: this.options.keepAlive,
           options: this.buildRuntimeOptions(options),
         },
+        { signal: controls.signal },
       );
 
       const usage = mapUsage(response.prompt_eval_count, response.eval_count);
@@ -900,7 +940,25 @@ export class OllamaProvider implements AIInterface {
         finishReason: mapFinishReason(response.done_reason),
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'ollama',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'ollama',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -924,6 +982,9 @@ export class OllamaProvider implements AIInterface {
       tools: options.tools,
       toolChoice: options.toolChoice,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
 
@@ -1001,7 +1062,7 @@ export class OllamaProvider implements AIInterface {
     const defaultPrompt =
       'Describe this image for a search index. Include objects, mood, lighting, and any visible text.';
 
-    const imageUrl = await this.imageToDataUrl(image);
+    const imageUrl = await this.imageToDataUrl(image, options.signal);
     const response = await this.chat(
       [
         {
@@ -1023,8 +1084,11 @@ export class OllamaProvider implements AIInterface {
       ],
       {
         model: options.model,
-        maxTokens: options.maxTokens || 500,
-        thinkingLevel: false,
+        maxTokens: options.maxTokens ?? 500,
+        reasoning: options.reasoning || { effort: 'none', maxTokens: 0 },
+        signal: options.signal,
+        timeout: options.timeout,
+        usageTags: options.usageTags,
       },
     );
 
@@ -1035,7 +1099,15 @@ export class OllamaProvider implements AIInterface {
     prompt: string,
     options: ImageGenerationOptions = {},
   ): Promise<ImageGenerationResponse> {
+    let controls: PreparedRequestControls | undefined;
     try {
+      options = normalizeImageGenerationOptions(
+        this.options,
+        options,
+        'ollama',
+        options.model,
+      );
+      controls = prepareRequestControls(this.options, options);
       if (options.imageInput) {
         throw new AIError(
           'Ollama image generation does not support imageInput in this adapter yet.',
@@ -1058,13 +1130,13 @@ export class OllamaProvider implements AIInterface {
         {
           model,
           prompt,
-          n: options.n || 1,
+          n: options.n,
           size: options.size || '1024x1024',
           response_format: 'b64_json',
           quality: options.quality,
           style: options.style,
         },
-        { compatibility: true },
+        { compatibility: true, signal: controls.signal },
       );
 
       const images = (response.data || []).map((item) => {
@@ -1084,7 +1156,25 @@ export class OllamaProvider implements AIInterface {
         model,
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'ollama',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'ollama',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -1093,23 +1183,35 @@ export class OllamaProvider implements AIInterface {
     options: ChatOptions = {},
   ): AsyncIterable<string> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
+      options = normalizeChatOptions(
+        this.options,
+        options,
+        'ollama',
+        options.model || this.options.defaultModel,
+      );
+      controls = prepareRequestControls(this.options, options);
       const model = await this.resolveModel(
         this.isVisionRequest(messages) ? 'vision' : 'chat',
         options.model,
       );
 
-      const response = await this.requestStream('/chat', {
-        model,
-        messages: await this.mapMessagesToOllama(messages),
-        stream: true,
-        format:
-          options.responseFormat?.type === 'json_object' ? 'json' : undefined,
-        tools: this.mapTools(options.tools, options.toolChoice),
-        think: this.mapThink(options),
-        keep_alive: this.options.keepAlive,
-        options: this.buildRuntimeOptions(options),
-      });
+      const response = await this.requestStream(
+        '/chat',
+        {
+          model,
+          messages: await this.mapMessagesToOllama(messages, controls.signal),
+          stream: true,
+          format:
+            options.responseFormat?.type === 'json_object' ? 'json' : undefined,
+          tools: this.mapTools(options.tools, options.toolChoice),
+          think: this.mapThink(options),
+          keep_alive: this.options.keepAlive,
+          options: this.buildRuntimeOptions(options),
+        },
+        controls.signal,
+      );
 
       let finalUsage: TokenUsage | undefined;
       let finalModel = model;
@@ -1146,7 +1248,25 @@ export class OllamaProvider implements AIInterface {
         options.usageTags,
       );
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'ollama',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'ollama',
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 

--- a/packages/ai/src/shared/providers/openai.ts
+++ b/packages/ai/src/shared/providers/openai.ts
@@ -9,6 +9,13 @@
 
 import OpenAI from 'openai';
 import { extractRetryAfterSeconds } from '../rate-limit';
+import {
+  normalizeBaseAIOptions,
+  normalizeChatOptions,
+  normalizeImageGenerationOptions,
+  type PreparedRequestControls,
+  prepareRequestControls,
+} from '../safety';
 import type {
   AICapabilities,
   AIInterface,
@@ -144,8 +151,8 @@ export interface OpenAICompatibleOptions extends BaseAIOptions {
  */
 export class OpenAIProvider implements AIInterface {
   private client: OpenAI;
-  private options: OpenAICompatibleOptions;
-  private readonly profile: OpenAICompatibleProfile;
+  protected options: OpenAICompatibleOptions;
+  protected readonly profile: OpenAICompatibleProfile;
 
   /**
    * Creates a new OpenAI provider instance
@@ -156,10 +163,10 @@ export class OpenAIProvider implements AIInterface {
     profile: OpenAICompatibleProfile = OPENAI_PROFILE,
   ) {
     this.profile = profile;
-    this.options = {
+    this.options = normalizeBaseAIOptions({
       defaultModel: this.profile.defaultModel,
       ...options,
-    };
+    });
 
     this.client = new OpenAI({
       apiKey: this.options.apiKey,
@@ -196,10 +203,18 @@ export class OpenAIProvider implements AIInterface {
     options: ChatOptions = {},
   ): Promise<AIResponse> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       const model =
         options.model || this.options.defaultModel || this.profile.defaultModel;
-      const response = await this.client.chat.completions.create({
+      options = normalizeChatOptions(
+        this.options,
+        options,
+        this.profile.providerName,
+        model,
+      );
+      controls = prepareRequestControls(this.options, options);
+      const request = {
         model,
         messages: this.mapMessagesToOpenAI(messages),
         max_tokens: options.maxTokens,
@@ -222,6 +237,26 @@ export class OpenAIProvider implements AIInterface {
         response_format: options.responseFormat,
         seed: options.seed,
         stream: false,
+      } as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming & {
+        reasoning?: {
+          effort?: string;
+          max_tokens?: number;
+          include_thoughts?: boolean;
+        };
+      };
+      if (
+        this.profile.providerName === 'bifrost' ||
+        this.profile.providerName === 'litellm'
+      ) {
+        request.reasoning = {
+          effort: options.reasoning?.effort,
+          max_tokens: options.reasoning?.maxTokens,
+          include_thoughts: options.reasoning?.includeThoughts,
+        };
+      }
+      const response = await this.client.chat.completions.create(request, {
+        signal: controls.signal,
+        timeout: controls.timeout,
       });
 
       const choice = response.choices[0];
@@ -261,7 +296,25 @@ export class OpenAIProvider implements AIInterface {
           })),
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          this.profile.providerName,
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          this.profile.providerName,
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -294,6 +347,9 @@ export class OpenAIProvider implements AIInterface {
       stop: options.stop,
       stream: options.stream,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
   }
@@ -346,6 +402,9 @@ export class OpenAIProvider implements AIInterface {
       tools: options.tools,
       toolChoice: options.toolChoice,
       onProgress: options.onProgress,
+      signal: options.signal,
+      timeout: options.timeout,
+      reasoning: options.reasoning,
       usageTags: options.usageTags,
     });
 
@@ -413,7 +472,10 @@ export class OpenAIProvider implements AIInterface {
    * @returns base64 data URL string
    * @private
    */
-  private async imageToBase64(image: string | Buffer): Promise<string> {
+  private async imageToBase64(
+    image: string | Buffer,
+    signal?: AbortSignal,
+  ): Promise<string> {
     if (Buffer.isBuffer(image)) {
       return `data:image/png;base64,${image.toString('base64')}`;
     }
@@ -421,7 +483,7 @@ export class OpenAIProvider implements AIInterface {
       return image; // Already base64 data URL
     }
     // It's a URL - fetch and convert
-    const response = await fetch(image);
+    const response = await fetch(image, { signal });
     if (!response.ok) {
       throw new AIError(
         `Failed to fetch image: ${response.status} ${response.statusText}`,
@@ -456,7 +518,7 @@ export class OpenAIProvider implements AIInterface {
       const defaultPrompt =
         'Describe this image for a search index. Include objects, mood, lighting, and any visible text.';
 
-      const imageUrl = await this.imageToBase64(image);
+      const imageUrl = await this.imageToBase64(image, options.signal);
 
       const response = await this.chat(
         [
@@ -479,7 +541,11 @@ export class OpenAIProvider implements AIInterface {
             options.model ||
             this.options.defaultModel ||
             this.profile.defaultModel,
-          maxTokens: options.maxTokens || 500,
+          maxTokens: options.maxTokens ?? 500,
+          signal: options.signal,
+          timeout: options.timeout,
+          reasoning: options.reasoning,
+          usageTags: options.usageTags,
         },
       );
 
@@ -537,13 +603,21 @@ export class OpenAIProvider implements AIInterface {
     prompt: string,
     options: ImageGenerationOptions = {},
   ): Promise<ImageGenerationResponse> {
+    let controls: PreparedRequestControls | undefined;
     try {
       const model = options.model || 'dall-e-3';
+      options = normalizeImageGenerationOptions(
+        this.options,
+        options,
+        this.profile.providerName,
+        model,
+      );
+      controls = prepareRequestControls(this.options, options);
 
       const requestParams: OpenAI.Images.ImageGenerateParams = {
         model,
         prompt,
-        n: model === 'dall-e-3' ? 1 : options.n || 1,
+        n: model === 'dall-e-3' ? 1 : options.n,
         size:
           (options.size as OpenAI.Images.ImageGenerateParams['size']) ||
           '1024x1024',
@@ -560,7 +634,10 @@ export class OpenAIProvider implements AIInterface {
         }
       }
 
-      const response = await this.client.images.generate(requestParams);
+      const response = await this.client.images.generate(requestParams, {
+        signal: controls.signal,
+        timeout: controls.timeout,
+      });
 
       const images = (response.data || []).map((item) => {
         let data: Buffer | string;
@@ -587,7 +664,25 @@ export class OpenAIProvider implements AIInterface {
         model,
       };
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          this.profile.providerName,
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          this.profile.providerName,
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -612,10 +707,18 @@ export class OpenAIProvider implements AIInterface {
     options: ChatOptions = {},
   ): AsyncIterable<string> {
     const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
     try {
       const model =
         options.model || this.options.defaultModel || this.profile.defaultModel;
-      const stream = await this.client.chat.completions.create({
+      options = normalizeChatOptions(
+        this.options,
+        options,
+        this.profile.providerName,
+        model,
+      );
+      controls = prepareRequestControls(this.options, options);
+      const request = {
         model,
         messages: this.mapMessagesToOpenAI(messages),
         max_tokens: options.maxTokens,
@@ -626,6 +729,26 @@ export class OpenAIProvider implements AIInterface {
         presence_penalty: options.presencePenalty,
         user: options.user,
         stream: true,
+      } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & {
+        reasoning?: {
+          effort?: string;
+          max_tokens?: number;
+          include_thoughts?: boolean;
+        };
+      };
+      if (
+        this.profile.providerName === 'bifrost' ||
+        this.profile.providerName === 'litellm'
+      ) {
+        request.reasoning = {
+          effort: options.reasoning?.effort,
+          max_tokens: options.reasoning?.maxTokens,
+          include_thoughts: options.reasoning?.includeThoughts,
+        };
+      }
+      const stream = await this.client.chat.completions.create(request, {
+        signal: controls.signal,
+        timeout: controls.timeout,
       });
 
       for await (const chunk of stream) {
@@ -648,7 +771,25 @@ export class OpenAIProvider implements AIInterface {
         options.usageTags,
       );
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          this.profile.providerName,
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          this.profile.providerName,
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 

--- a/packages/ai/src/shared/providers/openai.ts
+++ b/packages/ai/src/shared/providers/openai.ts
@@ -245,8 +245,9 @@ export class OpenAIProvider implements AIInterface {
         };
       };
       if (
-        this.profile.providerName === 'bifrost' ||
-        this.profile.providerName === 'litellm'
+        (this.profile.providerName === 'bifrost' ||
+          this.profile.providerName === 'litellm') &&
+        (options.reasoning?.maxTokens || 0) > 0
       ) {
         request.reasoning = {
           effort: options.reasoning?.effort,
@@ -514,11 +515,13 @@ export class OpenAIProvider implements AIInterface {
     prompt?: string,
     options: ImageDescriptionOptions = {},
   ): Promise<string> {
+    let controls: PreparedRequestControls | undefined;
     try {
       const defaultPrompt =
         'Describe this image for a search index. Include objects, mood, lighting, and any visible text.';
 
-      const imageUrl = await this.imageToBase64(image, options.signal);
+      controls = prepareRequestControls(this.options, options);
+      const imageUrl = await this.imageToBase64(image, controls.signal);
 
       const response = await this.chat(
         [
@@ -542,8 +545,8 @@ export class OpenAIProvider implements AIInterface {
             this.options.defaultModel ||
             this.profile.defaultModel,
           maxTokens: options.maxTokens ?? 500,
-          signal: options.signal,
-          timeout: options.timeout,
+          signal: controls.signal,
+          timeout: controls.timeout,
           reasoning: options.reasoning,
           usageTags: options.usageTags,
         },
@@ -551,7 +554,25 @@ export class OpenAIProvider implements AIInterface {
 
       return response.content;
     } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          this.profile.providerName,
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          this.profile.providerName,
+          options.model,
+        );
+      }
       throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
     }
   }
 
@@ -737,8 +758,9 @@ export class OpenAIProvider implements AIInterface {
         };
       };
       if (
-        this.profile.providerName === 'bifrost' ||
-        this.profile.providerName === 'litellm'
+        (this.profile.providerName === 'bifrost' ||
+          this.profile.providerName === 'litellm') &&
+        (options.reasoning?.maxTokens || 0) > 0
       ) {
         request.reasoning = {
           effort: options.reasoning?.effort,

--- a/packages/ai/src/shared/rate-limit.ts
+++ b/packages/ai/src/shared/rate-limit.ts
@@ -207,7 +207,7 @@ function normalizeRateLimitConfig(
     key: rateLimit?.key?.trim() || deriveBudgetKey(options),
     maxAttempts: Math.max(
       1,
-      normalizeNonNegativeInteger(rateLimit?.maxAttempts, 3),
+      normalizeNonNegativeInteger(rateLimit?.maxAttempts, 1),
     ),
   };
 }

--- a/packages/ai/src/shared/safety.ts
+++ b/packages/ai/src/shared/safety.ts
@@ -168,10 +168,15 @@ export function normalizeChatOptions<
         thinkingLevel?: ChatOptions['thinkingLevel'];
       }
     ).thinkingLevel;
-  const requestedReasoning =
-    options.reasoning?.maxTokens ??
-    reasoningTokensForEffort(options.reasoning?.effort ?? legacyEffort) ??
-    limits.maxReasoningTokens;
+  const reasoningWasRequested =
+    options.reasoning !== undefined ||
+    legacyEffort !== undefined ||
+    options.includeThoughts === true;
+  const requestedReasoning = reasoningWasRequested
+    ? (options.reasoning?.maxTokens ??
+      reasoningTokensForEffort(options.reasoning?.effort ?? legacyEffort) ??
+      limits.maxReasoningTokens)
+    : 0;
 
   return {
     ...options,

--- a/packages/ai/src/shared/safety.ts
+++ b/packages/ai/src/shared/safety.ts
@@ -1,0 +1,520 @@
+import type {
+  AIGenerationLimits,
+  AIInterface,
+  AIReasoningOptions,
+  AIRequestControls,
+  AIRequestEvent,
+  AIRequestOperation,
+  AIRequestStatus,
+  BaseAIOptions,
+  ChatOptions,
+  ImageGenerationOptions,
+} from './types';
+import { AIError } from './types';
+
+export const DEFAULT_AI_TIMEOUT_MS = 120_000;
+export const DEFAULT_AI_MAX_RETRIES = 0;
+
+export const DEFAULT_AI_GENERATION_LIMITS: Readonly<AIGenerationLimits> =
+  Object.freeze({
+    maxOutputTokens: 4096,
+    maxReasoningTokens: 1024,
+    maxImagesPerRequest: 1,
+    onExceeded: 'error',
+  });
+
+export interface NormalizedBaseAIOptions extends BaseAIOptions {
+  timeout: number;
+  maxRetries: number;
+  generationLimits: AIGenerationLimits;
+}
+
+export interface PreparedRequestControls {
+  signal: AbortSignal;
+  timeout: number;
+  cleanup(): void;
+  didTimeout(): boolean;
+}
+
+function positiveInteger(
+  value: number | undefined,
+  fallback: number,
+  field: string,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new AIError(
+      `${field} must be a positive finite number`,
+      'AI_LIMIT_INVALID',
+    );
+  }
+  return Math.trunc(value);
+}
+
+export function normalizeBaseAIOptions<T extends BaseAIOptions>(
+  options: T,
+): T & NormalizedBaseAIOptions {
+  const configuredLimits = options.generationLimits || {};
+  const generationLimits: AIGenerationLimits = {
+    maxOutputTokens: positiveInteger(
+      configuredLimits.maxOutputTokens,
+      DEFAULT_AI_GENERATION_LIMITS.maxOutputTokens,
+      'generationLimits.maxOutputTokens',
+    ),
+    maxReasoningTokens: positiveInteger(
+      configuredLimits.maxReasoningTokens,
+      DEFAULT_AI_GENERATION_LIMITS.maxReasoningTokens,
+      'generationLimits.maxReasoningTokens',
+    ),
+    maxImagesPerRequest: positiveInteger(
+      configuredLimits.maxImagesPerRequest,
+      DEFAULT_AI_GENERATION_LIMITS.maxImagesPerRequest,
+      'generationLimits.maxImagesPerRequest',
+    ),
+    onExceeded:
+      configuredLimits.onExceeded || DEFAULT_AI_GENERATION_LIMITS.onExceeded,
+  };
+
+  if (!['error', 'clamp'].includes(generationLimits.onExceeded)) {
+    throw new AIError(
+      'generationLimits.onExceeded must be "error" or "clamp"',
+      'AI_LIMIT_INVALID',
+    );
+  }
+
+  return {
+    ...options,
+    timeout: positiveInteger(options.timeout, DEFAULT_AI_TIMEOUT_MS, 'timeout'),
+    maxRetries: (() => {
+      if (options.maxRetries === undefined) return DEFAULT_AI_MAX_RETRIES;
+      if (!Number.isFinite(options.maxRetries) || options.maxRetries < 0) {
+        throw new AIError(
+          'maxRetries must be a non-negative finite number',
+          'AI_LIMIT_INVALID',
+        );
+      }
+      return Math.trunc(options.maxRetries);
+    })(),
+    generationLimits,
+  };
+}
+
+function reasoningTokensForEffort(
+  effort: AIReasoningOptions['effort'] | false | undefined,
+): number | undefined {
+  switch (effort) {
+    case false:
+    case 'none':
+      return 0;
+    case 'minimal':
+      return 1024;
+    case 'low':
+      return 2048;
+    case 'medium':
+      return 4096;
+    case 'high':
+      return 8192;
+    default:
+      return undefined;
+  }
+}
+
+function enforceLimit(
+  requested: number,
+  limit: number,
+  behavior: AIGenerationLimits['onExceeded'],
+  label: string,
+  provider?: string,
+  model?: string,
+): number {
+  if (!Number.isFinite(requested) || requested < 0) {
+    throw new AIError(
+      `${label} must be a non-negative finite number`,
+      'AI_LIMIT_INVALID',
+      provider,
+      model,
+    );
+  }
+  const normalized = Math.trunc(requested);
+  if (normalized <= limit) return normalized;
+  if (behavior === 'clamp') return limit;
+  throw new AIError(
+    `${label} ${normalized} exceeds configured ceiling ${limit}`,
+    'AI_LIMIT_EXCEEDED',
+    provider,
+    model,
+  );
+}
+
+export function normalizeChatOptions<
+  T extends AIRequestControls & {
+    maxTokens?: number;
+    thinkingLevel?: ChatOptions['thinkingLevel'];
+    includeThoughts?: boolean;
+  },
+>(
+  providerOptions: BaseAIOptions,
+  options: T,
+  provider?: string,
+  model?: string,
+): T & { maxTokens: number; reasoning: AIReasoningOptions } {
+  const normalizedProvider = normalizeBaseAIOptions(providerOptions);
+  const limits = normalizedProvider.generationLimits;
+  const requestedOutput = options.maxTokens ?? limits.maxOutputTokens;
+  const legacyEffort =
+    options.thinkingLevel ??
+    (
+      providerOptions as BaseAIOptions & {
+        thinkingLevel?: ChatOptions['thinkingLevel'];
+      }
+    ).thinkingLevel;
+  const requestedReasoning =
+    options.reasoning?.maxTokens ??
+    reasoningTokensForEffort(options.reasoning?.effort ?? legacyEffort) ??
+    limits.maxReasoningTokens;
+
+  return {
+    ...options,
+    maxTokens: enforceLimit(
+      requestedOutput,
+      limits.maxOutputTokens,
+      limits.onExceeded,
+      'maxTokens',
+      provider,
+      model,
+    ),
+    reasoning: {
+      ...options.reasoning,
+      maxTokens: enforceLimit(
+        requestedReasoning,
+        limits.maxReasoningTokens,
+        limits.onExceeded,
+        'reasoning.maxTokens',
+        provider,
+        model,
+      ),
+      includeThoughts:
+        options.reasoning?.includeThoughts ?? options.includeThoughts,
+    },
+  };
+}
+
+export function normalizeImageGenerationOptions<
+  T extends ImageGenerationOptions,
+>(
+  providerOptions: BaseAIOptions,
+  options: T,
+  provider?: string,
+  model?: string,
+): T & { n: number } {
+  const normalizedProvider = normalizeBaseAIOptions(providerOptions);
+  const limits = normalizedProvider.generationLimits;
+  return {
+    ...options,
+    n: enforceLimit(
+      options.n ?? 1,
+      limits.maxImagesPerRequest,
+      limits.onExceeded,
+      'n',
+      provider,
+      model,
+    ),
+  };
+}
+
+export function prepareRequestControls(
+  providerOptions: BaseAIOptions,
+  requestOptions: AIRequestControls = {},
+): PreparedRequestControls {
+  const normalized = normalizeBaseAIOptions(providerOptions);
+  const timeout = positiveInteger(
+    requestOptions.timeout,
+    normalized.timeout,
+    'timeout',
+  );
+  const controller = new AbortController();
+  let timedOut = false;
+
+  const abortFromCaller = () => controller.abort(requestOptions.signal?.reason);
+  if (requestOptions.signal?.aborted) {
+    abortFromCaller();
+  } else {
+    requestOptions.signal?.addEventListener('abort', abortFromCaller, {
+      once: true,
+    });
+  }
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new Error(`AI request timed out after ${timeout}ms`));
+  }, timeout);
+
+  return {
+    signal: controller.signal,
+    timeout,
+    didTimeout: () => timedOut,
+    cleanup: () => {
+      clearTimeout(timer);
+      requestOptions.signal?.removeEventListener('abort', abortFromCaller);
+    },
+  };
+}
+
+function mergeTags(
+  providerOptions: BaseAIOptions,
+  callTags?: Record<string, string>,
+): Record<string, string> | undefined {
+  return providerOptions.usageTags || callTags
+    ? { ...providerOptions.usageTags, ...callTags }
+    : undefined;
+}
+
+export function emitRequestEvent(
+  providerOptions: BaseAIOptions,
+  event: Omit<AIRequestEvent, 'tags'> & {
+    tags?: Record<string, string>;
+  },
+): void {
+  if (!providerOptions.onRequest) return;
+  try {
+    providerOptions.onRequest({
+      ...event,
+      tags: mergeTags(providerOptions, event.tags),
+    });
+  } catch {
+    // Consumer telemetry must never affect an AI request.
+  }
+}
+
+export function classifyRequestFailure(
+  error: unknown,
+  didTimeout = false,
+): { status: AIRequestStatus; errorCode?: string } {
+  const code = error instanceof AIError ? error.code : undefined;
+  if (code === 'AI_LIMIT_EXCEEDED' || code === 'AI_LIMIT_INVALID') {
+    return { status: 'rejected', errorCode: code };
+  }
+  if (didTimeout || code === 'AI_TIMEOUT' || code === 'TIMEOUT') {
+    return { status: 'timed_out', errorCode: code || 'AI_TIMEOUT' };
+  }
+  if (error instanceof Error && error.name === 'AbortError') {
+    return { status: 'aborted', errorCode: 'ABORTED' };
+  }
+  if (code === 'AI_ABORTED') {
+    return { status: 'aborted', errorCode: code };
+  }
+  return {
+    status: 'failed',
+    errorCode: code || (error instanceof Error ? error.name : undefined),
+  };
+}
+
+export function requestEventBase(options: {
+  providerOptions: BaseAIOptions;
+  provider: string;
+  model: string;
+  operation: AIRequestOperation;
+  callOptions?: { maxTokens?: number; usageTags?: Record<string, string> };
+  effectiveMaxOutputTokens?: number;
+}): Omit<AIRequestEvent, 'status' | 'duration'> & {
+  tags?: Record<string, string>;
+} {
+  const normalized = normalizeBaseAIOptions(options.providerOptions);
+  return {
+    provider: options.provider,
+    model: options.model,
+    operation: options.operation,
+    attempts: normalized.maxRetries + 1,
+    requestedMaxOutputTokens: options.callOptions?.maxTokens,
+    effectiveMaxOutputTokens:
+      options.operation === 'generateImage'
+        ? undefined
+        : (options.effectiveMaxOutputTokens ??
+          normalized.generationLimits.maxOutputTokens),
+    tags: options.callOptions?.usageTags,
+  };
+}
+
+const OBSERVED_OPERATIONS = new Set<AIRequestOperation>([
+  'chat',
+  'complete',
+  'message',
+  'describeImage',
+  'generateImage',
+  'stream',
+]);
+
+function callOptionsFor(
+  operation: AIRequestOperation,
+  args: unknown[],
+):
+  | (AIRequestControls & {
+      model?: string;
+      maxTokens?: number;
+      usageTags?: Record<string, string>;
+    })
+  | undefined {
+  const index = operation === 'describeImage' ? 2 : 1;
+  const value = args[index];
+  return value && typeof value === 'object'
+    ? (value as AIRequestControls & {
+        model?: string;
+        maxTokens?: number;
+        usageTags?: Record<string, string>;
+      })
+    : undefined;
+}
+
+function providerName(options: BaseAIOptions): string {
+  const configured = (options as BaseAIOptions & { type?: string }).type;
+  return configured || 'openai';
+}
+
+function effectiveOutputTokens(
+  operation: AIRequestOperation,
+  providerOptions: BaseAIOptions,
+  callOptions:
+    | (AIRequestControls & {
+        model?: string;
+        maxTokens?: number;
+        n?: number;
+      })
+    | undefined,
+): number | undefined {
+  if (operation === 'generateImage') {
+    normalizeImageGenerationOptions(
+      providerOptions,
+      callOptions || {},
+      providerName(providerOptions),
+      callOptions?.model,
+    );
+    return undefined;
+  }
+
+  return normalizeChatOptions(
+    providerOptions,
+    callOptions || {},
+    providerName(providerOptions),
+    callOptions?.model || providerOptions.defaultModel,
+  ).maxTokens;
+}
+
+/**
+ * Wrap a public provider instance with prompt-free lifecycle observation.
+ * Provider adapters still enforce limits internally so direct construction is
+ * protected; this wrapper adds one terminal event to the public getAI() path.
+ */
+export function createObservedAI<T extends AIInterface>(
+  client: T,
+  providerOptions: BaseAIOptions,
+): T {
+  if (!providerOptions.onRequest) return client;
+
+  return new Proxy(client, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (
+        typeof property !== 'string' ||
+        typeof value !== 'function' ||
+        !OBSERVED_OPERATIONS.has(property as AIRequestOperation)
+      ) {
+        return typeof value === 'function' ? value.bind(target) : value;
+      }
+
+      const operation = property as AIRequestOperation;
+      if (operation === 'stream') {
+        return async function* (...args: unknown[]) {
+          const startedAt = Date.now();
+          const callOptions = callOptionsFor(operation, args);
+          let base: ReturnType<typeof requestEventBase> | undefined;
+          try {
+            base = requestEventBase({
+              providerOptions,
+              provider: providerName(providerOptions),
+              model:
+                callOptions?.model || providerOptions.defaultModel || 'unknown',
+              operation,
+              callOptions,
+              effectiveMaxOutputTokens: effectiveOutputTokens(
+                operation,
+                providerOptions,
+                callOptions,
+              ),
+            });
+            const iterable = Reflect.apply(
+              value,
+              target,
+              args,
+            ) as AsyncIterable<string>;
+            for await (const chunk of iterable) yield chunk;
+            emitRequestEvent(providerOptions, {
+              ...base,
+              status: 'succeeded',
+              duration: Date.now() - startedAt,
+            });
+          } catch (error) {
+            const failure = classifyRequestFailure(error);
+            base ||= requestEventBase({
+              providerOptions,
+              provider: providerName(providerOptions),
+              model:
+                callOptions?.model || providerOptions.defaultModel || 'unknown',
+              operation,
+              callOptions,
+            });
+            emitRequestEvent(providerOptions, {
+              ...base,
+              ...failure,
+              duration: Date.now() - startedAt,
+            });
+            throw error;
+          }
+        };
+      }
+
+      return async (...args: unknown[]) => {
+        const startedAt = Date.now();
+        const callOptions = callOptionsFor(operation, args);
+        let base: ReturnType<typeof requestEventBase> | undefined;
+        try {
+          base = requestEventBase({
+            providerOptions,
+            provider: providerName(providerOptions),
+            model:
+              callOptions?.model || providerOptions.defaultModel || 'unknown',
+            operation,
+            callOptions,
+            effectiveMaxOutputTokens: effectiveOutputTokens(
+              operation,
+              providerOptions,
+              callOptions,
+            ),
+          });
+          const result = await Reflect.apply(value, target, args);
+          emitRequestEvent(providerOptions, {
+            ...base,
+            status: 'succeeded',
+            duration: Date.now() - startedAt,
+          });
+          return result;
+        } catch (error) {
+          const failure = classifyRequestFailure(error);
+          base ||= requestEventBase({
+            providerOptions,
+            provider: providerName(providerOptions),
+            model:
+              callOptions?.model || providerOptions.defaultModel || 'unknown',
+            operation,
+            callOptions,
+          });
+          emitRequestEvent(providerOptions, {
+            ...base,
+            ...failure,
+            duration: Date.now() - startedAt,
+          });
+          throw error;
+        }
+      };
+    },
+  });
+}

--- a/packages/ai/src/shared/types.ts
+++ b/packages/ai/src/shared/types.ts
@@ -9,6 +9,84 @@
 export type GeminiThinkingLevel = 'minimal' | 'low' | 'medium' | 'high';
 
 /**
+ * Cost and output limits applied to every generative request.
+ *
+ * Provider instances merge partial overrides with the exported safe defaults.
+ */
+export interface AIGenerationLimits {
+  /** Maximum text tokens a single request may generate. */
+  maxOutputTokens: number;
+
+  /** Maximum reasoning/thinking tokens a single request may generate. */
+  maxReasoningTokens: number;
+
+  /** Maximum images a single image-generation request may produce. */
+  maxImagesPerRequest: number;
+
+  /** Behavior when a request exceeds one of the configured limits. */
+  onExceeded: 'error' | 'clamp';
+}
+
+/** Provider-neutral reasoning controls for a single generation request. */
+export interface AIReasoningOptions {
+  effort?: 'none' | GeminiThinkingLevel;
+  maxTokens?: number;
+  includeThoughts?: boolean;
+}
+
+/** Request-scoped cancellation, timeout, and reasoning controls. */
+export interface AIRequestControls {
+  /** Caller cancellation signal. Provider timeouts are composed with this signal. */
+  signal?: AbortSignal;
+
+  /** Request timeout in milliseconds. Overrides the provider default. */
+  timeout?: number;
+
+  /** Provider-neutral reasoning controls. */
+  reasoning?: AIReasoningOptions;
+
+  /** Sanitized dimensions attached to lifecycle and usage events. */
+  usageTags?: Record<string, string>;
+}
+
+/** Operations reported through {@link AIRequestEvent}. */
+export type AIRequestOperation =
+  | 'chat'
+  | 'complete'
+  | 'message'
+  | 'embed'
+  | 'embedImage'
+  | 'describeImage'
+  | 'generateImage'
+  | 'stream';
+
+/** Terminal lifecycle state for a provider request. */
+export type AIRequestStatus =
+  | 'succeeded'
+  | 'failed'
+  | 'timed_out'
+  | 'aborted'
+  | 'rejected';
+
+/**
+ * Prompt-free request lifecycle event.
+ *
+ * This intentionally excludes request and response content and credentials.
+ */
+export interface AIRequestEvent {
+  provider: string;
+  model: string;
+  operation: AIRequestOperation;
+  status: AIRequestStatus;
+  attempts: number;
+  requestedMaxOutputTokens?: number;
+  effectiveMaxOutputTokens?: number;
+  duration: number;
+  errorCode?: string;
+  tags?: Record<string, string>;
+}
+
+/**
  * Supported AI provider types
  */
 export const AI_PROVIDER_TYPES = [
@@ -135,7 +213,7 @@ export interface AIMessage {
 /**
  * Options for chat completion requests
  */
-export interface ChatOptions {
+export interface ChatOptions extends AIRequestControls {
   /**
    * Model to use for completion
    */
@@ -224,12 +302,14 @@ export interface ChatOptions {
    *
    * Ollama also accepts `false` to explicitly disable visible/internal thinking
    * for models that support it.
+   * @deprecated Use `reasoning.effort` and `reasoning.maxTokens` instead.
    */
   thinkingLevel?: GeminiThinkingLevel | false;
 
   /**
    * Whether to include the model's internal thoughts in the response
    * Only applicable for Gemini 3 models with thinking enabled
+   * @deprecated Use `reasoning.includeThoughts` instead.
    */
   includeThoughts?: boolean;
 
@@ -243,7 +323,7 @@ export interface ChatOptions {
 /**
  * Options for text completion requests (non-chat models)
  */
-export interface CompletionOptions {
+export interface CompletionOptions extends AIRequestControls {
   /**
    * Model to use for completion
    */
@@ -347,7 +427,7 @@ export interface ImageEmbeddingOptions {
 /**
  * Options for image description generation
  */
-export interface ImageDescriptionOptions {
+export interface ImageDescriptionOptions extends AIRequestControls {
   /**
    * Model to use for image description
    * - OpenAI: defaults to 'gpt-4o'
@@ -369,7 +449,7 @@ export interface ImageDescriptionOptions {
 /**
  * Options for image generation
  */
-export interface ImageGenerationOptions {
+export interface ImageGenerationOptions extends AIRequestControls {
   /**
    * Model to use for image generation
    * - OpenAI: 'dall-e-3' (default), 'dall-e-2'
@@ -454,7 +534,7 @@ export interface ImageGenerationResponse {
  * Options for simple message requests (convenience method)
  * This provides a simpler interface than chat() for single-turn interactions
  */
-export interface MessageOptions {
+export interface MessageOptions extends AIRequestControls {
   /**
    * Model to use for completion
    */
@@ -1078,15 +1158,7 @@ export interface UsageEvent {
   model: string;
 
   /** Operation type that generated this usage */
-  operation:
-    | 'chat'
-    | 'complete'
-    | 'message'
-    | 'embed'
-    | 'embedImage'
-    | 'describeImage'
-    | 'generateImage'
-    | 'stream';
+  operation: AIRequestOperation;
 
   /** Token usage breakdown, if available from the provider */
   usage?: TokenUsage;
@@ -1546,6 +1618,12 @@ export interface BaseAIOptions {
   maxRetries?: number;
 
   /**
+   * Per-request generation guardrails. Partial overrides are merged with the
+   * package defaults; raising a ceiling must therefore be deliberate.
+   */
+  generationLimits?: Partial<AIGenerationLimits>;
+
+  /**
    * Custom headers
    */
   headers?: Record<string, string>;
@@ -1565,6 +1643,12 @@ export interface BaseAIOptions {
    * @param event - Usage event with provider, model, operation, tokens, and timing
    */
   onUsage?: (event: UsageEvent) => void;
+
+  /**
+   * Callback invoked once for every terminal request outcome, including local
+   * limit rejection and timeout. Prompt and response content are never emitted.
+   */
+  onRequest?: (event: AIRequestEvent) => void;
 
   /**
    * Global tags to include in every usage event.
@@ -1682,6 +1766,9 @@ export interface GeminiOptions extends BaseAIOptions {
    * - 'high': Maximizes reasoning depth (default for Gemini 3)
    *
    * Note: Only works with Gemini 3 models. Gemini 2.5 uses thinkingBudget instead.
+   *
+   * @deprecated Use request-level `reasoning` controls instead. This alias is
+   * normalized through `generationLimits.maxReasoningTokens`.
    */
   thinkingLevel?: GeminiThinkingLevel;
 }


### PR DESCRIPTION
## Summary

- enforce provider-wide output, reasoning, image, timeout, retry, cancellation, and prompt-free lifecycle guardrails for @happyvertical/ai
- default every upstream generation to one attempt, 4,096 output tokens, an opt-in 1,024 reasoning-token ceiling, one image, and a composed 120-second timeout
- preserve deprecated thinking-level aliases while normalizing them into bounded controls
- include a minor changeset targeting the first protected release, 0.79.0

Closes #1088

## Validation

- @happyvertical/ai tests: 169 passed, 24 skipped
- @happyvertical/ai build: passed
- workspace pre-push typecheck: 19 tasks passed
- package pack validation: passed

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-019f5ebf-sdk-1089-review",
  "issue": "happyvertical/sdk#1088",
  "policy_revision": "1.0.0",
  "validation": [
    "@happyvertical/ai tests: 169 passed, 24 skipped",
    "@happyvertical/ai build: passed",
    "workspace pre-push typecheck: 19 tasks passed",
    "package pack validation: passed"
  ]
}