### PR TITLE
fix(sql): load JSON data files whose records have different key sets

### DIFF
--- a/.changeset/json-ragged-data-files.md
+++ b/.changeset/json-ragged-data-files.md
@@ -1,0 +1,7 @@
+---
+'@happyvertical/sql': patch
+---
+
+Fix the JSON adapter failing to load any data file whose records have different key sets — that is, any file with an optional field. The loader derived its whole column list from the first record alone, so a later record missing that key bound `undefined`, DuckDB rejected the multi-row INSERT with "Cannot create values of type ANY", and every row was lost. `loadJSONData` swallowed the failure as a dismissive `console.warn`, so the caller was left with a table that existed but held zero rows and no meaningful error. In the mirror case — a later record carrying a field the first record lacked — the insert succeeded with the correct row count while that column was silently dropped.
+
+Columns are now unioned across all records, a record omitting a key binds `NULL`, and a field with no matching column (including a case-variant of one already claimed) is reported and skipped instead of costing the whole load. Non-object array elements are skipped rather than emitting phantom all-`NULL` rows. When a file that did parse still cannot be loaded, the adapter now logs the failure loudly (`console.error`, stating the table is left empty) rather than hiding it — while still loading every other table in the same data directory or `syncSchema()` call. An unreadable or malformed file remains tolerated with a warning.

