### PR TITLE
fix(sql): stop postgres pool crashes and transaction connection leaks

### DIFF
--- a/.changeset/postgres-connection-lifecycle-hardening.md
+++ b/.changeset/postgres-connection-lifecycle-hardening.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/sql': patch
+---
+
+Fix PostgreSQL connection lifecycle defects that could crash the process or deadlock the pool. The pool now registers an `error` handler, so an idle client whose backend goes away (restart, failover, proxy timeout) no longer raises an unhandled `error` event and terminates the process. Transactions release their pooled client on every teardown path, including a throwing `COMMIT` or `ROLLBACK`, which previously stranded a connection permanently and exhausted the pool. A failing rollback also no longer replaces the caller's original error; it is attached as `cause` instead.

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -42,7 +42,7 @@
     "test": "vitest --config ../../vitest.package.config.ts run",
     "test:watch": "vitest --config ../../vitest.package.config.ts",
     "test:sqlite": "vitest --config ../../vitest.package.config.ts run src/sqlite.spec.ts",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- vitest --config ../../vitest.package.config.ts run src/postgres.spec.ts src/postgres-vector.spec.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- vitest --config ../../vitest.package.config.ts run src/postgres.spec.ts src/postgres-vector.spec.ts src/postgres-connection-lifecycle.spec.ts",
     "test:duckdb": "vitest --config ../../vitest.package.config.ts run src/duckdb.spec.ts",
     "build": "vite build",
     "build:watch": "vite build --watch",

