### PR TITLE
fix(sql)!: require raw() marker for buildWhere expression keys (#1127)

### DIFF
--- a/.changeset/buildwhere-raw-expression-keys.md
+++ b/.changeset/buildwhere-raw-expression-keys.md
@@ -1,0 +1,22 @@
+---
+'@happyvertical/sql': minor
+---
+
+**Breaking:** condition keys are now validated as plain SQL identifiers whether or not they carry an operator suffix. Previously a key ending in a recognised operator (`>`, `like`, `in`, …) suppressed identifier validation for the whole key, so everything before the operator was emitted as raw SQL — `{ "name = '' OR 1=1 --  =": x }` was accepted and injected. Keys *without* an operator suffix were already validated, which made the escape hatch easy to cross by accident: the same condition object was safe or unsafe depending on whether the caller appended an operator.
+
+Expression keys now require the new `raw()` marker, which states that the SQL is caller-authored:
+
+```typescript
+import { buildWhere, raw } from '@happyvertical/sql';
+
+buildWhere({ 'LOWER(status) =': 'paid' });          // now throws
+buildWhere({ [raw('LOWER(status) =')]: 'paid' });   // WHERE LOWER(status) = $1
+```
+
+`raw()` prefixes the expression with a fixed, non-secret marker that `buildWhere` strips before emitting SQL. The point is worth stating plainly: this stops an expression key being used *by accident* — the shape of the key no longer grants raw access, only a call to `raw()` does — but it is not a sanitizer. A caller that maps an entire attacker-controlled string into a key, marker included, can still reach raw SQL, so continue to validate at your own trust boundary. The marker holds no secret, so keys stay readable in errors, logs and `DatabaseError` context, and wrapping one expression never changes what an unmarked key means elsewhere.
+
+This also removes an inconsistency inside the package: `buildAggregate` already validated where-keys regardless of operator suffix and rejected the expression shape `buildWhere` accepted. Both builders now behave the same, `buildAggregate` composes its `HAVING` expressions through `raw()`, and a `raw()` key in `having` is emitted verbatim instead of being expanded as a select alias.
+
+**Scope of the break.** This is not limited to callers of `buildWhere` and `buildAggregate`. Every adapter routes the caller's `where` through `buildWhere`, so `get`, `list`, `update`, `delete`, `count` and `getOrInsert` on the PostgreSQL, SQLite, sqlite-native, DuckDB and JSON adapters are affected too — `db.list('users', { 'LOWER(email) =': x })` now throws. (`upsert` matches on `conflictColumns`, not a `where`, so it is unaffected.)
+
+To migrate, wrap developer-authored expression keys in `raw()`. Plain identifiers, with or without operator suffixes (`'price >'`, `'orders.total <='`), are unaffected. Note that enforcement is at runtime: `WhereClause` keys are plain `string`, so TypeScript will not flag an unmarked expression key at the call site.

--- a/docs/content/sql.md
+++ b/docs/content/sql.md
@@ -357,6 +357,17 @@ const { sql, values } = buildWhere({
 const products = await db.many`SELECT * FROM products ${sql}`;
 ```
 
+Condition keys are validated as plain SQL identifiers. Expression keys must be
+wrapped in `raw()`, which asserts the SQL is caller-authored rather than derived
+from a request:
+
+```typescript
+import { buildWhere, raw } from '@happyvertical/sql';
+
+buildWhere({ [raw('LOWER(status) =')]: 'paid' });
+// WHERE LOWER(status) = $1
+```
+
 ### Schema Synchronization
 
 ```typescript

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -162,9 +162,30 @@ buildWhere([
 // WHERE (status = $1 AND price > $2) OR (status = $3 AND priority = $4)
 ```
 
-Condition keys with explicit operator suffixes are emitted as SQL
-field/expression text. Keep those keys developer-controlled; do not pass
-end-user input as condition keys.
+Every condition key is validated as a plain SQL identifier, with or without an
+operator suffix, so mapping untrusted input into a key throws instead of
+emitting attacker-controlled SQL. To use expression text as a key, wrap it in
+`raw()`:
+
+```typescript
+import { buildWhere, raw } from '@happyvertical/sql';
+
+buildWhere({
+  status: 'active',              // validated as an identifier
+  [raw('LOWER(name) like')]: '%shirt%',  // caller-authored SQL
+});
+```
+
+`raw()` asserts that the caller, not the request, authored that SQL — never
+build its argument from end-user input. It marks a key rather than sanitizing
+it: it stops an expression key being used by accident, but a caller that maps an
+entire attacker-controlled string into a key can still reach raw SQL, so keep
+validating at your own trust boundary. Enforcement is at runtime — `WhereClause`
+keys are plain `string`, so TypeScript will not flag an unmarked expression key.
+
+The same validation applies to every adapter method that takes a `where`
+(`get`, `list`, `update`, `delete`, `count`, `getOrInsert`), not just to
+`buildWhere` itself.
 
 ### Aggregate Query Building
 
@@ -314,7 +335,7 @@ shipping it beyond development or test environments.
 
 **Interface** (`DatabaseInterface`): `many`, `single`, `pluck`, `execute`, `query`, `insert`, `get`, `list`, `update`, `upsert`, `getOrInsert`, `delete`, `count`, `table`, `tableExists`, `syncSchema`, `transaction`, `beginTransaction`, `vector`, `notifications`, `close`.
 
-**Utilities**: `buildWhere`, `syncSchema`, `tableExists`, `escapeSqlValue`, `validateColumnName`, `formatDbError`, `convertUniqueIndexesToInlineConstraints`.
+**Utilities**: `buildWhere`, `raw`, `syncSchema`, `tableExists`, `escapeSqlValue`, `validateColumnName`, `formatDbError`, `convertUniqueIndexesToInlineConstraints`.
 
 **Schema**: `DatabaseSchemaManager` for JSON manifest-based schema initialization with dependency resolution.
 

--- a/packages/sql/src/aggregate.spec.ts
+++ b/packages/sql/src/aggregate.spec.ts
@@ -4,6 +4,7 @@ import {
   bucketExpr,
   buildAggregate,
   getDatabase,
+  raw,
   syncSchema,
 } from './index.js';
 
@@ -325,5 +326,71 @@ describe('aggregate SQL builder', () => {
         having: { 'count = count OR count': 1 },
       }),
     ).toThrow('Invalid SQL identifier');
+    expect(() =>
+      buildAggregate({
+        from: 'orders',
+        select: [{ fn: 'count', as: 'count' }],
+        where: { 'tenant_id = tenant_id OR status >': 'paid' },
+      }),
+    ).toThrow('Invalid SQL identifier');
+  });
+
+  it('accepts raw() expression keys in where', () => {
+    const result = buildAggregate({
+      from: 'orders',
+      select: [{ fn: 'count', as: 'order_count' }],
+      where: { [raw('LOWER(status) =')]: 'paid' },
+    });
+
+    expect(result.sql).toBe(
+      'SELECT COUNT(*) AS order_count FROM orders WHERE LOWER(status) = $1',
+    );
+    expect(result.values).toEqual(['paid']);
+  });
+
+  it('accepts raw() expression keys in having, verbatim', () => {
+    // `having` is typed WhereClause like `where`, so raw() has to work here too
+    // — and must not fall through to identifier validation.
+    const result = buildAggregate({
+      from: 'orders',
+      select: [
+        { column: 'customer_id' },
+        { fn: 'sum', column: 'total', as: 'revenue' },
+      ],
+      having: { [raw('MIN(total) >')]: 5 },
+    });
+
+    expect(result.sql).toBe(
+      'SELECT customer_id AS customer_id, SUM(total) AS revenue FROM orders GROUP BY customer_id HAVING MIN(total) > $1',
+    );
+    expect(result.values).toEqual([5]);
+  });
+
+  it('expands select aliases in having but leaves raw() keys alone', () => {
+    const spec = {
+      from: 'orders',
+      select: [
+        { column: 'customer_id' },
+        { fn: 'sum', column: 'total', as: 'revenue' },
+      ],
+    } as const;
+
+    // An alias key is expanded to its select expression...
+    expect(
+      buildAggregate({
+        ...spec,
+        select: [...spec.select],
+        having: { 'revenue >': 1 },
+      }).sql,
+    ).toContain('HAVING SUM(total) > $1');
+
+    // ...while a raw() key is emitted exactly as written.
+    expect(
+      buildAggregate({
+        ...spec,
+        select: [...spec.select],
+        having: { [raw('revenue >')]: 1 },
+      }).sql,
+    ).toContain('HAVING revenue > $1');
   });
 });

--- a/packages/sql/src/aggregate.ts
+++ b/packages/sql/src/aggregate.ts
@@ -2,7 +2,9 @@ import type { WhereClause } from './shared/types.js';
 import {
   buildWhere,
   parseConditionKey,
+  raw,
   type SqlAdapterType,
+  unwrapRawKey,
 } from './shared/utils.js';
 
 export type AggregateTimeBucketUnit =
@@ -151,32 +153,22 @@ function selectExpression(
   return { expression, alias, groupingCandidate: false };
 }
 
-function validateWhereShape(where: AggregateSpec['where']): void {
-  if (!where) return;
-  const validateKey = (key: string) => {
-    const { field } = parseConditionKey(key);
-    if (field) validateSqlIdentifier(field);
-  };
-  if (Array.isArray(where)) {
-    for (const andGroup of where) {
-      for (const condition of andGroup) {
-        for (const key of Object.keys(condition)) validateKey(key);
-      }
-    }
-    return;
-  }
-  for (const key of Object.keys(where)) validateKey(key);
-}
-
 function expandHavingKey(
   key: string,
   expressionByAlias: Map<string, string>,
 ): string {
+  // A key the caller already wrapped in raw() is used verbatim: raw() means
+  // "this exact SQL", so it deliberately bypasses select-alias expansion.
+  if (unwrapRawKey(key).isRaw) return key;
+
   const parsed = parseConditionKey(key);
   const expression =
     expressionByAlias.get(parsed.field) ?? validateSqlIdentifier(parsed.field);
 
-  return `${expression} ${parsed.operator}`;
+  // The caller's key is validated above (as an alias or a plain identifier);
+  // what comes out is a select expression such as `SUM(total) >`, which only
+  // buildWhere's raw channel accepts.
+  return raw(`${expression} ${parsed.operator}`);
 }
 
 function expandHaving(
@@ -243,8 +235,6 @@ export function buildAggregate(
       'AggregateSpec.select must contain at least one expression',
     );
   }
-
-  validateWhereShape(spec.where);
 
   const expressionByAlias = new Map<string, string>();
   const groupingAliases: string[] = [];

--- a/packages/sql/src/index.spec.ts
+++ b/packages/sql/src/index.spec.ts
@@ -1,10 +1,11 @@
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildWhere, getDatabase, syncSchema } from './index';
+import { buildWhere, getDatabase, raw, syncSchema } from './index';
 
 const _TMP_DIR = path.resolve(`${tmpdir()}/kissd`);
 const deletedAt = 'deleted_at';
+const tenantId = 'tenant_id';
 
 it.skip('should be able to get the adapter for a postgres database', async () => {
   const db = await getDatabase({
@@ -172,11 +173,11 @@ it('should handle IN clauses with arrays', () => {
   ]);
 });
 
-it('should handle expression fields with spaces', () => {
+it('should handle expression fields wrapped in raw()', () => {
   const result = buildWhere({
-    'COUNT(DISTINCT user_id) >=': 2,
-    'SUM(total_amount) >': 100,
-    'LOWER(status) =': 'paid',
+    [raw('COUNT(DISTINCT user_id) >=')]: 2,
+    [raw('SUM(total_amount) >')]: 100,
+    [raw('LOWER(status) =')]: 'paid',
   });
 
   expect(result.sql).toBe(
@@ -189,6 +190,125 @@ it('should reject unsafe implicit equality keys', () => {
   expect(() =>
     buildWhere({ 'tenant_id = tenant_id OR status': 'paid' }),
   ).toThrow('Invalid SQL identifier');
+});
+
+describe('raw() expression keys', () => {
+  it('rejects expression keys that carry an operator suffix', () => {
+    // A trailing operator used to suppress identifier validation for the whole
+    // key, so everything before it reached the query as SQL text. Each of these
+    // was accepted before the raw() marker existed.
+    expect(() => buildWhere({ "name = '' OR 1=1 --  =": 'x' })).toThrow(
+      'Invalid SQL identifier',
+    );
+    expect(() => buildWhere({ 'COUNT(DISTINCT unminted_a) >=': 2 })).toThrow(
+      'Invalid SQL identifier',
+    );
+    expect(() =>
+      buildWhere([[{ 'tenant_id = tenant_id OR status >': 'paid' }]]),
+    ).toThrow('Invalid SQL identifier');
+  });
+
+  it('still accepts plain identifiers with and without operator suffixes', () => {
+    const result = buildWhere({
+      status: 'paid',
+      'price >': 100,
+      'orders.total <=': 5,
+    });
+
+    expect(result.sql).toBe(
+      'WHERE status = $1 AND price > $2 AND orders.total <= $3',
+    );
+    expect(result.values).toEqual(['paid', 100, 5]);
+  });
+
+  it('points the caller at raw() when validation fails', () => {
+    expect(() => buildWhere({ 'LOWER(unminted_b) =': 'paid' })).toThrow(
+      /raw\(\)/,
+    );
+  });
+
+  it('marks per key, so minting one expression does not change a plain key', () => {
+    // The marker lives on the returned key, not in a global registry, so wrapping
+    // an expression never retroactively makes the bare string raw elsewhere.
+    const expression = 'LOWER(unminted_c) =';
+    raw(expression);
+
+    expect(() => buildWhere({ [expression]: 'x' })).toThrow(
+      'Invalid SQL identifier',
+    );
+  });
+
+  it('cannot be reached by an unmarked key, whatever its shape', () => {
+    // The marker is the only thing that grants raw access; no bare prefix does.
+    const forged = ['raw:', 'raw(', 'hv-sql-raw', '__raw__', 'RAW '];
+
+    for (const prefix of forged) {
+      expect(() => buildWhere({ [`${prefix}1=1 OR name =`]: 'x' })).toThrow(
+        'Invalid SQL identifier',
+      );
+    }
+  });
+
+  it('keeps the emitted SQL and error messages free of the marker', () => {
+    // The marker is stripped before the field reaches SQL, and a validation
+    // failure echoes only the caller's own key text, never the marker.
+    expect(buildWhere({ [raw('LOWER(status) =')]: 'paid' }).sql).toBe(
+      'WHERE LOWER(status) = $1',
+    );
+
+    let message = '';
+    try {
+      buildWhere({ 'SUM(total) >=': 1 });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('SUM(total)');
+    expect(message).not.toContain('hv-sql-raw');
+  });
+
+  it('is idempotent, so double wrapping cannot nest a marker', () => {
+    expect(raw(raw('LOWER(status) ='))).toBe(raw('LOWER(status) ='));
+    expect(buildWhere({ [raw(raw('LOWER(status) ='))]: 'paid' }).sql).toBe(
+      'WHERE LOWER(status) = $1',
+    );
+  });
+
+  it('supports raw keys on the NULL, IN, Date and 2D-array paths', () => {
+    expect(buildWhere({ [raw('LOWER(status)')]: null }).sql).toBe(
+      'WHERE LOWER(status) IS NULL',
+    );
+    expect(buildWhere({ [raw('LOWER(status) !=')]: null }).sql).toBe(
+      'WHERE LOWER(status) IS NOT NULL',
+    );
+
+    const inClause = buildWhere({ [raw('LOWER(status) in')]: ['a', 'b'] });
+    expect(inClause.sql).toBe('WHERE LOWER(status) IN ($1, $2)');
+    expect(inClause.values).toEqual(['a', 'b']);
+
+    const when = new Date('2026-01-01T00:00:00.000Z');
+    expect(
+      buildWhere({ [raw('date(created_at) >')]: when }, 1, 'duckdb').sql,
+    ).toBe('WHERE date(created_at) > CAST($1 AS TIMESTAMP)');
+    expect(
+      buildWhere({ [raw('date(created_at) >')]: when }, 1, 'postgres').sql,
+    ).toBe('WHERE date(created_at) > $1');
+
+    expect(
+      buildWhere([[{ [raw('LOWER(status) =')]: 'paid' }, { [tenantId]: 't1' }]])
+        .sql,
+    ).toBe('WHERE (LOWER(status) = $1 AND tenant_id = $2)');
+  });
+
+  it('rejects an empty expression', () => {
+    expect(() => raw('   ')).toThrow('non-empty SQL expression');
+  });
+
+  it('parameterizes values behind a raw key', () => {
+    const result = buildWhere({ [raw('LOWER(name) like')]: '%o%' });
+
+    expect(result.sql).toBe('WHERE LOWER(name) LIKE $1');
+    expect(result.values).toEqual(['%o%']);
+  });
 });
 
 it('should reject empty IN clauses', () => {

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -207,7 +207,7 @@ export function validateColumnName(column: string): string {
 }
 
 // Import utilities from shared utils
-import { buildWhere, formatDbError } from './shared/utils';
+import { buildWhere, formatDbError, raw } from './shared/utils';
 
 export {
   type AggregateBuildResult,
@@ -218,8 +218,8 @@ export {
   bucketExpr,
   buildAggregate,
 } from './aggregate.js';
-export type { SqlAdapterType } from './shared/utils';
-export { buildWhere, formatDbError };
+export type { RawSqlKey, SqlAdapterType } from './shared/utils';
+export { buildWhere, formatDbError, raw };
 
 // Import DuckDB schema transformation utilities
 import { convertUniqueIndexesToInlineConstraints } from './shared/duckdb-schema-utils';
@@ -272,6 +272,7 @@ export default {
   syncSchema,
   tableExists,
   buildWhere,
+  raw,
 };
 
 /** @internal */

--- a/packages/sql/src/shared/utils.ts
+++ b/packages/sql/src/shared/utils.ts
@@ -60,10 +60,98 @@ function isSimpleSqlIdentifier(field: string): boolean {
   return /^[a-zA-Z0-9_.]+$/.test(field);
 }
 
+declare const rawSqlKeyBrand: unique symbol;
+
+/**
+ * A WHERE-clause key produced by {@link raw}: SQL text the caller vouches for,
+ * exempt from the identifier validation `buildWhere` applies to every other key.
+ */
+export type RawSqlKey = string & { readonly [rawSqlKeyBrand]: true };
+
+/**
+ * Marks a condition key as caller-authored SQL text.
+ *
+ * A fixed, non-secret sentinel rather than a random per-process token. A random
+ * token has to travel inside the key, which means it reaches every place a key
+ * is echoed — error messages, logs, each adapter's `DatabaseError` context — and
+ * one disclosure would let a caller mint raw keys for the life of the process.
+ * A registry of minted expressions avoids that but is not referentially
+ * transparent: it would make `raw('revenue >')` in one query change what the
+ * plain key `'revenue >'` means in every other one.
+ *
+ * The NUL delimiters cannot appear in an identifier or in SQL a developer would
+ * write, so the marker never collides with a legitimate key.
+ */
+const RAW_KEY_PREFIX = '\u0000hv-sql-raw\u0000';
+
+/**
+ * Marks a WHERE-clause key as SQL expression text rather than an identifier.
+ *
+ * {@link buildWhere} validates every condition key as a plain identifier. Wrap a
+ * key in `raw()` to opt one condition out of that check:
+ *
+ * ```typescript
+ * buildWhere({
+ *   status: 'paid',                 // validated as an identifier
+ *   [raw('SUM(total) >')]: 100,     // caller-authored SQL, not validated
+ * });
+ * ```
+ *
+ * Never build the argument from end-user input. `raw()` is an assertion that
+ * the caller, not the request, authored this SQL.
+ *
+ * The returned key carries a marker, so it is a distinct string from the bare
+ * expression: minting `raw('revenue >')` never changes what the plain key
+ * `'revenue >'` means anywhere else.
+ *
+ * The marker is a fixed sentinel, not a secret. It stops an expression key being
+ * used by accident — the shape of the key no longer grants raw access, a call to
+ * `raw()` does — but a caller that controls a whole key string verbatim,
+ * including the NUL-delimited marker, can still reproduce it. Validate at your
+ * own trust boundary; do not rely on this as the only barrier against hostile
+ * input.
+ *
+ * Enforcement is at runtime: `WhereClause` keys are plain `string`, so a
+ * computed key widens and TypeScript will not reject an unmarked expression key
+ * at the call site.
+ *
+ * A trailing operator is recognised only if it is one of `=`, `!=`, `>`, `>=`,
+ * `<`, `<=`, `like`, `in`, `not in`. Any other trailing token is treated as part
+ * of the expression and `=` is appended, so `raw('name ILIKE')` silently emits
+ * `name ILIKE = $1`, which the database then rejects. Fold an unsupported
+ * operator into the expression instead: `raw('LOWER(name) like')`.
+ *
+ * @param expression - SQL field or expression text, optionally ending in a
+ *   supported operator (for example `SUM(total) >`)
+ * @returns A branded key for use in a {@link WhereClause}
+ * @throws If the expression is empty
+ */
+export function raw(expression: string): RawSqlKey {
+  // Unwrap first so raw(raw(x)) === raw(x) and a marker can never nest into the
+  // emitted SQL.
+  const trimmed = unwrapRawKey(expression).key.trim();
+  if (!trimmed) {
+    throw new Error('raw() requires a non-empty SQL expression');
+  }
+  return `${RAW_KEY_PREFIX}${trimmed}` as RawSqlKey;
+}
+
+/**
+ * Splits the raw marker off a condition key.
+ * @internal
+ */
+export function unwrapRawKey(fullKey: string): {
+  key: string;
+  isRaw: boolean;
+} {
+  return fullKey.startsWith(RAW_KEY_PREFIX)
+    ? { key: fullKey.slice(RAW_KEY_PREFIX.length), isRaw: true }
+    : { key: fullKey, isRaw: false };
+}
+
 export function parseConditionKey(fullKey: string): {
   field: string;
   operator: string;
-  explicitOperator: boolean;
 } {
   const trimmed = fullKey.trim();
   const lower = trimmed.toLowerCase();
@@ -74,12 +162,14 @@ export function parseConditionKey(fullKey: string): {
       return {
         field: trimmed.slice(0, -(operator.length + 1)).trim(),
         operator,
-        explicitOperator: true,
       };
     }
   }
 
-  return { field: trimmed, operator: '=', explicitOperator: false };
+  // Deliberately no `explicitOperator` flag: "key ends in an operator" was the
+  // condition that used to suppress identifier validation, and that was the
+  // vulnerability. Nothing should gate trust on the shape of the key again.
+  return { field: trimmed, operator: '=' };
 }
 
 /**
@@ -97,9 +187,13 @@ const buildCondition = (
   currIndex: { value: number },
   adapterType?: SqlAdapterType,
 ): { sql: string; values: any[] } => {
-  const { field, operator, explicitOperator } = parseConditionKey(fullKey);
-  if (!explicitOperator && !isSimpleSqlIdentifier(field)) {
-    throw new Error(`Invalid SQL identifier: ${field}`);
+  const { key, isRaw } = unwrapRawKey(fullKey);
+  const { field, operator } = parseConditionKey(key);
+  if (!isRaw && !isSimpleSqlIdentifier(field)) {
+    throw new Error(
+      `Invalid SQL identifier: ${field}. Condition keys must be plain ` +
+        'identifiers; wrap developer-authored SQL expressions in raw().',
+    );
   }
   const sqlOperator =
     VALID_OPERATORS[operator as keyof typeof VALID_OPERATORS] || '=';
@@ -148,11 +242,18 @@ const buildCondition = (
  *   - `'sqlite'` / `'postgres'` / `undefined`: Passes ISO strings directly
  *     (these adapters handle ISO timestamp strings natively).
  *
- * Keys with explicit operator suffixes are treated as SQL field/expression
- * text. Keep those keys developer-controlled; do not pass end-user input as a
- * condition key.
+ * Every condition key is validated as a plain SQL identifier, with or without
+ * an operator suffix. To use expression text as a key, wrap it in {@link raw}:
+ *
+ * ```typescript
+ * buildWhere({ [raw('LOWER(status) =')]: 'paid' });
+ * ```
+ *
+ * `raw()` is the only way to reach expression text, so mapping untrusted input
+ * into a condition key throws rather than emitting attacker-controlled SQL.
  *
  * @returns Object containing the SQL clause and array of values
+ * @throws If a key that is not wrapped in {@link raw} is not a plain identifier
  *
  * @example Basic Usage (Object format - AND-only):
  * ```typescript


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"cc9a5dd4-55fc-4230-b297-a4a36f855c53","issue":"https://github.com/happyvertical/sdk/issues/1127","policy_revision":"1.0.0","status":"complete","validation":["pnpm --filter @happyvertical/sql test (375 passed, 4 skipped, postgres:50)","pnpm typecheck","pnpm lint","pnpm build","pnpm agent:check","pnpm test:ci-scripts","order-independence verified under vitest --sequence.shuffle","built-package round-trip smoke test"]}
```

Closes #1127.

## Decision

Resolves the deferred half of #1114: whether `buildWhere`'s operator-suffix
escape hatch stays implicit or moves behind an explicit marker. **Chose to
harden `buildWhere` and add an explicit `raw()` marker** (option (a) in #1127),
as a documented breaking change in a minor release.

The deciding evidence was internal, not the downstream-usage tiebreaker:

- **`raw()` already has a first-party consumer.** `aggregate.ts` composes
  `HAVING` keys like `SUM(total) >` from validated parts and feeds them to
  `buildWhere`, so a trusted-expression channel has to exist either way. The
  only question was whether it is explicit or inferred from the shape of a
  string — and inferring it from string shape is what made the boundary
  crossable by accident.
- **The SDK was already internally inconsistent.** `buildAggregate` validated
  where-keys regardless of operator suffix and rejected the expression shape
  `buildWhere` accepted. This makes both builders behave the same.
- **Option (b) could not be delivered.** `WhereClause` keys are `string`; there
  is no type that distinguishes identifier from expression in key position, so
  the "strengthen the type signature" half of (b) had nothing to attach to.

One correction to the #1127 premise, verified against the code: a key like
`{ 'name = 1 OR 1=1 --': x }` was *already* rejected, because it does not end in
a recognised operator. The genuinely-accepted shapes end in an operator, e.g.
`{ "name = '' OR 1=1 --  =": x }`. The regression tests target the shapes that
actually changed behaviour (5 of the new tests fail against the pre-fix guard).

## What changed

- `buildCondition` validates every key as a plain identifier, raw or not.
- `raw(expr)` prefixes a **fixed, non-secret** sentinel that `buildWhere` strips
  before emitting SQL. It stops an expression key being used by accident; it
  does **not** sanitize hostile input, and the docs say so. A fixed sentinel was
  chosen over two rejected alternatives: a random per-process token (leaks
  through the 22 adapter `DatabaseError` context sites and is replayable) and a
  global registry of minted expressions (not referentially transparent —
  minting `raw('revenue >')` would change what the plain key `'revenue >'` means
  everywhere else).
- `buildAggregate` composes `HAVING` through `raw()`; a `raw()` key in `having`
  is emitted verbatim rather than expanded as a select alias. Its now-redundant
  local `validateWhereShape` is removed.
- `raw` and `RawSqlKey` are exported (named + default object).
- Changeset (`minor`, breaking), README, docs, and JSDoc updated.

## Scope of the break

Not limited to `buildWhere`/`buildAggregate`: every adapter routes `where`
through `buildWhere`, so `get`, `list`, `update`, `delete`, `count` and
`getOrInsert` on all five adapters now throw on an unmarked expression key.
`upsert` matches on `conflictColumns`, not a `where`, and is unaffected.

## Found in passing (filed separately, not fixed here)

- #1133 — `upsertVector` interpolates `where` keys without validation or quote
  escaping (bypasses `buildWhere` entirely). A distinct injection path.
- A pre-existing failure: three `postgres-vector.spec.ts` tests fail only when
  the four PostgreSQL specs share one database (identical on a clean tree),
  flagged for separate follow-up.

## Validation

`pnpm --filter @happyvertical/sql test` against a real PostgreSQL (pgvector):
375 passed / 4 skipped, plus the 50 PostgreSQL-only specs. `pnpm typecheck`,
`pnpm lint`, `pnpm build`, `pnpm agent:check`, `pnpm test:ci-scripts` all green.
Test order-independence confirmed under `vitest --sequence.shuffle`, and the
built package was smoke-tested for the `raw()` round-trip.
