### PR TITLE
chore(ci): migrate agent workflows to the generation-3 split layout

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -46,6 +46,7 @@
     ]
   },
   "runtime": {
-    "agent_policy_workflow": ".github/workflows/on-pull-request.yml"
+    "agent_validation_workflow": ".github/workflows/on-pull-request.yml",
+    "agent_lifecycle_stage": "compatibility"
   }
 }

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -1,0 +1,67 @@
+name: Agent Policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to recheck after a claim-only transition
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  packages: read
+
+jobs:
+  lifecycle:
+    name: lifecycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - name: Load pinned policy runtime
+        env:
+          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
+        run: |
+          case "$POLICY_ARTIFACT" in
+            ghcr.io/*@sha256:*) ;;
+            *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
+          esac
+          policy_dir="$RUNNER_TEMP/hv-policy"
+          rm -rf "$policy_dir"
+          mkdir -p "$policy_dir"
+          oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
+          archive="$policy_dir/agent-policy.tar.gz"
+          test -f "$archive" || { echo 'policy artifact is missing agent-policy.tar.gz' >&2; exit 1; }
+          python3 - "$archive" <<'PY'
+          import pathlib
+          import sys
+          import tarfile
+
+          with tarfile.open(sys.argv[1], "r:gz") as archive:
+              for member in archive.getmembers():
+                  path = pathlib.PurePosixPath(member.name)
+                  if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
+                      raise SystemExit(f"unsafe policy archive member: {member.name}")
+          PY
+          tar -xzf "$archive" -C "$policy_dir"
+          echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
+      - name: Validate lifecycle
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" | while IFS= read -r number; do
+            python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$number"
+          done

--- a/.github/workflows/build-json-native.yml
+++ b/.github/workflows/build-json-native.yml
@@ -74,7 +74,6 @@ jobs:
             package-suffix: win32-x64-msvc
 
     runs-on: ${{ matrix.os }}
-    name: Build ${{ matrix.package-suffix }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -1,0 +1,86 @@
+name: Dependabot Automation
+
+# Repository-owned dependabot automation, separated from the validation
+# workflow: validation jobs must run unconditionally under the agent
+# policy, while this actor-gated helper only approves; merging still
+# requires the full set of required checks.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  dependabot:
+    name: Dependabot Automation
+    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate security requirements
+        run: |
+          if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
+            echo "::error::GITHUB_TOKEN is not available"
+            exit 1
+          fi
+          echo "✅ Security requirements validated"
+          echo "::notice::Processing dependabot PR with enhanced security checks"
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24.18.0'
+          github-packages-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Security scan for dependency changes
+        run: |
+          echo "::notice::Checking for security vulnerabilities in dependencies"
+          echo "Dependency update type: ${{ steps.metadata.outputs.update-type }}"
+          echo "Package ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}"
+          echo "Package name: ${{ steps.metadata.outputs.dependency-names }}"
+          pnpm audit || {
+            echo "::error::Security vulnerabilities found in dependencies"
+            exit 1
+          }
+          echo "✅ No security vulnerabilities detected"
+
+      - name: Approve PR with security validation
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: |
+          echo "::notice::Approving dependabot PR after security validation"
+          gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          echo "::notice::Enabling auto-merge for ${{ steps.metadata.outputs.update-type }} update"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Require manual review for major updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "Major version update detected. Manual review required."
+          echo "This PR will not be automatically approved or merged."
+          gh pr comment "$PR_URL" \
+            --body "Major version update detected. Manual review required."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -3,22 +3,13 @@ name: Pull Request Validation
 on:
   pull_request:
     branches: [main, dependency-updates]
-    types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: Pull request number to recheck after a claim-only transition
-        required: true
-        type: number
-
-# Cancel superseded runs when new commits are pushed.
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number ||
-      inputs.pr_number ||
       github.event.merge_group.head_sha ||
       github.ref
     }}-${{
@@ -42,75 +33,14 @@ permissions:
   packages: read
 
 jobs:
-  # hv-agent-policy:start
-  lifecycle:
-    name: lifecycle
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
-      github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-      packages: read
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
-      - name: Load pinned policy runtime
-        env:
-          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
-        run: |
-          case "$POLICY_ARTIFACT" in
-            ghcr.io/*@sha256:*) ;;
-            *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
-          esac
-          policy_dir="$RUNNER_TEMP/hv-policy"
-          rm -rf "$policy_dir"
-          mkdir -p "$policy_dir"
-          oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
-          archive="$policy_dir/agent-policy.tar.gz"
-          test -f "$archive" || { echo 'policy artifact is missing agent-policy.tar.gz' >&2; exit 1; }
-          python3 - "$archive" <<'PY'
-          import pathlib
-          import sys
-          import tarfile
-
-          with tarfile.open(sys.argv[1], "r:gz") as archive:
-              for member in archive.getmembers():
-                  path = pathlib.PurePosixPath(member.name)
-                  if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
-                      raise SystemExit(f"unsafe policy archive member: {member.name}")
-          PY
-          tar -xzf "$archive" -C "$policy_dir"
-          echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
-      - name: Validate lifecycle
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
-          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
-        run: |
-          set -euo pipefail
-          numbers_file="$RUNNER_TEMP/hv-agent-lifecycle-prs"
-          "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" > "$numbers_file"
-          while IFS= read -r number; do
-            python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$number"
-          done < "$numbers_file"
-  # hv-agent-policy:end
 
   changeset-check:
     name: Check for Changeset
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
-    if: |
-      github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null)) &&
-      !startsWith(github.event.pull_request.head.ref, 'renovate/')
+    if: >-
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
 
     steps:
       - name: Checkout
@@ -232,10 +162,9 @@ jobs:
   validate-commits:
     name: Validate Conventional Commits
     if: >-
-      github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' &&
-      (github.event.changes.base != null || github.event.changes.title != null)))
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -391,9 +320,9 @@ jobs:
   validate-workflows:
     name: Validate Workflow Files
     if: >-
-      github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
 
     steps:
@@ -442,9 +371,9 @@ jobs:
   check-naming:
     name: Check for stale @have/ references
     if: >-
-      github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
 
     steps:
@@ -479,9 +408,9 @@ jobs:
   doc-coverage:
     name: Check documentation coverage
     if: >-
-      github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
 
     steps:
@@ -540,8 +469,7 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null)))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/test.yml
     with:
       mode: ${{ github.event_name == 'merge_group' && 'full' || (vars.CI_MERGE_QUEUE_ENABLED == 'true' && 'affected' || 'full') }}
@@ -554,8 +482,7 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null)))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
 
     steps:
@@ -600,9 +527,9 @@ jobs:
   secret-scan:
     name: Secret Scan
     if: >-
-      github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR history
@@ -635,8 +562,7 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null)))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     outputs:
       required: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.postgres }}
@@ -669,12 +595,9 @@ jobs:
     name: PostgreSQL Tests
     needs: postgres-scope
     if: >-
-      (github.event_name == 'merge_group' ||
+      github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null)))) &&
-      needs.postgres-scope.outputs.required == 'true' &&
-      vars.CI_POSTGRES_ENABLED == 'true'
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/postgres-tests.yml
     permissions:
       contents: read
@@ -683,285 +606,51 @@ jobs:
   publish-dry-run:
     name: Publish Dry Run
     if: >-
-      (github.event_name == 'merge_group' ||
+      github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null)))) &&
-      (github.event_name == 'merge_group' || vars.CI_MERGE_QUEUE_ENABLED != 'true')
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/publish-dry-run.yml
     permissions:
       contents: read
       packages: read
 
-  validation-gate:
-    name: >-
-      Required CI / ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) && 'inactive validation' || 'validation' }}
-    if: >-
-      always() &&
-      (github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))))
-    needs:
-      - lifecycle
-      - changeset-check
-      - validate-commits
-      - validate-workflows
-      - check-naming
-      - doc-coverage
-      - secret-scan
-      - postgres-scope
-      - postgres-tests
-      - test
-      - docs-build
-      - publish-dry-run
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Verify event-appropriate required job set
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action }}
-          BASE_CHANGED: ${{ github.event.changes.base != null }}
-          TITLE_CHANGED: ${{ github.event.changes.title != null }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          HEAD_REF: ${{ github.head_ref }}
-          MERGE_QUEUE_ENABLED: ${{ vars.CI_MERGE_QUEUE_ENABLED }}
-          LIFECYCLE: ${{ needs.lifecycle.result }}
-          CHANGESET: ${{ needs.changeset-check.result }}
-          COMMITS: ${{ needs.validate-commits.result }}
-          WORKFLOWS: ${{ needs.validate-workflows.result }}
-          NAMING: ${{ needs.check-naming.result }}
-          DOC_COVERAGE: ${{ needs.doc-coverage.result }}
-          SECRET_SCAN: ${{ needs.secret-scan.result }}
-          POSTGRES_SCOPE: ${{ needs.postgres-scope.result }}
-          POSTGRES_REQUIRED: ${{ needs.postgres-scope.outputs.required }}
-          POSTGRES_ENABLED: ${{ vars.CI_POSTGRES_ENABLED }}
-          POSTGRES: ${{ needs.postgres-tests.result }}
-          TEST: ${{ needs.test.result }}
-          DOCS: ${{ needs.docs-build.result }}
-          PACK: ${{ needs.publish-dry-run.result }}
-        run: |
-          set -euo pipefail
-          require_success() {
-            if [ "$2" != success ]; then
-              echo "$1 must succeed, got: $2"
-              exit 1
-            fi
-          }
-
-          require_success 'Lifecycle policy' "$LIFECYCLE"
-
-          require_success 'PostgreSQL scope detection' "$POSTGRES_SCOPE"
-          require_success 'Validate Changes' "$TEST"
-          require_success 'Documentation Build' "$DOCS"
-
-          if [ "$POSTGRES_REQUIRED" = true ] && [ "$POSTGRES_ENABLED" = true ]; then
-            require_success 'PostgreSQL Tests' "$POSTGRES"
-          elif [ "$POSTGRES" != skipped ]; then
-            echo "PostgreSQL Tests should be skipped, got: $POSTGRES"
-            exit 1
-          fi
-
-          if [ "$EVENT_NAME" = pull_request ]; then
-            if [[ "$HEAD_REF" == renovate/* ]]; then
-              test "$CHANGESET" = skipped
-            else
-              require_success 'Changeset Check' "$CHANGESET"
-            fi
-            require_success 'Conventional Commits' "$COMMITS"
-            require_success 'Workflow Validation' "$WORKFLOWS"
-            require_success 'Naming Check' "$NAMING"
-            require_success 'Documentation Coverage' "$DOC_COVERAGE"
-            require_success 'Secret Scan' "$SECRET_SCAN"
-            if [ "$MERGE_QUEUE_ENABLED" = true ]; then
-              test "$PACK" = skipped
-            else
-              require_success 'Publish Dry Run' "$PACK"
-            fi
-          else
-            for result in "$CHANGESET" "$COMMITS" "$WORKFLOWS" "$NAMING" "$DOC_COVERAGE" "$SECRET_SCAN"; do
-              test "$result" = skipped
-            done
-            require_success 'Publish Dry Run' "$PACK"
-          fi
-
-          echo "Validation baseline passed for $EVENT_NAME"
-
-  metadata-gate:
-    name: Required CI / metadata
-    if: >-
-      always() &&
-      (github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      !(github.event.action == 'edited' && github.event.changes.base != null)))
-    needs: [lifecycle, validate-commits]
-    outputs:
-      prerequisites-passed: ${{ steps.prerequisites.outputs.passed }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Validate metadata prerequisites
-        id: prerequisites
-        env:
-          EVENT_ACTION: ${{ github.event.action }}
-          TITLE_CHANGED: ${{ github.event.changes.title != null }}
-          LIFECYCLE: ${{ needs.lifecycle.result }}
-          COMMITS: ${{ needs.validate-commits.result }}
-        run: |
-          set -euo pipefail
-          [ "$LIFECYCLE" = success ] || { echo "::error::Lifecycle policy failed: $LIFECYCLE"; exit 1; }
-          if [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ] && [ "$COMMITS" != success ]; then
-            echo "::error::Conventional title validation failed: $COMMITS"
-            exit 1
-          fi
-          echo "passed=true" >> "$GITHUB_OUTPUT"
-      - name: Preserve validation baseline
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          set -euo pipefail
-          head_sha="$EVENT_HEAD_SHA"
-          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-            head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
-          fi
-          checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
-          pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
-          latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
-          if [ "$pending" -gt 0 ] || [ "$latest" != success ]; then
-            echo "::error::Validation baseline for $head_sha is pending=$pending latest=$latest"
-            exit 1
-          fi
-
   required-ci:
     name: Required CI
     if: always()
-    needs: [validation-gate, metadata-gate]
+    needs: [changeset-check, validate-commits, validate-workflows, check-naming, doc-coverage, test, docs-build, secret-scan, postgres-scope, postgres-tests, publish-dry-run]
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      pull-requests: read
+    timeout-minutes: 5
     steps:
-      - name: Require the event-appropriate gate
+      - name: Require full validation success
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          VALIDATION: ${{ needs.validation-gate.result }}
-          METADATA: ${{ needs.metadata-gate.result }}
-          METADATA_PREREQUISITES: ${{ needs.metadata-gate.outputs.prerequisites-passed }}
+          CHANGESET_CHECK: ${{ needs.changeset-check.result }}
+          VALIDATE_COMMITS: ${{ needs.validate-commits.result }}
+          VALIDATE_WORKFLOWS: ${{ needs.validate-workflows.result }}
+          CHECK_NAMING: ${{ needs.check-naming.result }}
+          DOC_COVERAGE: ${{ needs.doc-coverage.result }}
+          TEST: ${{ needs.test.result }}
+          DOCS_BUILD: ${{ needs.docs-build.result }}
+          SECRET_SCAN: ${{ needs.secret-scan.result }}
+          POSTGRES_SCOPE: ${{ needs.postgres-scope.result }}
+          POSTGRES_SCOPE_RESULT: ${{ needs.postgres-scope.result }}
+          POSTGRES_REQUIRED: ${{ needs.postgres-scope.outputs.required }}
+          POSTGRES_ENABLED: ${{ vars.CI_POSTGRES_ENABLED }}
+          POSTGRES_TESTS: ${{ needs.postgres-tests.result }}
+          PUBLISH_DRY_RUN: ${{ needs.publish-dry-run.result }}
         run: |
           set -euo pipefail
-          if [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; then
-            exit 0
-          fi
-          if [ "$VALIDATION" = skipped ] && [ "$METADATA_PREREQUISITES" = true ]; then
-            head_sha="$EVENT_HEAD_SHA"
-            if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-              head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
+          # The reusable PostgreSQL workflow scopes its suites internally; a
+          # skipped run is a pass only when scope detection says the change
+          # does not require them.
+          if [ "$POSTGRES_TESTS" != success ]; then
+            if { [ "$POSTGRES_REQUIRED" = "true" ] && [ "$POSTGRES_ENABLED" = "true" ]; } || [ "$POSTGRES_TESTS" != skipped ]; then
+              echo "::error::PostgreSQL validation did not succeed: required=$POSTGRES_REQUIRED result=$POSTGRES_TESTS"
+              exit 1
             fi
-            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
-            pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
-            latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
-            if [ "$pending" -eq 0 ] && [ "$latest" = success ]; then
-              exit 0
+          fi
+          for result in "$CHANGESET_CHECK" "$VALIDATE_COMMITS" "$VALIDATE_WORKFLOWS" "$CHECK_NAMING" "$DOC_COVERAGE" "$TEST" "$DOCS_BUILD" "$SECRET_SCAN" "$POSTGRES_SCOPE" "$PUBLISH_DRY_RUN"; do
+            if [ "$result" != success ]; then
+              echo "::error::full validation did not succeed: changeset-check=$CHANGESET_CHECK validate-commits=$VALIDATE_COMMITS validate-workflows=$VALIDATE_WORKFLOWS check-naming=$CHECK_NAMING doc-coverage=$DOC_COVERAGE test=$TEST docs-build=$DOCS_BUILD secret-scan=$SECRET_SCAN postgres-scope=$POSTGRES_SCOPE postgres-tests=$POSTGRES_TESTS publish-dry-run=$PUBLISH_DRY_RUN"
+              exit 1
             fi
-            echo "::error::Final validation baseline for $head_sha is pending=$pending latest=$latest"
-            exit 1
-          fi
-          echo "::error::Expected exactly one valid gate; validation=$VALIDATION metadata=$METADATA metadata_prerequisites=$METADATA_PREREQUISITES"
-          exit 1
-
-  dependabot:
-    name: Dependabot Automation
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
-    needs: [test]
-    if: |
-      github.actor == 'dependabot[bot]' &&
-      needs.test.outputs.success == 'true'
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Validate security requirements
-        run: |
-          if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
-            echo "::error::GITHUB_TOKEN is not available"
-            exit 1
-          fi
-          echo "✅ Security requirements validated"
-          echo "::notice::Processing dependabot PR with enhanced security checks"
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          node-version: '24.18.0'
-          github-packages-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Security scan for dependency changes
-        run: |
-          echo "::notice::Checking for security vulnerabilities in dependencies"
-          echo "Dependency update type: ${{ steps.metadata.outputs.update-type }}"
-          echo "Package ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}"
-          echo "Package name: ${{ steps.metadata.outputs.dependency-names }}"
-          pnpm audit || {
-            echo "::error::Security vulnerabilities found in dependencies"
-            exit 1
-          }
-          echo "✅ No security vulnerabilities detected"
-
-      - name: Approve PR with security validation
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: |
-          echo "::notice::Approving dependabot PR after security validation"
-          gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for minor and patch updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: |
-          echo "::notice::Enabling auto-merge for ${{ steps.metadata.outputs.update-type }} update"
-          gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Require manual review for major updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        run: |
-          echo "Major version update detected. Manual review required."
-          echo "This PR will not be automatically approved or merged."
-          gh pr comment "$PR_URL" \
-            --body "Major version update detected. Manual review required."
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          done

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -67,7 +67,6 @@ jobs:
           if-no-files-found: error
 
   pack:
-    name: Pack Validation (${{ matrix.shard }}/2)
     needs: prepare
     if: needs.prepare.outputs.validate == 'true'
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,7 +166,6 @@ jobs:
           if-no-files-found: error
 
   pack-release:
-    name: Release Pack Validation (${{ matrix.shard }}/2)
     needs: prepare-release
     if: needs.prepare-release.outputs.should-publish == 'true'
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}


### PR DESCRIPTION
Migrates this repository to the split agent-policy layout (generation-3 migrator, [have-config@2f0d526a](https://github.com/happyvertical/have-config/commit/2f0d526a331c5b9f3c0e45130a5e3af22712b39b), tag `agent-policy-v1.0.10`).

- dedicated byte-canonical `agent-policy.yml`; validation isolated to code events; folded block removed
- superseded `validation-gate`/`metadata-gate` meta-jobs removed; `Required CI` keeps its exact required context as a plain rollup of the eleven validation jobs
- canonical full-validation gates everywhere — this also flattens the postgres scope-skip (`postgres-tests` now always runs; the policy requires that green means fully validated)
- the actor-gated dependabot automation moves to `dependabot-automation.yml` (approval only; merging still requires the full required-check set)
- matrix-interpolated job display names dropped (`Build ${{ matrix.package-suffix }}` etc.) — a dynamic name cannot be proven distinct from the reserved `lifecycle` context, and matrix jobs display their values regardless
- kernel block preserved so this stays green under the v1.0.9 pin (repointed ahead of this PR); the pin advances to generation 3 after this lands

Context: [have-config#180](https://github.com/happyvertical/have-config/issues/180).