--- a/packages/sql/src/postgres-connection-lifecycle.spec.ts
+++ b/packages/sql/src/postgres-connection-lifecycle.spec.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getDatabase } from './index';
+
+function postgresTestOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'postgres' as const,
+    database: process.env.SQLOO_DATABASE || 'testdb',
+    host: process.env.SQLOO_HOST || 'localhost',
+    user: process.env.SQLOO_USER || 'postgres',
+    password: process.env.SQLOO_PASSWORD || 'postgres',
+    port: Number(process.env.SQLOO_PORT) || 5432,
+    ...overrides,
+  };
+}
+
+async function checkPostgreSQLConnection(): Promise<boolean> {
+  try {
+    const testDb = await getDatabase(
+      postgresTestOptions({ dbid: randomUUID() }),
+    );
+    await testDb.execute`SELECT 1`;
+    await testDb.client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('postgres connection lifecycle', () => {
+  let postgresAvailable = false;
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    postgresAvailable = await checkPostgreSQLConnection();
+    if (!postgresAvailable) {
+      console.log('PostgreSQL not available, skipping test');
+      return;
+    }
+    // dbid keeps each test on its own pool: the connection cache keys on
+    // url/dbid/host only, so without it these tests would share (and end) a
+    // pool with the rest of the suite.
+    db = await getDatabase(postgresTestOptions({ dbid: randomUUID(), max: 3 }));
+  });
+
+  afterEach(async () => {
+    if (!postgresAvailable || !db) return;
+    await db.client.end();
+  });
+
+  // Issue #1113
+  it('registers a pool error handler so an idle client failure cannot crash the process', async () => {
+    if (!postgresAvailable) return;
+
+    const pool = db.client as Pool;
+    expect(pool.listenerCount('error')).toBeGreaterThan(0);
+
+    // With no listener this emit would throw as an unhandled 'error' event,
+    // which in production terminates the process.
+    expect(() => {
+      pool.emit(
+        'error',
+        new Error('simulated backend disconnect'),
+        {} as never,
+      );
+    }).not.toThrow();
+
+    const stillWorks = await db.query('SELECT 1 AS ok');
+    expect(stillWorks.rows[0].ok).toBe(1);
+  });
+
+  // Issue #1112
+  it('returns the pooled client when COMMIT fails', async () => {
+    if (!postgresAvailable || !db.beginTransaction) return;
+
+    const table = `commit_fail_${randomUUID().replace(/-/g, '')}`;
+    await db.query(
+      `CREATE TABLE ${table} (
+         id int primary key,
+         u  int UNIQUE DEFERRABLE INITIALLY DEFERRED
+       )`,
+    );
+
+    const pool = db.client as Pool;
+
+    // A deferred UNIQUE violation is not detected until COMMIT, so this is a
+    // COMMIT that genuinely throws rather than one Postgres downgrades to a
+    // silent rollback.
+    const tx = await db.beginTransaction();
+    await tx.query(`INSERT INTO ${table} (id, u) VALUES (1, 7)`);
+    await tx.query(`INSERT INTO ${table} (id, u) VALUES (2, 7)`);
+    await expect(tx.commit()).rejects.toThrow(/duplicate key value/);
+
+    expect(tx.isActive()).toBe(false);
+    expect(pool.waitingCount).toBe(0);
+
+    // The real symptom of the leak: with max: 3, four more failed commits used
+    // to check out every connection permanently and hang all later queries.
+    for (let i = 0; i < 4; i++) {
+      const leaky = await db.beginTransaction();
+      await leaky.query(`INSERT INTO ${table} (id, u) VALUES (${10 + i}, 99)`);
+      await leaky.query(`INSERT INTO ${table} (id, u) VALUES (${20 + i}, 99)`);
+      await expect(leaky.commit()).rejects.toThrow(/duplicate key value/);
+    }
+
+    const after = await Promise.race([
+      db.query('SELECT 1 AS ok').then((r) => r.rows[0].ok),
+      new Promise((resolve) =>
+        setTimeout(() => resolve('pool exhausted'), 5000),
+      ),
+    ]);
+    expect(after).toBe(1);
+
+    await db.query(`DROP TABLE IF EXISTS ${table}`);
+  });
+
+  // Issue #1112
+  it('rejects a second commit/rollback after the transaction already ended', async () => {
+    if (!postgresAvailable || !db.beginTransaction) return;
+
+    const tx = await db.beginTransaction();
+    await tx.commit();
+    expect(tx.isActive()).toBe(false);
+    await expect(tx.commit()).rejects.toThrow('Transaction already ended');
+    await expect(tx.rollback()).rejects.toThrow('Transaction already ended');
+  });
+
+  // Issue #1112
+  it("preserves the caller's error when ROLLBACK also fails", async () => {
+    if (!postgresAvailable || !db.transaction) return;
+
+    let caught: Error | undefined;
+    try {
+      await db.transaction(async (tx) => {
+        // Kill the backend so the adapter's ROLLBACK cannot succeed.
+        await tx
+          .query('SELECT pg_terminate_backend(pg_backend_pid())')
+          .catch(() => undefined);
+        throw new Error('__ORIGINAL_CALLER_ERROR__');
+      });
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    expect(caught?.message).toBe('__ORIGINAL_CALLER_ERROR__');
+    // The rollback failure is preserved as context rather than replacing the
+    // error the caller actually needs to see.
+    expect(caught?.cause).toBeDefined();
+  });
+});

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -1,5 +1,5 @@
 import { DatabaseError, loadEnvConfig } from '@happyvertical/utils';
-import { Pool } from 'pg';
+import { Pool, type PoolClient } from 'pg';
 import { DatabaseSchemaManager } from './schema-manager';
 import {
   generateAddColumnStatement,
@@ -644,6 +644,19 @@ async function createDatabase(
         },
   );
 
+  // An idle pooled client that loses its backend (restart, failover, proxy
+  // idle timeout, TCP reset) emits 'error' on the pool. Without a listener Node
+  // treats that as an unhandled 'error' event and terminates the process, so
+  // routine database maintenance would crash every consumer of this adapter.
+  // pg has already removed the client from the pool by this point; absorb the
+  // event and let the pool carry on with its remaining connections.
+  pool.on('error', (error) => {
+    console.warn(
+      'Warning: PostgreSQL pool client error (connection discarded):',
+      error instanceof Error ? error.message : String(error),
+    );
+  });
+
   // Wrap pool.end() to evict from cache so stale pools are never returned.
   // This fixes the "Cannot use a pool after calling end on the pool" error
   // when tests or shutdown code calls db.client.end() and subsequent calls
@@ -841,12 +854,84 @@ async function createDatabase(
     return { operation: 'upsert', affected: insertResult.rowCount ?? 0 };
   };
 
+  /**
+   * Absorbs 'error' events for the clients currently checked out for a
+   * transaction, keyed by client so the listener can be removed on release.
+   */
+  const txErrorAbsorbers = new WeakMap<PoolClient, () => void>();
+  const releasedTxClients = new WeakSet<PoolClient>();
+
+  /**
+   * Checks out a pooled client for a transaction.
+   *
+   * pg-pool drops its own idle 'error' listener while a client is checked out,
+   * so a backend that dies mid-transaction would emit an unhandled 'error' and
+   * terminate the process. Absorb it here — the failure still reaches the
+   * caller as a rejected query — and drop the listener again on release so
+   * repeated checkouts of the same client cannot accumulate them.
+   */
+  const acquireTxClient = async (): Promise<PoolClient> => {
+    const txClient = await client.connect();
+    // The pool hands back the same client objects, so the release guard has to
+    // be reset per checkout — otherwise every reuse after the first would be
+    // treated as already released and stay checked out forever.
+    releasedTxClients.delete(txClient);
+    const absorb = () => {};
+    txClient.on('error', absorb);
+    txErrorAbsorbers.set(txClient, absorb);
+    return txClient;
+  };
+
+  /**
+   * Returns a transaction client to the pool exactly once.
+   *
+   * Every teardown path must run this, including the ones reached by a throwing
+   * COMMIT or ROLLBACK — a client that is never released stays checked out for
+   * the life of the process, and enough of them exhaust the pool. Releasing
+   * twice throws, so the released clients are tracked rather than assumed.
+   *
+   * @param txClient - The pooled client backing a transaction
+   * @param destroy - Destroy the connection instead of reusing it, for when the
+   *   transaction state could not be cleaned up
+   */
+  const releaseTxClient = (txClient: PoolClient, destroy = false): void => {
+    if (releasedTxClients.has(txClient)) return;
+    releasedTxClients.add(txClient);
+    const absorb = txErrorAbsorbers.get(txClient);
+    if (absorb) {
+      txClient.off('error', absorb);
+      txErrorAbsorbers.delete(txClient);
+    }
+    txClient.release(destroy || undefined);
+  };
+
+  /**
+   * Rolls back a failed transaction and returns its client to the pool.
+   *
+   * The connection may still be inside a transaction, so ROLLBACK is attempted
+   * to normalize it. If that works the connection is clean and worth reusing;
+   * if it does not, the state is unknown and the connection is destroyed rather
+   * than handed to unrelated code later.
+   *
+   * @returns The rollback failure, if the connection could not be normalized
+   */
+  const discardTxClient = async (txClient: PoolClient): Promise<unknown> => {
+    try {
+      await txClient.query('ROLLBACK');
+      releaseTxClient(txClient);
+      return undefined;
+    } catch (rollbackError) {
+      releaseTxClient(txClient, true);
+      return rollbackError;
+    }
+  };
+
   const executeNullAwarePostgresUpsertInTransaction = async (
     table: string,
     conflictColumns: string[],
     serializedData: Record<string, any>,
   ): Promise<BaseQueryResult> => {
-    const txClient = await client.connect();
+    const txClient = await acquireTxClient();
 
     try {
       await txClient.query('BEGIN');
@@ -857,12 +942,14 @@ async function createDatabase(
         serializedData,
       );
       await txClient.query('COMMIT');
+      releaseTxClient(txClient);
       return result;
     } catch (error) {
-      await txClient.query('ROLLBACK');
+      const rollbackError = await discardTxClient(txClient);
+      if (rollbackError !== undefined && error instanceof Error) {
+        error.cause ??= rollbackError;
+      }
       throw error;
-    } finally {
-      txClient.release();
     }
   };
 
@@ -1664,7 +1751,7 @@ async function createDatabase(
     callback: (tx: DatabaseInterface) => Promise<T>,
   ): Promise<T> => {
     // Get a client from the pool for the transaction
-    const txClient = await client.connect();
+    const txClient = await acquireTxClient();
 
     try {
       await txClient.query('BEGIN');
@@ -1855,12 +1942,17 @@ async function createDatabase(
 
       const result = await callback(txDb);
       await txClient.query('COMMIT');
+      releaseTxClient(txClient);
       return result;
     } catch (error) {
-      await txClient.query('ROLLBACK');
+      // Never let a failing ROLLBACK replace the caller's error. On a dead
+      // connection the rollback throws "Connection terminated unexpectedly",
+      // which would otherwise be the only thing the caller ever sees.
+      const rollbackError = await discardTxClient(txClient);
+      if (rollbackError !== undefined && error instanceof Error) {
+        error.cause ??= rollbackError;
+      }
       throw error;
-    } finally {
-      txClient.release();
     }
   };
 
@@ -1874,28 +1966,44 @@ async function createDatabase(
    */
   const beginTransaction = async (): Promise<TransactionHandle> => {
     // Get a client from the pool for the transaction
-    const txClient = await client.connect();
-    await txClient.query('BEGIN');
+    const txClient = await acquireTxClient();
+    try {
+      await txClient.query('BEGIN');
+    } catch (error) {
+      // BEGIN failed, so there is no transaction for the caller to end and no
+      // handle to release the client — return it here or it is stranded.
+      releaseTxClient(txClient, true);
+      throw error;
+    }
 
     let active = true;
 
-    const commit = async (): Promise<void> => {
+    // COMMIT and ROLLBACK both throw in ordinary operation — deferred
+    // constraint violations, serialization failures, a connection lost at
+    // commit time. The transaction is over either way, so end it and return the
+    // client before rethrowing; leaving it checked out would strand a pooled
+    // connection permanently and eventually deadlock the pool.
+    const end = async (command: 'COMMIT' | 'ROLLBACK'): Promise<void> => {
       if (!active) {
         throw new DatabaseError('Transaction already ended', {});
       }
-      await txClient.query('COMMIT');
-      active = false;
-      txClient.release();
+      try {
+        await txClient.query(command);
+        active = false;
+        releaseTxClient(txClient);
+      } catch (error) {
+        active = false;
+        const rollbackError = await discardTxClient(txClient);
+        if (rollbackError !== undefined && error instanceof Error) {
+          error.cause ??= rollbackError;
+        }
+        throw error;
+      }
     };
 
-    const rollback = async (): Promise<void> => {
-      if (!active) {
-        throw new DatabaseError('Transaction already ended', {});
-      }
-      await txClient.query('ROLLBACK');
-      active = false;
-      txClient.release();
-    };
+    const commit = (): Promise<void> => end('COMMIT');
+
+    const rollback = (): Promise<void> => end('ROLLBACK');
 
     const isActive = (): boolean => active;
 


### PR DESCRIPTION
Fixes two PostgreSQL connection-lifecycle defects found while verifying #1108.
Both are reachable without any application bug — one crashes the process, the
other deadlocks the pool.

Closes #1112
Closes #1113

## #1113 — an unhandled pool `error` crashes the process

The pool was created with no `'error'` listener. When an idle pooled client
loses its backend — a database restart, a failover, a PgBouncer/RDS Proxy idle
timeout, any TCP reset — pg emits `'error'` on the pool, and Node escalates an
unhandled `'error'` event to an uncaught exception. Nothing in application code
can catch it.

Observed during verification:

```
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
Error: Connection terminated unexpectedly
 ❯ Connection.<anonymous> node_modules/pg/lib/client.js:180:73
```

The adapter already guarded the narrow version of this for pinned sessions, with
a comment explaining the exact failure mode (`acquireSession`, `postgres.ts`);
the pool itself was never covered.

This adds the pool-level handler, and also absorbs the same event on clients
checked out for a transaction — pg-pool removes its own listener for the
duration of a checkout, so a backend that dies mid-transaction hit the identical
crash. The failure still reaches the caller as a rejected query.

## #1112 — a throwing COMMIT/ROLLBACK leaks the pooled client

`commit()` and `rollback()` released the client on the line *after* the query:

```ts
await txClient.query('COMMIT');   // throws -> the next two lines never run
active = false;
txClient.release();
```

There was no `try/finally`, so a throwing `COMMIT` left the connection checked
out permanently, with the handle still `active` so the caller could not release
it either. `COMMIT` throws in ordinary operation: deferred constraint
violations, serialization failures under `REPEATABLE READ`/`SERIALIZABLE`, and
connection loss at commit time.

Measured against a `DEFERRABLE INITIALLY DEFERRED` unique constraint before the
fix — `idleCount` pinned at zero while `totalCount` climbs, one connection burned
per failed commit:

```
pool start   -> total:1 idle:1
commit #0 threw: duplicate key value violates unique constraint
  after #0   -> total:1 idle:0
commit #1 threw: duplicate key value violates unique constraint
  after #1   -> total:2 idle:0
```

At the default `max: 20`, twenty failed commits deadlock the application.

Every teardown path now goes through one release helper. On failure the
connection is normalized with a `ROLLBACK` and reused; it is destroyed only when
that rollback also fails and the transaction state is genuinely unknown. The
same missing-release bug existed in `executeNullAwarePostgresUpsertInTransaction`
and in `beginTransaction`'s initial `BEGIN`; both are fixed here.

## #1112 — a failing ROLLBACK swallowed the caller's error

```ts
} catch (error) {
  await txClient.query('ROLLBACK');   // if this throws, `error` is lost
  throw error;
}
```

Verified before the fix: a transaction whose callback threw a business error on
a since-dead connection reported `Connection terminated unexpectedly` and
nothing else. The original error is now preserved and the rollback failure is
attached as `cause`.

## Tests

New `packages/sql/src/postgres-connection-lifecycle.spec.ts`. Three of the four
fail against `main` and pass here; the fourth pins existing
`Transaction already ended` behaviour that the refactor had to preserve.

Verified by stashing the fix and re-running:

```
× registers a pool error handler so an idle client failure cannot crash the process
× returns the pooled client when COMMIT fails
✓ rejects a second commit/rollback after the transaction already ended
× preserves the caller's error when ROLLBACK also fails
  Tests  3 failed | 1 passed (4)
```

The COMMIT-leak test drives five failed commits through a `max: 3` pool, which
hangs on `main` and passes here.

One bug this suite caught during development is worth flagging for review: pg
reuses `PoolClient` objects across checkouts, so the release-once guard has to
reset per checkout rather than per client object. Keyed on the object it made
every reuse after the first look "already released" and stranded it — the same
class of leak the change is meant to fix.

## Validation

- `packages/sql`: 345 passed, 4 skipped (22 files), against postgres:16
- 65 Postgres-backed tests confirmed connected, not skipped
- `typecheck`, `biome check`, `build`: clean
- `test:ci-scripts`: 20 passed; `agent:check`: clean

## Note on the remaining work

#1108 and the six other issues filed alongside it (#1109–#1111, #1114, #1115)
are untouched here — this PR is deliberately limited to the two defects that are
independent of the nested-transaction contract decision.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"6456b241-691b-4ac7-bb81-21649d7bf3c7","issue":"https://github.com/happyvertical/sdk/issues/1112","policy_revision":"1.0.0","status":"complete","validation":["pnpm --filter @happyvertical/sql test (345 passed, postgres:16)","typecheck","biome check","build","test:ci-scripts","agent:check"]}
```
