### PR TITLE
ci: use hosted runners for public workflows

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,36 +1,44 @@
 # SDK continuous integration
 
-SDK separates hosted metadata/security checks from Node workspace validation.
-No validation family is removed: pull requests run affected closures after the
-rollout flag is enabled, while merge groups run the exhaustive build,
-typecheck, lint, test, optional-adapter, documentation, package, and PostgreSQL
-suites.
+SDK routes portable CI for trusted repository work through the provider-neutral
+`arc-happyvertical` broker alias. No validation family is removed: pull
+requests run affected closures after the rollout flag is enabled, while merge
+groups run the exhaustive build, typecheck, lint, test, optional-adapter,
+documentation, package, and PostgreSQL suites.
 
 ## Runner selection
 
-- `ubuntu-latest` runs commit/workflow policy, naming, secret scanning, scope
-  detection, and result-only aggregation. These jobs do not install
-  the workspace.
-- `arc-happyvertical-node` runs Node-only builds, tests, documentation, and
-  package validation. It provides Node 24.18.0, pnpm 11.13.0, native build
-  prerequisites, PostgreSQL client tools, and an 8 GiB memory limit. It does
-  not provide Docker or deployment tooling.
-- `ci-linux-x64` is the shared general Linux pool for Docker service
-  containers and as the rollout fallback. Jobs may run on ARC or a warm PXE
-  host; job state is cleaned between JIT identities while safe caches may be
-  retained.
+- `arc-happyvertical` is the sole workflow-facing selector for portable,
+  repository-owned Linux CI. Runner-pool policy chooses its backing capacity;
+  workflows must not name a provider-specific backing label.
 - Matrix-native jobs such as `build-json-native.yml` retain their hosted OS
   runners.
+- The public `shared-direct-publish.yml` reusable workflow remains hosted so
+  arbitrary external callers are never routed into HappyVertical capacity.
 
-Set `CI_NODE_RUNNER_ENABLED=true` only after the node-runner smoke workflow
-passes. Clearing the variable immediately routes ordinary Node jobs back to
-`ci-linux-x64`. Each runner keeps the workspace and pnpm store isolated from
-concurrent jobs; safe caches may survive sequential jobs on a warm PXE host.
+Each brokered runner keeps the workspace and pnpm store isolated from
+concurrent jobs; safe caches may survive sequential jobs on a warm host.
 
-The runner workspace and `PNPM_STORE_DIR` must share a filesystem. The smoke
-workflow verifies matching device IDs and confirms that installed dependency
-files have hardlink counts above one. The persistent store is never restored
-through GitHub Actions; hosted runners may use an Actions-backed pnpm store.
+The runner workspace and the pnpm store derived by `pnpm store path` must share
+a filesystem. The smoke workflow verifies matching device IDs, confirms that
+installed dependency files have hardlink counts above one, and validates the
+digest-pinned PostgreSQL/pgvector service contract. The persistent store is
+never restored through GitHub Actions.
+
+## Trusted-base public pull requests
+
+The brokered PR, lifecycle, and Dependabot workflows use
+`pull_request_target`, so GitHub loads runner selection from the trusted base
+branch rather than contributor-controlled merge YAML. Only a same-repository
+PR explicitly checks out `github.event.pull_request.head.sha`; that SHA is
+passed into reusable validation workflows as `checkout_ref`. Merge groups use
+their synthetic `github.sha` normally.
+
+An external fork never gets an `arc-happyvertical` job: each job is guarded by
+the same-repository test before GitHub allocates a runner, and fork code is
+never checked out in this path. Broker-side admission independently denies fork
+events before reservation. This boundary is intentional; do not replace it
+with a job-level guard in an ordinary `pull_request` workflow.
 
 ## Turbo cache behavior
 
@@ -60,10 +68,10 @@ coverage rules to a package `vitest.config.ts`, not to its test command.
 - `true`: pull requests use Turbo's affected package/dependency closure. The
   merge group runs the complete release-confidence suite and publish dry run.
 
