### PR TITLE
ci(github-actions): migrate general CI to the stable logical target

### DIFF
--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -37,9 +37,41 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: v3.0.6
+      # cosign-installer v4 shells out to envsubst, which is not part of the
+      # provider-neutral general runner contract. Download the publisher-
+      # compatible cosign v3 binary directly and verify its pinned SHA-256 so
+      # lifecycle enforcement has the same dependencies on every provider.
+      - name: Install signature verifier
+        env:
+          COSIGN_VERSION: v3.0.6
+          COSIGN_SHA256_AMD64: c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74
+          COSIGN_SHA256_ARM64: bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            x86_64) asset=cosign-linux-amd64; expected="$COSIGN_SHA256_AMD64" ;;
+            aarch64 | arm64) asset=cosign-linux-arm64; expected="$COSIGN_SHA256_ARM64" ;;
+            *) echo "unsupported runner architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          install_dir="$RUNNER_TEMP/hv-cosign"
+          mkdir -p "$install_dir"
+          curl -fsSL -o "$install_dir/cosign" \
+            "https://github.com/sigstore/cosign/releases/download/$COSIGN_VERSION/$asset"
+          actual=$(python3 - "$install_dir/cosign" <<'PY'
+          import hashlib
+          import pathlib
+          import sys
+
+          print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+          PY
+          )
+          test "$actual" = "$expected" || {
+            echo "cosign checksum mismatch: expected $expected, got $actual" >&2
+            exit 1
+          }
+          chmod +x "$install_dir/cosign"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/cosign" version
       - name: Select source-owned policy channel
         shell: bash
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   dependabot:
     name: Dependabot Automation
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     if: github.actor == 'dependabot[bot]'
     permissions:
       contents: write

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,7 +36,7 @@ jobs:
 
   changeset-check:
     name: Check for Changeset
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
@@ -209,7 +209,7 @@ jobs:
         #       lets a title with command substitution execute the
         #       substitution at the runner's shell — real command
         #       injection, especially on the self-hosted
-        #       ci-linux-x64 runner this workflow runs on. Pass
+        #       arc-happyvertical runner this workflow runs on. Pass
         #       via env: instead, then quote the variable expansion.
         #   (2) scripts/validate-conventional-commits.js uses a
         #       hardcoded regex with permissive scope and a 50-char
@@ -489,7 +489,7 @@ jobs:
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -27,7 +27,7 @@ jobs:
   shared:
     name: Registered PostgreSQL Suites (Shared)
     if: inputs.backend != 'service-container' && (github.event_name == 'workflow_dispatch' || vars.CI_POSTGRES_ENABLED == 'true')
-    runs-on: arc-happyvertical-node
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -46,7 +46,7 @@ jobs:
   service-container:
     name: Registered PostgreSQL Suites (Fallback)
     if: github.event_name == 'workflow_dispatch' && inputs.backend == 'service-container'
-    runs-on: ci-linux-x64
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     services:
       postgres:

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   prepare:
     name: Prepare Versioned Workspace
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     outputs:
       validate: ${{ steps.version.outputs.validate }}
@@ -69,7 +69,7 @@ jobs:
   pack:
     needs: prepare
     if: needs.prepare.outputs.validate == 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     outputs:
       previous-version: ${{ steps.prepare.outputs.previous_version }}
@@ -168,7 +168,7 @@ jobs:
   pack-release:
     needs: prepare-release
     if: needs.prepare-release.outputs.should-publish == 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -207,7 +207,7 @@ jobs:
     name: Publish Verified Release
     needs: [prepare-release, pack-release]
     if: needs.prepare-release.outputs.should-publish == 'true' && needs.pack-release.result == 'success'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     concurrency:
       group: release-publish-${{ github.repository }}-${{ github.ref }}
@@ -330,7 +330,7 @@ jobs:
 
   sync-smrt:
     name: Sync SMRT SDK Dependencies
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     needs: release
     if: needs.release.outputs.published == 'true'
     permissions:
