### PR TITLE
fix(jobs): stop update() resolving caller keys via the prototype chain

### DIFF
--- a/.changeset/jobs-update-column-injection.md
+++ b/.changeset/jobs-update-column-injection.md
@@ -1,0 +1,9 @@
+---
+'@happyvertical/jobs': patch
+---
+
+Stop `update()` in the SQLite and PostgreSQL job stores from resolving caller-supplied keys through the prototype chain.
+
+Both adapters mapped each update key to a column with `const column = fieldMap[key]; if (!column) continue;`. `fieldMap` is a plain object literal, so the falsy guard ran against a lookup that falls through to `Object.prototype`: `update(id, { constructor: 1 })` resolved to the native `Object` constructor and interpolated `function Object() { [native code] } = ?` into the `SET` clause, and under prototype pollution elsewhere in the process an inherited string was spliced straight into the clause, rewriting an unrelated column on the targeted row. Values were always bound, but the column name was not. The column lookup now guards with `Object.hasOwn`.
+
+The status-change event branch had the same shape: it read `updates.status` directly, which also traverses the prototype chain, so a polluted `Object.prototype.status` could make an unrelated update emit a spurious `job.completed`, `job.failed`, or `job.cancelled`. It now reads `status` only when it is an own property of `updates`.

--- a/packages/jobs/src/adapters/postgres.ts
+++ b/packages/jobs/src/adapters/postgres.ts
@@ -308,8 +308,12 @@ export class PostgresJobStore extends BaseJobStore {
     };
 
     for (const [key, value] of Object.entries(updates)) {
+      // `hasOwn`, not `if (!fieldMap[key])`: the fieldMap literal inherits
+      // from Object.prototype, so keys like 'constructor' resolve to a truthy
+      // inherited value whose column would be interpolated into the SET clause.
+      // An own-property check drops unknown keys instead of injecting them.
+      if (!Object.hasOwn(fieldMap, key)) continue;
       const column = fieldMap[key];
-      if (!column) continue;
 
       setClause.push(`${column} = $${paramIndex}`);
 
@@ -343,15 +347,22 @@ export class PostgresJobStore extends BaseJobStore {
     const job = await this.get(id);
     if (!job) throw new Error(`Job not found after update: ${id}`);
 
-    if (updates.status === 'completed') {
+    // Emit events based on status changes. Read `status` only when it is an
+    // own key of `updates`: a bare `updates.status` traverses the prototype
+    // chain, so a polluted Object.prototype.status could make an unrelated
+    // update emit a spurious lifecycle event.
+    const statusUpdate = Object.hasOwn(updates, 'status')
+      ? updates.status
+      : undefined;
+    if (statusUpdate === 'completed') {
       await this.emitEvent('job.completed', job, {
         resultPointer: job.resultPointer ?? undefined,
       });
-    } else if (updates.status === 'failed') {
+    } else if (statusUpdate === 'failed') {
       await this.emitEvent('job.failed', job, {
         error: job.lastError ?? undefined,
       });
-    } else if (updates.status === 'cancelled') {
+    } else if (statusUpdate === 'cancelled') {
       await this.emitEvent('job.cancelled', job);
     }
 

--- a/packages/jobs/src/adapters/sqlite.ts
+++ b/packages/jobs/src/adapters/sqlite.ts
@@ -221,8 +221,12 @@ export class SqliteJobStore extends BaseJobStore {
     };
 
     for (const [key, value] of Object.entries(updates)) {
+      // `hasOwn`, not `if (!fieldMap[key])`: the fieldMap literal inherits
+      // from Object.prototype, so keys like 'constructor' resolve to a truthy
+      // inherited value whose column would be interpolated into the SET clause.
+      // An own-property check drops unknown keys instead of injecting them.
+      if (!Object.hasOwn(fieldMap, key)) continue;
       const column = fieldMap[key];
-      if (!column) continue;
 
       setClause.push(`${column} = ?`);
 
@@ -255,16 +259,22 @@ export class SqliteJobStore extends BaseJobStore {
     const job = await this.get(id);
     if (!job) throw new Error(`Job not found after update: ${id}`);
 
-    // Emit events based on status changes
-    if (updates.status === 'completed') {
+    // Emit events based on status changes. Read `status` only when it is an
+    // own key of `updates`: a bare `updates.status` traverses the prototype
+    // chain, so a polluted Object.prototype.status could make an unrelated
+    // update emit a spurious lifecycle event.
+    const statusUpdate = Object.hasOwn(updates, 'status')
+      ? updates.status
+      : undefined;
+    if (statusUpdate === 'completed') {
       await this.emitEvent('job.completed', job, {
         resultPointer: job.resultPointer ?? undefined,
       });
-    } else if (updates.status === 'failed') {
+    } else if (statusUpdate === 'failed') {
       await this.emitEvent('job.failed', job, {
         error: job.lastError ?? undefined,
       });
-    } else if (updates.status === 'cancelled') {
+    } else if (statusUpdate === 'cancelled') {
       await this.emitEvent('job.cancelled', job);
     }
 

--- a/packages/jobs/src/index.test.ts
+++ b/packages/jobs/src/index.test.ts
@@ -382,6 +382,126 @@ describe('@happyvertical/jobs', () => {
 
         expect(events).toContain('job.completed');
       });
+
+      it('should ignore update keys that resolve only through the prototype chain', async () => {
+        const job = await store.enqueue({
+          queue: 'original',
+          payload: {
+            objectType: 'Test',
+            objectId: null,
+            method: 't',
+            args: {},
+          },
+        });
+
+        // constructor / __proto__ / toString are absent from the fieldMap
+        // literal's own keys but resolve to truthy inherited members. A falsy
+        // guard would interpolate e.g. `function Object() {…} = ?` into the SET
+        // clause; the own-property guard treats them as unknown fields and
+        // drops them. Parsed from JSON so the collisions are real own keys.
+        const updated = await store.update(
+          job.id,
+          JSON.parse(
+            '{"constructor": 1, "__proto__": 1, "toString": 1}',
+          ) as Partial<Job>,
+        );
+
+        expect(updated.id).toBe(job.id);
+        expect(updated.queue).toBe('original');
+        expect(updated.status).toBe('pending');
+      });
+
+      it('should not let a polluted Object.prototype reach the update SET clause', async () => {
+        const job = await store.enqueue({
+          queue: 'original',
+          payload: {
+            objectType: 'Test',
+            objectId: null,
+            method: 't',
+            args: {},
+          },
+        });
+
+        // Simulate prototype pollution elsewhere in the process: an inherited
+        // key whose value is a crafted SQL fragment. A bracket lookup reads it
+        // through the chain, so a falsy guard would splice it straight into the
+        // SET clause and rewrite an unrelated column. Kept non-enumerable so
+        // the pollution cannot leak into unrelated iteration mid-test.
+        Object.defineProperty(Object.prototype, 'evilCol', {
+          value: "queue = 'pwned', status",
+          configurable: true,
+          enumerable: false,
+          writable: true,
+        });
+        try {
+          await store.update(job.id, {
+            evilCol: 'x',
+          } as unknown as Partial<Job>);
+
+          const reread = await store.get(job.id);
+          expect(reread?.queue).toBe('original');
+        } finally {
+          delete (Object.prototype as { evilCol?: unknown }).evilCol;
+        }
+      });
+
+      it('should keep valid update fields while dropping inherited keys', async () => {
+        const job = await store.enqueue({
+          queue: 'original',
+          payload: {
+            objectType: 'Test',
+            objectId: null,
+            method: 't',
+            args: {},
+          },
+        });
+
+        // A real field alongside an inherited-only key exercises the executed
+        // SQL path (not the empty-SET early return): the valid column is
+        // written and the inherited key is dropped rather than injected.
+        const updated = await store.update(
+          job.id,
+          JSON.parse(
+            '{"status": "completed", "constructor": 1}',
+          ) as Partial<Job>,
+        );
+
+        expect(updated.status).toBe('completed');
+        expect(updated.queue).toBe('original');
+      });
+
+      it('should not emit a status event for a status from the prototype chain', async () => {
+        const job = await store.enqueue({
+          payload: {
+            objectType: 'Test',
+            objectId: null,
+            method: 't',
+            args: {},
+          },
+        });
+
+        const events: string[] = [];
+        store.subscribe((event) => {
+          events.push(event.type);
+        });
+
+        // The event branch reads `updates.status`, which traverses the
+        // prototype chain. A polluted Object.prototype.status must not make an
+        // unrelated update (no own `status` key) look like a completion.
+        Object.defineProperty(Object.prototype, 'status', {
+          value: 'completed',
+          configurable: true,
+          enumerable: false,
+          writable: true,
+        });
+        try {
+          await store.update(job.id, { priority: 10 });
+        } finally {
+          delete (Object.prototype as { status?: unknown }).status;
+        }
+
+        expect(events).not.toContain('job.completed');
+      });
     });
 
     describe('list', () => {


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{"schema": "hv-agent-run:v1", "runtime": "claude", "session": "44f1fd0e-5846-4f56-9869-d75cc95de317", "branch": "claude/focused-liskov-798428", "issue": "https://github.com/happyvertical/sdk/issues/1131", "policy_revision": "1.0.0", "validation": ["pnpm --filter @happyvertical/jobs test", "pnpm build", "pnpm typecheck", "pnpm lint", "pnpm agent:check", "pnpm test:ci-scripts"]}
```

Closes #1131.

## Summary

`update()` in both SQL job-store adapters resolved caller-supplied `updates`
keys through the **prototype chain** in two places, so an own key colliding with
an inherited member — or a prototype-polluted key — could reach SQL / event
logic it should never touch.

**1. Column lookup → `SET`-clause injection (the reported bug).**
Both adapters mapped each key to a column with `const column = fieldMap[key]; if (!column) continue;`.
`fieldMap` is a plain object literal, so the falsy guard ran against a lookup
that falls through to `Object.prototype`:

- `update(id, { constructor: 1 })` resolved to the native `Object` constructor and
  interpolated `function Object() { [native code] } = ?` into the `SET` clause —
  a caller-triggerable query failure.
- Under prototype pollution elsewhere in the process, an inherited **string** was
  spliced straight into the `SET` clause, rewriting an unrelated column on the
  targeted row (values are bound; the column *name* was not).

**2. Status event branch → spurious lifecycle events (found in review).**
The event branch read `updates.status` directly, which also traverses the
prototype chain. A polluted `Object.prototype.status` could make an unrelated
`update(id, { priority: 10 })` emit a spurious `job.completed` / `job.failed` /
`job.cancelled` to subscribers.

## Fix

- Guard the column lookup with `Object.hasOwn(fieldMap, key)` in `SqliteJobStore.update()`
  and `PostgresJobStore.update()`.
- Read `status` only when it is an own property of `updates` (`Object.hasOwn(updates, 'status')`).

Legitimate updates are unaffected: every real call site passes fields (including
`status`) as own keys.

## Tests

Four regression tests added to `packages/jobs/src/index.test.ts` (`SqliteJobStore > update`):

- inherited keys (`constructor` / `__proto__` / `toString`) are dropped, not interpolated;
- a mixed valid + inherited update applies the valid column and drops the inherited key (exercises the executed-SQL path);
- a prototype-polluted `Object.prototype` value cannot reach the `SET` clause (asserts an unrelated column is not rewritten);
- a prototype-polluted `status` does not emit a spurious event.

Each was confirmed to **fail on the pre-fix code** and pass after.

## Validation

`pnpm typecheck` (20/20) · `pnpm lint` · `pnpm agent:check` · `pnpm test:ci-scripts` (20) ·
`@happyvertical/jobs` build (dts typecheck) · jobs suite **36 passing**.

## Notes

- **Related, not duplicate:** #1126 / #1135 fixed the same prototype-chain pattern
  in the shared `BaseJobStore.buildOrderBy`; that fix does not reach these two
  adapter-local `update()` implementations, which each carry their own `fieldMap`,
  and it is not in this branch's history.
- **Residual coverage note:** the package test suite only instantiates `SqliteJobStore`
  (no live Postgres), so the byte-identical PostgreSQL guard has no executing test.
  The postgres change is line-for-line identical to the covered sqlite change.