-`Required CI` is always present. It rejects failed, cancelled, or unexpectedly
-skipped jobs, using a different explicit job set for `pull_request` and
-`merge_group`. Pull-request runs cancel superseded commits; merge-group runs do
-not cancel each other.
+`Required CI` is always present for trusted PR and merge-group work. It rejects
+failed, cancelled, or unexpectedly skipped jobs using an explicit job set.
+`pull_request_target` runs cancel superseded commits; merge-group runs do not
+cancel each other.
 
 Observe `Required CI` alongside the existing required checks for ten successful
 representative pull requests before changing repository rules. The
@@ -89,8 +97,8 @@ databases older than six hours.
 
 The shared credential must be a least-privilege CI role able to create/drop
 only disposable CI databases and unable to connect to production databases.
-The manual `service-container` workflow option is the rollback path and stays
-on `ci-linux-x64`, where Docker is available.
+The manual `service-container` workflow option is the rollback path and runs
+through the broker, whose selected capacity must support service containers.
 
 Set `CI_POSTGRES_ENABLED=true` only after a shared-backend manual run succeeds.
 Clear it to remove the lane from the required set without weakening the normal
@@ -140,8 +148,7 @@ at least 30% fewer self-hosted runner-minutes per pull request.
 
 Rollback order:
 
-1. Clear `CI_MERGE_QUEUE_ENABLED`, `CI_POSTGRES_ENABLED`, and
-   `CI_NODE_RUNNER_ENABLED` as needed.
+1. Clear `CI_MERGE_QUEUE_ENABLED` and `CI_POSTGRES_ENABLED` as needed.
 2. Restore the previous required-context list and disable the merge queue.
 3. Use the PostgreSQL service-container fallback if the shared service is the
    failing phase.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,7 @@
 self-hosted-runner:
   labels:
     - arc-happyvertical
-    - arc-happyvertical-node
-    - ci-linux-x64
+    # The native matrix is a specialized macOS lane, not a brokered runner.
     - macos-13
 
 config-variables: null

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -1,9 +1,7 @@
 name: Agent Policy
 
 on:
-  # This trusted-base event prevents a fork from supplying workflow YAML that
-  # selects a self-hosted runner.
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
@@ -31,29 +29,49 @@ concurrency:
     }}
   cancel-in-progress: true
 
-env:
-  CHECKOUT_REF: >-
-    ${{ github.event_name == 'pull_request_target' &&
-    github.event.pull_request.head.repo.full_name == github.repository &&
-    github.event.pull_request.head.sha || github.sha }}
-
 jobs:
   lifecycle:
     name: lifecycle / diagnostic
-    # A fork PR is rejected before GitHub can allocate the brokered runner.
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: arc-happyvertical
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: ${{ env.CHECKOUT_REF }}
       - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: v3.0.6
+      # cosign-installer v4 shells out to envsubst, which is not part of the
+      # provider-neutral general runner contract. Download the publisher-
+      # compatible cosign v3 binary directly and verify its pinned SHA-256 so
+      # lifecycle enforcement has the same dependencies on every provider.
+      - name: Install signature verifier
+        env:
+          COSIGN_VERSION: v3.0.6
+          COSIGN_SHA256_AMD64: c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74
+          COSIGN_SHA256_ARM64: bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            x86_64) asset=cosign-linux-amd64; expected="$COSIGN_SHA256_AMD64" ;;
+            aarch64 | arm64) asset=cosign-linux-arm64; expected="$COSIGN_SHA256_ARM64" ;;
+            *) echo "unsupported runner architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          install_dir="$RUNNER_TEMP/hv-cosign"
+          mkdir -p "$install_dir"
+          curl -fsSL -o "$install_dir/cosign" \
+            "https://github.com/sigstore/cosign/releases/download/$COSIGN_VERSION/$asset"
+          actual=$(python3 - "$install_dir/cosign" <<'PY'
+          import hashlib
+          import pathlib
+          import sys
+
+          print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+          PY
+          )
+          test "$actual" = "$expected" || {
+            echo "cosign checksum mismatch: expected $expected, got $actual" >&2
+            exit 1
+          }
+          chmod +x "$install_dir/cosign"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/cosign" version
       - name: Select source-owned policy channel
         shell: bash
         env:

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -32,7 +32,11 @@ concurrency:
 jobs:
   lifecycle:
     name: lifecycle / diagnostic
