### PR TITLE
chore: standardize pnpm to 11.13.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -51,7 +51,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
     && apt-get install -y nodejs
 
 # Install pnpm globally
-RUN npm install -g pnpm@latest
+RUN npm install -g pnpm@11.13.0
 
 # Set working directory
 WORKDIR /workspaces

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -12,7 +12,7 @@ suites.
   detection, and result-only aggregation. These jobs do not install
   the workspace.
 - `arc-happyvertical-node` runs Node-only builds, tests, documentation, and
-  package validation. It provides Node 24.18.0, pnpm 11.11.0, native build
+  package validation. It provides Node 24.18.0, pnpm 11.13.0, native build
   prerequisites, PostgreSQL client tools, and an 8 GiB memory limit. It does
   not provide Docker or deployment tooling.
 - `arc-happyvertical` remains the compatibility runner for Docker service

--- a/.github/workflows/node-runner-smoke.yml
+++ b/.github/workflows/node-runner-smoke.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$(node --version)" = 'v24.18.0'
-          test "$(pnpm --version)" = '11.11.0'
+          test "$(pnpm --version)" = '11.13.0'
           command -v psql
           test ! -S /var/run/docker.sock
           test -r "$CI_POSTGRES_BASE_URL_FILE"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "engines": {
     "node": ">=24.18.0",
-    "pnpm": ">=11.11.0"
+    "pnpm": ">=11.13.0"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.13.0"
 }


### PR DESCRIPTION
Standardizes pnpm to 11.13.0 (current latest) as part of the org-wide version alignment.

## Changes
- `package.json`: `packageManager` pnpm@11.11.0 → 11.13.0, `engines.pnpm` >=11.11.0 → >=11.13.0
- `.github/workflows/node-runner-smoke.yml`: runner-contract assertion 11.11.0 → 11.13.0
- `.github/CI.md`: runner description updated to match
- `.devcontainer/Dockerfile`: global pnpm install pinned to 11.13.0 instead of floating `latest`

## Notes
- Ordinary CI is unaffected by runner-image lag: `setup-environment` reads `packageManager` and installs the exact version when the runner's pnpm differs.
- The `node-runner-smoke` workflow (workflow_dispatch-only) asserts the ARC runner image contract, so it will fail until the runner image ships pnpm 11.13.0 — tracked separately in happyvertical/iac#957.
- `pnpm install --frozen-lockfile` passes under 11.13.0 with no lockfile changes; `pnpm test:ci-scripts` (18/18) and `pnpm agent:check` pass.

Closes #1091

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude",
  "session": "claude-487a2bf4-sdk-1090",
  "issue": "happyvertical/sdk#1091",
  "policy_revision": "1.0.0",
  "validation": [
    "pnpm install --frozen-lockfile: passed under 11.13.0 with no lockfile changes",
    "pnpm test:ci-scripts: 18/18 passed",
    "pnpm agent:check: passed"
  ]
}
