### PR TITLE
fix(sql): stop count() binding the table name as a parameter on sqlite

### DIFF
--- a/.changeset/count-all-rows-sqlite.md
+++ b/.changeset/count-all-rows-sqlite.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/sql': patch
+---
+
+Fix `count()` throwing on the LibSQL SQLite adapter whenever it is called without a `where` clause. (The native SQLite path, used when a `capabilities` option is set, was unaffected.) The no-condition branch built its query through the `pluck` tagged template, which parameterizes every interpolation, so the table name was bound as a value and the adapter emitted `SELECT COUNT(*) FROM ?` — SQLite rejects a parameter in identifier position, surfacing as `DatabaseError: Failed to count records in table`. `db.count(table)` and `db.count(table, {})` had therefore never worked on that adapter; the branch that takes conditions built its SQL correctly, and the no-condition shape was only ever exercised against the JSON adapter, which builds it correctly too, so nothing covered the adapter that got it wrong. The query is now built the same way the conditional branch builds it, which is safe because `validateTableName()` already runs on the table name first. Adds coverage for the no-`where` call shape across every adapter.

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -41,9 +41,9 @@
   "scripts": {
     "test": "vitest --config ../../vitest.package.config.ts run",
     "test:watch": "vitest --config ../../vitest.package.config.ts",
-    "test:sqlite": "vitest --config ../../vitest.package.config.ts run src/sqlite.spec.ts",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- vitest --config ../../vitest.package.config.ts run src/postgres.spec.ts src/postgres-vector.spec.ts src/postgres-connection-lifecycle.spec.ts src/postgres-nested-transaction.spec.ts src/postgres-transaction-errors.spec.ts src/transaction-schema-scope.spec.ts src/identifier-injection.spec.ts src/postgres-insert-column-binding.spec.ts",
-    "test:duckdb": "vitest --config ../../vitest.package.config.ts run src/duckdb.spec.ts",
+    "test:sqlite": "vitest --config ../../vitest.package.config.ts run src/sqlite.spec.ts src/count.spec.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- vitest --config ../../vitest.package.config.ts run src/postgres.spec.ts src/postgres-vector.spec.ts src/postgres-connection-lifecycle.spec.ts src/postgres-nested-transaction.spec.ts src/postgres-transaction-errors.spec.ts src/transaction-schema-scope.spec.ts src/identifier-injection.spec.ts src/postgres-insert-column-binding.spec.ts src/postgres-count.spec.ts",
+    "test:duckdb": "vitest --config ../../vitest.package.config.ts run src/duckdb.spec.ts src/count.spec.ts",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "docs": "typedoc --plugin typedoc-plugin-markdown --out docs --entryPoints ./src/index.ts --tsconfig ./tsconfig.json --excludePrivate --excludeInternal --hideGenerator --fileExtension .md --readme none --categorizeByGroup false --includeVersion false --hidePageHeader --hidePageTitle false --outputFileStrategy modules",

--- a/packages/sql/src/count.spec.ts
+++ b/packages/sql/src/count.spec.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { getDatabase } from './index';
+import type {
+  DatabaseInterface,
+  DuckDBOptions,
+  JSONOptions,
+} from './shared/types';
+import type { SqliteOptions } from './sqlite';
+
+/**
+ * `count()` with no `where` argument built its SQL through the `pluck` tagged
+ * template, which parameterizes every interpolation. The table name was bound
+ * as a value, so the adapter emitted `SELECT COUNT(*) FROM ?` and the driver
+ * rejected it — `db.count(table)` had never worked on the LibSQL SQLite
+ * adapter. The `where` branch interpolates the identifier directly, which is
+ * why it stayed green.
+ *
+ * The no-`where` shape was exercised only against the `json` adapter (in
+ * `json-identifier-quoting.spec.ts` and `json-system-tables.spec.ts`), which
+ * builds the query correctly, so nothing covered the adapters that could get
+ * it wrong. These tests pin the shape on every adapter, since the same mistake
+ * is available to each of them.
+ */
+
+async function seed(db: DatabaseInterface, table: string, rows: number) {
+  await db.query(`CREATE TABLE ${table} (id INTEGER PRIMARY KEY, v TEXT)`);
+  for (let i = 1; i <= rows; i++) {
+    await db.query(`INSERT INTO ${table} VALUES (${i}, 'v${i % 2}')`);
+  }
+}
+
+/**
+ * Typed rather than `Record<string, unknown>` for editor feedback — note this
+ * is not a safety net, since the package tsconfig excludes `*.spec.ts` from
+ * typecheck. The `verify` hook below is what actually holds: a typo in
+ * `capabilities` silently hands back the LibSQL adapter, which would turn the
+ * native block into a second copy of the block above it — green, and testing
+ * nothing new.
+ */
+type AdapterOptions =
+  | (SqliteOptions & { type: 'sqlite' })
+  | (DuckDBOptions & { type: 'duckdb' })
+  | (JSONOptions & { type: 'json' });
+
+/** Each adapter reachable without external services, and how to construct it. */
+const ADAPTERS: Array<{
+  name: string;
+  options: AdapterOptions;
+  /** Asserts the intended implementation was the one actually constructed. */
+  verify?: (db: DatabaseInterface) => void;
+}> = [
+  { name: 'sqlite (libsql)', options: { type: 'sqlite', url: ':memory:' } },
+  // Reached whenever a capability is requested — a separate implementation
+  // with its own query construction, so it needs its own coverage. This
+  // deliberately hard-requires the optional `@sqliteai/sqlite-vector` peer
+  // rather than gating on its presence: gating would silently skip the block
+  // wherever the peer is missing, which is the failure mode this file exists
+  // to close. The lockfile pins the peer, so CI always exercises it.
+  {
+    name: 'sqlite (native capabilities path)',
+    options: {
+      type: 'sqlite',
+      url: ':memory:',
+      capabilities: { vector: true },
+    },
+    // Only the native adapter exposes `vector`, so this fails loudly if the
+    // capability stops routing there — or is simply misspelled here.
+    verify: (db) => expect(db.vector).toBeDefined(),
+  },
+  { name: 'duckdb', options: { type: 'duckdb', url: ':memory:' } },
+  { name: 'json', options: { type: 'json', url: ':memory:' } },
+];
+
+describe('count() without a where clause', () => {
+  for (const adapter of ADAPTERS) {
+    describe(adapter.name, () => {
+      async function open(): Promise<DatabaseInterface> {
+        const db = await getDatabase(adapter.options);
+        adapter.verify?.(db);
+        return db;
+      }
+
+      // The duckdb and json adapters cache their in-memory connection, so each
+      // test uses its own table rather than relying on a fresh database.
+      it('counts every row in the table', async () => {
+        const db = await open();
+        const table = `count_all_${randomUUID().replace(/-/g, '')}`;
+        await seed(db, table, 3);
+
+        expect(await db.count(table)).toBe(3);
+      });
+
+      it('returns 0 for an empty table', async () => {
+        const db = await open();
+        const table = `count_empty_${randomUUID().replace(/-/g, '')}`;
+        await seed(db, table, 0);
+
+        expect(await db.count(table)).toBe(0);
+
+        // `Number(...) || 0` collapses NaN to 0, so a broken result-shape read
+        // would also return 0 here. Counting again after an insert proves the
+        // zero above was real rather than a masked extraction failure.
+        await db.query(`INSERT INTO ${table} VALUES (1, 'v1')`);
+        expect(await db.count(table)).toBe(1);
+      });
+
+      // An empty `where` object takes the same branch as no `where` at all.
+      it('counts every row when given an empty where object', async () => {
+        const db = await open();
+        const table = `count_emptywhere_${randomUUID().replace(/-/g, '')}`;
+        await seed(db, table, 2);
+
+        expect(await db.count(table, {})).toBe(2);
+      });
+
+      // Guards the branch that already worked, so a fix to the no-where path
+      // cannot regress it.
+      it('still counts a filtered subset', async () => {
+        const db = await open();
+        const table = `count_where_${randomUUID().replace(/-/g, '')}`;
+        await seed(db, table, 4);
+
+        expect(await db.count(table, { v: 'v1' })).toBe(2);
+      });
+    });
+  }
+});

--- a/packages/sql/src/postgres-count.spec.ts
+++ b/packages/sql/src/postgres-count.spec.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getDatabase } from './index';
+import type { DatabaseInterface } from './shared/types';
+
+function postgresTestOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'postgres' as const,
+    database: process.env.SQLOO_DATABASE || 'testdb',
+    host: process.env.SQLOO_HOST || 'localhost',
+    user: process.env.SQLOO_USER || 'postgres',
+    password: process.env.SQLOO_PASSWORD || 'postgres',
+    port: Number(process.env.SQLOO_PORT) || 5432,
+    ...overrides,
+  };
+}
+
+/** `transaction` is optional on DatabaseInterface, so narrow rather than assert. */
+function txOf(db: DatabaseInterface) {
+  const fn = db.transaction;
+  if (!fn) throw new Error('adapter does not expose transaction()');
+  return fn.bind(db);
+}
+
+async function checkPostgreSQLConnection(): Promise<boolean> {
+  try {
+    const probe = await getDatabase(
+      postgresTestOptions({ dbid: randomUUID() }),
+    );
+    await probe.execute`SELECT 1`;
+    await probe.client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Companion to `count.spec.ts` — see #1128. The no-`where` branch of `count()`
+ * was only ever exercised against the JSON adapter, which is how the LibSQL
+ * implementation shipped binding the table name as a parameter. PostgreSQL
+ * defines `count()` three separate times (top level, the transaction-scoped
+ * `txDb`, and the `txHandle` returned by `beginTransaction`), so each is
+ * pinned here rather than assumed equivalent.
+ */
+describe('postgres count() without a where clause', () => {
+  let postgresAvailable = false;
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+  let table: string;
+
+  beforeEach(async () => {
+    postgresAvailable = await checkPostgreSQLConnection();
+    if (!postgresAvailable) {
+      console.log('PostgreSQL not available, skipping test');
+      return;
+    }
+    db = await getDatabase(postgresTestOptions({ dbid: randomUUID(), max: 4 }));
+    table = `count_${randomUUID().replace(/-/g, '')}`;
+    await db.query(`CREATE TABLE ${table} (id int primary key, v text)`);
+    for (let i = 1; i <= 4; i++) {
+      await db.query(`INSERT INTO ${table} VALUES (${i}, 'v${i % 2}')`);
+    }
+  });
+
+  afterEach(async () => {
+    if (!postgresAvailable || !db) return;
+    await db.query(`DROP TABLE IF EXISTS ${table}`);
+    await db.client.end();
+  });
+
+  it('counts every row in the table', async () => {
+    if (!postgresAvailable || !db) return;
+    expect(await db.count(table)).toBe(4);
+  });
+
+  it('counts every row when given an empty where object', async () => {
+    if (!postgresAvailable || !db) return;
+    expect(await db.count(table, {})).toBe(4);
+  });
+
+  it('returns 0 for an empty table', async () => {
+    if (!postgresAvailable || !db) return;
+    const empty = `count_empty_${randomUUID().replace(/-/g, '')}`;
+    await db.query(`CREATE TABLE ${empty} (id int primary key)`);
+    try {
+      expect(await db.count(empty)).toBe(0);
+    } finally {
+      await db.query(`DROP TABLE IF EXISTS ${empty}`);
+    }
+  });
+
+  it('still counts a filtered subset', async () => {
+    if (!postgresAvailable || !db) return;
+    expect(await db.count(table, { v: 'v1' })).toBe(2);
+  });
+
+  it('counts inside transaction()', async () => {
+    if (!postgresAvailable || !db) return;
+    const seen = await txOf(db)(async (tx) => {
+      await tx.query(`INSERT INTO ${table} VALUES (5, 'v1')`);
+      return tx.count(table);
+    });
+    // Reads the transaction's own uncommitted insert, so this exercises the
+    // transaction-scoped implementation rather than falling through to the
+    // pooled one.
+    expect(seen).toBe(5);
+  });
+
+  it('counts inside beginTransaction()', async () => {
+    if (!postgresAvailable || !db) return;
+    const begin = db.beginTransaction;
+    if (!begin) throw new Error('adapter does not expose beginTransaction()');
+    const tx = await begin.call(db);
+    try {
+      await tx.query(`INSERT INTO ${table} VALUES (6, 'v0')`);
+      expect(await tx.count(table)).toBe(5);
+    } finally {
+      await tx.rollback();
+    }
+  });
+});

--- a/packages/sql/src/sqlite.ts
+++ b/packages/sql/src/sqlite.ts
@@ -922,9 +922,15 @@ export async function getDatabase(
 
       try {
         if (!where || Object.keys(where).length === 0) {
-          // Count all records
-          const result = await pluck`SELECT COUNT(*) FROM ${table}`;
-          return Number(result) || 0;
+          // Count all records. Built as a plain string rather than through the
+          // `pluck` tagged template, which would bind the table name as a
+          // parameter and emit `SELECT COUNT(*) FROM ?`. Interpolating the
+          // identifier is safe because validateTableName ran above.
+          const result = await client.execute({
+            sql: `SELECT COUNT(*) as count FROM ${table}`,
+            args: [],
+          });
+          return Number(result.rows[0]?.count) || 0;
         }
 
         // Count with conditions


### PR DESCRIPTION
Closes #1128

## Problem

`db.count(table)` with no `where` clause has never worked on the LibSQL SQLite adapter — it throws on every call.

[`packages/sql/src/sqlite.ts:856`](https://github.com/happyvertical/sdk/blob/291ab8fe/packages/sql/src/sqlite.ts#L856) built the no-condition branch through the `pluck` tagged template, which parameterizes **every** interpolation. The table name was bound as a value, so the adapter emitted `SELECT COUNT(*) FROM ?`:

```
DatabaseError: Failed to count records in table
  originalError: DatabaseError: Failed to execute pluck query
    sql:    "SELECT COUNT(*) FROM ?"
    values: ["t"]
    originalError: SQLITE_ERROR: near "?": syntax error, code=SQLITE_ERROR
```

The very next branch — count *with* conditions — built the same query correctly with direct interpolation, which is why the method looked fine on inspection. `db.count(table, {})` took the same broken path.

`README.md:103` already documents `await db.count('posts')` as supported, so the docs were correct and the code was not.

## Fix

Build the SQL the way the sibling `where` branch already does. Direct interpolation is safe because `validateTableName(table)` (an `/^[a-zA-Z_][a-zA-Z0-9_]*$/` allowlist) runs on the first line of the method.

## Scope — only this one adapter

The other four already built this branch as a plain string: `sqlite-native.ts:1204`, `duckdb.ts:800`, `json.ts:1215`, `postgres.ts:1294`/`:1921`/`:2169`.

I swept the package for the general bug class — an SQL *identifier* interpolated into a tagged template that parameterizes interpolations — and this was the only production instance. The remaining tagged-template interpolations in `sqlite.ts` (`sqlite_master` name lookups, `pragma_*` table-valued function arguments) are genuine value positions; I confirmed empirically that libsql accepts a bound parameter in each of those positions and rejects it only in the `FROM` clause.

## Why it survived

The no-`where` shape *was* exercised — but only against the JSON adapter (`json-identifier-quoting.spec.ts`, `json-system-tables.spec.ts`), which builds it correctly. Every `count()` call against SQLite or PostgreSQL passed conditions, so those adapters only ever hit the working branch.

## Tests

- **`count.spec.ts`** — the four locally reachable adapters (LibSQL, native SQLite via `capabilities`, DuckDB, JSON) × no `where` / empty `where` / empty table / filtered subset. Each adapter entry carries a `verify` hook; the native entry asserts `db.vector` is defined, so a misspelled capability fails loudly instead of silently re-testing LibSQL. Worth noting because the package tsconfig excludes `*.spec.ts`, so type-level protection alone would be inert here.
- **`postgres-count.spec.ts`** — PostgreSQL defines `count()` three separate times (top level, `txDb`, `txHandle`); each is pinned rather than assumed equivalent. Registered in `test:postgres`, since that script names its spec files explicitly and would otherwise skip it silently in CI.
- `test:sqlite` and `test:duckdb` now include `count.spec.ts` too.

Verified failing before the fix (3 failures, LibSQL block only) and passing after.

## Validation

| check | result |
|---|---|
| `pnpm --filter @happyvertical/sql test` | 26 files, **384 passed / 4 skipped** (362 baseline + 22 new) |
| `pnpm test:postgres` (live PostgreSQL 17) | **69 passed / 3 failed** — see below |
| `pnpm typecheck` | pass |
| `pnpm build` | pass |
| `pnpm test:ci-scripts` | 20/20 pass |
| `pnpm agent:check` | pass |
| biome | clean |

### The 3 PostgreSQL failures are pre-existing and unrelated

They are in `postgres-vector.spec.ts` and reproduce identically on `main` with this branch stashed. They will not affect CI: `.github/workflows/postgres-tests.yml` runs `postgres:18-alpine`, which has no pgvector, so that spec's `CREATE EXTENSION vector` probe fails and the whole block skips. I only saw them because I ran against `pgvector/pgvector:pg17` locally.

They are the *same bug class as this PR*, in test code — `SELECT ... FROM "${testTable}"` inside a `single` tagged template, producing `relation "$1" does not exist`. Filed separately rather than expanded into this PR.

### Note on PostgreSQL CI coverage

The `PostgreSQL Tests` checks on this PR report **skipping** — the job gates on `vars.CI_POSTGRES_ENABLED == 'true'`, which is set at neither repository nor organization level. So registering `postgres-count.spec.ts` in `test:postgres` is necessary but not sufficient today, and no PostgreSQL assertion in this PR was exercised by CI. The 6 PostgreSQL tests above were verified locally against a real PostgreSQL 17 (6/6 passing); that local run is the evidence, not the green check.

They are the *same bug class as this PR*, in test code — `SELECT ... FROM "${testTable}"` inside a `single` tagged template, producing `relation "$1" does not exist`. Filed separately rather than expanded into this PR.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"03990957-afbc-4f7d-ac8e-da707cf724a7","issue":"https://github.com/happyvertical/sdk/issues/1128","policy_revision":"1.0.0","validation":["pnpm --filter @happyvertical/sql test (384 passed, 4 skipped, 26 files)","pnpm --filter @happyvertical/sql test:postgres (69 passed; 3 pre-existing postgres-vector failures, reproduced on main)","pnpm typecheck","pnpm build","pnpm test:ci-scripts (20 passed)","pnpm agent:check","biome check"]}
```