-    runs-on: ubuntu-latest
+    # A fork PR is rejected before GitHub can allocate the brokered runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: arc-happyvertical
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -1,7 +1,9 @@
 name: Agent Policy
 
 on:
-  pull_request:
+  # This trusted-base event prevents a fork from supplying workflow YAML that
+  # selects a self-hosted runner.
+  pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
@@ -29,17 +31,25 @@ concurrency:
     }}
   cancel-in-progress: true
 
+env:
+  CHECKOUT_REF: >-
+    ${{ github.event_name == 'pull_request_target' &&
+    github.event.pull_request.head.repo.full_name == github.repository &&
+    github.event.pull_request.head.sha || github.sha }}
+
 jobs:
   lifecycle:
     name: lifecycle / diagnostic
     # A fork PR is rejected before GitHub can allocate the brokered runner.
     if: >-
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: arc-happyvertical
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
       - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -5,7 +5,9 @@ name: Dependabot Automation
 # policy, while this actor-gated helper only approves; merging still
 # requires the full set of required checks.
 on:
-  pull_request:
+  # Load runner selection from the trusted base branch before granting the
+  # repository-owned Dependabot path its write-scoped token.
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -23,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Validate security requirements
         run: |

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -11,8 +11,11 @@ on:
 jobs:
   dependabot:
     name: Dependabot Automation
-    runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # Dependabot branches are repository-owned; fork PRs never get ARC work.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: arc-happyvertical
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   dependabot:
     name: Dependabot Automation
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     permissions:
       contents: write

--- a/.github/workflows/node-runner-smoke.yml
+++ b/.github/workflows/node-runner-smoke.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   smoke:
     name: Node Runner Shadow Validation
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/node-runner-smoke.yml
+++ b/.github/workflows/node-runner-smoke.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   smoke:
     name: Node Runner Shadow Validation
-    runs-on: arc-happyvertical-node
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/node-runner-smoke.yml
+++ b/.github/workflows/node-runner-smoke.yml
@@ -1,4 +1,4 @@
-name: Node Runner Smoke Test
+name: Brokered Runner Smoke Test
 
 on:
   workflow_dispatch:
@@ -9,31 +9,42 @@ permissions:
 
 jobs:
   smoke:
-    name: Node Runner Shadow Validation
+    name: Brokered Runner Validation
     runs-on: arc-happyvertical
     timeout-minutes: 15
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17@sha256:d2ef61f42ef767baa5a1475393303cc235bcd92febd9d7014eddb48b41f3bad0
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Verify runner contract
-        run: |
-          set -euo pipefail
-          test "$(node --version)" = 'v24.18.0'
-          test "$(pnpm --version)" = '11.13.0'
-          command -v psql
-          test ! -S /var/run/docker.sock
-          test -r "$CI_POSTGRES_BASE_URL_FILE"
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
           github-packages-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify node-local hardlink layout
+      - name: Verify brokered runner contract
         run: |
           set -euo pipefail
-          test "$(stat -c '%d' "$PNPM_STORE_DIR")" = "$(stat -c '%d' "$GITHUB_WORKSPACE")"
+          test "$(node --version)" = 'v24.18.0'
+          test "$(pnpm --version)" = '11.13.0'
+          command -v psql
+
+      - name: Verify pnpm hardlink layout
+        run: |
+          set -euo pipefail
+          store_dir=$(pnpm store path --silent)
+          test "$(stat -c '%d' "$store_dir")" = "$(stat -c '%d' "$GITHUB_WORKSPACE")"
           linked_file=$(find node_modules/.pnpm -type f -links +1 -print -quit)
           test -n "$linked_file"
           test "$(stat -c '%h' "$linked_file")" -gt 1
@@ -41,3 +52,5 @@ jobs:
 
       - name: Verify disposable PostgreSQL lifecycle
         run: node scripts/run-with-ci-postgres.mjs -- psql --command 'SELECT current_database()'
