### PR TITLE
feat(signatures): add BoldSign e-signature adapter

### DIFF
--- a/.changeset/bright-signatures-arrive.md
+++ b/.changeset/bright-signatures-arrive.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/signatures": minor
+---
+
+Add provider-neutral e-signature contracts and the first BoldSign adapter with Canadian residency, verified webhooks, tenant binding, cancellation/expiry, and hashed execution-evidence downloads.

--- a/AGENT.md
+++ b/AGENT.md
@@ -6,10 +6,10 @@
 
 ## Workspace Map
 - Package docs standard: `AGENT.md`
-- Local workspace packages: `31`
+- Local workspace packages: `32`
 - External catalog packages: `@happyvertical/ocr`, `@happyvertical/pdf`, `@happyvertical/spider`
 - Generated manifest: `ecosystem-manifest.json`
-- Top-level package order: `accounting`, `ai`, `analytics`, `auth`, `cache`, `comfyui`, `directory`, `documents`, `email`, `encryption`, `files`, `geo`, `github-actions`, `graphql`, `images`, `jobs`, `json`, `logger`, `messages`, `payments`, `projects`, `repos`, `sdk-mcp`, `secrets`, `social`, `speech`, `sql`, `translator`, `utils`, `video`, `weather`
+- Top-level package order: `accounting`, `ai`, `analytics`, `auth`, `cache`, `comfyui`, `directory`, `documents`, `email`, `encryption`, `files`, `geo`, `github-actions`, `graphql`, `images`, `jobs`, `json`, `logger`, `messages`, `payments`, `projects`, `repos`, `sdk-mcp`, `secrets`, `signatures`, `social`, `speech`, `sql`, `translator`, `utils`, `video`, `weather`
 
 ## Build & Test
 ```bash

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ These packages form the foundation everything else builds on.
 | Package | Description |
 |---------|-------------|
 | [**@happyvertical/payments**](./packages/payments/README.md) | Payment backend abstraction with adapters for Base USDC, BTCPay Server, and Stripe Checkout. Quote payment options, status polling, x402 verification, refunds, and payouts. |
+| [**@happyvertical/signatures**](./packages/signatures/README.md) | Provider-neutral e-signature requests, verified webhooks, cancellation/expiry, and hashed execution evidence, with BoldSign as the first adapter. |
 
 ### World Knowledge
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -98,6 +98,7 @@ export default {
         'repos',
         'sdk-mcp',
         'secrets',
+        'signatures',
         'social',
         'speech',
         'sql',

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -3,7 +3,7 @@
   "workspace": {
     "name": "@happyvertical/sdk",
     "path": ".",
-    "packageCount": 31,
+    "packageCount": 32,
     "localPackageOrder": [
       "accounting",
       "ai",
@@ -29,6 +29,7 @@
       "repos",
       "sdk-mcp",
       "secrets",
+      "signatures",
       "social",
       "speech",
       "sql",
@@ -54,7 +55,7 @@
       },
       "position": {
         "index": 1,
-        "count": 31
+        "count": 32
       },
       "description": "Multi-provider accounting integration for AR/AP sync and audit with QuickBooks, Stripe, and more",
       "commands": {
@@ -99,7 +100,7 @@
       },
       "position": {
         "index": 2,
-        "count": 31
+        "count": 32
       },
       "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
       "commands": {
@@ -149,7 +150,7 @@
       },
       "position": {
         "index": 3,
-        "count": 31
+        "count": 32
       },
       "description": "Unified analytics interface for Google Analytics 4, Plausible, and more",
       "commands": {
@@ -194,7 +195,7 @@
       },
       "position": {
         "index": 4,
-        "count": 31
+        "count": 32
       },
       "description": "Unified authentication interface supporting Keycloak, AWS Cognito, and Nostr with OAuth2/OIDC and public key identity",
       "commands": {
@@ -241,7 +242,7 @@
       },
       "position": {
         "index": 5,
-        "count": 31
+        "count": 32
       },
       "description": "Standardized caching interface supporting Memory, File, and Redis backends",
       "commands": {
@@ -291,7 +292,7 @@
       },
       "position": {
         "index": 6,
-        "count": 31
+        "count": 32
       },
       "description": "ComfyUI API client for workflow orchestration and video generation",
       "commands": {
@@ -335,7 +336,7 @@
       },
       "position": {
         "index": 7,
-        "count": 31
+        "count": 32
       },
       "description": "Unified directory services with adapter-based architecture (Kanidm, Stalwart, PostgreSQL, AWS)",
       "commands": {
@@ -384,7 +385,7 @@
       },
       "position": {
         "index": 8,
-        "count": 31
+        "count": 32
       },
       "description": "Multi-part document processing with support for PDF, HTML, and Markdown",
       "commands": {
@@ -433,7 +434,7 @@
       },
       "position": {
         "index": 9,
-        "count": 31
+        "count": 32
       },
       "description": "Low-level email protocol operations with adapter-based architecture",
       "commands": {
@@ -487,7 +488,7 @@
       },
       "position": {
         "index": 10,
-        "count": 31
+        "count": 32
       },
       "description": "Unified encryption and cryptography operations with adapter-based architecture",
       "commands": {
@@ -536,7 +537,7 @@
       },
       "position": {
         "index": 11,
-        "count": 31
+        "count": 32
       },
       "description": "File system utilities for local and remote file operations",
       "commands": {
@@ -586,7 +587,7 @@
       },
       "position": {
         "index": 12,
-        "count": 31
+        "count": 32
       },
       "description": "Standardized geographical information interface supporting Google Maps and OpenStreetMap",
       "commands": {
@@ -632,7 +633,7 @@
       },
       "position": {
         "index": 13,
-        "count": 31
+        "count": 32
       },
       "description": "Reusable GitHub Actions utilities for issue triage, PR validation, and workflow automation",
       "commands": {
@@ -677,7 +678,7 @@
       },
       "position": {
         "index": 14,
-        "count": 31
+        "count": 32
       },
       "description": "GitHub GraphQL client for SDK packages",
       "commands": {
@@ -721,7 +722,7 @@
       },
       "position": {
         "index": 15,
-        "count": 31
+        "count": 32
       },
       "description": "Image processing utilities with adapter pattern for scaling from static to enterprise",
       "commands": {
@@ -769,7 +770,7 @@
       },
       "position": {
         "index": 16,
-        "count": 31
+        "count": 32
       },
       "description": "Job queue abstraction with multiple backend adapters (SQLite, PostgreSQL, Bull, SQS)",
       "commands": {
@@ -818,7 +819,7 @@
       },
       "position": {
         "index": 17,
-        "count": 31
+        "count": 32
       },
       "description": "High-performance JSON parsing and serialization with Rust SIMD acceleration and automatic fallback",
       "commands": {
@@ -861,7 +862,7 @@
       },
       "position": {
         "index": 18,
-        "count": 31
+        "count": 32
       },
       "description": "Structured logging for HAVE SDK with signal adapter",
       "commands": {
@@ -913,7 +914,7 @@
       },
       "position": {
         "index": 19,
-        "count": 31
+        "count": 32
       },
       "description": "Unified multi-channel messaging with adapter-based architecture (Slack, Twitter, Email)",
       "commands": {
@@ -961,7 +962,7 @@
       },
       "position": {
         "index": 20,
-        "count": 31
+        "count": 32
       },
       "description": "Payment backend abstraction with adapters for Base USDC, BTCPay Server, and Stripe",
       "commands": {
@@ -1006,7 +1007,7 @@
       },
       "position": {
         "index": 21,
-        "count": 31
+        "count": 32
       },
       "description": "Standardized project management interface for GitHub Projects, Jira, ZenHub, and Linear",
       "commands": {
@@ -1052,7 +1053,7 @@
       },
       "position": {
         "index": 22,
-        "count": 31
+        "count": 32
       },
       "description": "Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOps",
       "commands": {
@@ -1100,7 +1101,7 @@
       },
       "position": {
         "index": 23,
-        "count": 31
+        "count": 32
       },
       "description": "MCP server for HAVE SDK - Routes queries to package experts using AGENT.md files",
       "commands": {
@@ -1148,7 +1149,7 @@
       },
       "position": {
         "index": 24,
-        "count": 31
+        "count": 32
       },
       "description": "Envelope encryption for per-tenant secret management with pluggable backends",
       "commands": {
@@ -1183,6 +1184,50 @@
       ]
     },
     {
+      "name": "@happyvertical/signatures",
+      "shortName": "signatures",
+      "path": "packages/signatures",
+      "docs": {
+        "agent": "packages/signatures/AGENT.md",
+        "metadata": "packages/signatures/metadata.json"
+      },
+      "position": {
+        "index": 25,
+        "count": 32
+      },
+      "description": "Provider-neutral e-signature workflows with a BoldSign adapter",
+      "commands": {
+        "build": "pnpm --filter @happyvertical/signatures build",
+        "test": "pnpm --filter @happyvertical/signatures test",
+        "typecheck": "pnpm --filter @happyvertical/signatures typecheck",
+        "clean": "pnpm --filter @happyvertical/signatures clean"
+      },
+      "correctionLoops": [
+        "If Vite or TypeScript reports missing packages, run `pnpm install` at the repo root and rerun `pnpm --filter @happyvertical/signatures build`.",
+        "If tests or exports fail after API, type, or bundle changes, run `pnpm --filter @happyvertical/signatures clean` followed by `pnpm --filter @happyvertical/signatures build` and `pnpm --filter @happyvertical/signatures test`.",
+        "If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands."
+      ],
+      "provides": [
+        "Provider-neutral e-signature workflows with a BoldSign adapter"
+      ],
+      "implements": [
+        "BoldSign"
+      ],
+      "requires": {
+        "workspace": [],
+        "externalHappyVertical": [],
+        "external": []
+      },
+      "dependents": [],
+      "stability": {
+        "level": "experimental",
+        "reason": "Marked as preview or experimental in package guidance."
+      },
+      "keywords": [
+        "signatures"
+      ]
+    },
+    {
       "name": "@happyvertical/social",
       "shortName": "social",
       "path": "packages/social",
@@ -1191,8 +1236,8 @@
         "metadata": "packages/social/metadata.json"
       },
       "position": {
-        "index": 25,
-        "count": 31
+        "index": 26,
+        "count": 32
       },
       "description": "Social platform adapters for publishing to YouTube, Threads, X, and Bluesky",
       "commands": {
@@ -1235,8 +1280,8 @@
         "metadata": "packages/speech/metadata.json"
       },
       "position": {
-        "index": 26,
-        "count": 31
+        "index": 27,
+        "count": 32
       },
       "description": "Speech provider abstraction for STT and TTS backends",
       "commands": {
@@ -1282,8 +1327,8 @@
         "metadata": "packages/sql/metadata.json"
       },
       "position": {
-        "index": 27,
-        "count": 31
+        "index": 28,
+        "count": 32
       },
       "description": "Database interface with support for SQLite, PostgreSQL, and DuckDB",
       "commands": {
@@ -1335,8 +1380,8 @@
         "metadata": "packages/translator/metadata.json"
       },
       "position": {
-        "index": 28,
-        "count": 31
+        "index": 29,
+        "count": 32
       },
       "description": "Standardized translation interface supporting Google Translate, DeepL, and LibreTranslate",
       "commands": {
@@ -1382,8 +1427,8 @@
         "metadata": "packages/utils/metadata.json"
       },
       "position": {
-        "index": 29,
-        "count": 31
+        "index": 30,
+        "count": 32
       },
       "description": "Foundation utilities for ID generation, date parsing, URL handling, string conversion, error handling, and logging",
       "commands": {
@@ -1451,8 +1496,8 @@
         "metadata": "packages/video/metadata.json"
       },
       "position": {
-        "index": 30,
-        "count": 31
+        "index": 31,
+        "count": 32
       },
       "description": "Video processing utilities with adapter pattern for composition and transcoding",
       "commands": {
@@ -1498,8 +1543,8 @@
         "metadata": "packages/weather/metadata.json"
       },
       "position": {
-        "index": 31,
-        "count": 31
+        "index": 32,
+        "count": 32
       },
       "description": "Weather data provider abstraction for HAppyVertical SDK",
       "commands": {
@@ -1818,6 +1863,16 @@
       "type": "provides",
       "from": "@happyvertical/secrets",
       "to": "Envelope encryption for per-tenant secret management with pluggable backends"
+    },
+    {
+      "type": "implements",
+      "from": "@happyvertical/signatures",
+      "to": "BoldSign"
+    },
+    {
+      "type": "provides",
+      "from": "@happyvertical/signatures",
+      "to": "Provider-neutral e-signature workflows with a BoldSign adapter"
     },
     {
       "type": "requires",

--- a/packages/accounting/AGENT.md
+++ b/packages/accounting/AGENT.md
@@ -7,7 +7,7 @@ Multi-provider accounting integration for AR/AP sync and audit with QuickBooks, 
 ## Package Map
 - Package: `@happyvertical/accounting`
 - Hierarchy path: `@happyvertical/sdk > packages > accounting`
-- Workspace position: `1 of 31` local packages
+- Workspace position: `1 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/accounting/metadata.json
+++ b/packages/accounting/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/accounting",
   "position": {
     "index": 1,
-    "count": 31
+    "count": 32
   },
   "description": "Multi-provider accounting integration for AR/AP sync and audit with QuickBooks, Stripe, and more",
   "provides": [

--- a/packages/ai/AGENT.md
+++ b/packages/ai/AGENT.md
@@ -7,7 +7,7 @@ Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic
 ## Package Map
 - Package: `@happyvertical/ai`
 - Hierarchy path: `@happyvertical/sdk > packages > ai`
-- Workspace position: `2 of 31` local packages
+- Workspace position: `2 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/sdk-mcp`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/ai/metadata.json
+++ b/packages/ai/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/ai",
   "position": {
     "index": 2,
-    "count": 31
+    "count": 32
   },
   "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
   "provides": [

--- a/packages/analytics/AGENT.md
+++ b/packages/analytics/AGENT.md
@@ -7,7 +7,7 @@ Unified analytics interface for Google Analytics 4, Plausible, and more
 ## Package Map
 - Package: `@happyvertical/analytics`
 - Hierarchy path: `@happyvertical/sdk > packages > analytics`
-- Workspace position: `3 of 31` local packages
+- Workspace position: `3 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/analytics/metadata.json
+++ b/packages/analytics/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/analytics",
   "position": {
     "index": 3,
-    "count": 31
+    "count": 32
   },
   "description": "Unified analytics interface for Google Analytics 4, Plausible, and more",
   "provides": [

--- a/packages/auth/AGENT.md
+++ b/packages/auth/AGENT.md
@@ -7,7 +7,7 @@ Unified authentication interface supporting Keycloak, AWS Cognito, and Nostr wit
 ## Package Map
 - Package: `@happyvertical/auth`
 - Hierarchy path: `@happyvertical/sdk > packages > auth`
-- Workspace position: `4 of 31` local packages
+- Workspace position: `4 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/auth/metadata.json
+++ b/packages/auth/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/auth",
   "position": {
     "index": 4,
-    "count": 31
+    "count": 32
   },
   "description": "Unified authentication interface supporting Keycloak, AWS Cognito, and Nostr with OAuth2/OIDC and public key identity",
   "provides": [

--- a/packages/cache/AGENT.md
+++ b/packages/cache/AGENT.md
@@ -7,7 +7,7 @@ Standardized caching interface supporting Memory, File, and Redis backends
 ## Package Map
 - Package: `@happyvertical/cache`
 - Hierarchy path: `@happyvertical/sdk > packages > cache`
-- Workspace position: `5 of 31` local packages
+- Workspace position: `5 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/geo`, `@happyvertical/translator`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/cache/metadata.json
+++ b/packages/cache/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/cache",
   "position": {
     "index": 5,
-    "count": 31
+    "count": 32
   },
   "description": "Standardized caching interface supporting Memory, File, and Redis backends",
   "provides": [

--- a/packages/comfyui/AGENT.md
+++ b/packages/comfyui/AGENT.md
@@ -7,7 +7,7 @@ ComfyUI API client for workflow orchestration and video generation
 ## Package Map
 - Package: `@happyvertical/comfyui`
 - Hierarchy path: `@happyvertical/sdk > packages > comfyui`
-- Workspace position: `6 of 31` local packages
+- Workspace position: `6 of 32` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/comfyui/metadata.json
+++ b/packages/comfyui/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/comfyui",
   "position": {
     "index": 6,
-    "count": 31
+    "count": 32
   },
   "description": "ComfyUI API client for workflow orchestration and video generation",
   "provides": [

--- a/packages/directory/AGENT.md
+++ b/packages/directory/AGENT.md
@@ -7,7 +7,7 @@ Unified directory services with adapter-based architecture (Kanidm, Stalwart, Po
 ## Package Map
 - Package: `@happyvertical/directory`
 - Hierarchy path: `@happyvertical/sdk > packages > directory`
-- Workspace position: `7 of 31` local packages
+- Workspace position: `7 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/directory/metadata.json
+++ b/packages/directory/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/directory",
   "position": {
     "index": 7,
-    "count": 31
+    "count": 32
   },
   "description": "Unified directory services with adapter-based architecture (Kanidm, Stalwart, PostgreSQL, AWS)",
   "provides": [

--- a/packages/documents/AGENT.md
+++ b/packages/documents/AGENT.md
@@ -7,7 +7,7 @@ Multi-part document processing with support for PDF, HTML, and Markdown
 ## Package Map
 - Package: `@happyvertical/documents`
 - Hierarchy path: `@happyvertical/sdk > packages > documents`
-- Workspace position: `8 of 31` local packages
+- Workspace position: `8 of 32` local packages
 - Internal dependencies: `@happyvertical/files`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/documents/metadata.json
+++ b/packages/documents/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/documents",
   "position": {
     "index": 8,
-    "count": 31
+    "count": 32
   },
   "description": "Multi-part document processing with support for PDF, HTML, and Markdown",
   "provides": [

--- a/packages/email/AGENT.md
+++ b/packages/email/AGENT.md
@@ -7,7 +7,7 @@ Low-level email protocol operations with adapter-based architecture
 ## Package Map
 - Package: `@happyvertical/email`
 - Hierarchy path: `@happyvertical/sdk > packages > email`
-- Workspace position: `9 of 31` local packages
+- Workspace position: `9 of 32` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: `@happyvertical/messages`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/email/metadata.json
+++ b/packages/email/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/email",
   "position": {
     "index": 9,
-    "count": 31
+    "count": 32
   },
   "description": "Low-level email protocol operations with adapter-based architecture",
   "provides": [

--- a/packages/encryption/AGENT.md
+++ b/packages/encryption/AGENT.md
@@ -7,7 +7,7 @@ Unified encryption and cryptography operations with adapter-based architecture
 ## Package Map
 - Package: `@happyvertical/encryption`
 - Hierarchy path: `@happyvertical/sdk > packages > encryption`
-- Workspace position: `10 of 31` local packages
+- Workspace position: `10 of 32` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/encryption/metadata.json
+++ b/packages/encryption/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/encryption",
   "position": {
     "index": 10,
-    "count": 31
+    "count": 32
   },
   "description": "Unified encryption and cryptography operations with adapter-based architecture",
   "provides": [

--- a/packages/files/AGENT.md
+++ b/packages/files/AGENT.md
@@ -7,7 +7,7 @@ File system utilities for local and remote file operations
 ## Package Map
 - Package: `@happyvertical/files`
 - Hierarchy path: `@happyvertical/sdk > packages > files`
-- Workspace position: `11 of 31` local packages
+- Workspace position: `11 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/documents`, `@happyvertical/sdk-mcp`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/files/metadata.json
+++ b/packages/files/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/files",
   "position": {
     "index": 11,
-    "count": 31
+    "count": 32
   },
   "description": "File system utilities for local and remote file operations",
   "provides": [

--- a/packages/geo/AGENT.md
+++ b/packages/geo/AGENT.md
@@ -7,7 +7,7 @@ Standardized geographical information interface supporting Google Maps and OpenS
 ## Package Map
 - Package: `@happyvertical/geo`
 - Hierarchy path: `@happyvertical/sdk > packages > geo`
-- Workspace position: `12 of 31` local packages
+- Workspace position: `12 of 32` local packages
 - Internal dependencies: `@happyvertical/cache`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/geo/metadata.json
+++ b/packages/geo/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/geo",
   "position": {
     "index": 12,
-    "count": 31
+    "count": 32
   },
   "description": "Standardized geographical information interface supporting Google Maps and OpenStreetMap",
   "provides": [

--- a/packages/github-actions/AGENT.md
+++ b/packages/github-actions/AGENT.md
@@ -7,7 +7,7 @@ Reusable GitHub Actions utilities for issue triage, PR validation, and workflow 
 ## Package Map
 - Package: `@happyvertical/github-actions`
 - Hierarchy path: `@happyvertical/sdk > packages > github-actions`
-- Workspace position: `13 of 31` local packages
+- Workspace position: `13 of 32` local packages
 - Internal dependencies: `@happyvertical/projects`, `@happyvertical/repos`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/github-actions/metadata.json
+++ b/packages/github-actions/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/github-actions",
   "position": {
     "index": 13,
-    "count": 31
+    "count": 32
   },
   "description": "Reusable GitHub Actions utilities for issue triage, PR validation, and workflow automation",
   "provides": [

--- a/packages/graphql/AGENT.md
+++ b/packages/graphql/AGENT.md
@@ -7,7 +7,7 @@ GitHub GraphQL client for SDK packages
 ## Package Map
 - Package: `@happyvertical/graphql`
 - Hierarchy path: `@happyvertical/sdk > packages > graphql`
-- Workspace position: `14 of 31` local packages
+- Workspace position: `14 of 32` local packages
 - Internal dependencies: none
 - Internal dependents: `@happyvertical/projects`, `@happyvertical/repos`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/graphql/metadata.json
+++ b/packages/graphql/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/graphql",
   "position": {
     "index": 14,
-    "count": 31
+    "count": 32
   },
   "description": "GitHub GraphQL client for SDK packages",
   "provides": [

--- a/packages/images/AGENT.md
+++ b/packages/images/AGENT.md
@@ -7,7 +7,7 @@ Image processing utilities with adapter pattern for scaling from static to enter
 ## Package Map
 - Package: `@happyvertical/images`
 - Hierarchy path: `@happyvertical/sdk > packages > images`
-- Workspace position: `15 of 31` local packages
+- Workspace position: `15 of 32` local packages
 - Internal dependencies: none
 - Internal dependents: `@happyvertical/video`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/images/metadata.json
+++ b/packages/images/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/images",
   "position": {
     "index": 15,
-    "count": 31
+    "count": 32
   },
   "description": "Image processing utilities with adapter pattern for scaling from static to enterprise",
   "provides": [

--- a/packages/jobs/AGENT.md
+++ b/packages/jobs/AGENT.md
@@ -7,7 +7,7 @@ Job queue abstraction with multiple backend adapters (SQLite, PostgreSQL, Bull, 
 ## Package Map
 - Package: `@happyvertical/jobs`
 - Hierarchy path: `@happyvertical/sdk > packages > jobs`
-- Workspace position: `16 of 31` local packages
+- Workspace position: `16 of 32` local packages
 - Internal dependencies: `@happyvertical/sql`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/jobs/metadata.json
+++ b/packages/jobs/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/jobs",
   "position": {
     "index": 16,
-    "count": 31
+    "count": 32
   },
   "description": "Job queue abstraction with multiple backend adapters (SQLite, PostgreSQL, Bull, SQS)",
   "provides": [

--- a/packages/json/AGENT.md
+++ b/packages/json/AGENT.md
@@ -7,7 +7,7 @@ High-performance JSON parsing and serialization with Rust SIMD acceleration and 
 ## Package Map
 - Package: `@happyvertical/json`
 - Hierarchy path: `@happyvertical/sdk > packages > json`
-- Workspace position: `17 of 31` local packages
+- Workspace position: `17 of 32` local packages
 - Internal dependencies: none
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/json/metadata.json
+++ b/packages/json/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/json",
   "position": {
     "index": 17,
-    "count": 31
+    "count": 32
   },
   "description": "High-performance JSON parsing and serialization with Rust SIMD acceleration and automatic fallback",
   "provides": [

--- a/packages/logger/AGENT.md
+++ b/packages/logger/AGENT.md
@@ -7,7 +7,7 @@ Structured logging for HAVE SDK with signal adapter
 ## Package Map
 - Package: `@happyvertical/logger`
 - Hierarchy path: `@happyvertical/sdk > packages > logger`
-- Workspace position: `18 of 31` local packages
+- Workspace position: `18 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/comfyui`, `@happyvertical/email`, `@happyvertical/encryption`, `@happyvertical/messages`, `@happyvertical/social`, `@happyvertical/video`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/logger/metadata.json
+++ b/packages/logger/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/logger",
   "position": {
     "index": 18,
-    "count": 31
+    "count": 32
   },
   "description": "Structured logging for HAVE SDK with signal adapter",
   "provides": [

--- a/packages/messages/AGENT.md
+++ b/packages/messages/AGENT.md
@@ -7,7 +7,7 @@ Unified multi-channel messaging with adapter-based architecture (Slack, Twitter,
 ## Package Map
 - Package: `@happyvertical/messages`
 - Hierarchy path: `@happyvertical/sdk > packages > messages`
-- Workspace position: `19 of 31` local packages
+- Workspace position: `19 of 32` local packages
 - Internal dependencies: `@happyvertical/email`, `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/messages/metadata.json
+++ b/packages/messages/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/messages",
   "position": {
     "index": 19,
-    "count": 31
+    "count": 32
   },
   "description": "Unified multi-channel messaging with adapter-based architecture (Slack, Twitter, Email)",
   "provides": [

--- a/packages/payments/AGENT.md
+++ b/packages/payments/AGENT.md
@@ -7,7 +7,7 @@ Payment backend abstraction with adapters for Base USDC, BTCPay Server, and Stri
 ## Package Map
 - Package: `@happyvertical/payments`
 - Hierarchy path: `@happyvertical/sdk > packages > payments`
-- Workspace position: `20 of 31` local packages
+- Workspace position: `20 of 32` local packages
 - Internal dependencies: none
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/payments/metadata.json
+++ b/packages/payments/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/payments",
   "position": {
     "index": 20,
-    "count": 31
+    "count": 32
   },
   "description": "Payment backend abstraction with adapters for Base USDC, BTCPay Server, and Stripe",
   "provides": [

--- a/packages/projects/AGENT.md
+++ b/packages/projects/AGENT.md
@@ -7,7 +7,7 @@ Standardized project management interface for GitHub Projects, Jira, ZenHub, and
 ## Package Map
 - Package: `@happyvertical/projects`
 - Hierarchy path: `@happyvertical/sdk > packages > projects`
-- Workspace position: `21 of 31` local packages
+- Workspace position: `21 of 32` local packages
 - Internal dependencies: `@happyvertical/graphql`, `@happyvertical/repos`
 - Internal dependents: `@happyvertical/github-actions`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/projects/metadata.json
+++ b/packages/projects/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/projects",
   "position": {
     "index": 21,
-    "count": 31
+    "count": 32
   },
   "description": "Standardized project management interface for GitHub Projects, Jira, ZenHub, and Linear",
   "provides": [

--- a/packages/repos/AGENT.md
+++ b/packages/repos/AGENT.md
@@ -7,7 +7,7 @@ Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOp
 ## Package Map
 - Package: `@happyvertical/repos`
 - Hierarchy path: `@happyvertical/sdk > packages > repos`
-- Workspace position: `22 of 31` local packages
+- Workspace position: `22 of 32` local packages
 - Internal dependencies: `@happyvertical/graphql`
 - Internal dependents: `@happyvertical/github-actions`, `@happyvertical/projects`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/repos/metadata.json
+++ b/packages/repos/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/repos",
   "position": {
     "index": 22,
-    "count": 31
+    "count": 32
   },
   "description": "Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOps",
   "provides": [

--- a/packages/sdk-mcp/AGENT.md
+++ b/packages/sdk-mcp/AGENT.md
@@ -7,7 +7,7 @@ MCP server for HAVE SDK - Routes queries to package experts using AGENT.md files
 ## Package Map
 - Package: `@happyvertical/sdk-mcp`
 - Hierarchy path: `@happyvertical/sdk > packages > sdk-mcp`
-- Workspace position: `23 of 31` local packages
+- Workspace position: `23 of 32` local packages
 - Internal dependencies: `@happyvertical/ai`, `@happyvertical/files`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/sdk-mcp/metadata.json
+++ b/packages/sdk-mcp/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/sdk-mcp",
   "position": {
     "index": 23,
-    "count": 31
+    "count": 32
   },
   "description": "MCP server for HAVE SDK - Routes queries to package experts using AGENT.md files",
   "provides": [

--- a/packages/secrets/AGENT.md
+++ b/packages/secrets/AGENT.md
@@ -7,7 +7,7 @@ Envelope encryption for per-tenant secret management with pluggable backends
 ## Package Map
 - Package: `@happyvertical/secrets`
 - Hierarchy path: `@happyvertical/sdk > packages > secrets`
-- Workspace position: `24 of 31` local packages
+- Workspace position: `24 of 32` local packages
 - Internal dependencies: `@happyvertical/sql`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/secrets/metadata.json
+++ b/packages/secrets/metadata.json
@@ -3,7 +3,7 @@
   "path": "packages/secrets",
   "position": {
     "index": 24,
-    "count": 31
+    "count": 32
   },
   "description": "Envelope encryption for per-tenant secret management with pluggable backends",
   "provides": [

--- a/packages/signatures/AGENT.md
+++ b/packages/signatures/AGENT.md
@@ -1,0 +1,49 @@
+# @happyvertical/signatures
+
+<!-- BEGIN AGENT:GENERATED -->
+## Purpose
+Provider-neutral e-signature workflows with a BoldSign adapter
+
+## Package Map
+- Package: `@happyvertical/signatures`
+- Hierarchy path: `@happyvertical/sdk > packages > signatures`
+- Workspace position: `25 of 32` local packages
+- Internal dependencies: none
+- Internal dependents: none
+- Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`
+
+## Build & Test
+```bash
+pnpm --filter @happyvertical/signatures build
+pnpm --filter @happyvertical/signatures test
+pnpm --filter @happyvertical/signatures typecheck
+pnpm --filter @happyvertical/signatures clean
+```
+
+## Agent Correction Loops
+- If Vite or TypeScript reports missing packages, run `pnpm install` at the repo root and rerun `pnpm --filter @happyvertical/signatures build`.
+- If tests or exports fail after API, type, or bundle changes, run `pnpm --filter @happyvertical/signatures clean` followed by `pnpm --filter @happyvertical/signatures build` and `pnpm --filter @happyvertical/signatures test`.
+- If failures span multiple packages or Turborepo ordering looks wrong, run `pnpm build` and `pnpm typecheck` from the repo root before retrying package-scoped commands.
+
+## Ecosystem Relationships
+- Provides: Provider-neutral e-signature workflows with a BoldSign adapter
+- Implements: BoldSign
+- Requires: none
+- Stability: experimental (Marked as preview or experimental in package guidance.)
+<!-- END AGENT:GENERATED -->
+
+
+## Package Status
+
+Experimental while the first downstream agreement workflow validates the provider-neutral contract.
+
+## Adapters
+
+- BoldSign (`type: 'boldsign'`) uses the regional v1 document API, HMAC-verified webhooks, and PDF artifact endpoints.
+
+## Security Boundaries
+
+- Construct one adapter per tenant credential and webhook secret set.
+- Preserve the raw webhook request body until HMAC verification completes.
+- Persist provider event IDs and creation idempotency keys under durable unique constraints; BoldSign does not advertise provider-enforced send idempotency.
+- Download signed documents and audit trails only after the normalized request reaches `completed`, consume each single-use stream into immutable storage, then await and persist its SHA-256 digest.

--- a/packages/signatures/CHANGELOG.md
+++ b/packages/signatures/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @happyvertical/signatures
+
+## 0.79.0
+
+### Minor Changes
+
+- Add provider-neutral e-signature contracts and the first BoldSign adapter with Canadian residency, verified webhooks, tenant binding, cancellation/expiry, and hashed execution-evidence downloads.

--- a/packages/signatures/README.md
+++ b/packages/signatures/README.md
@@ -1,0 +1,129 @@
+# @happyvertical/signatures
+
+Provider-neutral e-signature request, lifecycle, verified-webhook, and execution-evidence contracts. BoldSign is the first adapter.
+
+## Status
+
+This package is experimental while the first downstream agreement workflow validates the provider-neutral contract.
+
+## Install
+
+```bash
+pnpm add @happyvertical/signatures
+```
+
+## BoldSign quick start
+
+Create one adapter per tenant credential and webhook signing secret. HappyVertical deployments use BoldSign's Canadian region by default.
+
+```typescript
+import { createSignatureProvider } from '@happyvertical/signatures';
+
+const signatures = await createSignatureProvider({
+  type: 'boldsign',
+  tenantId: 'tenant_123',
+  apiKey: process.env.BOLDSIGN_API_KEY!,
+  webhookSecrets: [process.env.BOLDSIGN_WEBHOOK_SECRET!],
+  region: 'ca',
+});
+
+const request = await signatures.createRequest({
+  tenantId: 'tenant_123',
+  idempotencyKey: 'referral-agreement:version_456',
+  title: 'Referral Agreement',
+  documents: [
+    {
+      name: 'referral-agreement.pdf',
+      mediaType: 'application/pdf',
+      data: generatedPdf,
+    },
+  ],
+  signers: [
+    {
+      name: 'Alex Example',
+      email: 'alex@example.com',
+      authentication: { method: 'email_otp' },
+      fields: [
+        {
+          id: 'referrer_signature',
+          type: 'signature',
+          page: 3,
+          bounds: { x: 72, y: 620, width: 180, height: 36 },
+        },
+      ],
+    },
+  ],
+  expiresInDays: 30,
+});
+```
+
+## Adapters
+
+- BoldSign (`type: 'boldsign'`) uses the regional v1 document API, HMAC-verified webhooks, and PDF artifact endpoints.
+
+The package sends JSON with base64 documents to BoldSign's asynchronous `POST /v1/document/send` API. A successful create response means BoldSign accepted processing; the verified `Sent` or `SendFailed` webhook is authoritative for the next transition.
+
+## Webhooks and replay protection
+
+Pass the exact raw UTF-8 request body and `X-BoldSign-Signature` header. Do not parse and re-serialize the body before verification.
+
+```typescript
+const event = signatures.parseWebhook({
+  payload: rawBody,
+  signature: request.headers.get('x-boldsign-signature')!,
+});
+```
+
+The adapter verifies BoldSign's HMAC-SHA256 signature using constant-time comparison and rejects timestamps outside the configured tolerance (five minutes by default). It also requires the signed payload's `hvTenantId` metadata to match the adapter tenant. Persist `event.id` under a unique constraint before applying an event; the SDK intentionally does not pretend an in-memory replay cache is durable.
+
+Configure the webhook for `Sent`, `Signed`, `Completed`, `Viewed`, `Declined`, `Revoked`, `Expired`, `DeliveryFailed`, and `SendFailed`. Other signed event types are rejected until the provider-neutral contract defines their semantics.
+
+BoldSign sends an unsigned `Verification` callback while a webhook endpoint is configured. Acknowledge that control request before calling `parseWebhook`; do not treat it as a document event.
+
+## Idempotency and ambiguous failures
+
+`createRequest` requires an idempotency key and stores it in BoldSign metadata as `hvIdempotencyKey`. BoldSign's public send-document contract does not advertise an atomic idempotency header, so `capabilities.providerEnforcedIdempotency` is `false`. The durable application layer must claim the tenant/key before sending and persist the returned document ID. When `SignatureProviderError.requestMayHaveSucceeded` is true, reconcile rather than blindly sending a duplicate agreement.
+
+## Execution evidence
+
+Artifacts are available only after the normalized request status is `completed`:
+
+```typescript
+const signed = await signatures.downloadArtifact({
+  tenantId: 'tenant_123',
+  requestId: request.id,
+  kind: 'signed_document',
+});
+
+const audit = await signatures.downloadArtifact({
+  tenantId: 'tenant_123',
+  requestId: request.id,
+  kind: 'audit_trail',
+});
+
+await immutableAssets.put(signed.filename, signed.stream);
+const signedSha256 = await signed.sha256;
+```
+
+Each artifact exposes a single-use byte stream and a SHA-256 promise that resolves after that stream is consumed. Persist the stream to immutable/versioned storage, then await and record the digest together with the provider request ID, event ID, tenant, signer identity, retrieval time, and agreement version. The provider is a retrieval source, not the system of record for an executed agreement.
+
+## Operations and security
+
+- Keep API keys, OAuth tokens, access codes, and webhook secrets in the SDK/SMRT secret store; never put them in agreement metadata or logs.
+- Scope an adapter instance to exactly one tenant. Reads, mutations, downloads, and webhooks all enforce that tenant binding.
+- For secret rotation, configure both valid webhook secrets temporarily. BoldSign may also include both `s0` and `s1` signatures in its header.
+- `cancelRequest` requires a reason. `extendExpiry` verifies tenant ownership first and only accepts a future date.
+- API credentials may use either `X-API-KEY` or an OAuth bearer token, never both.
+- Use the sandbox for contract testing, but do not treat its watermarked PDFs as legal artifacts.
+
+## Provider references
+
+- [Regional API base URLs](https://developers.boldsign.com/api-overview/versioning/)
+- [Send document](https://developers.boldsign.com/documents/send-document/)
+- [Document details and status](https://developers.boldsign.com/documents/document-details-and-status)
+- [Revoke document](https://developers.boldsign.com/documents/revoke-document/)
+- [Extend document expiry](https://developers.boldsign.com/documents/extend-document-expiry/)
+- [Verify webhook events](https://developers.boldsign.com/webhooks/verify-webhook-events/)
+- [Webhook event metadata](https://developers.boldsign.com/webhooks/event-metadata/)
+- [Download signed document](https://developers.boldsign.com/documents/download-document/)
+- [Download audit trail](https://developers.boldsign.com/documents/download-audit-trail/)

--- a/packages/signatures/metadata.json
+++ b/packages/signatures/metadata.json
@@ -1,0 +1,28 @@
+{
+  "name": "@happyvertical/signatures",
+  "path": "packages/signatures",
+  "position": {
+    "index": 25,
+    "count": 32
+  },
+  "description": "Provider-neutral e-signature workflows with a BoldSign adapter",
+  "provides": [
+    "Provider-neutral e-signature workflows with a BoldSign adapter"
+  ],
+  "implements": [
+    "BoldSign"
+  ],
+  "requires": {
+    "workspace": [],
+    "externalHappyVertical": [],
+    "external": []
+  },
+  "dependents": [],
+  "stability": {
+    "level": "experimental",
+    "reason": "Marked as preview or experimental in package guidance."
+  },
+  "keywords": [
+    "signatures"
+  ]
+}

--- a/packages/signatures/package.json
+++ b/packages/signatures/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@happyvertical/signatures",
+  "version": "0.79.0",
+  "description": "Provider-neutral e-signature workflows with a BoldSign adapter",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./boldsign": {
+      "types": "./dist/adapters/boldsign.d.ts",
+      "import": "./dist/adapters/boldsign.js"
+    }
+  },
+  "scripts": {
+    "test": "vitest --config ../../vitest.package.config.ts run",
+    "test:watch": "vitest --config ../../vitest.package.config.ts",
+    "build": "vite build",
+    "build:watch": "vite build --watch",
+    "typecheck": "tsc --noEmit",
+    "docs": "typedoc --plugin typedoc-plugin-markdown --out docs --entryPoints ./src/index.ts --tsconfig ./tsconfig.json --excludePrivate --excludeInternal --hideGenerator --fileExtension .md --readme none --categorizeByGroup false --includeVersion false --hidePageHeader --hidePageTitle false --outputFileStrategy modules",
+    "clean": "rm -rf dist docs"
+  },
+  "keywords": [
+    "esignature",
+    "signature",
+    "boldsign",
+    "agreements"
+  ],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "AGENT.md",
+    "metadata.json"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/sdk.git",
+    "directory": "packages/signatures"
+  },
+  "bugs": {
+    "url": "https://github.com/happyvertical/sdk/issues"
+  },
+  "homepage": "https://github.com/happyvertical/sdk/tree/main/packages/signatures#readme",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "24.12.2",
+    "@vitest/coverage-v8": "4.1.5",
+    "typescript": "^5.9.3",
+    "vite": "7.3.2",
+    "vite-plugin-dts": "4.5.4",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/signatures/src/adapters/boldsign.ts
+++ b/packages/signatures/src/adapters/boldsign.ts
@@ -1,0 +1,1885 @@
+// biome-ignore-all lint/style/useNamingConvention: BoldSign's documented JSON wire fields use PascalCase.
+import { Buffer } from 'node:buffer';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  SignatureConfigurationError,
+  SignatureInputError,
+  SignatureProviderError,
+  SignatureTenantMismatchError,
+  SignatureVerificationError,
+} from '../errors.js';
+import {
+  getSignatureFetch,
+  normalizeDate,
+  parseOptionalEpochSeconds,
+  readBoolean,
+  readNumber,
+  readRecord,
+  readRecords,
+  readString,
+  requireNonEmptyString,
+  requireRecord,
+  type SignatureFetch,
+} from '../shared.js';
+import type {
+  CancelSignatureRequestInput,
+  CreateSignatureRequestInput,
+  DownloadSignatureArtifactInput,
+  ExtendSignatureRequestExpiryInput,
+  ParseSignatureWebhookInput,
+  SignatureArtifact,
+  SignatureAuthentication,
+  SignatureAuthenticationMethod,
+  SignatureField,
+  SignatureProvider,
+  SignatureProviderCapabilities,
+  SignatureRequest,
+  SignatureRequestReference,
+  SignatureRequestStatus,
+  SignatureSigner,
+  SignatureSignerInput,
+  SignatureSignerStatus,
+  SignatureWebhookEvent,
+} from '../types.js';
+
+export const BOLDSIGN_PROVIDER_ID = 'boldsign';
+export const BOLDSIGN_TENANT_METADATA_KEY = 'hvTenantId';
+export const BOLDSIGN_IDEMPOTENCY_METADATA_KEY = 'hvIdempotencyKey';
+
+const DEFAULT_WEBHOOK_TOLERANCE_SECONDS = 300;
+const MAX_BOLDSIGN_METADATA_ENTRIES = 50;
+const MAX_BOLDSIGN_METADATA_KEY_LENGTH = 50;
+const MAX_BOLDSIGN_METADATA_VALUE_LENGTH = 500;
+const MAX_BOLDSIGN_DOCUMENT_BYTES = 25 * 1024 * 1024;
+const MIN_EXPIRY_DAYS = 1;
+const MAX_EXPIRY_DAYS = 180;
+
+const SUPPORTED_BOLDSIGN_DOCUMENT_EVENTS = new Set([
+  'sent',
+  'signed',
+  'completed',
+  'declined',
+  'revoked',
+  'expired',
+  'viewed',
+  'deliveryfailed',
+  'sendfailed',
+]);
+
+export type BoldSignRegion = 'us' | 'eu' | 'ca' | 'au';
+
+const REGION_URLS: Readonly<Record<BoldSignRegion, string>> = {
+  us: 'https://api.boldsign.com/v1',
+  eu: 'https://api-eu.boldsign.com/v1',
+  ca: 'https://api-ca.boldsign.com/v1',
+  au: 'https://api-au.boldsign.com/v1',
+};
+
+export interface BoldSignAdapterOptions {
+  /** Bind one adapter and its credential/webhook secret to one tenant. */
+  tenantId: string;
+  apiKey?: string;
+  accessToken?: string;
+  /** Defaults to Canada for HappyVertical's first deployment. */
+  region?: BoldSignRegion;
+  apiBaseUrl?: string;
+  webhookSecrets?: string | readonly string[];
+  webhookToleranceSeconds?: number;
+  fetch?: SignatureFetch;
+  /** Testable wall clock used for replay checks and evidence timestamps. */
+  now?: () => Date;
+}
+
+interface BoldSignRequestOptions {
+  method?: string;
+  body?: unknown;
+  signal?: AbortSignal;
+  operation?: 'create' | 'read' | 'mutate';
+  expect?: 'json' | 'empty' | 'stream';
+}
+
+export class BoldSignAdapter implements SignatureProvider {
+  readonly capabilities: SignatureProviderCapabilities;
+
+  private readonly tenantId: string;
+  private readonly apiKey?: string;
+  private readonly accessToken?: string;
+  private readonly apiBaseUrl: string;
+  private readonly webhookSecrets: readonly string[];
+  private readonly webhookToleranceSeconds: number;
+  private readonly fetch: SignatureFetch;
+  private readonly now: () => Date;
+
+  constructor(options: BoldSignAdapterOptions) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      throw new SignatureConfigurationError(
+        'BoldSignAdapter options must be an object.',
+      );
+    }
+
+    this.tenantId = configurationString(
+      options.tenantId,
+      'BoldSignAdapter tenantId',
+    );
+    this.apiKey = optionalConfigurationString(
+      options.apiKey,
+      'BoldSignAdapter apiKey',
+    );
+    this.accessToken = optionalConfigurationString(
+      options.accessToken,
+      'BoldSignAdapter accessToken',
+    );
+
+    if (Boolean(this.apiKey) === Boolean(this.accessToken)) {
+      throw new SignatureConfigurationError(
+        'BoldSignAdapter requires exactly one of apiKey or accessToken.',
+      );
+    }
+
+    const region = options.region ?? 'ca';
+
+    if (!(region in REGION_URLS)) {
+      throw new SignatureConfigurationError(
+        `BoldSignAdapter region must be one of ${Object.keys(REGION_URLS).join(', ')}.`,
+      );
+    }
+
+    this.apiBaseUrl = normalizeBaseUrl(
+      options.apiBaseUrl ?? REGION_URLS[region],
+    );
+    this.webhookSecrets = normalizeWebhookSecrets(options.webhookSecrets);
+    this.webhookToleranceSeconds = normalizeWebhookTolerance(
+      options.webhookToleranceSeconds,
+    );
+    this.fetch = getSignatureFetch(options.fetch);
+    this.now = options.now ?? (() => new Date());
+
+    if (typeof this.now !== 'function') {
+      throw new SignatureConfigurationError(
+        'BoldSignAdapter now must be a function.',
+      );
+    }
+
+    this.capabilities = {
+      id: BOLDSIGN_PROVIDER_ID,
+      displayName: 'BoldSign',
+      region,
+      supportsWebhooks: true,
+      supportsCancellation: true,
+      supportsExpiryExtension: true,
+      supportsSignedDocument: true,
+      supportsAuditTrail: true,
+      providerEnforcedIdempotency: false,
+      authenticationMethods: [
+        'none',
+        'access_code',
+        'email_otp',
+        'sms_otp',
+        'identity_verification',
+      ],
+    };
+  }
+
+  async createRequest(
+    input: CreateSignatureRequestInput,
+  ): Promise<SignatureRequest> {
+    this.assertTenant(input.tenantId);
+    const idempotencyKey = requireNonEmptyString(
+      input.idempotencyKey,
+      'BoldSign idempotencyKey',
+    );
+    const title = requireNonEmptyString(input.title, 'BoldSign title');
+    const documents = await normalizeDocuments(input.documents, input.signal);
+    const signers = normalizeSignerInputs(input.signers);
+    const metadata = normalizeMetadata(input.metadata, {
+      [BOLDSIGN_TENANT_METADATA_KEY]: this.tenantId,
+      [BOLDSIGN_IDEMPOTENCY_METADATA_KEY]: idempotencyKey,
+    });
+    const expiresInDays = normalizeExpiryDays(input.expiresInDays);
+
+    const response = (await this.request('/document/send', {
+      method: 'POST',
+      operation: 'create',
+      signal: input.signal,
+      body: {
+        Title: title,
+        Message: optionalTrimmedString(input.message),
+        Files: documents.map((document) => ({
+          base64: `data:${document.mediaType};base64,${Buffer.from(document.data).toString('base64')}`,
+          fileName: document.name,
+        })),
+        Signers: signers.map(toBoldSignSigner),
+        EnableSigningOrder: input.signingOrder ?? false,
+        ExpiryDateType: 'Days',
+        ExpiryDays: expiresInDays,
+        ExpiryValue: expiresInDays,
+        MetaData: metadata,
+      },
+    })) as Record<string, unknown>;
+
+    const id = requireProviderString(
+      readString(response, 'documentId'),
+      'BoldSign send response documentId',
+    );
+
+    return {
+      provider: BOLDSIGN_PROVIDER_ID,
+      tenantId: this.tenantId,
+      id,
+      status: 'prepared',
+      title,
+      signers: signers.map(inputSignerToResult),
+      expiresAt: new Date(
+        this.now().getTime() + expiresInDays * 24 * 60 * 60 * 1_000,
+      ),
+      metadata,
+      raw: response,
+    };
+  }
+
+  async getRequest(
+    input: SignatureRequestReference,
+  ): Promise<SignatureRequest> {
+    this.assertTenant(input.tenantId);
+    const requestId = requireNonEmptyString(
+      input.requestId,
+      'BoldSign requestId',
+    );
+    const response = (await this.request(
+      `/document/properties?documentId=${encodeURIComponent(requestId)}`,
+      { signal: input.signal, operation: 'read' },
+    )) as Record<string, unknown>;
+
+    this.assertProviderTenant(response);
+
+    return mapBoldSignRequest(response, this.tenantId);
+  }
+
+  async cancelRequest(
+    input: CancelSignatureRequestInput,
+  ): Promise<SignatureRequest> {
+    const reason = requireNonEmptyString(
+      input.reason,
+      'BoldSign cancellation reason',
+    );
+    const current = await this.getRequest(input);
+
+    if (isTerminalStatus(current.status)) {
+      throw new SignatureInputError(
+        `BoldSign request ${current.id} cannot be cancelled from ${current.status}.`,
+      );
+    }
+
+    await this.request(
+      `/document/revoke?documentId=${encodeURIComponent(current.id)}`,
+      {
+        method: 'POST',
+        operation: 'mutate',
+        expect: 'empty',
+        signal: input.signal,
+        body: { Message: reason },
+      },
+    );
+
+    return { ...current, status: 'cancelled' };
+  }
+
+  async extendExpiry(
+    input: ExtendSignatureRequestExpiryInput,
+  ): Promise<SignatureRequest> {
+    const current = await this.getRequest(input);
+    const expiresAt = normalizeDate(input.expiresAt, 'BoldSign expiresAt');
+
+    if (isTerminalStatus(current.status)) {
+      throw new SignatureInputError(
+        `BoldSign request ${current.id} expiry cannot be extended from ${current.status}.`,
+      );
+    }
+
+    if (expiresAt.getTime() <= this.now().getTime()) {
+      throw new SignatureInputError(
+        'BoldSign expiresAt must be in the future.',
+      );
+    }
+
+    if (
+      current.expiresAt &&
+      expiresAt.getTime() <= current.expiresAt.getTime()
+    ) {
+      throw new SignatureInputError(
+        'BoldSign expiresAt must extend the current expiry date.',
+      );
+    }
+
+    if (
+      current.createdAt &&
+      expiresAt.getTime() >
+        current.createdAt.getTime() + MAX_EXPIRY_DAYS * 24 * 60 * 60 * 1_000
+    ) {
+      throw new SignatureInputError(
+        `BoldSign expiresAt cannot exceed ${MAX_EXPIRY_DAYS} days from document creation.`,
+      );
+    }
+
+    await this.request(
+      `/document/extendExpiry?documentId=${encodeURIComponent(current.id)}`,
+      {
+        method: 'PATCH',
+        operation: 'mutate',
+        expect: 'empty',
+        signal: input.signal,
+        body: {
+          // We create requests with BoldSign's `Days` expiry type, whose
+          // extendExpiry endpoint requires a yyyy-MM-dd value.
+          NewExpiryValue: expiresAt.toISOString().slice(0, 10),
+          WarnPrior: input.warnPrior,
+        },
+      },
+    );
+
+    return { ...current, expiresAt };
+  }
+
+  async downloadArtifact(
+    input: DownloadSignatureArtifactInput,
+  ): Promise<SignatureArtifact> {
+    if (!['signed_document', 'audit_trail'].includes(input.kind)) {
+      throw new SignatureInputError(
+        'BoldSign artifact kind must be signed_document or audit_trail.',
+      );
+    }
+
+    const current = await this.getRequest(input);
+
+    if (current.status !== 'completed') {
+      throw new SignatureInputError(
+        'BoldSign execution artifacts may only be downloaded after completion.',
+      );
+    }
+
+    const endpoint =
+      input.kind === 'signed_document'
+        ? '/document/download'
+        : '/document/downloadAuditLog';
+    const response = (await this.request(
+      `${endpoint}?documentId=${encodeURIComponent(current.id)}`,
+      {
+        signal: input.signal,
+        operation: 'read',
+        expect: 'stream',
+      },
+    )) as ReadableStream<Uint8Array>;
+    const suffix = input.kind === 'signed_document' ? 'signed' : 'audit';
+    const hashed = createSha256Stream(response);
+
+    return {
+      provider: BOLDSIGN_PROVIDER_ID,
+      tenantId: this.tenantId,
+      requestId: current.id,
+      kind: input.kind,
+      filename: `${safeFilename(current.id)}-${suffix}.pdf`,
+      mediaType: 'application/pdf',
+      stream: hashed.stream,
+      sha256: hashed.sha256,
+      retrievedAt: new Date(this.now()),
+    };
+  }
+
+  parseWebhook(input: ParseSignatureWebhookInput): SignatureWebhookEvent {
+    if (this.webhookSecrets.length === 0) {
+      throw new SignatureConfigurationError(
+        'BoldSignAdapter parseWebhook requires webhookSecrets.',
+      );
+    }
+
+    verifyBoldSignWebhookSignature({
+      ...input,
+      secrets: this.webhookSecrets,
+      toleranceSeconds: this.webhookToleranceSeconds,
+      now: this.now(),
+    });
+
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(input.payload);
+    } catch (error) {
+      throw new SignatureVerificationError(
+        'BoldSign webhook payload is not valid JSON.',
+        { cause: error },
+      );
+    }
+
+    const body = verificationRecord(parsed, 'BoldSign webhook payload');
+    const event = verificationRecord(
+      body.event,
+      'BoldSign webhook event metadata',
+    );
+    const data = verificationRecord(body.data, 'BoldSign webhook data');
+    this.assertProviderTenant(data);
+
+    const id = requireVerificationString(
+      readString(event, 'id'),
+      'BoldSign webhook event id',
+    );
+    const type = requireVerificationString(
+      readString(event, 'eventType'),
+      'BoldSign webhook event type',
+    );
+    const normalizedType = type.toLowerCase();
+
+    if (!SUPPORTED_BOLDSIGN_DOCUMENT_EVENTS.has(normalizedType)) {
+      throw new SignatureVerificationError(
+        `Unsupported BoldSign webhook event type: ${type}`,
+      );
+    }
+    const requestId = requireVerificationString(
+      readString(data, 'documentId'),
+      'BoldSign webhook documentId',
+    );
+    const created = readNumber(event, 'created');
+
+    if (
+      created === undefined ||
+      !Number.isSafeInteger(created) ||
+      created < 0 ||
+      Number.isNaN(new Date(created * 1_000).getTime())
+    ) {
+      throw new SignatureVerificationError(
+        'BoldSign webhook event created must be an epoch timestamp.',
+      );
+    }
+
+    return {
+      id,
+      provider: BOLDSIGN_PROVIDER_ID,
+      tenantId: this.tenantId,
+      requestId,
+      type,
+      status: mapBoldSignWebhookStatus(type, readString(data, 'status')),
+      createdAt: new Date(created * 1_000),
+      environment: optionalTrimmedString(readString(event, 'environment')),
+      signers: mapBoldSignSigners(data),
+      replay: {
+        deduplicationKey: `${BOLDSIGN_PROVIDER_ID}:${this.tenantId}:${id}`,
+        orderingKey: `${BOLDSIGN_PROVIDER_ID}:${this.tenantId}:${requestId}`,
+      },
+      raw: body,
+    };
+  }
+
+  private assertTenant(tenantId: string): void {
+    const normalized = requireNonEmptyString(tenantId, 'BoldSign tenantId');
+
+    if (normalized !== this.tenantId) {
+      throw new SignatureTenantMismatchError(
+        'Signature request tenant does not match the configured BoldSign tenant.',
+      );
+    }
+  }
+
+  private assertProviderTenant(value: Record<string, unknown>): void {
+    const metadata = readBoldSignMetadata(value);
+    const providerTenantId = metadata[BOLDSIGN_TENANT_METADATA_KEY];
+
+    if (providerTenantId !== this.tenantId) {
+      throw new SignatureTenantMismatchError(
+        'BoldSign resource is missing the configured tenant binding or belongs to another tenant.',
+      );
+    }
+  }
+
+  private async request(
+    path: string,
+    options: BoldSignRequestOptions = {},
+  ): Promise<Record<string, unknown> | ReadableStream<Uint8Array> | undefined> {
+    const headers = new Headers({ Accept: 'application/json' });
+
+    if (this.apiKey) {
+      headers.set('X-API-KEY', this.apiKey);
+    } else if (this.accessToken) {
+      headers.set('Authorization', `Bearer ${this.accessToken}`);
+    }
+
+    if (options.body !== undefined) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    let response: Response;
+
+    try {
+      response = await this.fetch(`${this.apiBaseUrl}${path}`, {
+        method: options.method ?? 'GET',
+        headers,
+        body:
+          options.body === undefined ? undefined : JSON.stringify(options.body),
+        signal: options.signal,
+      });
+    } catch (error) {
+      if (error instanceof SignatureProviderError) {
+        throw error;
+      }
+
+      throw new SignatureProviderError('BoldSign API request failed.', {
+        cause: error,
+        retryable: true,
+        requestMayHaveSucceeded: options.operation === 'create',
+      });
+    }
+
+    if (!response.ok) {
+      throw await boldSignResponseError(
+        response,
+        options.operation === 'create',
+      );
+    }
+
+    if (options.expect === 'empty' || response.status === 204) {
+      return undefined;
+    }
+
+    if (options.expect === 'stream') {
+      if (!response.body) {
+        throw new SignatureProviderError(
+          'BoldSign API returned an empty artifact stream.',
+        );
+      }
+
+      return response.body;
+    }
+
+    const text = await response.text();
+
+    if (!text) {
+      throw new SignatureProviderError(
+        'BoldSign API returned an empty JSON response.',
+      );
+    }
+
+    try {
+      return requireRecord(JSON.parse(text), 'BoldSign API response');
+    } catch (error) {
+      if (error instanceof SignatureProviderError) {
+        throw error;
+      }
+
+      throw new SignatureProviderError('BoldSign API returned invalid JSON.', {
+        cause: error,
+      });
+    }
+  }
+}
+
+export interface VerifyBoldSignWebhookSignatureInput
+  extends ParseSignatureWebhookInput {
+  secrets: string | readonly string[];
+  toleranceSeconds?: number;
+  now?: Date;
+}
+
+export function verifyBoldSignWebhookSignature(
+  input: VerifyBoldSignWebhookSignatureInput,
+): void {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new SignatureVerificationError(
+      'BoldSign webhook verification input must be an object.',
+    );
+  }
+
+  if (typeof input.payload !== 'string') {
+    throw new SignatureVerificationError(
+      'BoldSign webhook payload must be a string.',
+    );
+  }
+
+  const header = verificationString(
+    input.signature,
+    'BoldSign signature header',
+  );
+  const secrets = normalizeVerificationSecrets(input.secrets);
+  const toleranceSeconds = normalizeWebhookTolerance(input.toleranceSeconds);
+  const now = input.now ?? new Date();
+
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) {
+    throw new SignatureVerificationError(
+      'BoldSign webhook verification now must be a valid Date.',
+    );
+  }
+
+  const timestamps: string[] = [];
+  const signatures: string[] = [];
+
+  for (const part of header.split(',')) {
+    const [rawKey, ...rawValue] = part.split('=');
+    const key = rawKey?.trim();
+    const value = rawValue.join('=').trim();
+
+    if (!key || !value) {
+      continue;
+    }
+
+    if (key === 't') {
+      timestamps.push(value);
+    } else if (key === 's0' || key === 's1') {
+      signatures.push(value);
+    }
+  }
+
+  if (timestamps.length !== 1 || signatures.length === 0) {
+    throw new SignatureVerificationError('Invalid BoldSign signature header.');
+  }
+
+  const timestampText = timestamps[0] ?? '';
+
+  if (!/^\d+$/.test(timestampText)) {
+    throw new SignatureVerificationError('Invalid BoldSign webhook timestamp.');
+  }
+
+  const timestamp = Number(timestampText);
+
+  if (!Number.isSafeInteger(timestamp)) {
+    throw new SignatureVerificationError('Invalid BoldSign webhook timestamp.');
+  }
+
+  const ageSeconds = Math.abs(Math.floor(now.getTime() / 1_000) - timestamp);
+
+  if (ageSeconds > toleranceSeconds) {
+    throw new SignatureVerificationError(
+      'BoldSign webhook timestamp is outside the allowed tolerance.',
+    );
+  }
+
+  const signedPayload = `${timestampText}.${input.payload}`;
+  const matched = secrets.some((secret) => {
+    const expected = Buffer.from(
+      createHmac('sha256', secret).update(signedPayload).digest('hex'),
+      'utf8',
+    );
+
+    return signatures.some((signature) => {
+      if (!/^[a-f\d]{64}$/i.test(signature)) {
+        return false;
+      }
+
+      const received = Buffer.from(signature.toLowerCase(), 'utf8');
+
+      return (
+        received.length === expected.length &&
+        timingSafeEqual(received, expected)
+      );
+    });
+  });
+
+  if (!matched) {
+    throw new SignatureVerificationError(
+      'BoldSign webhook signature did not match.',
+    );
+  }
+}
+
+function configurationString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new SignatureConfigurationError(
+      `${context} must be a non-empty string.`,
+    );
+  }
+
+  return value.trim();
+}
+
+function optionalConfigurationString(
+  value: unknown,
+  context: string,
+): string | undefined {
+  return value === undefined ? undefined : configurationString(value, context);
+}
+
+function normalizeBaseUrl(value: string): string {
+  const raw = configurationString(value, 'BoldSignAdapter apiBaseUrl');
+  let url: URL;
+
+  try {
+    url = new URL(raw);
+  } catch (error) {
+    throw new SignatureConfigurationError(
+      'BoldSignAdapter apiBaseUrl must be a valid URL.',
+      { cause: error },
+    );
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new SignatureConfigurationError(
+      'BoldSignAdapter apiBaseUrl must use HTTPS.',
+    );
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new SignatureConfigurationError(
+      'BoldSignAdapter apiBaseUrl must not contain credentials, query parameters, or a fragment.',
+    );
+  }
+
+  return url.toString().replace(/\/+$/, '');
+}
+
+function normalizeWebhookSecrets(
+  value: string | readonly string[] | undefined,
+): readonly string[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  try {
+    return normalizeVerificationSecrets(value);
+  } catch (error) {
+    throw new SignatureConfigurationError(
+      'BoldSignAdapter webhookSecrets must contain non-empty strings.',
+      { cause: error },
+    );
+  }
+}
+
+function normalizeVerificationSecrets(
+  value: string | readonly string[],
+): readonly string[] {
+  const candidates = typeof value === 'string' ? [value] : value;
+
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    throw new SignatureVerificationError(
+      'BoldSign webhook secrets must contain at least one secret.',
+    );
+  }
+
+  return candidates.map((secret) =>
+    verificationString(secret, 'BoldSign webhook secret'),
+  );
+}
+
+function normalizeWebhookTolerance(value: number | undefined): number {
+  const tolerance = value ?? DEFAULT_WEBHOOK_TOLERANCE_SECONDS;
+
+  if (!Number.isFinite(tolerance) || tolerance <= 0) {
+    throw new SignatureConfigurationError(
+      'BoldSign webhook tolerance must be a positive finite number.',
+    );
+  }
+
+  return tolerance;
+}
+
+async function normalizeDocuments(
+  documents: readonly CreateSignatureRequestInput['documents'][number][],
+  signal?: AbortSignal,
+): Promise<readonly NormalizedSignatureDocument[]> {
+  if (!Array.isArray(documents) || documents.length === 0) {
+    throw new SignatureInputError(
+      'BoldSign createRequest requires at least one document.',
+    );
+  }
+
+  if (documents.length > 25) {
+    throw new SignatureInputError(
+      'BoldSign createRequest supports at most 25 documents.',
+    );
+  }
+
+  const normalized: NormalizedSignatureDocument[] = [];
+  let totalBytes = 0;
+
+  for (const [index, document] of documents.entries()) {
+    if (!document || typeof document !== 'object') {
+      throw new SignatureInputError(
+        `BoldSign document ${index + 1} must be an object.`,
+      );
+    }
+
+    const name = requireNonEmptyString(
+      document.name,
+      `BoldSign document ${index + 1} name`,
+    );
+    const mediaType = requireNonEmptyString(
+      document.mediaType,
+      `BoldSign document ${index + 1} mediaType`,
+    );
+    const data = await readByteSource(
+      document.data,
+      `BoldSign document ${index + 1} data`,
+      signal,
+    );
+    totalBytes += data.length;
+
+    if (totalBytes > MAX_BOLDSIGN_DOCUMENT_BYTES) {
+      throw new SignatureInputError(
+        'BoldSign document files exceed the 25 MB aggregate limit.',
+      );
+    }
+
+    normalized.push({ name, mediaType, data });
+  }
+
+  return normalized;
+}
+
+function normalizeSignerInputs(
+  signers: readonly SignatureSignerInput[],
+): readonly SignatureSignerInput[] {
+  if (!Array.isArray(signers) || signers.length === 0) {
+    throw new SignatureInputError(
+      'BoldSign createRequest requires at least one signer.',
+    );
+  }
+
+  const normalized = signers.map((signer, index) => {
+    if (!signer || typeof signer !== 'object') {
+      throw new SignatureInputError(
+        `BoldSign signer ${index + 1} must be an object.`,
+      );
+    }
+
+    const name = requireNonEmptyString(
+      signer.name,
+      `BoldSign signer ${index + 1} name`,
+    );
+    const email = requireNonEmptyString(
+      signer.email,
+      `BoldSign signer ${index + 1} email`,
+    );
+
+    if (!/^\S+@\S+\.\S+$/.test(email)) {
+      throw new SignatureInputError(
+        `BoldSign signer ${index + 1} email must be valid.`,
+      );
+    }
+
+    if (!Array.isArray(signer.fields) || signer.fields.length === 0) {
+      throw new SignatureInputError(
+        `BoldSign signer ${index + 1} requires at least one field.`,
+      );
+    }
+
+    const fields = (signer.fields as readonly SignatureField[]).map(
+      (field: SignatureField, fieldIndex: number) =>
+        normalizeField(field, index, fieldIndex),
+    );
+    const order = normalizeOptionalPositiveInteger(
+      signer.order,
+      `BoldSign signer ${index + 1} order`,
+    );
+
+    return {
+      ...signer,
+      name,
+      email,
+      role: optionalTrimmedString(signer.role),
+      privateMessage: optionalTrimmedString(signer.privateMessage),
+      order,
+      authentication: normalizeAuthentication(signer.authentication, index),
+      fields,
+    };
+  });
+
+  const emails = new Set<string>();
+
+  for (const signer of normalized) {
+    const email = signer.email.toLowerCase();
+
+    if (emails.has(email)) {
+      throw new SignatureInputError(
+        'BoldSign createRequest signer emails must be unique.',
+      );
+    }
+
+    emails.add(email);
+  }
+
+  return normalized;
+}
+
+function normalizeField(
+  field: SignatureField,
+  signerIndex: number,
+  fieldIndex: number,
+): SignatureField {
+  const context = `BoldSign signer ${signerIndex + 1} field ${fieldIndex + 1}`;
+
+  if (!field || typeof field !== 'object') {
+    throw new SignatureInputError(`${context} must be an object.`);
+  }
+
+  const id = requireNonEmptyString(field.id, `${context} id`);
+
+  if (!/^[A-Za-z_]\w*$/.test(id)) {
+    throw new SignatureInputError(
+      `${context} id must start with a letter or underscore and contain only letters, digits, and underscores.`,
+    );
+  }
+
+  if (!['signature', 'initial', 'date_signed', 'text'].includes(field.type)) {
+    throw new SignatureInputError(`${context} has an unsupported type.`);
+  }
+
+  const page = normalizePositiveInteger(field.page, `${context} page`);
+
+  if (!field.bounds || typeof field.bounds !== 'object') {
+    throw new SignatureInputError(`${context} bounds must be an object.`);
+  }
+
+  const bounds = {
+    x: normalizeNonNegativeFinite(field.bounds.x, `${context} bounds.x`),
+    y: normalizeNonNegativeFinite(field.bounds.y, `${context} bounds.y`),
+    width: normalizePositiveFinite(
+      field.bounds.width,
+      `${context} bounds.width`,
+    ),
+    height: normalizePositiveFinite(
+      field.bounds.height,
+      `${context} bounds.height`,
+    ),
+  };
+
+  return {
+    id,
+    type: field.type,
+    page,
+    bounds,
+    required: field.required ?? true,
+    value: optionalTrimmedString(field.value),
+  };
+}
+
+function normalizeAuthentication(
+  value: SignatureAuthentication | undefined,
+  signerIndex: number,
+): SignatureAuthentication {
+  const authentication = value ?? { method: 'none' };
+  const context = `BoldSign signer ${signerIndex + 1} authentication`;
+
+  if (!authentication || typeof authentication !== 'object') {
+    throw new SignatureInputError(`${context} must be an object.`);
+  }
+
+  if (
+    ![
+      'none',
+      'access_code',
+      'email_otp',
+      'sms_otp',
+      'identity_verification',
+    ].includes(authentication.method)
+  ) {
+    throw new SignatureInputError(`${context} method is unsupported.`);
+  }
+
+  if (authentication.method === 'access_code') {
+    return {
+      method: 'access_code',
+      accessCode: requireNonEmptyString(
+        authentication.accessCode,
+        `${context} accessCode`,
+      ),
+    };
+  }
+
+  if (authentication.method === 'sms_otp') {
+    const phone = authentication.phone;
+
+    if (!phone || typeof phone !== 'object') {
+      throw new SignatureInputError(
+        `${context} phone is required for sms_otp.`,
+      );
+    }
+
+    const countryCode = requireNonEmptyString(
+      phone.countryCode,
+      `${context} phone.countryCode`,
+    );
+    const number = requireNonEmptyString(
+      phone.number,
+      `${context} phone.number`,
+    );
+
+    if (
+      !/^\+\d{1,3}$/.test(countryCode) ||
+      !/^\d{4,15}$/.test(number) ||
+      countryCode.length - 1 + number.length > 15
+    ) {
+      throw new SignatureInputError(
+        `${context} phone must contain an E.164 country code and national number.`,
+      );
+    }
+
+    return { method: 'sms_otp', phone: { countryCode, number } };
+  }
+
+  if (authentication.method === 'identity_verification') {
+    const settings = authentication.identityVerification ?? {};
+    const frequency = normalizeOptionalEnum(
+      settings.frequency,
+      ['every_access', 'until_signed', 'once_per_document'] as const,
+      `${context} frequency`,
+    );
+    const nameMatch = normalizeOptionalEnum(
+      settings.nameMatch,
+      ['strict', 'moderate', 'lenient'] as const,
+      `${context} nameMatch`,
+    );
+    const maximumRetryCount = normalizeOptionalIntegerRange(
+      settings.maximumRetryCount,
+      1,
+      10,
+      `${context} maximumRetryCount`,
+    );
+    const allowedDocumentTypes = normalizeOptionalEnumArray(
+      settings.allowedDocumentTypes,
+      ['passport', 'identity_card', 'driver_license'] as const,
+      `${context} allowedDocumentTypes`,
+    );
+
+    if (
+      settings.allowedCountries !== undefined &&
+      !Array.isArray(settings.allowedCountries)
+    ) {
+      throw new SignatureInputError(
+        `${context} allowedCountries must be an array.`,
+      );
+    }
+
+    const allowedCountries = settings.allowedCountries?.map((country) => {
+      const normalized = requireNonEmptyString(
+        country,
+        `${context} allowed country`,
+      ).toUpperCase();
+
+      if (!/^[A-Z]{2}$/.test(normalized)) {
+        throw new SignatureInputError(
+          `${context} allowed countries must be ISO 3166-1 alpha-2 codes.`,
+        );
+      }
+
+      return normalized;
+    });
+
+    return {
+      method: 'identity_verification',
+      identityVerification: {
+        ...settings,
+        frequency,
+        nameMatch,
+        maximumRetryCount,
+        requireLiveCapture: normalizeOptionalBoolean(
+          settings.requireLiveCapture,
+          `${context} requireLiveCapture`,
+        ),
+        requireMatchingSelfie: normalizeOptionalBoolean(
+          settings.requireMatchingSelfie,
+          `${context} requireMatchingSelfie`,
+        ),
+        allowedDocumentTypes,
+        allowedCountries,
+      },
+    };
+  }
+
+  return { method: authentication.method };
+}
+
+function normalizeMetadata(
+  metadata: Readonly<Record<string, string>> | undefined,
+  reserved: Record<string, string>,
+): Readonly<Record<string, string>> {
+  if (
+    metadata !== undefined &&
+    (!metadata || typeof metadata !== 'object' || Array.isArray(metadata))
+  ) {
+    throw new SignatureInputError('BoldSign metadata must be an object.');
+  }
+
+  const result: Record<string, string> = {};
+  const reservedKeys = new Set(Object.keys(reserved));
+
+  for (const [key, value] of Object.entries(metadata ?? {})) {
+    const normalizedKey = requireNonEmptyString(key, 'BoldSign metadata key');
+
+    if (reservedKeys.has(normalizedKey)) {
+      throw new SignatureInputError(
+        `BoldSign metadata key ${normalizedKey} is reserved.`,
+      );
+    }
+
+    if (normalizedKey.length > MAX_BOLDSIGN_METADATA_KEY_LENGTH) {
+      throw new SignatureInputError(
+        `BoldSign metadata key ${normalizedKey} exceeds ${MAX_BOLDSIGN_METADATA_KEY_LENGTH} characters.`,
+      );
+    }
+
+    if (typeof value !== 'string') {
+      throw new SignatureInputError(
+        `BoldSign metadata value for ${normalizedKey} must be a string.`,
+      );
+    }
+
+    if (value.length > MAX_BOLDSIGN_METADATA_VALUE_LENGTH) {
+      throw new SignatureInputError(
+        `BoldSign metadata value for ${normalizedKey} exceeds ${MAX_BOLDSIGN_METADATA_VALUE_LENGTH} characters.`,
+      );
+    }
+
+    result[normalizedKey] = value;
+  }
+
+  for (const [key, value] of Object.entries(reserved)) {
+    if (value.length > MAX_BOLDSIGN_METADATA_VALUE_LENGTH) {
+      throw new SignatureInputError(
+        `BoldSign ${key} exceeds ${MAX_BOLDSIGN_METADATA_VALUE_LENGTH} characters.`,
+      );
+    }
+
+    result[key] = value;
+  }
+
+  if (Object.keys(result).length > MAX_BOLDSIGN_METADATA_ENTRIES) {
+    throw new SignatureInputError(
+      `BoldSign metadata supports at most ${MAX_BOLDSIGN_METADATA_ENTRIES} entries including tenant and idempotency bindings.`,
+    );
+  }
+
+  return result;
+}
+
+function normalizeExpiryDays(value: number | undefined): number {
+  const days = value ?? 60;
+
+  if (
+    !Number.isSafeInteger(days) ||
+    days < MIN_EXPIRY_DAYS ||
+    days > MAX_EXPIRY_DAYS
+  ) {
+    throw new SignatureInputError(
+      `BoldSign expiresInDays must be an integer from ${MIN_EXPIRY_DAYS} to ${MAX_EXPIRY_DAYS}.`,
+    );
+  }
+
+  return days;
+}
+
+function toBoldSignSigner(
+  signer: SignatureSignerInput,
+): Record<string, unknown> {
+  const authentication = signer.authentication ?? { method: 'none' as const };
+  const result: Record<string, unknown> = {
+    Name: signer.name,
+    EmailAddress: signer.email,
+    SignerType: 'Signer',
+    SignerRole: signer.role,
+    Order: signer.order,
+    PrivateMessage: signer.privateMessage,
+    Locale: 'EN',
+    FormFields: signer.fields.map((field) => ({
+      Id: field.id,
+      Name: field.id,
+      FieldType: toBoldSignFieldType(field.type),
+      PageNumber: field.page,
+      Bounds: {
+        X: field.bounds.x,
+        Y: field.bounds.y,
+        Width: field.bounds.width,
+        Height: field.bounds.height,
+      },
+      IsRequired: field.required ?? true,
+      Value: field.value,
+    })),
+    ...toBoldSignAuthentication(authentication),
+  };
+
+  return withoutUndefined(result);
+}
+
+function toBoldSignFieldType(type: SignatureField['type']): string {
+  switch (type) {
+    case 'signature':
+      return 'Signature';
+    case 'initial':
+      return 'Initial';
+    case 'date_signed':
+      return 'DateSigned';
+    case 'text':
+      return 'TextBox';
+  }
+}
+
+function toBoldSignAuthentication(
+  authentication: SignatureAuthentication,
+): Record<string, unknown> {
+  switch (authentication.method) {
+    case 'access_code':
+      return {
+        AuthenticationType: 'AccessCode',
+        AuthenticationCode: authentication.accessCode,
+      };
+    case 'email_otp':
+      return { AuthenticationType: 'EmailOTP', EnableEmailOTP: true };
+    case 'sms_otp':
+      return {
+        AuthenticationType: 'SMSOTP',
+        PhoneNumber: authentication.phone
+          ? {
+              CountryCode: authentication.phone.countryCode,
+              Number: authentication.phone.number,
+            }
+          : undefined,
+      };
+    case 'identity_verification':
+      return {
+        AuthenticationType: 'IdVerification',
+        IdentityVerificationSettings: toBoldSignIdentityVerification(
+          authentication.identityVerification,
+        ),
+      };
+    case 'none':
+      return { AuthenticationType: 'None' };
+  }
+}
+
+function toBoldSignIdentityVerification(
+  settings: SignatureAuthentication['identityVerification'],
+): Record<string, unknown> {
+  return withoutUndefined({
+    Type:
+      settings?.frequency === undefined
+        ? undefined
+        : {
+            every_access: 'EveryAccess',
+            until_signed: 'UntilSignCompleted',
+            once_per_document: 'OncePerDocument',
+          }[settings.frequency],
+    MaximumRetryCount: settings?.maximumRetryCount,
+    RequireLiveCapture: settings?.requireLiveCapture,
+    RequireMatchingSelfie: settings?.requireMatchingSelfie,
+    NameMatcher:
+      settings?.nameMatch === undefined
+        ? undefined
+        : {
+            strict: 'Strict',
+            moderate: 'Moderate',
+            lenient: 'Lenient',
+          }[settings.nameMatch],
+    AllowedDocumentTypes: settings?.allowedDocumentTypes?.map(
+      (type) =>
+        ({
+          passport: 'Passport',
+          identity_card: 'IDCard',
+          driver_license: 'DriverLicense',
+        })[type],
+    ),
+    AllowedCountries: settings?.allowedCountries,
+  });
+}
+
+function inputSignerToResult(signer: SignatureSignerInput): SignatureSigner {
+  return {
+    name: signer.name,
+    email: signer.email,
+    role: signer.role,
+    order: signer.order,
+    status: 'pending',
+    authenticationMethod: signer.authentication?.method ?? 'none',
+  };
+}
+
+function mapBoldSignRequest(
+  value: Record<string, unknown>,
+  tenantId: string,
+): SignatureRequest {
+  const id = requireProviderString(
+    readString(value, 'documentId'),
+    'BoldSign document properties documentId',
+  );
+  const createdAt = parseOptionalEpochSeconds(value.createdDate);
+  const expiresAt = parseBoldSignExpiry(value, createdAt);
+
+  return {
+    provider: BOLDSIGN_PROVIDER_ID,
+    tenantId,
+    id,
+    status: mapBoldSignStatus(readString(value, 'status')),
+    title: optionalTrimmedString(readString(value, 'messageTitle')),
+    signers: mapBoldSignSigners(value),
+    createdAt,
+    expiresAt,
+    metadata: readBoldSignMetadata(value),
+    raw: value,
+  };
+}
+
+function mapBoldSignSigners(value: Record<string, unknown>): SignatureSigner[] {
+  return readRecords(value, 'signerDetails').map((signer) => ({
+    id: optionalTrimmedString(readString(signer, 'id')),
+    name: requireProviderString(
+      readString(signer, 'signerName'),
+      'BoldSign signer name',
+    ),
+    email: requireProviderString(
+      readString(signer, 'signerEmail'),
+      'BoldSign signer email',
+    ),
+    role: optionalTrimmedString(readString(signer, 'signerRole')),
+    order: readNumber(signer, 'order'),
+    status: mapBoldSignSignerStatus(
+      readString(signer, 'status'),
+      readBoolean(signer, 'isDeliveryFailed'),
+      readBoolean(signer, 'isViewed'),
+      readBoolean(signer, 'isAuthenticationFailed') === true ||
+        readString(readRecord(signer, 'idVerification'), 'status')
+          ?.trim()
+          .toLowerCase() === 'failed',
+    ),
+    authenticationMethod: mapBoldSignAuthentication(
+      readString(signer, 'authenticationType'),
+    ),
+    viewed: readBoolean(signer, 'isViewed'),
+    deliveryFailed: readBoolean(signer, 'isDeliveryFailed'),
+  }));
+}
+
+function mapBoldSignStatus(value: string | undefined): SignatureRequestStatus {
+  switch (value?.trim().toLowerCase()) {
+    case 'draft':
+      return 'prepared';
+    case 'inprogress':
+    case 'in_progress':
+    case 'sent':
+    case 'needsattention':
+    case 'needs_attention':
+    case 'needs attention':
+      return 'sent';
+    case 'viewed':
+      return 'viewed';
+    case 'partiallysigned':
+    case 'partially_signed':
+      return 'partially_signed';
+    case 'completed':
+      return 'completed';
+    case 'declined':
+      return 'declined';
+    case 'revoked':
+    case 'cancelled':
+    case 'canceled':
+      return 'cancelled';
+    case 'expired':
+      return 'expired';
+    case 'failed':
+    case 'sendfailed':
+      return 'failed';
+    default:
+      throw new SignatureProviderError(
+        `Unsupported BoldSign document status: ${value ?? '<missing>'}`,
+      );
+  }
+}
+
+function mapBoldSignWebhookStatus(
+  eventType: string,
+  documentStatus: string | undefined,
+): SignatureRequestStatus {
+  switch (eventType.trim().toLowerCase()) {
+    case 'sent':
+      return 'sent';
+    case 'delivered':
+      return 'delivered';
+    case 'viewed':
+      return 'viewed';
+    case 'signed':
+      return documentStatus?.toLowerCase() === 'completed'
+        ? 'completed'
+        : 'partially_signed';
+    case 'completed':
+      return 'completed';
+    case 'declined':
+      return 'declined';
+    case 'revoked':
+      return 'cancelled';
+    case 'expired':
+      return 'expired';
+    case 'sendfailed':
+      return 'failed';
+    default:
+      return mapBoldSignStatus(documentStatus);
+  }
+}
+
+function mapBoldSignSignerStatus(
+  value: string | undefined,
+  deliveryFailed: boolean | undefined,
+  viewed: boolean | undefined,
+  authenticationFailed = false,
+): SignatureSignerStatus {
+  if (deliveryFailed || authenticationFailed) {
+    return 'failed';
+  }
+
+  switch (value?.trim().toLowerCase()) {
+    case 'notcompleted':
+    case 'not_completed':
+    case 'pending':
+      return viewed ? 'viewed' : 'pending';
+    case 'completed':
+    case 'signed':
+      return 'signed';
+    case 'declined':
+      return 'declined';
+    case 'expired':
+      return 'expired';
+    case 'failed':
+    case 'authenticationfailed':
+      return 'failed';
+    default:
+      throw new SignatureProviderError(
+        `Unsupported BoldSign signer status: ${value ?? '<missing>'}`,
+      );
+  }
+}
+
+function mapBoldSignAuthentication(
+  value: string | undefined,
+): SignatureAuthenticationMethod | undefined {
+  switch (value?.trim().toLowerCase()) {
+    case 'none':
+      return 'none';
+    case 'accesscode':
+      return 'access_code';
+    case 'emailotp':
+      return 'email_otp';
+    case 'smsotp':
+      return 'sms_otp';
+    case 'idverification':
+      return 'identity_verification';
+    default:
+      return undefined;
+  }
+}
+
+function readBoldSignMetadata(
+  value: Record<string, unknown>,
+): Record<string, string> {
+  const metadata =
+    readRecord(value, 'metaData') ??
+    readRecord(value, 'metadata') ??
+    readRecord(value, 'MetaData') ??
+    {};
+  const result: Record<string, string> = {};
+
+  for (const [key, item] of Object.entries(metadata)) {
+    if (typeof item === 'string') {
+      result[key] = item;
+    }
+  }
+
+  return result;
+}
+
+function parseBoldSignExpiry(
+  value: Record<string, unknown>,
+  createdAt: Date | undefined,
+): Date | undefined {
+  const raw = value.expiryDate;
+
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return new Date(raw * 1_000);
+  }
+
+  if (typeof raw === 'string' && raw.trim()) {
+    const date = new Date(raw);
+
+    if (!Number.isNaN(date.getTime())) {
+      return date;
+    }
+  }
+
+  const expiryDays = readNumber(value, 'expiryDays');
+
+  return createdAt && expiryDays !== undefined
+    ? new Date(createdAt.getTime() + expiryDays * 24 * 60 * 60 * 1_000)
+    : undefined;
+}
+
+async function boldSignResponseError(
+  response: Response,
+  createOperation: boolean,
+): Promise<SignatureProviderError> {
+  const text = await response.text();
+  let body: Record<string, unknown> | undefined;
+
+  if (text) {
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      body =
+        parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : undefined;
+    } catch {
+      body = undefined;
+    }
+  }
+
+  const nestedError = body ? readRecord(body, 'error') : undefined;
+  const message =
+    optionalTrimmedString(readString(body, 'message')) ??
+    optionalTrimmedString(readString(nestedError, 'message')) ??
+    `HTTP ${response.status}`;
+  const retryable =
+    response.status === 408 ||
+    response.status === 425 ||
+    response.status === 429 ||
+    response.status >= 500;
+
+  return new SignatureProviderError(`BoldSign API: ${message}`, {
+    status: response.status,
+    retryable,
+    retryAfterMs: parseRetryAfter(response.headers.get('Retry-After')),
+    requestMayHaveSucceeded:
+      createOperation && (response.status === 408 || response.status >= 500),
+  });
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const seconds = Number(value);
+
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1_000);
+  }
+
+  const date = new Date(value);
+
+  return Number.isNaN(date.getTime())
+    ? undefined
+    : Math.max(0, date.getTime() - Date.now());
+}
+
+function normalizePositiveInteger(value: number, context: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new SignatureInputError(`${context} must be a positive integer.`);
+  }
+
+  return value;
+}
+
+function normalizeOptionalPositiveInteger(
+  value: number | undefined,
+  context: string,
+): number | undefined {
+  return value === undefined
+    ? undefined
+    : normalizePositiveInteger(value, context);
+}
+
+function normalizeOptionalIntegerRange(
+  value: number | undefined,
+  min: number,
+  max: number,
+  context: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new SignatureInputError(
+      `${context} must be an integer from ${min} to ${max}.`,
+    );
+  }
+
+  return value;
+}
+
+function normalizeOptionalBoolean(
+  value: boolean | undefined,
+  context: string,
+): boolean | undefined {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new SignatureInputError(`${context} must be a boolean.`);
+  }
+
+  return value;
+}
+
+function normalizeOptionalEnum<const T extends string>(
+  value: T | undefined,
+  allowed: readonly T[],
+  context: string,
+): T | undefined {
+  if (value !== undefined && !allowed.includes(value)) {
+    throw new SignatureInputError(
+      `${context} must be one of ${allowed.join(', ')}.`,
+    );
+  }
+
+  return value;
+}
+
+function normalizeOptionalEnumArray<const T extends string>(
+  value: readonly T[] | undefined,
+  allowed: readonly T[],
+  context: string,
+): readonly T[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new SignatureInputError(`${context} must be an array.`);
+  }
+
+  return value.map((item) => {
+    const normalized = normalizeOptionalEnum(item, allowed, context);
+
+    if (normalized === undefined) {
+      throw new SignatureInputError(`${context} must not contain undefined.`);
+    }
+
+    return normalized;
+  });
+}
+
+function normalizeNonNegativeFinite(value: number, context: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new SignatureInputError(
+      `${context} must be a non-negative finite number.`,
+    );
+  }
+
+  return value;
+}
+
+function normalizePositiveFinite(value: number, context: string): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new SignatureInputError(
+      `${context} must be a positive finite number.`,
+    );
+  }
+
+  return value;
+}
+
+function optionalTrimmedString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function requireProviderString(
+  value: string | undefined,
+  context: string,
+): string {
+  if (!value?.trim()) {
+    throw new SignatureProviderError(`${context} must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function verificationString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new SignatureVerificationError(
+      `${context} must be a non-empty string.`,
+    );
+  }
+
+  return value.trim();
+}
+
+function requireVerificationString(
+  value: string | undefined,
+  context: string,
+): string {
+  return verificationString(value, context);
+}
+
+function verificationRecord(
+  value: unknown,
+  context: string,
+): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new SignatureVerificationError(`${context} must be an object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function withoutUndefined(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined),
+  );
+}
+
+function safeFilename(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, '_').slice(0, 120) || 'document';
+}
+
+interface NormalizedSignatureDocument {
+  name: string;
+  mediaType: string;
+  data: Uint8Array;
+}
+
+async function readByteSource(
+  source: CreateSignatureRequestInput['documents'][number]['data'],
+  context: string,
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  if (source instanceof Uint8Array) {
+    if (source.length === 0) {
+      throw new SignatureInputError(`${context} must not be empty.`);
+    }
+
+    if (source.length > MAX_BOLDSIGN_DOCUMENT_BYTES) {
+      throw new SignatureInputError(
+        `${context} exceeds BoldSign's 25 MB limit.`,
+      );
+    }
+
+    return source;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const append = (chunk: unknown) => {
+    signal?.throwIfAborted();
+
+    if (!(chunk instanceof Uint8Array) || chunk.length === 0) {
+      throw new SignatureInputError(
+        `${context} stream must yield non-empty Uint8Array chunks.`,
+      );
+    }
+
+    total += chunk.length;
+
+    if (total > MAX_BOLDSIGN_DOCUMENT_BYTES) {
+      throw new SignatureInputError(
+        `${context} exceeds BoldSign's 25 MB limit.`,
+      );
+    }
+
+    chunks.push(chunk);
+  };
+
+  signal?.throwIfAborted();
+
+  if (isReadableStream(source)) {
+    const reader = source.getReader();
+
+    try {
+      while (true) {
+        const result = await reader.read();
+
+        if (result.done) {
+          break;
+        }
+
+        append(result.value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  } else if (isAsyncIterable(source)) {
+    for await (const chunk of source) {
+      append(chunk);
+    }
+  } else {
+    throw new SignatureInputError(
+      `${context} must be a Uint8Array, ReadableStream, or AsyncIterable.`,
+    );
+  }
+
+  if (total === 0) {
+    throw new SignatureInputError(`${context} must not be empty.`);
+  }
+
+  const result = new Uint8Array(total);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result;
+}
+
+function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    typeof (value as { getReader?: unknown }).getReader === 'function'
+  );
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<Uint8Array> {
+  return (
+    value !== null &&
+    value !== undefined &&
+    typeof value === 'object' &&
+    Symbol.asyncIterator in value
+  );
+}
+
+function createSha256Stream(source: ReadableStream<Uint8Array>): {
+  stream: ReadableStream<Uint8Array>;
+  sha256: Promise<string>;
+} {
+  const reader = source.getReader();
+  const hash = createHash('sha256');
+  let settled = false;
+  let resolveHash: (value: string) => void;
+  let rejectHash: (reason?: unknown) => void;
+  const sha256 = new Promise<string>((resolve, reject) => {
+    resolveHash = resolve;
+    rejectHash = reject;
+  });
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+
+        if (result.done) {
+          settled = true;
+          resolveHash(hash.digest('hex'));
+          controller.close();
+          return;
+        }
+
+        hash.update(result.value);
+        controller.enqueue(result.value);
+      } catch (error) {
+        settled = true;
+        rejectHash(error);
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        if (!settled) {
+          settled = true;
+          rejectHash(
+            new SignatureProviderError(
+              'BoldSign artifact stream was cancelled before hashing completed.',
+            ),
+          );
+        }
+      }
+    },
+  });
+
+  return { stream, sha256 };
+}
+
+function isTerminalStatus(status: SignatureRequestStatus): boolean {
+  return ['completed', 'declined', 'cancelled', 'expired', 'failed'].includes(
+    status,
+  );
+}

--- a/packages/signatures/src/adapters/boldsign.ts
+++ b/packages/signatures/src/adapters/boldsign.ts
@@ -1384,8 +1384,6 @@ function mapBoldSignWebhookStatus(
   switch (eventType.trim().toLowerCase()) {
     case 'sent':
       return 'sent';
-    case 'delivered':
-      return 'delivered';
     case 'viewed':
       return 'viewed';
     case 'signed':

--- a/packages/signatures/src/boldsign.test.ts
+++ b/packages/signatures/src/boldsign.test.ts
@@ -1,0 +1,1018 @@
+// biome-ignore-all lint/style/useNamingConvention: Fixtures assert BoldSign's documented PascalCase wire fields.
+import { createHmac } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BOLDSIGN_IDEMPOTENCY_METADATA_KEY,
+  BOLDSIGN_TENANT_METADATA_KEY,
+  BoldSignAdapter,
+  verifyBoldSignWebhookSignature,
+} from './adapters/boldsign.js';
+import {
+  SignatureConfigurationError,
+  SignatureInputError,
+  SignatureProviderError,
+  SignatureTenantMismatchError,
+  SignatureVerificationError,
+} from './errors.js';
+import { createSignatureProvider } from './factory.js';
+import type { CreateSignatureRequestInput, SignatureFetch } from './index.js';
+
+const tenantId = 'tenant_123';
+const apiKey = 'api-key-secret';
+const webhookSecret = 'webhook-secret';
+const now = new Date('2026-07-14T20:00:00.000Z');
+
+function jsonResponse(body: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function propertiesResponse(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    documentId: 'doc_123',
+    messageTitle: 'Referral Agreement',
+    status: 'Completed',
+    createdDate: 1_752_523_200,
+    expiryDays: 30,
+    metaData: {
+      [BOLDSIGN_TENANT_METADATA_KEY]: tenantId,
+      [BOLDSIGN_IDEMPOTENCY_METADATA_KEY]: 'agreement:v1',
+    },
+    signerDetails: [
+      {
+        id: 'signer_1',
+        signerName: 'Alex Example',
+        signerEmail: 'alex@example.com',
+        signerRole: 'Referrer',
+        status: 'Completed',
+        authenticationType: 'EmailOTP',
+        isViewed: true,
+        isDeliveryFailed: false,
+        order: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function baseInput(
+  overrides: Partial<CreateSignatureRequestInput> = {},
+): CreateSignatureRequestInput {
+  return {
+    tenantId,
+    idempotencyKey: 'agreement:v1',
+    title: 'Referral Agreement',
+    message: 'Please sign.',
+    documents: [
+      {
+        name: 'agreement.pdf',
+        mediaType: 'application/pdf',
+        data: new Uint8Array([37, 80, 68, 70]),
+      },
+    ],
+    signers: [
+      {
+        name: 'Alex Example',
+        email: 'alex@example.com',
+        role: 'Referrer',
+        order: 1,
+        authentication: { method: 'email_otp' },
+        fields: [
+          {
+            id: 'referrer_signature',
+            type: 'signature',
+            page: 2,
+            bounds: { x: 72, y: 600, width: 180, height: 36 },
+          },
+        ],
+      },
+    ],
+    signingOrder: true,
+    expiresInDays: 30,
+    metadata: { agreementVersionId: 'version_1' },
+    ...overrides,
+  };
+}
+
+function baseSigner() {
+  const signer = baseInput().signers[0];
+
+  if (!signer) {
+    throw new Error('Test fixture signer is missing.');
+  }
+
+  return signer;
+}
+
+function adapter(
+  fetch: SignatureFetch,
+  overrides: Partial<ConstructorParameters<typeof BoldSignAdapter>[0]> = {},
+) {
+  return new BoldSignAdapter({
+    tenantId,
+    apiKey,
+    webhookSecrets: webhookSecret,
+    fetch,
+    now: () => now,
+    ...overrides,
+  });
+}
+
+function webhookPayload(
+  eventType = 'Signed',
+  overrides: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    event: {
+      id: 'event_123',
+      eventType,
+      created: Math.floor(now.getTime() / 1_000),
+      environment: 'Test',
+    },
+    data: {
+      object: 'document',
+      documentId: 'doc_123',
+      status: 'InProgress',
+      metaData: { [BOLDSIGN_TENANT_METADATA_KEY]: tenantId },
+      signerDetails: [
+        {
+          id: 'signer_1',
+          signerName: 'Alex Example',
+          signerEmail: 'alex@example.com',
+          status: 'Completed',
+          authenticationType: 'EmailOTP',
+          isViewed: true,
+        },
+      ],
+      ...overrides,
+    },
+  });
+}
+
+function webhookSignature(
+  payload: string,
+  secret = webhookSecret,
+  timestamp = Math.floor(now.getTime() / 1_000),
+  key = 's0',
+): string {
+  const signature = createHmac('sha256', secret)
+    .update(`${timestamp}.${payload}`)
+    .digest('hex');
+
+  return `t=${timestamp},${key}=${signature}`;
+}
+
+async function readStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+describe('BoldSignAdapter configuration', () => {
+  it('defaults to the Canadian region and discloses provider idempotency limits', () => {
+    const provider = adapter(vi.fn());
+
+    expect(provider.capabilities).toMatchObject({
+      id: 'boldsign',
+      region: 'ca',
+      providerEnforcedIdempotency: false,
+      supportsAuditTrail: true,
+    });
+  });
+
+  it('requires exactly one authentication credential', () => {
+    expect(
+      () =>
+        new BoldSignAdapter({
+          tenantId,
+          apiKey,
+          accessToken: 'token',
+          fetch: vi.fn(),
+        }),
+    ).toThrow('exactly one of apiKey or accessToken');
+    expect(() => new BoldSignAdapter({ tenantId, fetch: vi.fn() })).toThrow(
+      'exactly one of apiKey or accessToken',
+    );
+  });
+
+  it('rejects blank webhook secrets and non-HTTPS endpoints', () => {
+    expect(() => adapter(vi.fn(), { webhookSecrets: [' '] })).toThrow(
+      SignatureConfigurationError,
+    );
+    expect(() =>
+      adapter(vi.fn(), { apiBaseUrl: 'http://api.example/v1' }),
+    ).toThrow('must use HTTPS');
+    expect(() =>
+      adapter(vi.fn(), { apiBaseUrl: 'https://user@example.com/v1?debug=1' }),
+    ).toThrow('must not contain credentials');
+  });
+});
+
+describe('BoldSignAdapter createRequest', () => {
+  it('sends the provider-neutral request to the Canadian JSON API', async () => {
+    const signal = new AbortController().signal;
+    const fetch = vi.fn(async () =>
+      jsonResponse({ documentId: 'doc_123' }, 201),
+    );
+    const provider = adapter(fetch);
+
+    const result = await provider.createRequest(baseInput({ signal }));
+
+    expect(result).toMatchObject({
+      provider: 'boldsign',
+      tenantId,
+      id: 'doc_123',
+      status: 'prepared',
+      title: 'Referral Agreement',
+      metadata: {
+        agreementVersionId: 'version_1',
+        [BOLDSIGN_TENANT_METADATA_KEY]: tenantId,
+        [BOLDSIGN_IDEMPOTENCY_METADATA_KEY]: 'agreement:v1',
+      },
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetch.mock.calls[0] ?? [];
+    expect(url).toBe('https://api-ca.boldsign.com/v1/document/send');
+    expect(init?.method).toBe('POST');
+    expect(init?.signal).toBe(signal);
+    const headers = new Headers(init?.headers);
+    expect(headers.get('X-API-KEY')).toBe(apiKey);
+    expect(headers.get('Authorization')).toBeNull();
+    const body = JSON.parse(String(init?.body));
+    expect(body).toMatchObject({
+      Title: 'Referral Agreement',
+      EnableSigningOrder: true,
+      ExpiryDateType: 'Days',
+      ExpiryValue: 30,
+      MetaData: {
+        agreementVersionId: 'version_1',
+        [BOLDSIGN_TENANT_METADATA_KEY]: tenantId,
+        [BOLDSIGN_IDEMPOTENCY_METADATA_KEY]: 'agreement:v1',
+      },
+    });
+    expect(body.Files).toEqual([
+      {
+        base64: 'data:application/pdf;base64,JVBERg==',
+        fileName: 'agreement.pdf',
+      },
+    ]);
+    expect(body.Signers[0]).toMatchObject({
+      Name: 'Alex Example',
+      EmailAddress: 'alex@example.com',
+      SignerRole: 'Referrer',
+      AuthenticationType: 'EmailOTP',
+      EnableEmailOTP: true,
+      FormFields: [
+        {
+          Id: 'referrer_signature',
+          FieldType: 'Signature',
+          PageNumber: 2,
+          Bounds: { X: 72, Y: 600, Width: 180, Height: 36 },
+        },
+      ],
+    });
+  });
+
+  it('supports OAuth bearer credentials without leaking them into the body', async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse({ documentId: 'doc_123' }, 201),
+    );
+    const provider = adapter(fetch, {
+      apiKey: undefined,
+      accessToken: 'oauth-secret',
+    });
+
+    await provider.createRequest(baseInput());
+
+    const [, init] = fetch.mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer oauth-secret');
+    expect(headers.get('X-API-KEY')).toBeNull();
+    expect(String(init?.body)).not.toContain('oauth-secret');
+  });
+
+  it('accepts ReadableStream and AsyncIterable document sources', async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse({ documentId: 'doc_123' }, 201),
+    );
+    const provider = adapter(fetch);
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([37, 80]));
+        controller.enqueue(new Uint8Array([68, 70]));
+        controller.close();
+      },
+    });
+    async function* iterable() {
+      yield new Uint8Array([1, 2]);
+      yield new Uint8Array([3]);
+    }
+
+    await provider.createRequest(
+      baseInput({
+        documents: [
+          { name: 'one.pdf', mediaType: 'application/pdf', data: readable },
+          { name: 'two.pdf', mediaType: 'application/pdf', data: iterable() },
+        ],
+      }),
+    );
+
+    const body = JSON.parse(String(fetch.mock.calls[0]?.[1]?.body));
+    expect(body.Files).toEqual([
+      {
+        base64: 'data:application/pdf;base64,JVBERg==',
+        fileName: 'one.pdf',
+      },
+      {
+        base64: 'data:application/pdf;base64,AQID',
+        fileName: 'two.pdf',
+      },
+    ]);
+  });
+
+  it("enforces BoldSign's aggregate document-size limit", async () => {
+    const provider = adapter(vi.fn());
+    const thirteenMegabytes = new Uint8Array(13 * 1024 * 1024);
+
+    await expect(
+      provider.createRequest(
+        baseInput({
+          documents: [
+            {
+              name: 'one.pdf',
+              mediaType: 'application/pdf',
+              data: thirteenMegabytes,
+            },
+            {
+              name: 'two.pdf',
+              mediaType: 'application/pdf',
+              data: thirteenMegabytes,
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow('25 MB aggregate limit');
+  });
+
+  it('normalizes access-code, SMS OTP, and identity verification inputs', async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse({ documentId: 'doc_123' }, 201),
+    );
+    const provider = adapter(fetch);
+    const signers = [
+      {
+        ...baseSigner(),
+        email: 'one@example.com',
+        authentication: { method: 'access_code' as const, accessCode: '4821' },
+      },
+      {
+        ...baseSigner(),
+        email: 'two@example.com',
+        authentication: {
+          method: 'sms_otp' as const,
+          phone: { countryCode: '+1', number: '4035550101' },
+        },
+      },
+      {
+        ...baseSigner(),
+        email: 'three@example.com',
+        authentication: {
+          method: 'identity_verification' as const,
+          identityVerification: {
+            frequency: 'once_per_document' as const,
+            maximumRetryCount: 3,
+            allowedDocumentTypes: ['passport' as const],
+            allowedCountries: ['ca'],
+          },
+        },
+      },
+    ];
+
+    await provider.createRequest(baseInput({ signers }));
+
+    const body = JSON.parse(String(fetch.mock.calls[0]?.[1]?.body));
+    expect(body.Signers[0]).toMatchObject({
+      AuthenticationType: 'AccessCode',
+      AuthenticationCode: '4821',
+    });
+    expect(body.Signers[1]).toMatchObject({
+      AuthenticationType: 'SMSOTP',
+      PhoneNumber: { CountryCode: '+1', Number: '4035550101' },
+    });
+    expect(body.Signers[2]).toMatchObject({
+      AuthenticationType: 'IdVerification',
+      IdentityVerificationSettings: {
+        Type: 'OncePerDocument',
+        MaximumRetryCount: 3,
+        AllowedDocumentTypes: ['Passport'],
+        AllowedCountries: ['CA'],
+      },
+    });
+  });
+
+  it('enforces tenant, idempotency, signer identity, and metadata boundaries', async () => {
+    const provider = adapter(vi.fn());
+
+    await expect(
+      provider.createRequest(baseInput({ tenantId: 'other_tenant' })),
+    ).rejects.toThrow(SignatureTenantMismatchError);
+    await expect(
+      provider.createRequest(baseInput({ idempotencyKey: ' ' })),
+    ).rejects.toThrow(SignatureInputError);
+    await expect(
+      provider.createRequest(
+        baseInput({
+          metadata: { [BOLDSIGN_TENANT_METADATA_KEY]: 'spoofed' },
+        }),
+      ),
+    ).rejects.toThrow('is reserved');
+    await expect(
+      provider.createRequest(
+        baseInput({
+          signers: [
+            {
+              ...baseSigner(),
+              authentication: { method: 'access_code' },
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow('accessCode');
+    await expect(
+      provider.createRequest(
+        baseInput({
+          signers: [
+            {
+              ...baseSigner(),
+              authentication: {
+                method: 'sms_otp',
+                phone: { countryCode: '+123', number: '123456789012345' },
+              },
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow('E.164');
+    await expect(
+      provider.createRequest(
+        baseInput({
+          signers: [
+            {
+              ...baseSigner(),
+              authentication: {
+                method: 'identity_verification',
+                identityVerification: {
+                  allowedDocumentTypes: ['future_type' as never],
+                },
+              },
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow('allowedDocumentTypes');
+  });
+
+  it('marks ambiguous transport and server failures for reconciliation', async () => {
+    const failedFetch = vi.fn(async () => {
+      throw new Error(`network failed near ${apiKey}`);
+    });
+    const provider = adapter(failedFetch);
+
+    const transportError = await provider
+      .createRequest(baseInput())
+      .catch((error: unknown) => error);
+    expect(transportError).toBeInstanceOf(SignatureProviderError);
+    expect(transportError).toMatchObject({
+      retryable: true,
+      requestMayHaveSucceeded: true,
+    });
+    expect(String(transportError)).not.toContain(apiKey);
+
+    const serverProvider = adapter(
+      vi.fn(async () =>
+        jsonResponse({ message: 'temporarily unavailable' }, 503),
+      ),
+    );
+    const serverError = await serverProvider
+      .createRequest(baseInput())
+      .catch((error: unknown) => error);
+    expect(serverError).toMatchObject({
+      status: 503,
+      retryable: true,
+      requestMayHaveSucceeded: true,
+    });
+  });
+
+  it('surfaces rate-limit retry guidance without treating it as accepted', async () => {
+    const provider = adapter(
+      vi.fn(async () =>
+        jsonResponse({ message: 'too many requests' }, 429, {
+          'Retry-After': '15',
+        }),
+      ),
+    );
+
+    const error = await provider
+      .createRequest(baseInput())
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      status: 429,
+      retryable: true,
+      retryAfterMs: 15_000,
+      requestMayHaveSucceeded: false,
+    });
+  });
+});
+
+describe('BoldSignAdapter lifecycle and evidence', () => {
+  it('maps provider properties into the normalized lifecycle', async () => {
+    const provider = adapter(
+      vi.fn(async () => jsonResponse(propertiesResponse())),
+    );
+
+    const result = await provider.getRequest({
+      tenantId,
+      requestId: 'doc_123',
+    });
+
+    expect(result).toMatchObject({
+      id: 'doc_123',
+      tenantId,
+      status: 'completed',
+      title: 'Referral Agreement',
+      signers: [
+        {
+          id: 'signer_1',
+          name: 'Alex Example',
+          email: 'alex@example.com',
+          role: 'Referrer',
+          status: 'signed',
+          authenticationMethod: 'email_otp',
+          viewed: true,
+        },
+      ],
+    });
+    expect(result.createdAt?.toISOString()).toBe('2025-07-14T20:00:00.000Z');
+    expect(result.expiresAt?.toISOString()).toBe('2025-08-13T20:00:00.000Z');
+  });
+
+  it('fails closed on unknown provider lifecycle and signer statuses', async () => {
+    const unknownDocument = adapter(
+      vi.fn(async () =>
+        jsonResponse(propertiesResponse({ status: 'FutureStatus' })),
+      ),
+    );
+    const unknownSigner = adapter(
+      vi.fn(async () =>
+        jsonResponse(
+          propertiesResponse({
+            signerDetails: [
+              {
+                signerName: 'Alex Example',
+                signerEmail: 'alex@example.com',
+                status: 'FutureSignerStatus',
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    await expect(
+      unknownDocument.getRequest({ tenantId, requestId: 'doc_123' }),
+    ).rejects.toThrow('Unsupported BoldSign document status');
+    await expect(
+      unknownSigner.getRequest({ tenantId, requestId: 'doc_123' }),
+    ).rejects.toThrow('Unsupported BoldSign signer status');
+  });
+
+  it('rejects reads when provider metadata lacks the tenant binding', async () => {
+    const provider = adapter(
+      vi.fn(async () =>
+        jsonResponse(propertiesResponse({ metaData: { hvTenantId: 'other' } })),
+      ),
+    );
+
+    await expect(
+      provider.getRequest({ tenantId, requestId: 'doc_123' }),
+    ).rejects.toThrow(SignatureTenantMismatchError);
+  });
+
+  it('verifies ownership before cancelling and requires a reason', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(propertiesResponse({ status: 'InProgress' })),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const provider = adapter(fetch);
+
+    const result = await provider.cancelRequest({
+      tenantId,
+      requestId: 'doc_123',
+      reason: 'Agreement superseded',
+    });
+
+    expect(result.status).toBe('cancelled');
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[1]?.[0]).toBe(
+      'https://api-ca.boldsign.com/v1/document/revoke?documentId=doc_123',
+    );
+    expect(JSON.parse(String(fetch.mock.calls[1]?.[1]?.body))).toEqual({
+      Message: 'Agreement superseded',
+    });
+
+    await expect(
+      provider.cancelRequest({ tenantId, requestId: 'doc_123', reason: ' ' }),
+    ).rejects.toThrow('cancellation reason');
+  });
+
+  it('extends expiry only to a future timestamp after ownership verification', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          propertiesResponse({
+            status: 'InProgress',
+            createdDate: Math.floor(now.getTime() / 1_000),
+            expiryDays: 10,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const provider = adapter(fetch);
+    const expiresAt = new Date('2026-08-01T18:30:00.000Z');
+
+    const result = await provider.extendExpiry({
+      tenantId,
+      requestId: 'doc_123',
+      expiresAt,
+      warnPrior: true,
+    });
+
+    expect(result.expiresAt).toEqual(expiresAt);
+    expect(fetch.mock.calls[1]?.[0]).toBe(
+      'https://api-ca.boldsign.com/v1/document/extendExpiry?documentId=doc_123',
+    );
+    expect(JSON.parse(String(fetch.mock.calls[1]?.[1]?.body))).toEqual({
+      NewExpiryValue: '2026-08-01',
+      WarnPrior: true,
+    });
+  });
+
+  it('rejects expiry reductions and dates beyond the provider maximum', async () => {
+    const properties = propertiesResponse({
+      status: 'InProgress',
+      createdDate: Math.floor(now.getTime() / 1_000),
+      expiryDays: 30,
+    });
+    const provider = adapter(vi.fn(async () => jsonResponse(properties)));
+
+    await expect(
+      provider.extendExpiry({
+        tenantId,
+        requestId: 'doc_123',
+        expiresAt: '2026-07-20T00:00:00.000Z',
+      }),
+    ).rejects.toThrow('must extend the current expiry date');
+    await expect(
+      provider.extendExpiry({
+        tenantId,
+        requestId: 'doc_123',
+        expiresAt: '2027-02-01T00:00:00.000Z',
+      }),
+    ).rejects.toThrow('cannot exceed 180 days');
+  });
+
+  it('refuses cancellation and expiry changes after a terminal state', async () => {
+    const provider = adapter(
+      vi.fn(async () =>
+        jsonResponse(propertiesResponse({ status: 'Completed' })),
+      ),
+    );
+
+    await expect(
+      provider.cancelRequest({
+        tenantId,
+        requestId: 'doc_123',
+        reason: 'Too late',
+      }),
+    ).rejects.toThrow('cannot be cancelled from completed');
+    await expect(
+      provider.extendExpiry({
+        tenantId,
+        requestId: 'doc_123',
+        expiresAt: '2026-08-01T00:00:00.000Z',
+      }),
+    ).rejects.toThrow('cannot be extended from completed');
+  });
+
+  it('downloads completed evidence with an exact SHA-256 digest', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(propertiesResponse()))
+      .mockResolvedValueOnce(new Response(bytes, { status: 200 }));
+    const provider = adapter(fetch);
+
+    const artifact = await provider.downloadArtifact({
+      tenantId,
+      requestId: 'doc_123',
+      kind: 'audit_trail',
+    });
+
+    expect(artifact).toMatchObject({
+      provider: 'boldsign',
+      tenantId,
+      requestId: 'doc_123',
+      kind: 'audit_trail',
+      filename: 'doc_123-audit.pdf',
+      mediaType: 'application/pdf',
+      retrievedAt: now,
+    });
+    expect(await readStream(artifact.stream)).toEqual(bytes);
+    expect(await artifact.sha256).toBe(
+      '9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a',
+    );
+    expect(fetch.mock.calls[1]?.[0]).toContain('/document/downloadAuditLog?');
+  });
+
+  it('refuses to label pre-completion downloads as execution evidence', async () => {
+    const provider = adapter(
+      vi.fn(async () =>
+        jsonResponse(propertiesResponse({ status: 'InProgress' })),
+      ),
+    );
+
+    await expect(
+      provider.downloadArtifact({
+        tenantId,
+        requestId: 'doc_123',
+        kind: 'signed_document',
+      }),
+    ).rejects.toThrow('only be downloaded after completion');
+  });
+
+  it('rejects unknown artifact kinds before contacting BoldSign', async () => {
+    const fetch = vi.fn();
+    const provider = adapter(fetch);
+
+    await expect(
+      provider.downloadArtifact({
+        tenantId,
+        requestId: 'doc_123',
+        kind: 'future_artifact' as never,
+      }),
+    ).rejects.toThrow('artifact kind');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('BoldSign webhook verification', () => {
+  it('accepts a matching current or rotated signature and normalizes the event', () => {
+    const payload = webhookPayload();
+    const provider = adapter(vi.fn(), {
+      webhookSecrets: ['old-secret', webhookSecret],
+    });
+    const current = webhookSignature(payload);
+    const old = webhookSignature(payload, 'old-secret', undefined, 's1').split(
+      '=',
+    )[2];
+    const event = provider.parseWebhook({
+      payload,
+      signature: `${current},s1=${old}`,
+    });
+
+    expect(event).toMatchObject({
+      id: 'event_123',
+      provider: 'boldsign',
+      tenantId,
+      requestId: 'doc_123',
+      type: 'Signed',
+      status: 'partially_signed',
+      environment: 'Test',
+      signers: [
+        {
+          id: 'signer_1',
+          status: 'signed',
+          authenticationMethod: 'email_otp',
+        },
+      ],
+      replay: {
+        deduplicationKey: 'boldsign:tenant_123:event_123',
+        orderingKey: 'boldsign:tenant_123:doc_123',
+      },
+    });
+    expect(event.createdAt).toEqual(now);
+  });
+
+  it('uses Completed, Revoked, Expired, and SendFailed as terminal states', () => {
+    const provider = adapter(vi.fn());
+
+    for (const [type, status] of [
+      ['Completed', 'completed'],
+      ['Revoked', 'cancelled'],
+      ['Expired', 'expired'],
+      ['SendFailed', 'failed'],
+    ] as const) {
+      const payload = webhookPayload(type);
+      expect(
+        provider.parseWebhook({
+          payload,
+          signature: webhookSignature(payload),
+        }).status,
+      ).toBe(status);
+    }
+  });
+
+  it('rejects modified, stale, future, and malformed webhook inputs', () => {
+    const payload = webhookPayload();
+    const valid = webhookSignature(payload);
+
+    expect(() =>
+      verifyBoldSignWebhookSignature({
+        payload: `${payload} `,
+        signature: valid,
+        secrets: webhookSecret,
+        now,
+      }),
+    ).toThrow(SignatureVerificationError);
+    expect(() =>
+      verifyBoldSignWebhookSignature({
+        payload,
+        signature: webhookSignature(
+          payload,
+          webhookSecret,
+          Math.floor(now.getTime() / 1_000) - 301,
+        ),
+        secrets: webhookSecret,
+        now,
+      }),
+    ).toThrow('outside the allowed tolerance');
+    expect(() =>
+      verifyBoldSignWebhookSignature({
+        payload,
+        signature: webhookSignature(
+          payload,
+          webhookSecret,
+          Math.floor(now.getTime() / 1_000) + 301,
+        ),
+        secrets: webhookSecret,
+        now,
+      }),
+    ).toThrow('outside the allowed tolerance');
+    expect(() =>
+      verifyBoldSignWebhookSignature({
+        payload,
+        signature: 't=nope,s0=abcd',
+        secrets: webhookSecret,
+        now,
+      }),
+    ).toThrow('timestamp');
+  });
+
+  it('rejects signed webhooks that are unbound or bound to another tenant', () => {
+    const provider = adapter(vi.fn());
+    const payload = webhookPayload('Signed', {
+      metaData: { [BOLDSIGN_TENANT_METADATA_KEY]: 'other_tenant' },
+    });
+
+    expect(() =>
+      provider.parseWebhook({
+        payload,
+        signature: webhookSignature(payload),
+      }),
+    ).toThrow(SignatureTenantMismatchError);
+  });
+
+  it('rejects unknown signed event types before normalization', () => {
+    const provider = adapter(vi.fn());
+    const payload = webhookPayload('FutureEvent');
+
+    expect(() =>
+      provider.parseWebhook({
+        payload,
+        signature: webhookSignature(payload),
+      }),
+    ).toThrow('Unsupported BoldSign webhook event type');
+  });
+
+  it('exposes stable replay keys and timestamps for duplicate and reordered events', () => {
+    const provider = adapter(vi.fn());
+    const first = webhookPayload('Sent');
+    const duplicate = provider.parseWebhook({
+      payload: first,
+      signature: webhookSignature(first),
+    });
+    const duplicateAgain = provider.parseWebhook({
+      payload: first,
+      signature: webhookSignature(first),
+    });
+    const olderTimestamp = Math.floor(now.getTime() / 1_000) - 10;
+    const older = JSON.stringify({
+      ...JSON.parse(webhookPayload('Sent')),
+      event: {
+        id: 'event_older',
+        eventType: 'Sent',
+        created: olderTimestamp,
+        environment: 'Test',
+      },
+    });
+    const reordered = provider.parseWebhook({
+      payload: older,
+      signature: webhookSignature(older, webhookSecret, olderTimestamp),
+    });
+
+    expect(duplicateAgain.replay.deduplicationKey).toBe(
+      duplicate.replay.deduplicationKey,
+    );
+    expect(reordered.replay.orderingKey).toBe(duplicate.replay.orderingKey);
+    expect(reordered.createdAt.getTime()).toBeLessThan(
+      duplicate.createdAt.getTime(),
+    );
+  });
+
+  it('maps delivery failures onto signer state', () => {
+    const provider = adapter(vi.fn());
+    const payload = webhookPayload('DeliveryFailed', {
+      signerDetails: [
+        {
+          id: 'signer_1',
+          signerName: 'Alex Example',
+          signerEmail: 'alex@example.com',
+          status: 'NotCompleted',
+          isDeliveryFailed: true,
+          isAuthenticationFailed: false,
+        },
+      ],
+    });
+    const event = provider.parseWebhook({
+      payload,
+      signature: webhookSignature(payload),
+    });
+
+    expect(event.type).toBe('DeliveryFailed');
+    expect(event.status).toBe('sent');
+    expect(event.signers[0]).toMatchObject({
+      status: 'failed',
+      deliveryFailed: true,
+    });
+  });
+
+  it('requires configured secrets and valid event identifiers', () => {
+    const payload = webhookPayload();
+    const noWebhookProvider = adapter(vi.fn(), { webhookSecrets: undefined });
+
+    expect(() =>
+      noWebhookProvider.parseWebhook({
+        payload,
+        signature: webhookSignature(payload),
+      }),
+    ).toThrow('requires webhookSecrets');
+
+    const invalidPayload = webhookPayload('Signed');
+    const missingId = invalidPayload.replace('"event_123"', '""');
+    expect(() =>
+      adapter(vi.fn()).parseWebhook({
+        payload: missingId,
+        signature: webhookSignature(missingId),
+      }),
+    ).toThrow('event id');
+
+    const invalidCreated = invalidPayload.replace(
+      String(Math.floor(now.getTime() / 1_000)),
+      '1.5',
+    );
+    expect(() =>
+      adapter(vi.fn()).parseWebhook({
+        payload: invalidCreated,
+        signature: webhookSignature(invalidCreated),
+      }),
+    ).toThrow('epoch timestamp');
+  });
+});
+
+describe('signature provider factory', () => {
+  it('loads the BoldSign adapter behind the provider-neutral factory', async () => {
+    const provider = await createSignatureProvider({
+      type: 'boldsign',
+      tenantId,
+      apiKey,
+      fetch: vi.fn(),
+    });
+
+    expect(provider).toBeInstanceOf(BoldSignAdapter);
+  });
+
+  it('rejects unknown provider types', async () => {
+    await expect(
+      createSignatureProvider({ type: 'unknown' } as never),
+    ).rejects.toThrow('Unknown signature provider type');
+  });
+});

--- a/packages/signatures/src/boldsign.test.ts
+++ b/packages/signatures/src/boldsign.test.ts
@@ -891,16 +891,19 @@ describe('BoldSign webhook verification', () => {
     ).toThrow(SignatureTenantMismatchError);
   });
 
-  it('rejects unknown signed event types before normalization', () => {
+  it('rejects signed event types outside the documented allowlist', () => {
     const provider = adapter(vi.fn());
-    const payload = webhookPayload('FutureEvent');
 
-    expect(() =>
-      provider.parseWebhook({
-        payload,
-        signature: webhookSignature(payload),
-      }),
-    ).toThrow('Unsupported BoldSign webhook event type');
+    for (const type of ['Delivered', 'FutureEvent']) {
+      const payload = webhookPayload(type);
+
+      expect(() =>
+        provider.parseWebhook({
+          payload,
+          signature: webhookSignature(payload),
+        }),
+      ).toThrow('Unsupported BoldSign webhook event type');
+    }
   });
 
   it('exposes stable replay keys and timestamps for duplicate and reordered events', () => {

--- a/packages/signatures/src/errors.ts
+++ b/packages/signatures/src/errors.ts
@@ -1,0 +1,82 @@
+export type SignatureErrorCode =
+  | 'SIGNATURE_CONFIGURATION_ERROR'
+  | 'SIGNATURE_INVALID_INPUT'
+  | 'SIGNATURE_PROVIDER_ERROR'
+  | 'SIGNATURE_VERIFICATION_FAILED'
+  | 'SIGNATURE_TENANT_MISMATCH';
+
+export class SignatureError extends Error {
+  readonly code: SignatureErrorCode;
+  readonly retryable: boolean;
+  readonly status?: number;
+  readonly retryAfterMs?: number;
+  /** A failed create call may have reached the provider and must be reconciled. */
+  readonly requestMayHaveSucceeded: boolean;
+
+  constructor(
+    message: string,
+    code: SignatureErrorCode,
+    options: {
+      cause?: unknown;
+      retryable?: boolean;
+      status?: number;
+      retryAfterMs?: number;
+      requestMayHaveSucceeded?: boolean;
+    } = {},
+  ) {
+    super(
+      message,
+      options.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.name = 'SignatureError';
+    this.code = code;
+    this.retryable = options.retryable ?? false;
+    this.status = options.status;
+    this.retryAfterMs = options.retryAfterMs;
+    this.requestMayHaveSucceeded = options.requestMayHaveSucceeded ?? false;
+  }
+}
+
+export class SignatureConfigurationError extends SignatureError {
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message, 'SIGNATURE_CONFIGURATION_ERROR', options);
+    this.name = 'SignatureConfigurationError';
+  }
+}
+
+export class SignatureInputError extends SignatureError {
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message, 'SIGNATURE_INVALID_INPUT', options);
+    this.name = 'SignatureInputError';
+  }
+}
+
+export class SignatureProviderError extends SignatureError {
+  constructor(
+    message: string,
+    options: {
+      cause?: unknown;
+      retryable?: boolean;
+      status?: number;
+      retryAfterMs?: number;
+      requestMayHaveSucceeded?: boolean;
+    } = {},
+  ) {
+    super(message, 'SIGNATURE_PROVIDER_ERROR', options);
+    this.name = 'SignatureProviderError';
+  }
+}
+
+export class SignatureVerificationError extends SignatureError {
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message, 'SIGNATURE_VERIFICATION_FAILED', options);
+    this.name = 'SignatureVerificationError';
+  }
+}
+
+export class SignatureTenantMismatchError extends SignatureError {
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message, 'SIGNATURE_TENANT_MISMATCH', options);
+    this.name = 'SignatureTenantMismatchError';
+  }
+}

--- a/packages/signatures/src/factory.ts
+++ b/packages/signatures/src/factory.ts
@@ -1,0 +1,36 @@
+import type { BoldSignAdapterOptions } from './adapters/boldsign.js';
+import { SignatureConfigurationError } from './errors.js';
+import type { SignatureProvider } from './types.js';
+
+export type SignatureProviderOptions = {
+  type: 'boldsign';
+} & BoldSignAdapterOptions;
+
+export async function createSignatureProvider(
+  options: SignatureProviderOptions,
+): Promise<SignatureProvider> {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new SignatureConfigurationError(
+      'Signature provider options must be an object.',
+    );
+  }
+
+  const type = (options as { type?: unknown }).type;
+
+  if (typeof type !== 'string' || !type.trim()) {
+    throw new SignatureConfigurationError(
+      'Signature provider type must be a non-empty string.',
+    );
+  }
+
+  switch (type.trim()) {
+    case 'boldsign': {
+      const { BoldSignAdapter } = await import('./adapters/boldsign.js');
+      return new BoldSignAdapter(options);
+    }
+    default:
+      throw new SignatureConfigurationError(
+        `Unknown signature provider type: ${type.trim()}`,
+      );
+  }
+}

--- a/packages/signatures/src/index.ts
+++ b/packages/signatures/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Provider-neutral e-signature request, webhook, and evidence contracts.
+ *
+ * Adapter implementations are available from provider subpath exports.
+ *
+ * @packageDocumentation
+ */
+
+export type {
+  BoldSignAdapterOptions,
+  BoldSignRegion,
+} from './adapters/boldsign.js';
+export * from './errors.js';
+export * from './factory.js';
+export type { SignatureFetch } from './shared.js';
+export * from './types.js';

--- a/packages/signatures/src/shared.ts
+++ b/packages/signatures/src/shared.ts
@@ -1,0 +1,111 @@
+import { SignatureInputError, SignatureProviderError } from './errors.js';
+
+export type SignatureFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export function getSignatureFetch(fetchLike?: SignatureFetch): SignatureFetch {
+  const resolved = fetchLike ?? globalThis.fetch;
+
+  if (typeof resolved !== 'function') {
+    throw new SignatureProviderError(
+      'A fetch implementation is required in this runtime.',
+    );
+  }
+
+  return resolved.bind(globalThis) as SignatureFetch;
+}
+
+export function requireNonEmptyString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new SignatureInputError(`${context} must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+export function requireRecord(
+  value: unknown,
+  context: string,
+): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new SignatureProviderError(`${context} must be an object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export function readString(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const item = value?.[key];
+
+  return typeof item === 'string' ? item : undefined;
+}
+
+export function readNumber(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const item = value?.[key];
+
+  return typeof item === 'number' && Number.isFinite(item) ? item : undefined;
+}
+
+export function readBoolean(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const item = value?.[key];
+
+  return typeof item === 'boolean' ? item : undefined;
+}
+
+export function readRecord(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  const item = value?.[key];
+
+  return item && typeof item === 'object' && !Array.isArray(item)
+    ? (item as Record<string, unknown>)
+    : undefined;
+}
+
+export function readRecords(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown>[] {
+  const item = value?.[key];
+
+  return Array.isArray(item)
+    ? item.filter(
+        (candidate): candidate is Record<string, unknown> =>
+          Boolean(candidate) &&
+          typeof candidate === 'object' &&
+          !Array.isArray(candidate),
+      )
+    : [];
+}
+
+export function normalizeDate(value: Date | string, context: string): Date {
+  if (!(value instanceof Date) && typeof value !== 'string') {
+    throw new SignatureInputError(`${context} must be a Date or ISO string.`);
+  }
+
+  const date = value instanceof Date ? new Date(value) : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new SignatureInputError(`${context} must be a valid date.`);
+  }
+
+  return date;
+}
+
+export function parseOptionalEpochSeconds(value: unknown): Date | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? new Date(value * 1_000)
+    : undefined;
+}

--- a/packages/signatures/src/types.ts
+++ b/packages/signatures/src/types.ts
@@ -1,0 +1,242 @@
+export type SignatureProviderType = 'boldsign';
+
+export type SignatureRequestStatus =
+  | 'prepared'
+  | 'sent'
+  | 'delivered'
+  | 'viewed'
+  | 'partially_signed'
+  | 'completed'
+  | 'declined'
+  | 'cancelled'
+  | 'expired'
+  | 'failed';
+
+export type SignatureSignerStatus =
+  | 'pending'
+  | 'viewed'
+  | 'signed'
+  | 'declined'
+  | 'expired'
+  | 'failed';
+
+export type SignatureAuthenticationMethod =
+  | 'none'
+  | 'access_code'
+  | 'email_otp'
+  | 'sms_otp'
+  | 'identity_verification';
+
+export type SignatureFieldType =
+  | 'signature'
+  | 'initial'
+  | 'date_signed'
+  | 'text';
+
+export type SignatureArtifactKind = 'signed_document' | 'audit_trail';
+
+export interface SignatureProviderCapabilities {
+  id: string;
+  displayName: string;
+  region: string;
+  supportsWebhooks: boolean;
+  supportsCancellation: boolean;
+  supportsExpiryExtension: boolean;
+  supportsSignedDocument: boolean;
+  supportsAuditTrail: boolean;
+  /** Whether the remote API provides atomic request-creation idempotency. */
+  providerEnforcedIdempotency: boolean;
+  authenticationMethods: readonly SignatureAuthenticationMethod[];
+}
+
+export type SignatureByteSource =
+  | Uint8Array
+  | ReadableStream<Uint8Array>
+  | AsyncIterable<Uint8Array>;
+
+export interface SignatureDocument {
+  name: string;
+  mediaType: string;
+  data: SignatureByteSource;
+}
+
+export interface SignatureFieldBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SignatureField {
+  id: string;
+  type: SignatureFieldType;
+  /** One-based page number in the provider's combined document. */
+  page: number;
+  bounds: SignatureFieldBounds;
+  required?: boolean;
+  value?: string;
+}
+
+export interface SignaturePhoneNumber {
+  /** E.164 country calling code, including the leading `+`. */
+  countryCode: string;
+  /** National phone number, without the country calling code. */
+  number: string;
+}
+
+export interface SignatureIdentityVerificationOptions {
+  frequency?: 'every_access' | 'until_signed' | 'once_per_document';
+  maximumRetryCount?: number;
+  requireLiveCapture?: boolean;
+  requireMatchingSelfie?: boolean;
+  nameMatch?: 'strict' | 'moderate' | 'lenient';
+  allowedDocumentTypes?: readonly (
+    | 'passport'
+    | 'identity_card'
+    | 'driver_license'
+  )[];
+  allowedCountries?: readonly string[];
+}
+
+export interface SignatureAuthentication {
+  method: SignatureAuthenticationMethod;
+  /** Required only for `access_code`; never returned by provider reads/events. */
+  accessCode?: string;
+  /** Required only for `sms_otp`. */
+  phone?: SignaturePhoneNumber;
+  identityVerification?: SignatureIdentityVerificationOptions;
+}
+
+export interface SignatureSignerInput {
+  name: string;
+  email: string;
+  role?: string;
+  order?: number;
+  privateMessage?: string;
+  authentication?: SignatureAuthentication;
+  fields: readonly SignatureField[];
+}
+
+export interface SignatureSigner {
+  id?: string;
+  name: string;
+  email: string;
+  role?: string;
+  order?: number;
+  status: SignatureSignerStatus;
+  authenticationMethod?: SignatureAuthenticationMethod;
+  viewed?: boolean;
+  deliveryFailed?: boolean;
+}
+
+export interface CreateSignatureRequestInput {
+  /** Tenant boundary for the credential-bearing provider instance. */
+  tenantId: string;
+  /** Stable caller key persisted with the remote request for reconciliation. */
+  idempotencyKey: string;
+  title: string;
+  message?: string;
+  documents: readonly SignatureDocument[];
+  signers: readonly SignatureSignerInput[];
+  signingOrder?: boolean;
+  /** Provider document lifetime. BoldSign accepts 1–180 days. */
+  expiresInDays?: number;
+  metadata?: Readonly<Record<string, string>>;
+  signal?: AbortSignal;
+}
+
+export interface SignatureRequestReference {
+  tenantId: string;
+  requestId: string;
+  signal?: AbortSignal;
+}
+
+export interface SignatureRequest {
+  provider: string;
+  tenantId: string;
+  id: string;
+  status: SignatureRequestStatus;
+  title?: string;
+  signers: readonly SignatureSigner[];
+  createdAt?: Date;
+  expiresAt?: Date;
+  metadata?: Readonly<Record<string, string>>;
+  raw?: unknown;
+}
+
+export interface CancelSignatureRequestInput extends SignatureRequestReference {
+  reason: string;
+}
+
+export interface ExtendSignatureRequestExpiryInput
+  extends SignatureRequestReference {
+  expiresAt: Date | string;
+  warnPrior?: boolean;
+}
+
+export interface DownloadSignatureArtifactInput
+  extends SignatureRequestReference {
+  kind: SignatureArtifactKind;
+}
+
+export interface SignatureArtifact {
+  provider: string;
+  tenantId: string;
+  requestId: string;
+  kind: SignatureArtifactKind;
+  filename: string;
+  mediaType: string;
+  /** Single-use stream of the exact provider response bytes. */
+  stream: ReadableStream<Uint8Array>;
+  /** Resolves after `stream` is fully consumed with its lowercase SHA-256. */
+  sha256: Promise<string>;
+  retrievedAt: Date;
+}
+
+export interface SignatureWebhookReplayMetadata {
+  /** Persist under a unique constraint before applying the event. */
+  deduplicationKey: string;
+  /** Partition ordering comparisons by this provider request key. */
+  orderingKey: string;
+}
+
+export interface SignatureWebhookEvent {
+  /** Provider event identifier; consumers must persist it as a unique key. */
+  id: string;
+  provider: string;
+  tenantId: string;
+  requestId: string;
+  type: string;
+  status: SignatureRequestStatus;
+  createdAt: Date;
+  environment?: string;
+  signers: readonly SignatureSigner[];
+  replay: SignatureWebhookReplayMetadata;
+  raw: unknown;
+}
+
+export interface ParseSignatureWebhookInput {
+  /** Exact, unmodified UTF-8 request body. */
+  payload: string;
+  signature: string;
+}
+
+export interface SignatureProvider {
+  readonly capabilities: SignatureProviderCapabilities;
+
+  createRequest(input: CreateSignatureRequestInput): Promise<SignatureRequest>;
+
+  getRequest(input: SignatureRequestReference): Promise<SignatureRequest>;
+
+  cancelRequest(input: CancelSignatureRequestInput): Promise<SignatureRequest>;
+
+  extendExpiry(
+    input: ExtendSignatureRequestExpiryInput,
+  ): Promise<SignatureRequest>;
+
+  downloadArtifact(
+    input: DownloadSignatureArtifactInput,
+  ): Promise<SignatureArtifact>;
+
+  parseWebhook(input: ParseSignatureWebhookInput): SignatureWebhookEvent;
+}

--- a/packages/signatures/tsconfig.json
+++ b/packages/signatures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/signatures/vite.config.ts
+++ b/packages/signatures/vite.config.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+const packageDir = resolve(__dirname);
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        index: resolve(packageDir, 'src/index.ts'),
+        'adapters/boldsign': resolve(packageDir, 'src/adapters/boldsign.ts'),
+      },
+      formats: ['es'] as const,
+    },
+    rollupOptions: {
+      output: {
+        dir: resolve(packageDir, 'dist'),
+        format: 'es' as const,
+        preserveModules: false,
+        entryFileNames: '[name].js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+      },
+      external: [/^node:/, /^@happyvertical\//],
+    },
+    minify: false,
+    sourcemap: true,
+    target: 'es2022',
+    reportCompressedSize: false,
+  },
+  plugins: [
+    dts({
+      outDir: resolve(packageDir, 'dist'),
+      include: [resolve(packageDir, 'src/**/*.ts')],
+      exclude: ['**/*.test.ts', '**/*.spec.ts'],
+      insertTypesEntry: false,
+      rollupTypes: false,
+      tsconfigPath: resolve(packageDir, 'tsconfig.json'),
+    }),
+  ],
+});

--- a/packages/social/AGENT.md
+++ b/packages/social/AGENT.md
@@ -7,7 +7,7 @@ Social platform adapters for publishing to YouTube, Threads, X, and Bluesky
 ## Package Map
 - Package: `@happyvertical/social`
 - Hierarchy path: `@happyvertical/sdk > packages > social`
-- Workspace position: `25 of 31` local packages
+- Workspace position: `26 of 32` local packages
 - Internal dependencies: `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/social/metadata.json
+++ b/packages/social/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/social",
   "path": "packages/social",
   "position": {
-    "index": 25,
-    "count": 31
+    "index": 26,
+    "count": 32
   },
   "description": "Social platform adapters for publishing to YouTube, Threads, X, and Bluesky",
   "provides": [

--- a/packages/speech/AGENT.md
+++ b/packages/speech/AGENT.md
@@ -7,7 +7,7 @@ Speech provider abstraction for STT and TTS backends
 ## Package Map
 - Package: `@happyvertical/speech`
 - Hierarchy path: `@happyvertical/sdk > packages > speech`
-- Workspace position: `26 of 31` local packages
+- Workspace position: `27 of 32` local packages
 - Internal dependencies: none
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/speech/metadata.json
+++ b/packages/speech/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/speech",
   "path": "packages/speech",
   "position": {
-    "index": 26,
-    "count": 31
+    "index": 27,
+    "count": 32
   },
   "description": "Speech provider abstraction for STT and TTS backends",
   "provides": [

--- a/packages/sql/AGENT.md
+++ b/packages/sql/AGENT.md
@@ -7,7 +7,7 @@ Database interface with support for SQLite, PostgreSQL, and DuckDB
 ## Package Map
 - Package: `@happyvertical/sql`
 - Hierarchy path: `@happyvertical/sdk > packages > sql`
-- Workspace position: `27 of 31` local packages
+- Workspace position: `28 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: `@happyvertical/jobs`, `@happyvertical/secrets`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/sql/metadata.json
+++ b/packages/sql/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/sql",
   "path": "packages/sql",
   "position": {
-    "index": 27,
-    "count": 31
+    "index": 28,
+    "count": 32
   },
   "description": "Database interface with support for SQLite, PostgreSQL, and DuckDB",
   "provides": [

--- a/packages/translator/AGENT.md
+++ b/packages/translator/AGENT.md
@@ -7,7 +7,7 @@ Standardized translation interface supporting Google Translate, DeepL, and Libre
 ## Package Map
 - Package: `@happyvertical/translator`
 - Hierarchy path: `@happyvertical/sdk > packages > translator`
-- Workspace position: `28 of 31` local packages
+- Workspace position: `29 of 32` local packages
 - Internal dependencies: `@happyvertical/cache`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/translator/metadata.json
+++ b/packages/translator/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/translator",
   "path": "packages/translator",
   "position": {
-    "index": 28,
-    "count": 31
+    "index": 29,
+    "count": 32
   },
   "description": "Standardized translation interface supporting Google Translate, DeepL, and LibreTranslate",
   "provides": [

--- a/packages/utils/AGENT.md
+++ b/packages/utils/AGENT.md
@@ -7,7 +7,7 @@ Foundation utilities for ID generation, date parsing, URL handling, string conve
 ## Package Map
 - Package: `@happyvertical/utils`
 - Hierarchy path: `@happyvertical/sdk > packages > utils`
-- Workspace position: `29 of 31` local packages
+- Workspace position: `30 of 32` local packages
 - Internal dependencies: none
 - Internal dependents: `@happyvertical/accounting`, `@happyvertical/ai`, `@happyvertical/analytics`, `@happyvertical/auth`, `@happyvertical/cache`, `@happyvertical/comfyui`, `@happyvertical/directory`, `@happyvertical/documents`, `@happyvertical/email`, `@happyvertical/encryption`, `@happyvertical/files`, `@happyvertical/geo`, `@happyvertical/jobs`, `@happyvertical/logger`, `@happyvertical/messages`, `@happyvertical/sdk-mcp`, `@happyvertical/secrets`, `@happyvertical/social`, `@happyvertical/sql`, `@happyvertical/translator`, `@happyvertical/video`, `@happyvertical/weather`
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/utils/metadata.json
+++ b/packages/utils/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/utils",
   "path": "packages/utils",
   "position": {
-    "index": 29,
-    "count": 31
+    "index": 30,
+    "count": 32
   },
   "description": "Foundation utilities for ID generation, date parsing, URL handling, string conversion, error handling, and logging",
   "provides": [

--- a/packages/video/AGENT.md
+++ b/packages/video/AGENT.md
@@ -7,7 +7,7 @@ Video processing utilities with adapter pattern for composition and transcoding
 ## Package Map
 - Package: `@happyvertical/video`
 - Hierarchy path: `@happyvertical/sdk > packages > video`
-- Workspace position: `30 of 31` local packages
+- Workspace position: `31 of 32` local packages
 - Internal dependencies: `@happyvertical/images`, `@happyvertical/logger`, `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/video/metadata.json
+++ b/packages/video/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/video",
   "path": "packages/video",
   "position": {
-    "index": 30,
-    "count": 31
+    "index": 31,
+    "count": 32
   },
   "description": "Video processing utilities with adapter pattern for composition and transcoding",
   "provides": [

--- a/packages/weather/AGENT.md
+++ b/packages/weather/AGENT.md
@@ -7,7 +7,7 @@ Weather data provider abstraction for HAppyVertical SDK
 ## Package Map
 - Package: `@happyvertical/weather`
 - Hierarchy path: `@happyvertical/sdk > packages > weather`
-- Workspace position: `31 of 31` local packages
+- Workspace position: `32 of 32` local packages
 - Internal dependencies: `@happyvertical/utils`
 - Internal dependents: none
 - Knowledge graph files: `AGENT.md`, `metadata.json`, `ecosystem-manifest.json`

--- a/packages/weather/metadata.json
+++ b/packages/weather/metadata.json
@@ -2,8 +2,8 @@
   "name": "@happyvertical/weather",
   "path": "packages/weather",
   "position": {
-    "index": 31,
-    "count": 31
+    "index": 32,
+    "count": 32
   },
   "description": "Weather data provider abstraction for HAppyVertical SDK",
   "provides": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,6 +881,27 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
+  packages/signatures:
+    devDependencies:
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
+      '@vitest/coverage-v8':
+        specifier: 4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 7.3.2
+        version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: 4.5.4
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+
   packages/social:
     dependencies:
       '@happyvertical/logger':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,6 +67,7 @@
     { "path": "./packages/email" },
     { "path": "./packages/messages" },
     { "path": "./packages/payments" },
+    { "path": "./packages/signatures" },
     { "path": "./packages/directory" },
 
     // Developer tools


### PR DESCRIPTION
## Summary

- add the provider-neutral @happyvertical/signatures package
- implement the first adapter for BoldSign with Canada as the default data region
- cover request lifecycle, signer identity, cancellation and expiry, signed artifacts, audit evidence, tenant isolation, and idempotency metadata
- verify webhook HMACs over the raw body with rotation, replay protection, timestamp tolerance, and fail-closed event handling
- document integration, reconciliation, security, residency, and operational guidance

## Validation

- Node 24.18.0 and pnpm 11.13.0
- package tests: 31 passed
- full test: 44 tasks passed
- full build: 32 tasks passed
- full typecheck: 20 tasks passed
- lint, docs build, agent context check, changeset status, package build, package tarball, and import smoke passed
- GitHub Required CI and lifecycle: passed
- no live provider requests or real credentials used

## Provenance

- BoldSign API: https://developers.boldsign.com/
- BoldSign webhooks: https://developers.boldsign.com/webhooks/
- BoldSign data residency: https://developers.boldsign.com/data-residency/

Fixes #1092

Downstream: happyvertical/smrt#2012
Downstream: happyvertical/projects.happyvertical.com#116

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "019f609c-1cde-7ad3-afee-e6daad8484ce",
  "issue": "happyvertical/sdk#1092",
  "policy_revision": "1.0.0",
  "validation": [
    "Node 24.18.0 and pnpm 11.13.0",
    "@happyvertical/signatures tests: 31 passed",
    "workspace test: 44 tasks passed",
    "workspace build: 32 tasks passed",
    "workspace typecheck: 20 tasks passed",
    "lint, docs build, agent check, changeset status, package tarball, and import smoke passed",
    "GitHub Required CI and lifecycle: passed"
  ]
}
