### PR TITLE
chore(ci): migrate to the channel-aware agent-policy consumer workflow

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -16,6 +16,8 @@
       "claude": "dispatch: claude",
       "codex": "dispatch: codex",
       "hermes": "dispatch: hermes",
+      "jcode": "dispatch: jcode",
+      "kimi": "dispatch: kimi",
       "zcode": "dispatch: zcode"
     }
   },

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -40,14 +40,43 @@ jobs:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v3.0.6
-      - name: Load pinned policy runtime
+      - name: Select source-owned policy channel
+        shell: bash
         env:
-          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          source_repository=$(gh api repos/happyvertical/.github --jq '.id')
+          test "$source_repository" = 1129270614 || {
+            echo "trusted policy source repository id is $source_repository, expected 1129270614" >&2
+            exit 1
+          }
+          channel_state="$RUNNER_TEMP/hv-agent-policy-channels.json"
+          gh api 'repos/happyvertical/.github/contents/.github/agent-policy-channels.json?ref=main' \
+            --jq '.content' | base64 --decode > "$channel_state"
+          protected_selector="$RUNNER_TEMP/hv-agent-policy-channel-select"
+          gh api 'repos/happyvertical/.github/contents/scripts/hv-agent-policy-channel-select?ref=main' \
+            --jq '.content' | base64 --decode > "$protected_selector"
+          chmod +x "$protected_selector"
+          selected_lock="$RUNNER_TEMP/hv-agent-policy-selected-lock.json"
+          target_repository_id=$(gh api "repos/$TARGET_REPOSITORY" --jq '.node_id')
+          channel=$(python3 "$protected_selector" \
+            "$channel_state" "$selected_lock" "$target_repository_id")
+          artifact=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["artifact"])' "$selected_lock")
+          {
+            echo "HV_POLICY_ARTIFACT=$artifact"
+            echo "HV_POLICY_CHANNEL=$channel"
+            echo "HV_POLICY_LOCK=$selected_lock"
+          } >> "$GITHUB_ENV"
+      - name: Load selected policy runtime
+        env:
+          POLICY_ARTIFACT: ${{ env.HV_POLICY_ARTIFACT }}
           POLICY_PUBLISHER_IDENTITY: ${{ vars.AGENT_POLICY_PUBLISHER_IDENTITY }}
         run: |
           case "$POLICY_ARTIFACT" in
             ghcr.io/happyvertical/agent-policy@sha256:*) ;;
-            *) echo 'AGENT_POLICY_ARTIFACT must pin the trusted HappyVertical policy image by digest' >&2; exit 1 ;;
+            *) echo 'source-owned policy channel must select the trusted HappyVertical policy image by digest' >&2; exit 1 ;;
           esac
           expected_publisher_identity_sha256=86a917ce537a9e923ce02103068c76eb72629247ab584f7d368ac238a0209857
           publisher_identity_sha256=$(python3 -c 'import hashlib, os; print(hashlib.sha256(os.environ["POLICY_PUBLISHER_IDENTITY"].encode()).hexdigest())')
@@ -84,14 +113,33 @@ jobs:
           PY
           tar -xzf "$archive" -C "$policy_dir"
           identity=$(python3 "$policy_dir/scripts/verify-policy-artifact" "$policy_dir")
-          echo "Loaded $identity from $POLICY_ARTIFACT"
+          python3 - "$HV_POLICY_LOCK" "$policy_dir/policy-artifact.json" "$POLICY_ARTIFACT" <<'PY'
+          import json
+          import sys
+
+          lock = json.load(open(sys.argv[1], encoding="utf-8"))
+          manifest = json.load(open(sys.argv[2], encoding="utf-8"))
+          expected = {
+              "artifact": sys.argv[3],
+              "generation": manifest.get("generation"),
+              "policy_revision": manifest.get("policy_revision"),
+              "source_commit": manifest.get("source_commit"),
+              "source_tree_sha256": manifest.get("source_tree_sha256"),
+          }
+          for field, value in expected.items():
+              if lock.get(field) != value:
+                  raise SystemExit(
+                      f"selected policy lock {field} does not match signed artifact manifest"
+                  )
+          PY
+          echo "Loaded $identity from $HV_POLICY_CHANNEL channel $POLICY_ARTIFACT"
           echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
           echo "HV_POLICY_IDENTITY=$identity" >> "$GITHUB_ENV"
       - name: Validate lifecycle
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
+          POLICY_ARTIFACT: ${{ env.HV_POLICY_ARTIFACT }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -99,6 +147,10 @@ jobs:
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -euo pipefail
+          if test "$EVENT_NAME" = workflow_dispatch && test "${PR_NUMBER:-0}" = 0; then
+            python3 "$HV_POLICY_DIR/scripts/hv-agent" audit .
+            exit
+          fi
           numbers_file="$RUNNER_TEMP/hv-agent-lifecycle-prs"
           "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" > "$numbers_file"
           while IFS= read -r number; do


### PR DESCRIPTION
Closes #1124. Rollout checklist step 3 for generation 7 — the representative consumer migration.

## What

Generated by `hv-agent migrate-repo --profile happyvertical --apply` from have-config at `d0cc62f`:

- `.github/workflows/agent-policy.yml` — replaced with the channel-aware consumer workflow, **byte-identical** (`cmp`) to the canonical template. Lifecycle now fetches the central channel state and selector from protected authority main and selects the policy artifact by channel; the repository `AGENT_POLICY_ARTIFACT` pin becomes inert.
- `.agents/project.yaml` — adds the `jcode` and `kimi` dispatch labels from the current profile.

## Why now

The generation-7 channel state is live centrally (happyvertical/.github#20, #22), and the migration deadlock for diagnostic-stage consumers was fixed in happyvertical/have-config#238 / #239: the cutover preflight waives only this repository's own canary and accepts the repinned generation-6 cohort's bridge evidence. The preflight passed cleanly before this diff was generated.

## Effect

- This repository stops depending on manual artifact repins (the mechanism behind the generation-6 staleness documented in happyvertical/have-config#236).
- Satisfies the outstanding happyvertical/have-config#214 acceptance item — a representative consumer selecting, verifying, pulling, and executing the artifact via the channel path with its scoped `GITHUB_TOKEN` — once this merges and its lifecycle runs green.
- Unblocks the generation-8 central prepare (happyvertical/have-config#228 steps 4–5); this repo is in the smoke ring.

The merge-group resolver fix itself is already active here via the repinned variable; this migration makes that delivery path structural instead of manual.

<!-- hv-agent-run:v1 -->
<!--
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude",
  "session": "a8e59670-e177-4f86-9561-736248f8d3f9",
  "issue": "https://github.com/happyvertical/sdk/issues/1124",
  "policy_revision": "1.0.0",
  "validation": [
    "cmp byte-identity of .github/workflows/agent-policy.yml against the canonical channel-aware template",
    "hv-agent migrate-repo diagnostic cutover preflight passed against live authority state"
  ]
}
-->