+        env:
+          CI_POSTGRES_BASE_URL: postgresql://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,7 +1,9 @@
 name: Pull Request Validation
 
 on:
-  pull_request:
+  # GitHub loads this workflow from the trusted base branch. That keeps runner
+  # selection out of a contributor-controlled merge commit.
+  pull_request_target:
     branches: [main, dependency-updates]
     types: [opened, synchronize, reopened]
   merge_group:
@@ -13,13 +15,13 @@ concurrency:
       github.event.merge_group.head_sha ||
       github.ref
     }}-${{
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       github.event.action == 'edited' &&
       github.event.changes.title != null &&
       github.event.changes.base == null) &&
       'title' ||
       (github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null))) &&
       'lifecycle' ||
@@ -32,9 +34,17 @@ permissions:
   pull-requests: read
   packages: read
 
-# Every self-hosted job in this workflow must keep the same-repository guard.
-# GitHub evaluates a job-level `if` before allocating its runner, so fork PRs
-# are skipped before they can reach the brokered pool.
+env:
+  # Reusable workflows receive the reviewed head only for repository-owned
+  # branches. Fork PR jobs are skipped before self-hosted allocation.
+  CHECKOUT_REF: >-
+    ${{ github.event_name == 'pull_request_target' &&
+    github.event.pull_request.head.repo.full_name == github.repository &&
+    github.event.pull_request.head.sha || github.sha }}
+
+# Every self-hosted job in this trusted-base wrapper keeps the same-repository
+# guard. GitHub evaluates a job-level `if` before allocating its runner, so
+# fork PRs are skipped before they can reach the brokered pool.
 jobs:
 
   changeset-check:
@@ -42,7 +52,7 @@ jobs:
     runs-on: arc-happyvertical
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
 
@@ -50,10 +60,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Check for skip conditions
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         id: skip-check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +79,7 @@ jobs:
           fi
 
       - name: Setup Environment
-        if: github.event_name == 'pull_request' && steps.skip-check.outputs.skip != 'true'
+        if: github.event_name == 'pull_request_target' && steps.skip-check.outputs.skip != 'true'
         uses: ./.github/actions/setup-environment
         with:
           node-version: '24.18.0'
@@ -76,7 +87,7 @@ jobs:
           github-packages-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for changeset
-        if: github.event_name == 'pull_request' && steps.skip-check.outputs.skip != 'true'
+        if: github.event_name == 'pull_request_target' && steps.skip-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
@@ -168,7 +179,7 @@ jobs:
     name: Validate Conventional Commits
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-happyvertical
@@ -181,6 +192,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Validate commit messages
@@ -193,13 +205,13 @@ jobs:
       # because that composite action installs apt packages and the
       # complete workspace dependency graph on the self-hosted runner.
       - name: Setup Node.js for PR title validation
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.18.0'
 
       - name: Install commitlint dependencies
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           npm install --prefix "$RUNNER_TEMP/commitlint" --no-save \
             --ignore-scripts --no-audit --no-fund \
@@ -207,7 +219,7 @@ jobs:
             @commitlint/config-conventional@20.5.0
 
       - name: Validate PR title for squash merge
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         # PR title is user-controlled metadata. Two non-obvious risks
         # the previous form had:
         #   (1) Interpolating the title directly into a shell script
@@ -240,7 +252,7 @@ jobs:
               --config commitlint.config.mjs
 
       - name: Determine version bump
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         id: version
         run: |
           base_ref="${{ github.event.pull_request.base.ref }}"
@@ -266,7 +278,7 @@ jobs:
           fi
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -332,7 +344,7 @@ jobs:
     name: Validate Workflow Files
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-happyvertical
@@ -340,6 +352,8 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Get changed workflow files
         id: changed-files
@@ -384,7 +398,7 @@ jobs:
     name: Check for stale @have/ references
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-happyvertical
@@ -392,6 +406,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Get changed markdown files
         id: changed-md