@@ -400,7 +400,7 @@ jobs:
     name: Deploy Documentation
     needs: release
     if: inputs.skip-docs != true
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -76,7 +76,7 @@ permissions:
 jobs:
   release:
     name: Version and Publish
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     outputs:
       published: ${{ steps.publish.outputs.published }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     # Keep this name stable: the main-branch ruleset requires
     # "Validate Changes / Run Tests" from the calling workflow.
     name: Run Tests
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
+    runs-on: arc-happyvertical
     timeout-minutes: 40
     outputs:
       success: ${{ steps.result.outputs.success }}


### PR DESCRIPTION
## Why nothing in this repository can be scheduled

Every general job selected a runner label with no provider.

Thirteen of them used:

```yaml
runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'ci-linux-x64' }}
```

`CI_NODE_RUNNER_ENABLED` is unset at both repository and organization level (both return 404), so every one resolved to the fallback — `ci-linux-x64`. No organization runner group serves that label, and the root-capable runner contract lists it in `label_isolation.forbidden_labels`. Three more selected the transitional labels directly (`postgres-tests.yml` ×2, and a stale comment reference).

That is why this repository's PR checks sit queued indefinitely while its `ubuntu-latest` jobs pass.

## Why `arc-happyvertical` and not the `-node` sibling

`arc-happyvertical-node` is a previous generation of the routing plan. No job has ever completed on it — the only jobs carrying that label are `skipped`, and the successful `node-runner-smoke` runs executed an older revision on `arc-happyvertical`.

happyvertical/iac#1088 is explicit:

> Direct ARC listeners and provider-specific sibling labels are transition mechanisms, not the final interface.

`arc-happyvertical` is the stable logical target (`target_policy.template: "arc-{organization}"`, `provider_specific_targets: "forbid"`), and it is demonstrably serving this organization from **both** providers right now — `landgraf-*` and `patdown-jit-*` JIT runners in `brokered-general-linux-x64`.

Retiring the conditional also retires `CI_NODE_RUNNER_ENABLED`, which existed only to pick between two labels iac#1088 removes.

## Classification

Per iac#1088's requirement to classify rather than silently route:

- **Migrated to the logical target** — `build.yml`, `test.yml`, `publish.yml`, `publish-dry-run.yml`, `on-pull-request.yml`, `shared-direct-publish.yml`, `dependabot-automation.yml`, `postgres-tests.yml`. The Postgres suites use service containers, which the root-capable contract's DinD behaviour covers, so they are general CI rather than a specialized lane.
- **Deliberately left on `ubuntu-latest`** — the `lifecycle` job in `agent-policy.yml`. That file is byte-canonical policy vendored from `have-config` and must not be edited here; it is hosted by design so lifecycle enforcement never depends on self-hosted capacity.
- **Left untouched, needs a decision** — `node-runner-smoke.yml`. It exists solely to shadow-validate the retired node pool, so repointing it at the general target would make it a duplicate of an ordinary job. It should probably be deleted, but removing a workflow is beyond a selector migration and is called out rather than done.
- **Out of scope** — the remaining `ubuntu-latest` jobs. Whether those are general CI that should also move is a separate classification pass.


## Also carries the canonical lifecycle workflow re-vendor

Split from this change originally (#1153), but the two deadlock each other: the re-vendor PR cannot run its checks because its branch still carries the dead selectors, and this PR cannot pass the drift check because its branch still carries the stale `agent-policy.yml`. Folded in so the branch is self-consistent.

That second commit replaces `.github/workflows/agent-policy.yml` with canonical (`50d04dbd…`, byte-equal to what `happyvertical/smrt` runs). **Supersedes #1153**, which will be closed.

## Verification

15 selectors across 8 files, plus one stale comment that still named `ci-linux-x64` as "the runner this workflow runs on". After the change, no generic workflow retains a transitional or provider-specific selector.

`actionlint` clean on all seven files that had no prior findings. `shared-direct-publish.yml` reports 14 shellcheck info/style findings — **identical count before and after**, all pre-existing in `run:` blocks unrelated to the one `runs-on` line changed there. Unrelated work preserved.

Closes #1154
Refs happyvertical/iac#1088

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"claude","session":"claude-sdk-general-ci-r2-9a1d24","issue":"1154","policy_revision":"1.0.0","validation":["actionlint clean on all changed files with no prior findings","pre-existing shellcheck findings in shared-direct-publish.yml confirmed unchanged (14 before, 14 after)","no residual ci-linux-x64 or CI_NODE_RUNNER_ENABLED outside the flagged node-runner-smoke.yml","arc-happyvertical confirmed live from both providers (landgraf-* and patdown-jit-*)","CI_NODE_RUNNER_ENABLED confirmed unset at repository and organization level","agent-policy.yml lifecycle job deliberately preserved on ubuntu-latest as vendored byte-canonical policy"]}