--- a/packages/sql/src/json-ragged-records.spec.ts
+++ b/packages/sql/src/json-ragged-records.spec.ts
@@ -1,0 +1,439 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearConnectionCache, getDatabase } from './index';
+
+/**
+ * A JSON data file whose records have different key sets - i.e. any file with
+ * an optional field - is normal input. Before issue #1132 the loader derived
+ * its column list from the first record alone, so a later record missing a key
+ * bound `undefined` (DuckDB rejected the statement, losing every row) and a
+ * later record with an extra key had that column silently dropped.
+ */
+describe('JSON adapter ragged data files (Issue #1132)', () => {
+  let testDataDir: string;
+
+  const ITEMS_DDL =
+    'CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT, note TEXT)';
+
+  /**
+   * createTableFromSchema() parses the `schemas` option DDL line by line and
+   * needs the closing parenthesis on its own line, so that path gets the
+   * multi-line form. A .schema.sql file is executed verbatim and does not.
+   */
+  const ITEMS_DDL_MULTILINE = `CREATE TABLE items (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    note TEXT
+  )`;
+
+  /** Second record omits the optional `note` field entirely */
+  const MISSING_KEY_RECORDS = [
+    { id: 'a', name: 'first', note: 'has note' },
+    { id: 'b', name: 'second' },
+  ];
+
+  /** First record omits `note`, so it is absent from the first-record key set */
+  const EXTRA_KEY_RECORDS = [
+    { id: 'a', name: 'first' },
+    { id: 'b', name: 'second', note: 'appears late' },
+  ];
+
+  const writeData = (table: string, records: unknown[]) =>
+    writeFileSync(join(testDataDir, `${table}.json`), JSON.stringify(records));
+
+  const writeSchema = (table: string, ddl: string) =>
+    writeFileSync(join(testDataDir, `${table}.schema.sql`), `${ddl};`);
+
+  // loadJSONData logs `console.error('...Failed to load data for <table>...', err)`.
+  // Assert on the load-failure message (not just the table name) so the check
+  // can't be satisfied by some other console.error that happens to name it.
+  const loggedLoadFailure = (
+    spy: ReturnType<typeof vi.spyOn>,
+    table: string,
+  ): boolean =>
+    spy.mock.calls.some((call) => {
+      const first = String(call[0]);
+      return first.includes(table) && first.includes('the table will be empty');
+    });
+
+  beforeEach(() => {
+    testDataDir = mkdtempSync(join(tmpdir(), 'json-ragged-'));
+  });
+
+  afterEach(() => {
+    clearConnectionCache();
+    rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  describe('records missing an optional field', () => {
+    it('loads every row via a .schema.sql file, binding NULL for the missing key', async () => {
+      writeData('items', MISSING_KEY_RECORDS);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+
+    it('loads every row via an explicitly provided schema', async () => {
+      writeData('items', MISSING_KEY_RECORDS);
+
+      const db = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        schemas: { items: { tableName: 'items', ddl: ITEMS_DDL_MULTILINE } },
+      });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+
+    it('loads every row via deferred loading through syncSchema()', async () => {
+      writeData('items', MISSING_KEY_RECORDS);
+
+      const db = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        eagerLoadTables: false,
+      });
+      await db.syncSchema(`${ITEMS_DDL};`);
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+
+    it('loads every row via deferred loading through execute() DDL', async () => {
+      writeData('items', MISSING_KEY_RECORDS);
+
+      const db = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        eagerLoadTables: false,
+      });
+      await db.execute`CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT, note TEXT)`;
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+
+    it('loads a file where no record has the optional field', async () => {
+      writeData('items', [
+        { id: 'a', name: 'first' },
+        { id: 'b', name: 'second' },
+      ]);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: null },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+
+    it('loads a large file where a single record omits the field', async () => {
+      const records = Array.from({ length: 500 }, (_, i) => ({
+        id: `id-${i}`,
+        name: `name-${i}`,
+        ...(i === 384 ? {} : { note: `note-${i}` }),
+      }));
+      writeData('items', records);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      expect(await db.count('items')).toBe(500);
+      expect(await db.get('items', { id: 'id-384' })).toEqual({
+        id: 'id-384',
+        name: 'name-384',
+        note: null,
+      });
+    });
+  });
+
+  describe('records with a field the first record lacks', () => {
+    it('preserves a column that only later records carry', async () => {
+      writeData('items', EXTRA_KEY_RECORDS);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: null },
+        { id: 'b', name: 'second', note: 'appears late' },
+      ]);
+    });
+  });
+
+  describe('inferred schemas', () => {
+    it('loads a ragged file when no schema file is present', async () => {
+      writeData('items', MISSING_KEY_RECORDS);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+
+    it('loads a ragged file through inferSchemaFromJSON()', async () => {
+      writeData('items', MISSING_KEY_RECORDS);
+
+      const db: any = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        eagerLoadTables: false,
+      });
+      await db.inferSchemaFromJSON('items');
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+  });
+
+  describe('non-object array elements', () => {
+    it('skips a null hole in the array without emitting a phantom row', async () => {
+      writeData('items', [{ id: 'a', name: 'first', note: 'x' }, null]);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([{ id: 'a', name: 'first', note: 'x' }]);
+    });
+
+    it('does not let a null hole abort the load under a PRIMARY KEY', async () => {
+      // A phantom all-NULL row would violate the PK and lose the valid row too
+      writeData('items', [null, { id: 'a', name: 'first' }, null]);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      expect(await db.count('items')).toBe(1);
+      expect(await db.get('items', { id: 'a' })).toEqual({
+        id: 'a',
+        name: 'first',
+        note: null,
+      });
+    });
+  });
+
+  // Written as raw JSON so the on-disk keys keep their exact casing without
+  // tripping the camelCase lint on object literals
+  const writeRawData = (table: string, json: string) =>
+    writeFileSync(join(testDataDir, `${table}.json`), json);
+
+  describe('case-insensitive column matching', () => {
+    it('matches JSON keys to columns regardless of case', async () => {
+      writeRawData(
+        'items',
+        '[{"ID":"a","Name":"first","NOTE":"has note"},{"ID":"b","Name":"second"}]',
+      );
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+
+    it('does not emit a duplicate column when two keys fold to one column', async () => {
+      // `id` and `ID` both resolve to column `id`; the load must not build
+      // `INSERT INTO items ("id", "name", "id")`
+      writeRawData(
+        'items',
+        '[{"id":"a","name":"first"},{"id":"b","name":"second","ID":"b-again"}]',
+      );
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: null },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
+  });
+
+  describe('fields with no matching column', () => {
+    it('loads the matching columns and skips the unmatched field', async () => {
+      writeData('items', [
+        { id: 'a', name: 'first', stray: 'no such column' },
+        { id: 'b', name: 'second', note: 'has note' },
+      ]);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: null },
+        { id: 'b', name: 'second', note: 'has note' },
+      ]);
+    });
+
+    it('leaves the table empty and logs when no field matches any column', async () => {
+      writeData('items', [{ nope: 1 }, { neither: 2 }]);
+      writeSchema('items', ITEMS_DDL);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      expect(await db.count('items')).toBe(0);
+      expect(loggedLoadFailure(errorSpy, 'items')).toBe(true);
+      errorSpy.mockRestore();
+    });
+
+    it('warns and leaves the table empty when records have no fields', async () => {
+      // All records are objects but empty - hits the "no fields" branch
+      writeData('items', [{}, {}]);
+      writeSchema('items', ITEMS_DDL);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      expect(await db.count('items')).toBe(0);
+      expect(
+        warnSpy.mock.calls.some((call) =>
+          String(call[0]).includes('no fields'),
+        ),
+      ).toBe(true);
+      warnSpy.mockRestore();
+      await db.insert('items', { id: 'a', name: 'first', note: null });
+      expect(await db.count('items')).toBe(1);
+    });
+
+    it('leaves the table empty and usable when the array has no objects', async () => {
+      writeData('items', [null, 42, 'nope']);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      expect(await db.count('items')).toBe(0);
+      await db.insert('items', { id: 'a', name: 'first', note: null });
+      expect(await db.count('items')).toBe(1);
+    });
+
+    it('skips a record whose keys are all unmatched without losing valid rows', async () => {
+      // The second record shares no column with the table; it must not emit an
+      // all-NULL row that violates the PRIMARY KEY and fails the whole load
+      writeData('items', [
+        { id: 'a', name: 'first' },
+        { onlyjunk: 'x', morejunk: 'y' },
+      ]);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      expect(await db.count('items')).toBe(1);
+      expect(await db.get('items', { id: 'a' })).toEqual({
+        id: 'a',
+        name: 'first',
+        note: null,
+      });
+    });
+  });
+
+  describe('a single bad table does not abort its siblings', () => {
+    it('loads a healthy table even when another table in the dir cannot load', async () => {
+      // `bad` violates NOT NULL; `good` sits alongside it and must still load
+      writeData('bad', [{ id: 'x', name: 'has name' }, { id: 'y' }]);
+      writeSchema(
+        'bad',
+        'CREATE TABLE bad (id TEXT PRIMARY KEY, name TEXT NOT NULL)',
+      );
+      writeData('good', MISSING_KEY_RECORDS);
+      writeSchema(
+        'good',
+        'CREATE TABLE good (id TEXT PRIMARY KEY, name TEXT, note TEXT)',
+      );
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      // The healthy sibling loaded in full
+      const good = await db.many`SELECT * FROM good ORDER BY id`;
+      expect(good).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+      // The failure was surfaced loudly, not silently swallowed
+      expect(loggedLoadFailure(errorSpy, 'bad')).toBe(true);
+      // ...and the log carries the underlying cause, not just a generic wrapper
+      const badCall = errorSpy.mock.calls.find((call) =>
+        String(call[0]).includes('bad'),
+      );
+      const loggedError = badCall?.[1] as {
+        context?: { originalError?: string };
+      };
+      expect(loggedError?.context?.originalError).toMatch(/NOT NULL/i);
+      errorSpy.mockRestore();
+    });
+
+    it('still tolerates a malformed data file, leaving the table usable', async () => {
+      writeFileSync(join(testDataDir, 'items.json'), '{ not valid json');
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+
+      expect(await db.count('items')).toBe(0);
+      await db.insert('items', { id: 'a', name: 'first', note: null });
+      expect(await db.count('items')).toBe(1);
+    });
+  });
+
+  describe('round trip', () => {
+    it('exports and reloads a table that was loaded from a ragged file', async () => {
+      writeData('items', MISSING_KEY_RECORDS);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        writeStrategy: 'immediate',
+      });
+      await db.insert('items', { id: 'c', name: 'third', note: null });
+
+      clearConnectionCache();
+
+      const reopened = await getDatabase({
+        type: 'json',
+        url: testDataDir,
+        writeStrategy: 'immediate',
+      });
+      const rows = await reopened.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+        { id: 'c', name: 'third', note: null },
+      ]);
+    });
+  });
+});

