### PR TITLE
fix: migrate generation 5 lifecycle

### DIFF
--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+  statuses: read
   packages: read
 
 jobs:
@@ -58,6 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -49,6 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check for skip conditions
+        if: github.event_name == 'pull_request'
         id: skip-check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +64,7 @@ jobs:
           fi
 
       - name: Setup Environment
-        if: steps.skip-check.outputs.skip != 'true'
+        if: github.event_name == 'pull_request' && steps.skip-check.outputs.skip != 'true'
         uses: ./.github/actions/setup-environment
         with:
           node-version: '24.18.0'
@@ -71,7 +72,7 @@ jobs:
           github-packages-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for changeset
-        if: steps.skip-check.outputs.skip != 'true'
+        if: github.event_name == 'pull_request' && steps.skip-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
@@ -187,11 +188,13 @@ jobs:
       # because that composite action installs apt packages and the
       # complete workspace dependency graph on the self-hosted runner.
       - name: Setup Node.js for PR title validation
+        if: github.event_name == 'pull_request'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.18.0'
 
       - name: Install commitlint dependencies
+        if: github.event_name == 'pull_request'
         run: |
           npm install --prefix "$RUNNER_TEMP/commitlint" --no-save \
             --ignore-scripts --no-audit --no-fund \
@@ -199,6 +202,7 @@ jobs:
             @commitlint/config-conventional@20.5.0
 
       - name: Validate PR title for squash merge
+        if: github.event_name == 'pull_request'
         # PR title is user-controlled metadata. Two non-obvious risks
         # the previous form had:
         #   (1) Interpolating the title directly into a shell script
@@ -231,6 +235,7 @@ jobs:
               --config commitlint.config.mjs
 
       - name: Determine version bump
+        if: github.event_name == 'pull_request'
         id: version
         run: |
           base_ref="${{ github.event.pull_request.base.ref }}"
@@ -256,6 +261,7 @@ jobs:
           fi
 
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |


### PR DESCRIPTION
Closes #1104.

Adds the generation-5 lifecycle capability repair (`statuses: read` and explicit event action) after the signed artifact pin. `CI_MERGE_QUEUE_ENABLED=true` is set so merge groups run the full gate and main avoids duplicate validation; changeset publication remains in the existing on-merge workflow. No SDK package behavior changes. Parent rollout: happyvertical/have-config#193.

Validated by the canonical policy audit, workflow validation, actionlint, git diff --check, and the repository pre-push typecheck.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-20260718-sdk-1104-queue-4cdb","issue":"https://github.com/happyvertical/sdk/issues/1104","policy_revision":"1.0.0","validation":["hv-agent audit","workflow validation","actionlint","git diff --check","pre-push typecheck"]}
```
