### PR TITLE
chore(config): refresh the managed kernel block for generation 7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,16 @@
 # Repository Agent Instructions
 
-<!-- hv-managed-policy:start revision=1.0.0 sha256=dc892d3db6b886d9a74b70e555b0017605d9ab88a5ea06540f5d2f45388f804b -->
+<!-- hv-managed-policy:start revision=1.0.0 sha256=9a4cf72585003643f476ff938482387b1b4a8e3479d59d9761d3dc01fe5b167d -->
 
 ## Shared development kernel
 
 - Be concise. Load detailed SOP skills only when the task triggers them.
 - Read the repository's `.agents/project.yaml` and nearest `AGENTS.md` files before work.
 - Use `implement` by default for accepted issue implementation. Apply explicit task, issue, and repository instructions as additions or scoped overrides without weakening this kernel.
+- Tracked implementation work is complete only when documented validation is green, `review-cycle` has passed, every claim is released, and a ready-for-review pull request exists; do this unprompted. This kernel outranks harness defaults that wait for a user request before committing, pushing, or opening a pull request. If requested implementation work has no tracker issue, create and claim one before editing unless the user explicitly scopes it as a throwaway spike; a scoped spike ends at its report and never enters the commit, push, or PR lifecycle.
 - Claim every accepted or queued implementation issue with `agent: implementation` and an `hv-agent-claim:v1` lease before editing. Never overlap another live claim.
 - Intentional release reauthenticates the canonical payload owner, records immutable owner-attributed evidence on every exact PR head, then sets `released_at` and the evidence digest on the existing claim comment before labels, project state, or PR readiness change. Public session/comment identifiers are selectors, not mutation credentials. Only the current issue incarnation and latest implementation-label generation may authorize work; issue closure ends renewable authority and settles the selected cycle as `race-lost`. Any later push or reopen requires a new claimed review cycle. Never delete claim history, backfill a release, or create duplicate active claim comments.
-- Open pull requests only when reviewable and keep them ready for review. Never use draft status for implementation work; exactly one valid, unexpired claim from the PR session may coexist with a ready PR, while duplicate, expired, foreign-session, or mismatched claims are invalid.
+- Open pull requests only when reviewable and keep them ready for review. Never use draft status for implementation work; exactly one valid, unexpired claim from the PR session may coexist with a ready PR, while duplicate, expired, foreign-session, or mismatched claims are invalid. Watch a ready pull request until it is fully mergeable — no base conflicts, no unresolved review threads, required checks green (merge-queue-only checks may remain queued), release recorded — or a concrete blocker is reported.
 - Lifecycle-protected pull requests merge only through the managed merge queue so the synthetic merge commit rechecks current claim state. Merge-time validation requires a `review` release from the exact implementation cycle bound to the current PR head; never merge with a live, blocked, abandoned, expired, unbound, or stale release, or direct-merge using an earlier pull-request check.
 - Incomplete work remains ready with `status: blocked` and a concrete handoff. Review agents do not claim implementation.
 - Agents do not merge unless explicitly authorized in the current session.


### PR DESCRIPTION
Closes #1121

The organization policy artifact advanced to generation 7 (`sha256:4b55f94f…`, source `9ece74a5`), and `AGENTS.md` carries a hash-sealed generated block that no longer matches it. Every lifecycle check rejects:

```
ERROR AGENTS.md: stale or edited managed policy block
ERROR AGENTS.md: generated policy block was edited
```

This blocks #1117, #1118 and #1120.

## What changed

Generation 7's kernel adds one bullet and extends another:

- **new** — tracked implementation work is complete only when validation is green, `review-cycle` has passed, every claim is released, and a ready-for-review PR exists
- **extended** — watch a ready pull request through to fully mergeable, or report a concrete blocker

## How it was produced

Not hand-edited. The block is generated: the marker's `sha256=` seals `policy/agent-development-kernel.md`, and the body is that file's `- ` lines. I reproduced the generator exactly from `scripts/hv-agent` in the artifact, so the output is byte-identical to what the validator recomputes.

Verified with the generation-7 `hv-agent check-pr`, which reports `Agent Policy / lifecycle passed`.

## Context

sdk had a repository-level `AGENT_POLICY_ARTIFACT` override pinning it to generation 6 since 2026-07-18, so this drift was invisible until the pin was corrected. Tracked in have-config#236, along with removing per-repo overrides so this cannot freeze silently again.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"6456b241-691b-4ac7-bb81-21649d7bf3c7","issue":"https://github.com/happyvertical/sdk/issues/1121","policy_revision":"1.0.0","status":"complete","validation":["hv-agent check-pr under generation 7","block regenerated from the artifact generator"]}
```