@@ -422,7 +438,7 @@ jobs:
     name: Check documentation coverage
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-happyvertical
@@ -431,6 +447,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Get changed files
@@ -482,12 +499,16 @@ jobs:
     name: Validate Changes
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/test.yml
     with:
       mode: ${{ github.event_name == 'merge_group' && 'full' || (vars.CI_MERGE_QUEUE_ENABLED == 'true' && 'affected' || 'full') }}
+      checkout_ref: >-
+        ${{ github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read
@@ -496,7 +517,7 @@ jobs:
     name: Validate Documentation Build
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-happyvertical
@@ -504,10 +525,12 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Get changed files
         id: changed-files
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
         with:
           files: |
@@ -544,7 +567,7 @@ jobs:
     name: Secret Scan
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-happyvertical
@@ -552,6 +575,7 @@ jobs:
       - name: Checkout PR history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
       - name: Install Gitleaks CLI
         env:
@@ -578,7 +602,7 @@ jobs:
     name: Detect PostgreSQL Test Scope
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-happyvertical
@@ -587,9 +611,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Detect PostgreSQL-sensitive changes
         id: filter
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
@@ -614,10 +640,15 @@ jobs:
     needs: postgres-scope
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/postgres-tests.yml
+    with:
+      checkout_ref: >-
+        ${{ github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read
@@ -626,10 +657,15 @@ jobs:
     name: Publish Dry Run
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/publish-dry-run.yml
+    with:
+      checkout_ref: >-
+        ${{ github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -32,15 +32,19 @@ permissions:
   pull-requests: read
   packages: read
 
+# Every self-hosted job in this workflow must keep the same-repository guard.
+# GitHub evaluates a job-level `if` before allocating its runner, so fork PRs
+# are skipped before they can reach the brokered pool.
 jobs:
 
   changeset-check:
     name: Check for Changeset
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
       - name: Checkout
@@ -165,8 +169,9 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ubuntu-latest
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-happyvertical
     permissions:
       contents: read
       pull-requests: write
@@ -208,8 +213,8 @@ jobs:
         #   (1) Interpolating the title directly into a shell script
         #       lets a title with command substitution execute the
         #       substitution at the runner's shell — real command
-        #       injection, especially on the self-hosted
-        #       ci-linux-x64 runner this workflow runs on. Pass
+        #       injection, especially on the brokered
+        #       arc-happyvertical runner this workflow runs on. Pass
         #       via env: instead, then quote the variable expansion.
         #   (2) scripts/validate-conventional-commits.js uses a
         #       hardcoded regex with permissive scope and a 50-char
@@ -328,8 +333,9 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ubuntu-latest
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout PR branch
@@ -379,8 +385,9 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ubuntu-latest
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout
@@ -416,8 +423,9 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ubuntu-latest
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout
@@ -475,7 +483,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/test.yml
     with:
       mode: ${{ github.event_name == 'merge_group' && 'full' || (vars.CI_MERGE_QUEUE_ENABLED == 'true' && 'affected' || 'full') }}
@@ -488,8 +497,9 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ubuntu-latest
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout PR branch
@@ -535,8 +545,9 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ubuntu-latest
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout PR history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -568,8 +579,9 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ubuntu-latest
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-happyvertical
     outputs:
       required: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.postgres }}
     steps:
@@ -603,7 +615,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/postgres-tests.yml
     permissions:
       contents: read
@@ -614,7 +627,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/publish-dry-run.yml
     permissions:
       contents: read
@@ -622,9 +636,11 @@ jobs:
 
   required-ci:
     name: Required CI
-    if: always()
+    if: >-
+      always() && (github.event_name == 'merge_group' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     needs: [changeset-check, validate-commits, validate-workflows, check-naming, doc-coverage, test, docs-build, secret-scan, postgres-scope, postgres-tests, publish-dry-run]
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 5
     steps:
       - name: Require full validation success

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -38,8 +38,7 @@ env:
   # Reusable workflows receive the reviewed head only for repository-owned
   # branches. Fork PR jobs are skipped before self-hosted allocation.
   CHECKOUT_REF: >-
-    ${{ github.event_name == 'pull_request_target' &&
-    github.event.pull_request.head.repo.full_name == github.repository &&
+    ${{ github.event.pull_request.head.repo.full_name == github.repository &&
     github.event.pull_request.head.sha || github.sha }}
 
 # Every self-hosted job in this trusted-base wrapper keeps the same-repository
@@ -53,8 +52,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
 
     steps:
       - name: Checkout
@@ -180,8 +179,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
     permissions:
       contents: read
@@ -345,8 +344,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
 
     steps:
@@ -399,8 +398,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
 
     steps:
@@ -439,8 +438,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
 
     steps:
@@ -500,15 +499,12 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/test.yml
     with:
       mode: ${{ github.event_name == 'merge_group' && 'full' || (vars.CI_MERGE_QUEUE_ENABLED == 'true' && 'affected' || 'full') }}
-      checkout_ref: >-
-        ${{ github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.sha || github.sha }}
+      checkout_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read
@@ -518,8 +514,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
 
     steps:
@@ -568,8 +564,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
     steps:
       - name: Checkout PR history
@@ -603,8 +599,8 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
     outputs:
       required: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.postgres }}
@@ -641,14 +637,11 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/postgres-tests.yml
     with:
-      checkout_ref: >-
-        ${{ github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.sha || github.sha }}
+      checkout_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read
@@ -658,25 +651,24 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/publish-dry-run.yml
     with:
-      checkout_ref: >-
-        ${{ github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.sha || github.sha }}
+      checkout_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read
 
   required-ci:
+    # Hosted, and always runs — including on fork pull requests, where every
+    # protected job is skipped before any self-hosted allocation. The loop below
+    # then fails on the skipped results, so a fork cannot satisfy the required
+    # gate by having validation silently not run.
     name: Required CI
-    if: >-
-      always() && (github.event_name == 'merge_group' ||
-      github.event.pull_request.head.repo.full_name == github.repository)
+    if: always()
     needs: [changeset-check, validate-commits, validate-workflows, check-naming, doc-coverage, test, docs-build, secret-scan, postgres-scope, postgres-tests, publish-dry-run]
-    runs-on: arc-happyvertical
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Require full validation success

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,7 +36,7 @@ jobs:
 
   changeset-check:
     name: Check for Changeset
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
@@ -489,7 +489,7 @@ jobs:
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -27,7 +27,7 @@ jobs:
   shared:
     name: Registered PostgreSQL Suites (Shared)
     if: inputs.backend != 'service-container' && (github.event_name == 'workflow_dispatch' || vars.CI_POSTGRES_ENABLED == 'true')
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     services:
       postgres:
@@ -57,7 +57,7 @@ jobs:
   service-container:
     name: Registered PostgreSQL Suites (Fallback)
     if: github.event_name == 'workflow_dispatch' && inputs.backend == 'service-container'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     services:
       postgres:

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: shared
+      checkout_ref:
+        description: 'Trusted caller-selected revision to validate'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       backend:
@@ -22,6 +27,9 @@ on:
 permissions:
   contents: read
   packages: read
+
+env:
+  CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
 
 jobs:
   shared:
@@ -44,6 +52,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
@@ -74,6 +84,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -27,7 +27,7 @@ jobs:
   shared:
     name: Registered PostgreSQL Suites (Shared)
     if: inputs.backend != 'service-container' && (github.event_name == 'workflow_dispatch' || vars.CI_POSTGRES_ENABLED == 'true')
-    runs-on: arc-happyvertical-node
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -46,7 +46,7 @@ jobs:
   service-container:
     name: Registered PostgreSQL Suites (Fallback)
     if: github.event_name == 'workflow_dispatch' && inputs.backend == 'service-container'
-    runs-on: ci-linux-x64
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     services:
       postgres:

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -29,6 +29,18 @@ jobs:
     if: inputs.backend != 'service-container' && (github.event_name == 'workflow_dispatch' || vars.CI_POSTGRES_ENABLED == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17@sha256:d2ef61f42ef767baa5a1475393303cc235bcd92febd9d7014eddb48b41f3bad0
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -36,11 +48,10 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           github-packages-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove abandoned databases older than six hours
-        run: node scripts/cleanup-ci-postgres.mjs
       - name: Run registered PostgreSQL suites
         run: pnpm turbo run test:postgres --concurrency=2
         env:
+          CI_POSTGRES_BASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
           NODE_ENV: test
 
   service-container:

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   prepare:
     name: Prepare Versioned Workspace
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     outputs:
       validate: ${{ steps.version.outputs.validate }}
@@ -69,7 +69,7 @@ jobs:
   pack:
     needs: prepare
     if: needs.prepare.outputs.validate == 'true'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -107,7 +107,7 @@ jobs:
     name: Version And Pack Validation
     needs: [prepare, pack]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 5
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   prepare:
     name: Prepare Versioned Workspace
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
       validate: ${{ steps.version.outputs.validate }}
@@ -69,7 +69,7 @@ jobs:
   pack:
     needs: prepare
     if: needs.prepare.outputs.validate == 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -2,6 +2,12 @@ name: Publish Dry Run
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: 'Trusted caller-selected revision to validate'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
 
 permissions:
@@ -9,6 +15,7 @@ permissions:
   packages: read
 
 env:
+  CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
   PUBLISH_PACK_SHARD_COUNT: '2'
 
 jobs:
@@ -22,6 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -79,6 +87,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Download versioned workspace
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
@@ -113,6 +123,8 @@ jobs:
       - name: Checkout repository
         if: needs.prepare.outputs.validate == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Download verified tarballs
         if: needs.prepare.outputs.validate == 'true'
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
       previous-version: ${{ steps.prepare.outputs.previous_version }}
@@ -168,7 +168,7 @@ jobs:
   pack-release:
     needs: prepare-release
     if: needs.prepare-release.outputs.should-publish == 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -207,7 +207,7 @@ jobs:
     name: Publish Verified Release
     needs: [prepare-release, pack-release]
     if: needs.prepare-release.outputs.should-publish == 'true' && needs.pack-release.result == 'success'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
       group: release-publish-${{ github.repository }}-${{ github.ref }}
@@ -330,7 +330,7 @@ jobs:
 
   sync-smrt:
     name: Sync SMRT SDK Dependencies
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     needs: release
     if: needs.release.outputs.published == 'true'
     permissions:
@@ -400,7 +400,7 @@ jobs:
     name: Deploy Documentation
     needs: release
     if: inputs.skip-docs != true
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     outputs:
       previous-version: ${{ steps.prepare.outputs.previous_version }}
@@ -168,7 +168,7 @@ jobs:
   pack-release:
     needs: prepare-release
     if: needs.prepare-release.outputs.should-publish == 'true'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -207,7 +207,7 @@ jobs:
     name: Publish Verified Release
     needs: [prepare-release, pack-release]
     if: needs.prepare-release.outputs.should-publish == 'true' && needs.pack-release.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     concurrency:
       group: release-publish-${{ github.repository }}-${{ github.ref }}
@@ -295,7 +295,7 @@ jobs:
     name: Release Result
     needs: [prepare-release, pack-release, publish-release]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     permissions:
       contents: read
     outputs:
@@ -330,7 +330,7 @@ jobs:
 
   sync-smrt:
     name: Sync SMRT SDK Dependencies
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     needs: release
     if: needs.release.outputs.published == 'true'
     permissions:
@@ -400,7 +400,7 @@ jobs:
     name: Deploy Documentation
     needs: release
     if: inputs.skip-docs != true
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -76,7 +76,7 @@ permissions:
 jobs:
   release:
     name: Version and Publish
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
       published: ${{ steps.publish.outputs.published }}

--- a/.github/workflows/shared-merge-orchestrator.yml
+++ b/.github/workflows/shared-merge-orchestrator.yml
@@ -55,7 +55,7 @@ jobs:
   summary:
     needs: [test, publish]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     # Keep this name stable: the main-branch ruleset requires
     # "Validate Changes / Run Tests" from the calling workflow.
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 40
     outputs:
       success: ${{ steps.result.outputs.success }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     # Keep this name stable: the main-branch ruleset requires
     # "Validate Changes / Run Tests" from the calling workflow.
     name: Run Tests
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:
       success: ${{ steps.result.outputs.success }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: full
+      checkout_ref:
+        description: 'Trusted caller-selected revision to validate'
+        required: false
+        type: string
+        default: ''
     outputs:
       success:
         description: 'Whether the selected validation suite passed'
@@ -25,6 +30,9 @@ permissions:
   contents: read
   packages: read
 
+env:
+  CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
+
 jobs:
   validate:
     # Keep this name stable: the main-branch ruleset requires
@@ -38,6 +46,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           # Affected validation needs the PR merge commit plus its base/head parents.
           # Neither mode needs every branch and tag from the repository history.
           fetch-depth: ${{ inputs.mode == 'affected' && '2' || '1' }}


### PR DESCRIPTION
## Summary

- route trusted same-repository pull-request, merge-queue, and main-branch CI through `arc-happyvertical`
- use trusted-base `pull_request_target` wrappers for PR, lifecycle, and Dependabot workflows; same-repository paths explicitly check out the reviewed head SHA
- pass the trusted head SHA through reusable validation workflows, while external forks are skipped before any self-hosted runner allocation or fork-code checkout
- retain specialized native OS lanes and the public external reusable/issue-metadata behavior; retain the PostgreSQL service-container robustness fix and brokered smoke contract

## Validation

- `pnpm install --frozen-lockfile`
- full workflow `actionlint`, changed-workflow `yamllint`, `git diff --check`, and trusted-base fork/checkout static assertions
- `pnpm test:ci-scripts`
- `pnpm agent:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- workflow pre-commit, commit-message, and pre-push hooks
- focused security review: clear

No runner backend activation, capacity change, or production cutover was performed.

Resolves #1148

Epic: happyvertical/iac#1088

<!-- hv-agent-run:v1 -->
```json
{"runtime":"claude","session":"claude-1148-trusted-base-9a1d24","policy_revision":"1.0.0","validation":"trusted-base validator reports 0 errors (was 18); actionlint clean on both changed files; all 11 protected jobs verified to retain the same-repository guard so no fork-reachable job can allocate a self-hosted runner; agent-policy.yml re-vendored byte-equal to canonical 50d04dbd; prior codex claim confirmed released on this exact head before pickup","schema":"hv-agent-run:v1","issue":"1148"}
```


---

## Update: conformed to generation-16 trusted-base policy

This branch was authored against **generation 13**. The trusted-base validation rules tightened afterwards, so its `lifecycle` check reported **18 errors**. The design was already correct — the policy compares *normalized expression text* against exact constants, and this branch differed textually:

| Delta | Canonical form |
|---|---|
| `CHECKOUT_REF` had an extra leading `github.event_name == 'pull_request_target' &&` | selects the head solely on `head.repo.full_name == github.repository`; `pull_request_target` already guarantees the event |
| 11 protected jobs ordered `contains(...)` before the same-repo check | `head.repo.full_name` comes first |
| 3 reusable jobs passed the same redundant clause in `checkout_ref` | `head.sha \|\| github.sha` — the job gate already established same-repository |
| `required-ci` ran on `arc-happyvertical` behind a same-repo gate | hosted `always()` fan-in |

That last one was the substantive gap. On a fork, `required-ci` was skipped along with everything it aggregates — so nothing reported and nothing failed. It is now hosted and always-running, so a fork's skipped protected jobs fail the required gate **explicitly** rather than silently not running.

Also folds in the canonical `agent-policy.yml` re-vendor (`50d04dbd…`), which was the check's first error. Splitting it deadlocks: the re-vendor PR cannot run its checks while this branch's selectors are unscheduled, and this branch cannot pass the drift check while its workflow is stale. #1153 and #1155 were closed for that reason.

**Verification:** the trusted-base validator reports **0 errors** (from 18), `actionlint` is clean on both changed files, and all eleven protected jobs retain the same-repository guard — no fork-reachable job can allocate a self-hosted runner.

Handoff note: #1148's prior claim (`codex-1148-trusted-base-019f9ea2`) was released on this exact head before I picked it up; no claim was overlapped.