--- a/packages/sql/src/json-ragged-records.spec.ts
+++ b/packages/sql/src/json-ragged-records.spec.ts
@@ -279,6 +279,25 @@ describe('JSON adapter ragged data files (Issue #1132)', () => {
         { id: 'b', name: 'second', note: null },
       ]);
     });
+
+    it('loads when the data file name casing differs from the table identifier', async () => {
+      // Data file `Items.json` backs a table created as lowercase `items`.
+      // DuckDB addresses it case-insensitively, so the column lookup must too -
+      // otherwise every field reads as unmatched and the table loads empty.
+      writeData('Items', MISSING_KEY_RECORDS);
+      writeFileSync(
+        join(testDataDir, 'Items.schema.sql'),
+        'CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT, note TEXT);',
+      );
+
+      const db = await getDatabase({ type: 'json', url: testDataDir });
+      const rows = await db.many`SELECT * FROM items ORDER BY id`;
+
+      expect(rows).toEqual([
+        { id: 'a', name: 'first', note: 'has note' },
+        { id: 'b', name: 'second', note: null },
+      ]);
+    });
   });
 
   describe('fields with no matching column', () => {

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -156,6 +156,16 @@ async function createJSONConnection(options: JSONOptions) {
  * This function only loads data - it assumes the table already exists with proper schema.
  * Used after DDL creates the table to load persisted JSON data.
  *
+ * An unreadable or malformed file is tolerated with a warning - the table
+ * structure is what matters and there is no data to lose.
+ *
+ * A failure to insert records that DID parse is logged loudly rather than
+ * swallowed with the old dismissive "that's okay" warning: the resulting empty
+ * table is a real surprise the caller should see (issue #1132). It is logged
+ * rather than thrown so that one unloadable table cannot abort the load of every
+ * other table sharing the same data directory or syncSchema() call - both of
+ * those paths already load each table independently.
+ *
  * @param connection - DuckDB connection
  * @param tableName - Name of the table to load data into
  * @param filePath - Path to the JSON file
@@ -165,21 +175,42 @@ async function loadJSONData(
   tableName: string,
   filePath: string,
 ): Promise<void> {
+  let records: unknown;
+
   try {
     const { readFile } = await import('node:fs/promises');
     const jsonContent = await readFile(filePath, 'utf-8');
-    const records = JSON.parse(jsonContent);
+    records = JSON.parse(jsonContent);
+  } catch (error) {
+    // Missing, empty, or malformed file - table structure is what matters
+    console.warn(
+      `[json-adapter] Could not read data for ${tableName}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
 
-    if (Array.isArray(records) && records.length > 0) {
-      await insertRecordsWithCast(connection, tableName, records);
+  if (!Array.isArray(records) || records.length === 0) {
+    return;
+  }
+
+  try {
+    const inserted = await insertRecordsWithCast(
+      connection,
+      tableName,
+      records,
+    );
+    if (inserted > 0) {
       console.log(
-        `[json-adapter] Loaded ${records.length} records into ${tableName} from JSON`,
+        `[json-adapter] Loaded ${inserted} records into ${tableName} from JSON`,
       );
     }
   } catch (error) {
-    // If load fails (e.g., empty file, parse error), that's okay - table structure is what matters
-    console.warn(
-      `[json-adapter] Could not load data for ${tableName}: ${error instanceof Error ? error.message : String(error)}`,
+    // Pass the raw error as a second argument so its context (the underlying
+    // DuckDB cause, e.g. a NOT NULL violation) is rendered, not just the wrapper
+    // message - diagnosability is the point of surfacing this (issue #1132)
+    console.error(
+      `[json-adapter] Failed to load data for ${tableName}; the table will be empty:`,
+      error,
     );
   }
 }
@@ -516,45 +547,157 @@ async function createTableFromSchema(
 }
 
 /**
+ * Reads the column names of an existing table, keyed by lowercase name
+ *
+ * @param connection - DuckDB connection
+ * @param tableName - Name of the table to describe
+ * @returns Map of lowercase column name to the column's declared name
+ */
+async function getTableColumns(
+  connection: any,
+  tableName: string,
+): Promise<Map<string, string>> {
+  const reader = await connection.runAndReadAll(
+    'SELECT column_name FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position',
+    [tableName],
+  );
+
+  return new Map(
+    reader
+      .getRowObjects()
+      .map((row: any) => [
+        String(row.column_name).toLowerCase(),
+        String(row.column_name),
+      ]),
+  );
+}
+
+/**
  * Inserts records with proper CAST handling for empty strings
  *
  * This helper avoids using read_json() with auto_detect, which causes DuckDB
  * to re-infer column types from data (causing ANY type for empty strings).
  * Instead, it uses parameterized INSERT with CAST to maintain table schema.
  *
- * Unlike `insert()`, this loads records that came out of a JSON file on disk
- * rather than from a caller, so it deliberately does not use
- * `resolveInsertColumns`: optional fields are ordinary in a JSON document, and
- * rejecting the batch would turn a file that partially loads into one that
- * loads nothing at all — silently, because `loadJSONData` swallows the failure
- * as a warning. Keys beyond the first record's are dropped and absent ones
- * bind NULL, which is the pre-existing behavior.
+ * Used only for loading a JSON data file, where records having different key
+ * sets is normal input rather than a caller error: a document with an optional
+ * field omits that key entirely on the records that lack it. Columns are
+ * therefore unioned across ALL records and any record missing a key binds NULL.
+ * Deriving them from the first record alone bound `undefined` for a missing key
+ * (which DuckDB rejects, losing every row) and dropped keys the first record
+ * did not have (losing the column silently). See issue #1132.
+ *
+ * The caller-facing insert() API is a separate implementation (it resolves
+ * columns through `resolveInsertColumns`) and is not affected by this
+ * file-loading tolerance.
  *
  * @param connection - DuckDB connection
  * @param tableName - Name of the table to insert into
  * @param records - Array of records to insert
+ * @returns Number of records inserted (0 if there was nothing loadable)
+ * @throws DatabaseError if the resolved records cannot be inserted
  */
 async function insertRecordsWithCast(
   connection: any,
   tableName: string,
-  records: Record<string, any>[],
-): Promise<void> {
-  if (records.length === 0) return;
+  records: unknown[],
+): Promise<number> {
+  if (records.length === 0) return 0;
 
-  const keys = Object.keys(records[0]);
+  // Only object records contribute columns AND rows. A non-object element
+  // (e.g. a `null` hole in the array) must be skipped entirely - iterating it
+  // for values would emit a phantom all-NULL row.
+  const objectRecords = records.filter(
+    (record): record is Record<string, any> =>
+      record != null && typeof record === 'object' && !Array.isArray(record),
+  );
+
+  if (objectRecords.length === 0) {
+    return 0;
+  }
+
+  // Union keys across every record, preserving first-appearance order
+  const unionedKeys: string[] = [];
+  const seenKeys = new Set<string>();
+  for (const record of objectRecords) {
+    for (const key of Object.keys(record)) {
+      if (!seenKeys.has(key)) {
+        seenKeys.add(key);
+        unionedKeys.push(key);
+      }
+    }
+  }
+
+  if (unionedKeys.length === 0) {
+    console.warn(
+      `[json-adapter] Skipping data load for ${tableName}: records have no fields`,
+    );
+    return 0;
+  }
+
+  // Resolve keys against the table's real columns. A JSON field with no
+  // matching column cannot be inserted; report it instead of failing the whole
+  // load, so one stray field does not cost every row. Column matching is
+  // case-insensitive (DuckDB folds identifier case), so track which columns are
+  // already claimed - two case-variant keys (`id` and `ID`) must not both emit
+  // the same column, which would produce a duplicate-column INSERT.
+  const tableColumns = await getTableColumns(connection, tableName);
+  const keys: string[] = [];
+  const columnNames: string[] = [];
+  const unmatchedKeys: string[] = [];
+  const claimedColumns = new Set<string>();
+
+  for (const key of unionedKeys) {
+    const column = tableColumns.get(key.toLowerCase());
+    if (column === undefined || claimedColumns.has(column.toLowerCase())) {
+      // No matching column, or a differently-cased key already claimed it
+      unmatchedKeys.push(key);
+    } else {
+      claimedColumns.add(column.toLowerCase());
+      keys.push(key);
+      columnNames.push(column);
+    }
+  }
+
+  if (unmatchedKeys.length > 0) {
+    console.warn(
+      `[json-adapter] Ignoring ${unmatchedKeys.length} field(s) in ${tableName} data with no matching column: ${unmatchedKeys.join(', ')}`,
+    );
+  }
+
+  if (keys.length === 0) {
+    throw new DatabaseError(
+      `No fields in the ${tableName} data file match a column on the table`,
+      {
+        tableName,
+        fields: unionedKeys,
+        columns: [...tableColumns.values()],
+      },
+    );
+  }
+
+  // A record that carries none of the matched keys would insert a row of all
+  // NULLs - which is not data the file meant to provide and can violate a NOT
+  // NULL / PRIMARY KEY column, failing the whole batch. Skip such records so a
+  // stray record, like a stray field, does not cost the rest of the load.
+  // (keys is non-empty here, and every key came from some record, so at least
+  // that record survives - insertableRecords cannot be empty.)
+  const insertableRecords = objectRecords.filter((record) =>
+    keys.some((key) => key in record),
+  );
 
   // Build placeholders - schema has NOT NULL DEFAULT '' to prevent ANY type
   const values: any[] = [];
   let paramIdx = 1;
 
-  const placeholders = records
+  const placeholders = insertableRecords
     .map((record) => {
       const rowPlaceholders = keys.map((key) => {
         const value = record[key];
 
-        // `undefined` is what a record missing this key yields. DuckDB cannot
-        // bind it ("Cannot create values of type ANY"), which would fail the
-        // whole load, so treat it as NULL exactly as duckdb.ts does.
+        // `undefined` covers a key this record omits; binding it directly makes
+        // DuckDB reject the whole INSERT ("Cannot create values of type ANY"),
+        // so bind NULL for the missing field, exactly as duckdb.ts does.
         if (value === null || value === undefined) {
           return 'NULL';
         } else if (value === '' && typeof value === 'string') {
@@ -588,9 +731,23 @@ async function insertRecordsWithCast(
     })
     .join(', ');
 
-  const sql = `INSERT INTO ${tableName} (${keys.join(', ')}) VALUES ${placeholders}`;
+  // Use the table's own column names - they came from information_schema, so
+  // no JSON-supplied identifier reaches the statement
+  const columnList = columnNames.map((name) => `"${name}"`).join(', ');
+  const sql = `INSERT INTO "${tableName}" (${columnList}) VALUES ${placeholders}`;
 
-  await connection.run(sql, values);
+  try {
+    await connection.run(sql, values);
+  } catch (e) {
+    throw new DatabaseError('Failed to load records into table', {
+      tableName,
+      recordCount: insertableRecords.length,
+      columns: columnNames,
+      originalError: formatDbError(e),
+    });
+  }
+
+  return insertableRecords.length;
 }
 
 /**
@@ -1782,7 +1939,9 @@ export async function getDatabase(
             // Check if there's pending JSON data for this table (deferred loading)
             const pendingFile = pendingJSONFiles.get(tableName);
             if (pendingFile) {
-              // Table was just created by DDL - now load the JSON data
+              // Table was just created by DDL - now load the JSON data.
+              // loadJSONData logs an unloadable file rather than throwing, so a
+              // single bad table does not abort the rest of this schema sync
               await loadJSONData(connection, tableName, pendingFile);
               pendingJSONFiles.delete(tableName);
             } else if (writeStrategy !== 'none') {

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -549,6 +549,11 @@ async function createTableFromSchema(
 /**
  * Reads the column names of an existing table, keyed by lowercase name
  *
+ * The table-name predicate is case-insensitive: DuckDB resolves identifiers
+ * case-insensitively, so a data file named `Items.json` can back a table
+ * created as `items`. Matching table_name exactly would find no columns and
+ * make the loader wrongly report that every field is unmatched (issue #1132).
+ *
  * @param connection - DuckDB connection
  * @param tableName - Name of the table to describe
  * @returns Map of lowercase column name to the column's declared name
@@ -558,7 +563,7 @@ async function getTableColumns(
   tableName: string,
 ): Promise<Map<string, string>> {
   const reader = await connection.runAndReadAll(
-    'SELECT column_name FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position',
+    'SELECT column_name FROM information_schema.columns WHERE LOWER(table_name) = LOWER($1) ORDER BY ordinal_position',
     [tableName],
   );
 


### PR DESCRIPTION
## Summary

Fixes #1132 — the JSON adapter (`packages/sql/src/json.ts`) could not load any data file whose records have different key sets, i.e. **any file with an optional field**.

`insertRecordsWithCast` derived its entire column list from `records[0]`. A later record missing that key bound `undefined`, DuckDB rejected the whole multi-row INSERT with *"Cannot create values of type ANY"*, and **every** row was lost. `loadJSONData` swallowed that as a dismissive `console.warn("that's okay")`, so the caller got a table that existed but held zero rows and no meaningful error. In the mirror case — a later record carrying a field the first record lacked — the insert succeeded with the right row count while that column was **silently dropped**.

This is pre-existing and independent of #1129.

## What changed

- **Union columns across all records**; a record omitting a key binds `NULL`.
- **Resolve keys against the table's real columns** via `information_schema`, so no JSON-supplied identifier reaches the SQL string. A stray field — including a case-variant of a column already claimed (`id` vs `ID`, which would otherwise produce a duplicate-column INSERT) — is reported and skipped rather than costing the whole load.
- **Skip non-object array elements** (a `null` hole) and **object records that carry none of the matched columns**, instead of emitting phantom all-`NULL` rows that can violate a constraint and fail the batch.
- **Surface genuine load failures loudly** (`console.error`, including the underlying DuckDB cause) instead of the old quiet warning — but keep loading **per-table**, so one unloadable table no longer aborts every other table in the same directory or `syncSchema()` call. An unreadable/malformed file stays tolerated.

Inferred-schema loading (`read_json_auto`) already unioned keys natively and was never affected; the caller-facing `insert()` API is a separate implementation and is untouched (left to #1129).

## Tests

New `packages/sql/src/json-ragged-records.spec.ts` (21 tests) covers all four file-loading entry points (provided `schemas`, `.schema.sql`, deferred via `execute()` and `syncSchema()`), both the missing-key and extra-key directions, inferred schemas, case-insensitive matching and duplicate-column avoidance, non-object/all-unmatched records, sibling isolation on failure (asserting the underlying cause is logged), and the malformed-file tolerance. Reverting the fix fails the finding-driven tests.

Follow-up #1139 tracks making genuine load failures observable to calling code (not just stderr) — deliberately scoped out to keep this a focused patch.

## Validation

- `pnpm --filter @happyvertical/sql test` — 383 passed, 4 skipped
- `pnpm typecheck` · `pnpm build` · `pnpm test:ci-scripts` (20/20) · `pnpm agent:check` — all green
- `biome` clean on changed files (2 pre-existing `column_name`/`data_type` warnings in unrelated code)

Reviewed across four independent perspectives (correctness, security, test-coverage, maintainability) over two rounds; all material findings resolved.

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude-code",
  "owner": "willgriffin",
  "session": "ff257046-9e50-40e6-a433-d01ca4a50d1e",
  "issue": 1132,
  "policy_revision": "1.0.0",
  "validation": {
    "sql_tests": "383 passed / 4 skipped",
    "typecheck": "pass",
    "build": "pass",
    "ci_scripts": "20/20 pass",
    "agent_check": "pass",
    "lint": "pass (pre-existing warnings only)"
  }
}
```
