### PR TITLE
feat(sql): make JSON data-file load failures observable to calling code

### DIFF
--- a/.changeset/json-observable-load-errors.md
+++ b/.changeset/json-observable-load-errors.md
@@ -1,0 +1,7 @@
+---
+'@happyvertical/sql': minor
+---
+
+Make JSON-adapter data-file load failures observable to calling code. When a `.json` data file parses but its records cannot be inserted into the table created for it — a renamed or dropped column, a `NOT NULL` / `PRIMARY KEY` violation, or a file whose fields match no column — the adapter still keeps that table (present but empty) and loads every other table, but the failure was previously only visible as a `console.error` on stderr, so calling code could not tell an empty table apart from one that failed to load. The JSON adapter now exposes a `getTableLoadErrors()` method returning the `{ table, filePath, error }` failures (accumulated across the connection's lifetime, covering both connection-time and deferred `syncSchema()` / `execute()` loads), and accepts an `onTableLoadError` callback in `JSONOptions` for real-time notification. A new `JSONTableLoadError` type is exported.
+
+This is additive and JSON-specific — the shared `DatabaseInterface` is unchanged. The JSON adapter is the only one that loads a data file into a constrained table (where a bad file yields the silent present-but-empty case); the DuckDB adapter exposes JSON files as views, and the others have no connection-time file load. Because connections are cached per URL, `getTableLoadErrors()` reflects the shared connection's failures; the `onTableLoadError` callback is registered only for the `getDatabase()` call that first opens a URL.

--- a/packages/sql/src/json-load-errors.spec.ts
+++ b/packages/sql/src/json-load-errors.spec.ts
@@ -1,0 +1,268 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JSONTableLoadError } from './index';
+import { clearConnectionCache, getDatabase } from './index';
+
+/**
+ * A JSON data file that parses but cannot be inserted (a renamed/dropped
+ * column, a NOT NULL / PRIMARY KEY violation, or a file whose fields match no
+ * column) leaves its table created-but-empty and only logs to stderr. Issue
+ * #1139 makes those failures observable to calling code via a `getTableLoadErrors()`
+ * accessor and an `onTableLoadError` callback.
+ */
+describe('JSON adapter observable data-load errors (Issue #1139)', () => {
+  let dir: string;
+
+  const ITEMS_DDL =
+    'CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT, note TEXT)';
+  const NOT_NULL_DDL =
+    'CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT NOT NULL)';
+
+  const writeData = (table: string, records: unknown[]) =>
+    writeFileSync(join(dir, `${table}.json`), JSON.stringify(records));
+  const writeSchema = (table: string, ddl: string) =>
+    writeFileSync(join(dir, `${table}.schema.sql`), `${ddl};`);
+
+  // A record that omits the NOT NULL `name` makes the whole INSERT fail
+  const raggedNotNull = [{ id: 'a', name: 'first' }, { id: 'b' }];
+
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'json-load-errors-'));
+    // Silence the stderr diagnostic these tests deliberately trigger
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    clearConnectionCache();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const open = (extra: Record<string, unknown> = {}): Promise<any> =>
+    getDatabase({ type: 'json', url: dir, ...extra });
+
+  describe('getTableLoadErrors()', () => {
+    it('reports a table whose data could not be loaded', async () => {
+      writeData('items', raggedNotNull);
+      writeSchema('items', NOT_NULL_DDL);
+
+      const db = await open();
+      const errors = db.getTableLoadErrors();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].table).toBe('items');
+      expect(errors[0].filePath).toBe(join(dir, 'items.json'));
+      // The underlying engine cause is carried, not just a wrapper message
+      expect(errors[0].error?.context?.originalError).toMatch(/NOT NULL/i);
+    });
+
+    it('is empty when every table loads successfully', async () => {
+      writeData('items', [
+        { id: 'a', name: 'first', note: 'x' },
+        { id: 'b', name: 'second' },
+      ]);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await open();
+
+      expect(db.getTableLoadErrors()).toEqual([]);
+    });
+
+    it('reports a file whose fields match no column', async () => {
+      writeData('items', [{ nope: 1 }, { neither: 2 }]);
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await open();
+      const errors = db.getTableLoadErrors();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].table).toBe('items');
+      expect(errors[0].error?.message).toMatch(/match a column/);
+    });
+
+    it('reports the bad table without losing a healthy sibling', async () => {
+      writeData('bad', raggedNotNull);
+      writeSchema(
+        'bad',
+        'CREATE TABLE bad (id TEXT PRIMARY KEY, name TEXT NOT NULL)',
+      );
+      writeData('good', [{ id: 'a', name: 'first', note: 'y' }]);
+      writeSchema(
+        'good',
+        'CREATE TABLE good (id TEXT PRIMARY KEY, name TEXT, note TEXT)',
+      );
+
+      const db = await open();
+
+      expect(
+        db.getTableLoadErrors().map((e: JSONTableLoadError) => e.table),
+      ).toEqual(['bad']);
+      // The healthy sibling still loaded in full
+      expect(await db.count('good')).toBe(1);
+    });
+
+    it('returns a fresh array each call so callers cannot mutate adapter state', async () => {
+      writeData('items', raggedNotNull);
+      writeSchema('items', NOT_NULL_DDL);
+
+      const db = await open();
+      const first = db.getTableLoadErrors();
+      first.push({ table: 'injected', filePath: 'x', error: null });
+
+      expect(db.getTableLoadErrors()).toHaveLength(1);
+      expect(db.getTableLoadErrors()).not.toBe(first);
+    });
+
+    it('does not surface a malformed (unparseable) file as a load error', async () => {
+      // A file that cannot even be parsed is tolerated as "no data", distinct
+      // from a parsed file whose records fail to insert
+      writeFileSync(join(dir, 'items.json'), '{ not valid json');
+      writeSchema('items', ITEMS_DDL);
+
+      const db = await open();
+
+      expect(db.getTableLoadErrors()).toEqual([]);
+      expect(await db.count('items')).toBe(0);
+    });
+  });
+
+  describe('deferred loads accumulate into the same accessor', () => {
+    it('reports a failure that only happens during syncSchema()', async () => {
+      writeData('items', raggedNotNull);
+
+      const db = await open({ eagerLoadTables: false });
+      // Nothing has loaded yet - the table is deferred
+      expect(db.getTableLoadErrors()).toEqual([]);
+
+      await db.syncSchema(`${NOT_NULL_DDL};`);
+
+      expect(
+        db.getTableLoadErrors().map((e: JSONTableLoadError) => e.table),
+      ).toEqual(['items']);
+    });
+
+    it('reports a failure that only happens during execute() DDL', async () => {
+      writeData('items', raggedNotNull);
+
+      const db = await open({ eagerLoadTables: false });
+      await db.execute`CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT NOT NULL)`;
+
+      expect(
+        db.getTableLoadErrors().map((e: JSONTableLoadError) => e.table),
+      ).toEqual(['items']);
+    });
+  });
+
+  describe('onTableLoadError callback', () => {
+    it('fires with the same info for a connection-time failure', async () => {
+      writeData('items', raggedNotNull);
+      writeSchema('items', NOT_NULL_DDL);
+      const seen: JSONTableLoadError[] = [];
+
+      const db = await open({ onTableLoadError: (info) => seen.push(info) });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0].table).toBe('items');
+      expect(seen[0].filePath).toBe(join(dir, 'items.json'));
+      // The callback and the accessor report the same failures
+      expect(seen).toEqual(db.getTableLoadErrors());
+    });
+
+    it('fires for a deferred syncSchema() failure', async () => {
+      writeData('items', raggedNotNull);
+      const seen: string[] = [];
+
+      const db = await open({
+        eagerLoadTables: false,
+        onTableLoadError: (info) => seen.push(info.table),
+      });
+      expect(seen).toEqual([]);
+
+      await db.syncSchema(`${NOT_NULL_DDL};`);
+
+      expect(seen).toEqual(['items']);
+    });
+
+    it('does not fire when loads succeed', async () => {
+      writeData('items', [{ id: 'a', name: 'first', note: 'x' }]);
+      writeSchema('items', ITEMS_DDL);
+      const seen: JSONTableLoadError[] = [];
+
+      await open({ onTableLoadError: (info) => seen.push(info) });
+
+      expect(seen).toEqual([]);
+    });
+
+    it('a throwing callback does not break loading of the remaining tables', async () => {
+      writeData('bad', raggedNotNull);
+      writeSchema(
+        'bad',
+        'CREATE TABLE bad (id TEXT PRIMARY KEY, name TEXT NOT NULL)',
+      );
+      writeData('good', [{ id: 'a', name: 'first', note: 'y' }]);
+      writeSchema(
+        'good',
+        'CREATE TABLE good (id TEXT PRIMARY KEY, name TEXT, note TEXT)',
+      );
+
+      const db = await open({
+        onTableLoadError: () => {
+          throw new Error('callback boom');
+        },
+      });
+
+      // Loading continued despite the callback throwing: good is intact and the
+      // failure is still recorded
+      expect(await db.count('good')).toBe(1);
+      expect(
+        db.getTableLoadErrors().map((e: JSONTableLoadError) => e.table),
+      ).toEqual(['bad']);
+    });
+  });
+
+  describe('connection caching', () => {
+    it('shares getTableLoadErrors() but does not re-wire a later callback', async () => {
+      writeData('items', raggedNotNull);
+
+      // First open creates the connection (no callback, deferred load)
+      const db1 = await open({ eagerLoadTables: false });
+      // Second open for the same URL is a cache hit - the same object
+      const late: JSONTableLoadError[] = [];
+      const db2 = await open({
+        eagerLoadTables: false,
+        onTableLoadError: (info) => late.push(info),
+      });
+      expect(db2).toBe(db1);
+
+      // Trigger the deferred load failure through the shared connection
+      await db2.syncSchema(`${NOT_NULL_DDL};`);
+
+      // The late caller's callback is NOT registered (connection was cached)...
+      expect(late).toEqual([]);
+      // ...but the shared accessor still reflects the failure
+      expect(
+        db2.getTableLoadErrors().map((e: JSONTableLoadError) => e.table),
+      ).toEqual(['items']);
+    });
+  });
+
+  describe('scope: schema-less eager loads are out of scope', () => {
+    it('does not report an eager inferred-schema load that fails to create the table', async () => {
+      // A schema-less file with duplicate keys cannot be inferred by DuckDB, so
+      // the table is never created. That is NOT the silent present-but-empty
+      // case this feature targets - a query against the missing table throws, so
+      // the failure is already observable. It is deliberately not reported here.
+      writeFileSync(join(dir, 'dup.json'), '[{"id": 1, "id": 2}]');
+
+      const db = await open();
+
+      expect(db.getTableLoadErrors()).toEqual([]);
+      // The failure surfaces the other way: the table does not exist
+      await expect(db.query('SELECT * FROM dup')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/sql/src/json.ts
+++ b/packages/sql/src/json.ts
@@ -12,6 +12,7 @@ import { createTransactionLock } from './shared/transaction-lock';
 import type {
   DatabaseInterface,
   JSONOptions,
+  JSONTableLoadError,
   QueryResult,
   SchemaInitializationOptions,
   TableInterface,
@@ -109,6 +110,22 @@ async function createJSONConnection(options: JSONOptions) {
   // Track tables created with inferred schemas (need DROP before syncSchema())
   const inferredSchemaTables = new Set<string>();
 
+  // Accumulate data-load failures so calling code can detect a table that was
+  // created but left empty because its data could not be inserted (issue #1139)
+  const tableLoadErrors: JSONTableLoadError[] = [];
+  const reportLoadError = (info: JSONTableLoadError): void => {
+    tableLoadErrors.push(info);
+    // A caller callback must never break loading of the remaining tables
+    try {
+      options.onTableLoadError?.(info);
+    } catch (callbackError) {
+      console.error(
+        '[json-adapter] onTableLoadError callback threw:',
+        callbackError,
+      );
+    }
+  };
+
   try {
     // Dynamic import to avoid bundling
     const duckdbModule = '@duckdb/node-api';
@@ -134,10 +151,17 @@ async function createJSONConnection(options: JSONOptions) {
         pendingJSONFiles,
         eagerLoadTables,
         inferredSchemaTables,
+        reportLoadError,
       );
     }
 
-    return { connection, pendingJSONFiles, inferredSchemaTables };
+    return {
+      connection,
+      pendingJSONFiles,
+      inferredSchemaTables,
+      tableLoadErrors,
+      reportLoadError,
+    };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new DatabaseError(
@@ -169,11 +193,13 @@ async function createJSONConnection(options: JSONOptions) {
  * @param connection - DuckDB connection
  * @param tableName - Name of the table to load data into
  * @param filePath - Path to the JSON file
+ * @param reportLoadError - Sink invoked when parsed records fail to insert (issue #1139)
  */
 async function loadJSONData(
   connection: any,
   tableName: string,
   filePath: string,
+  reportLoadError?: (info: JSONTableLoadError) => void,
 ): Promise<void> {
   let records: unknown;
 
@@ -212,6 +238,9 @@ async function loadJSONData(
       `[json-adapter] Failed to load data for ${tableName}; the table will be empty:`,
       error,
     );
+    // Also surface it to calling code, which cannot otherwise tell an empty
+    // table apart from a table that failed to load (issue #1139)
+    reportLoadError?.({ table: tableName, filePath, error });
   }
 }
 
@@ -239,6 +268,7 @@ async function loadJSONData(
  * @param pendingJSONFiles - Map to store JSON files pending deferred loading
  * @param eagerLoadTables - Whether to eagerly create tables with inferred schemas
  * @param inferredSchemaTables - Set to track tables created with inferred schemas
+ * @param reportLoadError - Sink for per-table data-load failures (issue #1139)
  */
 async function loadJSONTables(
   connection: any,
@@ -247,6 +277,7 @@ async function loadJSONTables(
   pendingJSONFiles: Map<string, string> = new Map(),
   eagerLoadTables: boolean = true,
   inferredSchemaTables: Set<string> = new Set(),
+  reportLoadError?: (info: JSONTableLoadError) => void,
 ) {
   try {
     const files = await readdir(dataDir);
@@ -269,7 +300,7 @@ async function loadJSONTables(
         await createTableFromSchema(connection, tableName, schema);
 
         // Load JSON data into properly-typed table
-        await loadJSONData(connection, tableName, filePath);
+        await loadJSONData(connection, tableName, filePath, reportLoadError);
       } else {
         // Check for schema file first (preserves constraints like PRIMARY KEY, UNIQUE, etc.)
         const schemaPath = join(dataDir, `${tableName}.schema.sql`);
@@ -289,7 +320,12 @@ async function loadJSONTables(
           try {
             const schemaDDL = await readFile(schemaPath, 'utf-8');
             await connection.run(schemaDDL);
-            await loadJSONData(connection, tableName, filePath);
+            await loadJSONData(
+              connection,
+              tableName,
+              filePath,
+              reportLoadError,
+            );
           } catch (error) {
             console.warn(
               `[json-adapter] Could not load ${tableName} with schema file: ${error instanceof Error ? error.message : String(error)}`,
@@ -311,6 +347,13 @@ async function loadJSONTables(
                 `[json-adapter] Eagerly created ${tableName} with inferred schema (no UNIQUE constraints)`,
               );
             } catch (error) {
+              // Deliberately NOT reported via reportLoadError (issue #1139):
+              // CREATE TABLE AS SELECT is atomic, so any read_json_auto failure
+              // leaves NO table — which surfaces loudly as a missing-table error
+              // when queried, unlike the silent present-but-empty case that
+              // getTableLoadErrors()/onTableLoadError target. If this branch ever
+              // gains something like read_json(..., ignore_errors := true) that
+              // could leave a partially-created/empty table, revisit that scope.
               console.warn(
                 `[json-adapter] Could not eagerly load ${tableName}: ${error instanceof Error ? error.message : String(error)}`,
               );
@@ -812,8 +855,13 @@ export async function getDatabase(
 
   // Create a new connection promise
   const connectionPromise = (async () => {
-    const { connection, pendingJSONFiles, inferredSchemaTables } =
-      await createJSONConnection(options);
+    const {
+      connection,
+      pendingJSONFiles,
+      inferredSchemaTables,
+      tableLoadErrors,
+      reportLoadError,
+    } = await createJSONConnection(options);
     const writeStrategy = options.writeStrategy || 'immediate';
     const { url } = options;
 
@@ -1595,6 +1643,33 @@ export async function getDatabase(
     };
 
     /**
+     * Returns the table-load failures collected for this connection
+     *
+     * A JSON data file that parses but whose records cannot be inserted into a
+     * table created for it (a renamed/dropped column, a NOT NULL / PRIMARY KEY
+     * violation, or a file whose fields match no column) leaves that table
+     * present-but-empty and is logged to stderr; calling code otherwise cannot
+     * tell it apart from a legitimately empty one. This exposes those failures
+     * so a caller can detect and react to them (issue #1139).
+     *
+     * Scope: this covers loads into a table created from a provided schema, a
+     * `.schema.sql` file, or deferred `syncSchema()` / `execute()` DDL. A file
+     * with no schema at all is loaded by DuckDB's own inference; if that fails
+     * the table is simply not created, which already surfaces as an error when
+     * you query it, so it is not reported here.
+     *
+     * The list accumulates across the connection's lifetime — covering both
+     * connection-time and later deferred loads — and is append-only (a later
+     * successful reload of the same table does not remove an earlier failure).
+     * A fresh array is returned each call, so mutating it does not affect the
+     * adapter's state. Because connections are cached per URL, callers sharing a
+     * URL share this list.
+     *
+     * @returns Table-load failures, oldest first
+     */
+    const getTableLoadErrors = (): JSONTableLoadError[] => [...tableLoadErrors];
+
+    /**
      * Creates a table by inferring schema from a JSON file
      *
      * This utility is for users who want automatic schema inference from JSON.
@@ -1783,7 +1858,12 @@ export async function getDatabase(
           const pendingFile = pendingJSONFiles.get(tableName);
           if (pendingFile) {
             // Table was just created by DDL - now load the JSON data
-            await loadJSONData(connection, tableName, pendingFile);
+            await loadJSONData(
+              connection,
+              tableName,
+              pendingFile,
+              reportLoadError,
+            );
             pendingJSONFiles.delete(tableName);
           } else if (writeStrategy !== 'none') {
             // No pending data - export empty table (preserves SMRT system tables)
@@ -1947,7 +2027,12 @@ export async function getDatabase(
               // Table was just created by DDL - now load the JSON data.
               // loadJSONData logs an unloadable file rather than throwing, so a
               // single bad table does not abort the rest of this schema sync
-              await loadJSONData(connection, tableName, pendingFile);
+              await loadJSONData(
+                connection,
+                tableName,
+                pendingFile,
+                reportLoadError,
+              );
               pendingJSONFiles.delete(tableName);
             } else if (writeStrategy !== 'none') {
               // No pending data - export empty table (preserves SMRT system tables)
@@ -2214,12 +2299,14 @@ export async function getDatabase(
       // JSON-specific methods
       exportTable,
       inferSchemaFromJSON,
+      getTableLoadErrors,
     } as DatabaseInterface & {
       exportTable: (table: string) => Promise<void>;
       inferSchemaFromJSON: (
         tableName: string,
         jsonPath?: string,
       ) => Promise<void>;
+      getTableLoadErrors: () => JSONTableLoadError[];
     };
   })();
 

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -138,6 +138,28 @@ export interface DuckDBOptions extends DatabaseOptions {
 }
 
 /**
+ * A JSON data file that parsed but whose records could not be loaded into the
+ * table — e.g. a renamed or dropped column, a NOT NULL / PRIMARY KEY violation,
+ * or a file whose fields match no column on the table.
+ *
+ * The JSON adapter keeps the table (empty) and continues loading every other
+ * table, logging the failure to stderr. This record makes the same failure
+ * observable to calling code so a table that silently stays empty can be
+ * detected. See issue #1139.
+ */
+export interface JSONTableLoadError {
+  /** Name of the table whose data file failed to load */
+  table: string;
+  /** Path to the JSON data file that could not be loaded */
+  filePath: string;
+  /**
+   * The underlying failure. Typically a `DatabaseError` whose `context`
+   * carries the engine-level cause (e.g. the DuckDB constraint message).
+   */
+  error: unknown;
+}
+
+/**
  * JSON database adapter options (DuckDB-backed)
  *
  * Uses DuckDB's in-memory engine to query JSON files directly.
@@ -264,6 +286,35 @@ export interface JSONOptions {
    * });
    */
   clearCache?: boolean;
+
+  /**
+   * Called when a JSON data file parses but its records cannot be loaded into a
+   * table that was created for it — from a provided schema, a `.schema.sql`
+   * file, or deferred `syncSchema()` / `execute()` DDL — leaving that table
+   * present but empty (renamed/dropped column, NOT NULL / PRIMARY KEY violation,
+   * or a file whose fields match no column). Every other table still loads.
+   *
+   * This targets the *silent* failure: a present-but-empty table a query cannot
+   * tell apart from a legitimately empty one. A file with no schema at all is
+   * loaded by DuckDB's own inference; if that fails the table is simply not
+   * created, which already surfaces as an error when you query it, so it is not
+   * reported here.
+   *
+   * Fires for both connection-time and deferred (`syncSchema()` / `execute()`)
+   * loads. Without it, such a failure is only visible as a `console.error` on
+   * stderr. The same failures are also retrievable after the fact via the
+   * adapter's `getTableLoadErrors()` method.
+   *
+   * Registered once, on the `getDatabase()` call that creates the connection.
+   * The JSON adapter caches connections per URL, so a later `getDatabase()` for
+   * the same directory returns the existing connection and does *not* re-wire a
+   * different `onTableLoadError` — read `getTableLoadErrors()` on the returned
+   * adapter instead, which reflects the shared connection's failures.
+   *
+   * A callback that throws is caught and ignored so it cannot break loading of
+   * the remaining tables. See issue #1139.
+   */
+  onTableLoadError?: (info: JSONTableLoadError) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1139 (follow-up to #1132). When a JSON data file parses but its records cannot be inserted into the table created for it — a renamed/dropped column, a `NOT NULL` / `PRIMARY KEY` violation, or a file whose fields match no column — the adapter keeps that table present-but-empty and loads every other table, but the failure was only visible as a `console.error` on stderr. Calling code could not tell an empty table apart from one that failed to load — functionally the same silent shape #1132 was filed over, with a narrower trigger.

## What changed

Two complementary ways to observe the failures, plus a new exported type:

- **`getTableLoadErrors(): JSONTableLoadError[]`** — a method on the JSON adapter returning `{ table, filePath, error }` for each failure, accumulated across the connection's lifetime (covers connection-time **and** deferred `syncSchema()` / `execute()` loads). Returns a fresh snapshot each call.
- **`onTableLoadError`** — an optional `JSONOptions` callback for real-time notification. A throwing callback is caught so it can't break loading of the remaining tables.
- **`JSONTableLoadError`** — exported type (`{ table, filePath, error }`).

## Design decisions

- **JSON-specific, not on the shared `DatabaseInterface`.** The JSON adapter is the only one that loads a data file into a *constrained table* where a bad file yields the silent present-but-empty case. DuckDB exposes JSON as views (no such failure mode); the others have no connection-time file load. Placed alongside the existing `exportTable`/`inferSchemaFromJSON` extensions.
- **Scope is the *silent* failure.** A schema-less file loaded by DuckDB's own inference (`read_json_auto`) that fails leaves **no table** (CREATE-TABLE-AS-SELECT is atomic), which already surfaces loudly as a missing-table error when queried — so it is deliberately not reported here (documented, with a guard comment at the call site and a test).
- **Connection caching.** Connections are cached per URL, so `getTableLoadErrors()` reflects the shared connection's failures, while `onTableLoadError` is registered only for the `getDatabase()` call that first opens a URL — documented, mirroring the existing `transactionQueueTimeout` caveat.

## Tests

New `packages/sql/src/json-load-errors.spec.ts` (14 tests): the accessor and callback for connection-time and deferred (`syncSchema()`/`execute()`) failures, the "fields match no column" case, sibling isolation, empty-on-success, the underlying-cause payload, snapshot-copy semantics, a throwing callback, the connection-caching caveat, and the eager-path scope boundary (query throws, not reported). Malformed (unparseable) files remain non-errors.

## Validation

- `pnpm --filter @happyvertical/sql test` — 605 passed, 4 skipped
- `pnpm typecheck` · `pnpm build` — green
- `biome` clean on changed files (2 pre-existing `column_name`/`data_type` warnings in unrelated code)

Reviewed across two perspectives (correctness/completeness, API-design/maintainability); every finding resolved and re-verified.

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude-code",
  "owner": "willgriffin",
  "session": "ff257046-9e50-40e6-a433-d01ca4a50d1e",
  "issue": "https://github.com/happyvertical/sdk/issues/1139",
  "branch": "claude/issue-1139-observable-load-errors",
  "policy_revision": "1.0.0",
  "validation": [
    "pnpm --filter @happyvertical/sql test: 605 passed / 4 skipped",
    "pnpm typecheck: pass",
    "pnpm build: pass",
    "biome: pass (pre-existing warnings only)"
  ]
}
```
