### PR TITLE
ci(github-actions): key pnpm store reuse on PNPM_STORE_DIR, not runner name

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -16,14 +16,60 @@ documentation, package, and PostgreSQL suites.
 - The public `shared-direct-publish.yml` reusable workflow remains hosted so
   arbitrary external callers are never routed into HappyVertical capacity.
 
-Each brokered runner keeps the workspace and pnpm store isolated from
-concurrent jobs; safe caches may survive sequential jobs on a warm host.
+Each brokered runner keeps the workspace isolated from concurrent jobs. The
+node-local pnpm store is deliberately not isolated: every job landing on a node
+shares it, which is what makes reuse possible and why a runner that advertises no
+persistent store is treated as a fault below. Only the per-job fallback store is
+job-scoped. Safe caches may survive sequential jobs on a warm host.
 
 The runner workspace and the pnpm store derived by `pnpm store path` must share
 a filesystem. The smoke workflow verifies matching device IDs, confirms that
 installed dependency files have hardlink counts above one, and validates the
 digest-pinned PostgreSQL/pgvector service contract. The persistent store is
 never restored through GitHub Actions.
+
+`.github/actions/setup-environment/select-pnpm-store.sh` picks between the
+three stores. A self-hosted runner that exports `PNPM_STORE_DIR` gets the
+node-local persistent store; a hosted runner gets the Actions-backed cache.
+Selection keys on `RUNNER_ENVIRONMENT` and that export only — never on
+`RUNNER_NAME`. Runner names are provider-specific and the runner contract
+forbids naming a provider-specific backing label, so a name-based gate silently
+stops matching whenever a pool is renamed or consolidated.
+`scripts/select-pnpm-store.test.mjs`, under `pnpm test:ci-scripts`, gates that
+decision table on every pull request.
+
+### A self-hosted runner without `PNPM_STORE_DIR` fails the job
+
+`PNPM_STORE_DIR` is **not** part of the runner target contract, so no provider
+is obligated to export it. Every `arc-runners-happyvertical` variant and the
+Landgraf broker provider do export it today, but a provider that quietly
+stopped would cost a cold store on every job while every check stayed green —
+the same silent degradation that made this bug invisible for as long as it was.
+happyvertical/have-config#335 proposes raising it into the contract, which
+would make the guarantee real rather than conventional.
+
+So that case is a hard error, not a fallback. Two opt-outs accept a cold per-job
+store under `$RUNNER_TEMP` instead, and the job then warns — naming the runner
+and which opt-out applied — rather than failing:
+
+- `allow-ephemeral-store: true` passed to `setup-environment`, for a single
+  workflow that knowingly runs without a persistent store. It needs no
+  infrastructure access and wins over the environment variable.
+- `CI_ALLOW_EPHEMERAL_PNPM_STORE=true` exported from the runner or set in a
+  workflow `env:` block, for recovering fleet-wide without a code change if a
+  provider stops exporting `PNPM_STORE_DIR`.
+
+Only the exact string `true` opts out. Anything else fails closed, and the
+error names all three remedies.
+
+The device-ID and hardlink-count checks prove the store and workspace can
+hardlink; they cannot prove reuse, because pnpm hardlinks into `node_modules`
+on every install regardless of whether the store was already populated. So each
+smoke job also asserts `use-actions-cache=false` and a resolved store path under
+`PNPM_STORE_DIR`, and the `store-reuse` job reports whether the store arrived
+warm from the preceding job. Warmth is reported rather than gated: the broker
+spans several nodes and issues ephemeral JIT identities, so a later job may
+legitimately land on an untouched node.
 
 ## Trusted-base public pull requests
 

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -23,6 +23,13 @@ inputs:
     description: 'GitHub Packages token override; defaults to the workflow token'
     required: false
     default: ''
+  allow-ephemeral-store:
+    description: >-
+      Accept a cold per-job pnpm store on a self-hosted runner that does not
+      export PNPM_STORE_DIR. Unset, the CI_ALLOW_EPHEMERAL_PNPM_STORE
+      environment variable decides and a missing store is a hard error.
+    required: false
+    default: ''
 
 outputs:
   pnpm-cache-hit:
@@ -31,6 +38,9 @@ outputs:
   store-path:
     description: 'pnpm store path'
     value: ${{ steps.pnpm-store.outputs.path }}
+  use-actions-cache:
+    description: 'Whether the pnpm store is backed by the hosted Actions cache'
+    value: ${{ steps.pnpm-store-strategy.outputs.use-actions-cache }}
 
 runs:
   using: 'composite'
@@ -121,22 +131,14 @@ runs:
     - name: Determine pnpm store strategy
       id: pnpm-store-strategy
       shell: bash
-      run: |
-        if [[ "${RUNNER_NAME:-}" == arc-happyvertical-node-* ]] && \
-          [ -n "${PNPM_STORE_DIR:-}" ]; then
-          echo "store-root=$PNPM_STORE_DIR" >> "$GITHUB_OUTPUT"
-          echo "use-actions-cache=false" >> "$GITHUB_OUTPUT"
-          echo "Using the node-local persistent pnpm store"
-        elif [ "${RUNNER_ENVIRONMENT:-}" = self-hosted ]; then
-          store_root="$RUNNER_TEMP/pnpm-store-${GITHUB_RUN_ID}-${GITHUB_JOB}-${GITHUB_RUN_ATTEMPT}"
-          echo "store-root=$store_root" >> "$GITHUB_OUTPUT"
-          echo "use-actions-cache=false" >> "$GITHUB_OUTPUT"
-          echo "Using an isolated compatibility-runner pnpm store"
-        else
-          echo "store-root=$HOME/.local/share/pnpm/store" >> "$GITHUB_OUTPUT"
-          echo "use-actions-cache=true" >> "$GITHUB_OUTPUT"
-          echo "Using a hosted-runner pnpm cache"
-        fi
+      # Passed under its own name so the script owns the precedence. Binding
+      # the input straight onto CI_ALLOW_EPHEMERAL_PNPM_STORE would clobber an
+      # inherited value with an empty string whenever the input is unset.
+      env:
+        INPUT_ALLOW_EPHEMERAL_STORE: ${{ inputs.allow-ephemeral-store }}
+      # Invoked through bash so the step does not depend on the executable bit
+      # surviving checkout.
+      run: bash "$GITHUB_ACTION_PATH/select-pnpm-store.sh"
 
     - name: Configure pnpm store directory
       shell: bash

--- a/.github/actions/setup-environment/select-pnpm-store.sh
+++ b/.github/actions/setup-environment/select-pnpm-store.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Choose the pnpm store root for this job and whether the hosted Actions cache
+# backs it. Writes `store-root` and `use-actions-cache` to $GITHUB_OUTPUT.
+#
+# The persistent branch keys on PNPM_STORE_DIR being exported, never on the
+# runner's name. A provider that offers a node-local store advertises it by
+# exporting that variable; one that does not, does not. Runner names are
+# provider-specific and change without notice: this branch previously required
+# `RUNNER_NAME` to match `arc-happyvertical-node-*`, and the runner-pool
+# consolidation renamed every runner serving that label, which made the branch
+# unreachable and silently dropped every self-hosted job onto a cold per-job
+# store. The runner contract sets `provider_specific_targets: forbid` for the
+# same reason.
+#
+# Extracted from the composite action so `scripts/select-pnpm-store.test.mjs`
+# can exercise the decision table directly — the hardlink assertion in
+# `node-runner-smoke.yml` cannot detect this regression, because pnpm hardlinks
+# into `node_modules` on every install whether or not the store was reused.
+#
+# A self-hosted runner that does not export PNPM_STORE_DIR is treated as a
+# fault, not a supported configuration. PNPM_STORE_DIR is not part of the
+# runner target contract, so nothing obligates a provider to export it, and a
+# provider that quietly stops would cost a cold store on every job while every
+# check stayed green — the same silent degradation this script exists to fix.
+# Failing loudly is the point. Set CI_ALLOW_EPHEMERAL_PNPM_STORE=true (from the
+# runner environment, a workflow `env:` block, or the action's
+# allow-ephemeral-store input) to accept the cold store and downgrade the error
+# to a warning.
+set -euo pipefail
+
+# The action's allow-ephemeral-store input wins when set; otherwise
+# CI_ALLOW_EPHEMERAL_PNPM_STORE inherited from the runner or a workflow `env:`
+# block decides. Resolved here rather than in a workflow expression because the
+# `env` context is not documented as available inside composite actions.
+allow_ephemeral="${INPUT_ALLOW_EPHEMERAL_STORE:-}"
+allow_source="the allow-ephemeral-store input"
+if [ -z "$allow_ephemeral" ]; then
+  allow_ephemeral="${CI_ALLOW_EPHEMERAL_PNPM_STORE:-false}"
+  allow_source='CI_ALLOW_EPHEMERAL_PNPM_STORE'
+fi
+
+if [ "${RUNNER_ENVIRONMENT:-}" = self-hosted ] && [ -n "${PNPM_STORE_DIR:-}" ]; then
+  store_root="$PNPM_STORE_DIR"
+  use_actions_cache=false
+  description='node-local persistent pnpm store'
+elif [ "${RUNNER_ENVIRONMENT:-}" = self-hosted ]; then
+  if [ "$allow_ephemeral" != true ]; then
+    echo "::error::self-hosted runner ${RUNNER_NAME:-<unnamed>} did not export PNPM_STORE_DIR, so every job on it would rebuild the pnpm store from scratch. Fix it at the runner by exporting PNPM_STORE_DIR, or accept a cold per-job store by passing allow-ephemeral-store: true to this action or setting CI_ALLOW_EPHEMERAL_PNPM_STORE=true (the literal string 'true' in both cases)."
+    exit 1
+  fi
+  echo "::warning::self-hosted runner ${RUNNER_NAME:-<unnamed>} did not export PNPM_STORE_DIR; falling back to a cold per-job store because $allow_source is set to true."
+  store_root="$RUNNER_TEMP/pnpm-store-${GITHUB_RUN_ID}-${GITHUB_JOB}-${GITHUB_RUN_ATTEMPT}"
+  use_actions_cache=false
+  description='isolated compatibility-runner pnpm store'
+else
+  store_root="$HOME/.local/share/pnpm/store"
+  use_actions_cache=true
+  description='hosted-runner pnpm cache'
+fi
+
+{
+  echo "store-root=$store_root"
+  echo "use-actions-cache=$use_actions_cache"
+} >>"$GITHUB_OUTPUT"
+
+echo "Using the $description: $store_root"

--- a/.github/workflows/node-runner-smoke.yml
+++ b/.github/workflows/node-runner-smoke.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup environment
+        id: setup
         uses: ./.github/actions/setup-environment
         with:
           github-packages-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +41,35 @@ jobs:
           test "$(pnpm --version)" = '11.13.0'
           command -v psql
 
+      - name: Verify persistent pnpm store selection
+        env:
+          STORE_PATH: ${{ steps.setup.outputs.store-path }}
+          USE_ACTIONS_CACHE: ${{ steps.setup.outputs.use-actions-cache }}
+        run: |
+          set -euo pipefail
+          test -n "$PNPM_STORE_DIR"
+          test "$USE_ACTIONS_CACHE" = 'false'
+
+          # `pnpm store path` appends a store-version segment (.../v11), so the
+          # node-local root is a prefix of the resolved path, not equal to it.
+          # A job that fell through to the per-job compatibility store resolves
+          # under $RUNNER_TEMP instead and fails here. pnpm builds the resolved
+          # path with path.join, which collapses a trailing slash, so strip one
+          # first or the glob would need a literal `//` and never match.
+          store_root="${PNPM_STORE_DIR%/}"
+          case "$STORE_PATH" in
+            "$store_root" | "$store_root"/*) ;;
+            *)
+              echo "::error::pnpm resolved $STORE_PATH, outside the node-local persistent store $PNPM_STORE_DIR"
+              exit 1
+              ;;
+          esac
+          echo "Verified persistent store selection: $STORE_PATH"
+
+      # Proves the store and workspace share a filesystem so pnpm can hardlink.
+      # This cannot prove the store persisted: pnpm hardlinks into node_modules
+      # on every install, including from a store it just filled from scratch.
+      # The selection check above and the store-reuse job below cover that.
       - name: Verify pnpm hardlink layout
         run: |
           set -euo pipefail
@@ -54,3 +84,62 @@ jobs:
         run: node scripts/run-with-ci-postgres.mjs -- psql --command 'SELECT current_database()'
         env:
           CI_POSTGRES_BASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+
+  store-reuse:
+    name: Brokered Runner Store Reuse
+    needs: smoke
+    runs-on: arc-happyvertical
+    timeout-minutes: 15
+    steps:
+      - name: Measure store warmth before install
+        id: warmth
+        run: |
+          set -euo pipefail
+          test -n "$PNPM_STORE_DIR"
+          if [ -n "$(find "$PNPM_STORE_DIR" -type f -print -quit 2>/dev/null)" ]; then
+            echo 'state=warm' >> "$GITHUB_OUTPUT"
+          else
+            echo 'state=cold' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup environment
+        id: setup
+        uses: ./.github/actions/setup-environment
+        with:
+          github-packages-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report cross-job store reuse
+        env:
+          STORE_PATH: ${{ steps.setup.outputs.store-path }}
+          USE_ACTIONS_CACHE: ${{ steps.setup.outputs.use-actions-cache }}
+          WARMTH: ${{ steps.warmth.outputs.state }}
+        run: |
+          set -euo pipefail
+
+          # Selection is deterministic and gated, exactly as in the first job.
+          test "$USE_ACTIONS_CACHE" = 'false'
+          store_root="${PNPM_STORE_DIR%/}"
+          case "$STORE_PATH" in
+            "$store_root" | "$store_root"/*) ;;
+            *)
+              echo "::error::pnpm resolved $STORE_PATH, outside the node-local persistent store $PNPM_STORE_DIR"
+              exit 1
+              ;;
+          esac
+
+          # Warmth is reported, not gated. The broker spans several nodes and
+          # hands out ephemeral JIT identities, so this job may legitimately
+          # land on a node the first job never touched. A cold result there is
+          # scheduling, not regression; a warm result is direct evidence that
+          # the store survives across jobs.
+          if [ "$WARMTH" = 'warm' ]; then
+            summary="Store was warm before install on $RUNNER_NAME: reuse confirmed across jobs."
+          else
+            summary="Store was cold before install on $RUNNER_NAME: this job landed on a node the first job did not use."
+            echo "::notice::$summary"
+          fi
+          echo "$summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "$summary"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -367,15 +367,21 @@ jobs:
           files="${{ steps.changed-files.outputs.all_changed_files }}"
           echo "Changed files: $files"
 
-          # The brokered image marks its Python as externally managed (PEP 668),
-          # so a bare --user install is refused where the previous hosted runner
-          # allowed it. The runner is ephemeral and runs one job, so opting out
-          # of the guard for a --user install touches nothing that outlives it.
-          python3 -m pip install --user --break-system-packages yamllint
+          # yamllint ships in the brokered runner image, which verifies
+          # `which yamllint` at build time. Installing it here shadowed that
+          # copy with a `pip install --user`, which the image's externally
+          # managed Python (PEP 668) refuses outright — so once the job moved
+          # to arc-happyvertical, every pull request touching a workflow file
+          # failed this check. Use the tool the runner contract provides.
+          if ! command -v yamllint >/dev/null 2>&1; then
+            echo '::error::yamllint is missing from the runner image; it is part of the runner tool contract'
+            exit 1
+          fi
+          yamllint --version
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo "  Checking $file..."
-            "$HOME/.local/bin/yamllint" -c .github/.yamllint.yml "$file" || exit 1
+            yamllint -c .github/.yamllint.yml "$file" || exit 1
           done
 
           echo "✅ YAML syntax validation passed"

--- a/scripts/select-pnpm-store.test.mjs
+++ b/scripts/select-pnpm-store.test.mjs
@@ -1,0 +1,232 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(
+  new URL(
+    '../.github/actions/setup-environment/select-pnpm-store.sh',
+    import.meta.url,
+  ),
+);
+
+// Runner names observed serving the consolidated `arc-happyvertical` pool.
+// The retired `arc-happyvertical-node-*` prefix matches none of them, which is
+// what silently disabled persistent store reuse. Store selection must not
+// consult the runner name at all.
+const CONSOLIDATED_RUNNER_NAMES = [
+  'landgraf-9175a7e5b7fc301f96cced3d',
+  'landgraf-d089e2b07b8f3ffc99eab938',
+  'patdown-jit-124ee1a96d100de58647a7be-runner',
+  'patdown-jit-0f7aac129209b3507ec6bfee-runner',
+];
+
+function runScript(env) {
+  const directory = mkdtempSync(join(tmpdir(), 'select-pnpm-store-'));
+  const outputPath = join(directory, 'github-output');
+  writeFileSync(outputPath, '');
+
+  try {
+    let status = 0;
+    let stdout = '';
+
+    try {
+      stdout = execFileSync('bash', [script], {
+        env: {
+          HOME: '/home/runner',
+          RUNNER_TEMP: '/runner/_temp',
+          GITHUB_RUN_ID: '17',
+          GITHUB_JOB: 'test',
+          GITHUB_RUN_ATTEMPT: '2',
+          GITHUB_OUTPUT: outputPath,
+          ...env,
+        },
+        stdio: 'pipe',
+        encoding: 'utf8',
+      });
+    } catch (error) {
+      status = error.status;
+      stdout = error.stdout ?? '';
+    }
+
+    const outputs = Object.fromEntries(
+      readFileSync(outputPath, 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => {
+          const separator = line.indexOf('=');
+          return [line.slice(0, separator), line.slice(separator + 1)];
+        }),
+    );
+
+    return { status, stdout, outputs };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function selectStore(env) {
+  const result = runScript(env);
+  assert.equal(result.status, 0, `script exited ${result.status}:\n${result.stdout}`);
+  return result.outputs;
+}
+
+test('reuses the node-local persistent store whatever the runner is named', () => {
+  for (const runnerName of CONSOLIDATED_RUNNER_NAMES) {
+    assert.deepEqual(
+      selectStore({
+        RUNNER_ENVIRONMENT: 'self-hosted',
+        RUNNER_NAME: runnerName,
+        PNPM_STORE_DIR: '/opt/pnpm-store',
+      }),
+      { 'store-root': '/opt/pnpm-store', 'use-actions-cache': 'false' },
+      `${runnerName} must select the persistent store`,
+    );
+  }
+});
+
+test('reuses the persistent store when the runner name is absent entirely', () => {
+  assert.deepEqual(
+    selectStore({
+      RUNNER_ENVIRONMENT: 'self-hosted',
+      PNPM_STORE_DIR: '/opt/pnpm-store',
+    }),
+    { 'store-root': '/opt/pnpm-store', 'use-actions-cache': 'false' },
+  );
+});
+
+// PNPM_STORE_DIR is not part of the runner target contract, so a provider is
+// free to stop exporting it. That must fail the job rather than quietly cost a
+// cold store on every run — the silent-degradation shape this script exists to
+// eliminate. See .github/CI.md.
+test('fails the job when a self-hosted runner advertises no persistent store', () => {
+  for (const env of [
+    { RUNNER_ENVIRONMENT: 'self-hosted', RUNNER_NAME: 'patdown-jit-abc-runner' },
+    // An exported-but-empty PNPM_STORE_DIR advertises nothing.
+    { RUNNER_ENVIRONMENT: 'self-hosted', PNPM_STORE_DIR: '' },
+    // An explicit opt-out of anything other than `true` is not an opt-out.
+    {
+      RUNNER_ENVIRONMENT: 'self-hosted',
+      CI_ALLOW_EPHEMERAL_PNPM_STORE: 'false',
+    },
+    { RUNNER_ENVIRONMENT: 'self-hosted', CI_ALLOW_EPHEMERAL_PNPM_STORE: '' },
+  ]) {
+    const result = runScript(env);
+    assert.equal(result.status, 1, `expected failure for ${JSON.stringify(env)}`);
+    assert.match(result.stdout, /^::error::.*did not export PNPM_STORE_DIR/m);
+    assert.deepEqual(result.outputs, {}, 'a failed selection must write no outputs');
+
+    // The annotation is the whole user experience of this failure, so it must
+    // name every way out, including the one that needs no infrastructure access.
+    assert.match(result.stdout, /exporting PNPM_STORE_DIR/);
+    assert.match(result.stdout, /allow-ephemeral-store: true/);
+    assert.match(result.stdout, /CI_ALLOW_EPHEMERAL_PNPM_STORE=true/);
+  }
+});
+
+test('accepts a cold per-job store only when explicitly allowed, and says so', () => {
+  const result = runScript({
+    RUNNER_ENVIRONMENT: 'self-hosted',
+    RUNNER_NAME: 'patdown-jit-abc-runner',
+    CI_ALLOW_EPHEMERAL_PNPM_STORE: 'true',
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.outputs, {
+    'store-root': '/runner/_temp/pnpm-store-17-test-2',
+    'use-actions-cache': 'false',
+  });
+  assert.match(result.stdout, /^::warning::.*did not export PNPM_STORE_DIR/m);
+  assert.match(result.stdout, /because CI_ALLOW_EPHEMERAL_PNPM_STORE is set to true/);
+});
+
+test('the warning names the opt-out that actually applied', () => {
+  // Auditing why a job accepted a cold store means following this message. If
+  // it always blamed the environment variable, an input-driven opt-out would
+  // send the reader looking for a variable the runner never set.
+  const result = runScript({
+    RUNNER_ENVIRONMENT: 'self-hosted',
+    INPUT_ALLOW_EPHEMERAL_STORE: 'true',
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(
+    result.stdout,
+    /because the allow-ephemeral-store input is set to true/,
+  );
+  assert.doesNotMatch(result.stdout, /because CI_ALLOW_EPHEMERAL_PNPM_STORE/);
+});
+
+test('allow-ephemeral-store input overrides the inherited environment', () => {
+  const base = {
+    RUNNER_ENVIRONMENT: 'self-hosted',
+    RUNNER_NAME: 'patdown-jit-abc-runner',
+  };
+
+  // Input opts in over an environment that says otherwise.
+  assert.equal(
+    runScript({
+      ...base,
+      INPUT_ALLOW_EPHEMERAL_STORE: 'true',
+      CI_ALLOW_EPHEMERAL_PNPM_STORE: 'false',
+    }).status,
+    0,
+  );
+
+  // Input opts out over an environment that says otherwise.
+  assert.equal(
+    runScript({
+      ...base,
+      INPUT_ALLOW_EPHEMERAL_STORE: 'false',
+      CI_ALLOW_EPHEMERAL_PNPM_STORE: 'true',
+    }).status,
+    1,
+  );
+
+  // An unset input (the action's default) must not clobber the environment.
+  assert.equal(
+    runScript({
+      ...base,
+      INPUT_ALLOW_EPHEMERAL_STORE: '',
+      CI_ALLOW_EPHEMERAL_PNPM_STORE: 'true',
+    }).status,
+    0,
+  );
+});
+
+test('uses the hosted Actions cache on GitHub-hosted runners', () => {
+  const expected = {
+    'store-root': '/home/runner/.local/share/pnpm/store',
+    'use-actions-cache': 'true',
+  };
+
+  assert.deepEqual(
+    selectStore({
+      RUNNER_ENVIRONMENT: 'github-hosted',
+      RUNNER_NAME: 'GitHub Actions 4',
+    }),
+    expected,
+  );
+
+  // A hosted runner never owns a node-local store, so an inherited
+  // PNPM_STORE_DIR must not divert the Actions-backed cache.
+  assert.deepEqual(
+    selectStore({
+      RUNNER_ENVIRONMENT: 'github-hosted',
+      PNPM_STORE_DIR: '/opt/pnpm-store',
+    }),
+    expected,
+  );
+
+  assert.deepEqual(selectStore({}), expected);
+
+  // A hosted runner has no persistent store to lose, so the missing export is
+  // not a fault there and must not fail the job.
+  assert.deepEqual(
+    selectStore({ RUNNER_ENVIRONMENT: 'github-hosted', RUNNER_TEMP: '' }),
+    expected,
+  );
+});


### PR DESCRIPTION
## Problem

`.github/actions/setup-environment/action.yml` gated persistent pnpm store reuse on the runner *name*:

```bash
if [[ "${RUNNER_NAME:-}" == arc-happyvertical-node-* ]] && [ -n "${PNPM_STORE_DIR:-}" ]; then
```

The runner-pool consolidation (#1149, happyvertical/iac#1088) renamed every runner serving that label. Live names are `landgraf-<hex>` and `patdown-jit-<hex>-runner`, neither of which matches the pattern, so the branch was unreachable. Every self-hosted job fell through to the `elif` and built a fresh `$RUNNER_TEMP/pnpm-store-<run>-<job>-<attempt>` — a cold store, never reused, directly undoing the runner-minute reduction `.github/CI.md` claims for the consolidated pool.

## Why CI stayed green

`node-runner-smoke.yml` asserted hardlinking with `find node_modules/.pnpm -type f -links +1`. pnpm hardlinks from its local store into `node_modules` on *every* install, including from a store it just filled from scratch, so that assertion passed either way. It proves hardlinking works *within* a job; it can say nothing about persistence *across* jobs.

## Fix

Key the persistent branch on `RUNNER_ENVIRONMENT=self-hosted` plus `PNPM_STORE_DIR` being exported. That export is the real signal — a provider offering a node-local store advertises it — and it survives the next provider rename, which is what the runner contract's `provider_specific_targets: forbid` asks for.

The decision table moves out of the composite action into `.github/actions/setup-environment/select-pnpm-store.sh` so it can be tested directly. Behavior is otherwise unchanged for all three store classes.

## Tests

`scripts/select-pnpm-store.test.mjs` runs under `pnpm test:ci-scripts`, which gates every pull request. It covers all three branches, both regression-relevant edge cases (`RUNNER_NAME` absent entirely; `PNPM_STORE_DIR` exported but empty), and pins the four live consolidated runner names so a name-based gate can never silently return.

I verified the test is not vacuous by restoring the old `arc-happyvertical-node-*` condition and re-running: 2 of 4 tests fail, and both pass again with the fix.

`node-runner-smoke.yml` gains assertions that can actually detect the regression:

- Both jobs assert `use-actions-cache=false` and that the resolved store path falls under `$PNPM_STORE_DIR`. A job that fell through to the per-job store resolves under `$RUNNER_TEMP` and fails. The check is prefix-based because `pnpm store path` appends a store-version segment (`.../v11`), verified locally.
- A new `store-reuse` job reports whether the store arrived warm from the preceding job. Warmth is **reported, not gated**: the pool spans several nodes and issues ephemeral JIT identities, so a later job may legitimately land on a node the first never touched. A cold result there is scheduling, not regression; a warm result is direct evidence the store survives across jobs.

The device-ID and hardlink-count checks are kept — they still prove the store and workspace can hardlink — with a comment recording why they cannot prove reuse.

## Fail closed, don't degrade quietly

Keying on `PNPM_STORE_DIR` fixes the unreachable gate, but on its own it keeps the shape that made this bug invisible: a self-hosted runner that doesn't export `PNPM_STORE_DIR` falls through to a cold per-job store with every check still green.

That convention is not guaranteed:

- `PNPM_STORE_DIR` does **not** appear in have-config's `docs/agents/runner-target-contract.md`, so no provider is obligated to export it.
- Every `arc-runners-happyvertical` variant and the Landgraf broker provider do export it today (verified in iac `origin/main`).
- **Patdown** — which iac's `runner-broker-shadow/README.md` calls "the primary provider" — has no environment definition in iac at all, so nothing proves it does.

So a self-hosted runner without `PNPM_STORE_DIR` now fails the job, with an annotation naming the runner and every remedy. Two opt-outs accept a cold store and downgrade it to a warning:

- `allow-ephemeral-store: true` on the action — for one workflow that knowingly runs without a persistent store. Needs no infrastructure access, and wins over the environment variable.
- `CI_ALLOW_EPHEMERAL_PNPM_STORE=true` — exported from the runner or set in a workflow `env:` block, so a fleet-wide recovery needs no code change.

Only the literal string `true` opts out. The warning names *which* opt-out applied, so auditing a cold store doesn't send the reader hunting for a variable that was never set.

Precedence is resolved in the script rather than a workflow expression, because the `env` context is not documented as available inside composite actions, and binding the input straight onto `CI_ALLOW_EPHEMERAL_PNPM_STORE` would clobber an inherited value with an empty string whenever the input is unset.

**The real fix is contractual:** raising `PNPM_STORE_DIR` into the runner target contract would make this a guarantee instead of a convention. Filed as happyvertical/have-config#335; not in this PR.

## Review findings addressed

Two defects were found in review and fixed before this PR opened:

1. The step invoked the script by path, depending on the executable bit surviving checkout. Now `run: bash "$GITHUB_ACTION_PATH/…"`, which removes that dependency entirely. (The mode is committed as `100755` regardless — this is defense in depth, not a repair.)
2. **Real bug in the new assertion:** the `case` glob was built from an unstripped `$PNPM_STORE_DIR`. A trailing-slash value produced the pattern `/mnt/store//*`, which requires a literal double slash and never matches what `pnpm store path` returns — the smoke job would have hard-failed with an error asserting the exact opposite of reality. Both occurrences now strip the trailing slash first. Confirmed by hand across `/mnt/store`, `/mnt/store/`, and `/`, and confirmed the genuine regression case still fails as intended.
3. The fail-closed warning always blamed `CI_ALLOW_EPHEMERAL_PNPM_STORE`, even when the action input was the actual cause — a misleading audit trail. It now names the source that applied, and a test asserts it.

## Validation

- `pnpm test:ci-scripts` — 27/27
- `pnpm agent:check`, `pnpm typecheck` (20/20), `pnpm lint`, `pnpm build` (32/32)
- `actionlint` and `shellcheck` clean on the changed files

No changeset: `ci:` is not a releaseable type in `changeset-check`, so this correctly produces no version bump. A `fix(ci):` commit would have bumped every package for a CI-only change.

Closes #1156
Closes #1164

## Rebased onto #1149

#1149 merged, so the three blockers this PR reported are gone: `lifecycle` passes, and the previously stuck checks now run on `arc-happyvertical` instead of queueing forever against the retired `ci-linux-x64`.

Reconciled against the new main:

- `node-runner-smoke.yml` — took main's brokered rewrite (renamed workflow/job, `runs-on: arc-happyvertical`, pgvector service, hardlink check via `pnpm store path`) and layered the store assertions on top. The new `store-reuse` job moved to `arc-happyvertical`; `arc-happyvertical-node` is no longer in `.github/actionlint.yaml`, so the old label would have failed lint.
- `.github/CI.md` — main rewrote the section this PR edited, so the store paragraphs were re-sited under the new "Runner selection" text rather than pasted back.

Nothing in `.github/actions/setup-environment/` or `scripts/select-pnpm-store.test.mjs` conflicted — the substantive fix rebased untouched.

Revalidated on the rebased tree: `pnpm test:ci-scripts` 27/27, `agent:check`, `typecheck`, `lint`, `build`, plus actionlint and shellcheck.

### Squashed to one commit

Deliberate, and worth recording. `Validate Changes / Run Tests` failed on the two-commit version with `Unable to query SCM: bad object 9ff8e4f…`. That is not a flake: `test.yml` fetches `fetch-depth: 2` in affected mode but resolves the Turbo closure against `pull_request.base.sha`, which sits *N* commits back for an *N*-commit branch. Affected mode is therefore broken for **any** pull request with more than one commit. Filed as #1163; squashing works around it here, since the repository squash-merges anyway and the resulting tree is byte-identical (`git diff` between the two-commit and squashed heads is empty).

## Also fixes #1164 (bundled)

`Validate Workflow Files` failed on this PR — and on any PR touching `.github/workflows/**` — with `error: externally-managed-environment`. `Required CI` failed with it, so this PR could not go green without it. Bundled here at the maintainer's direction.

The job ran `python3 -m pip install --user yamllint`, then invoked `$HOME/.local/bin/yamllint`. But the `arc-runner` image already installs yamllint and verifies `which yamllint && yamllint --version` at build time (`images/arc-runner/Dockerfile`). So the install was **redundant** — it shadowed a working copy with a second one — and it does not work, because the image's Python is externally managed (PEP 668) and pip refuses outright. This only surfaced once #1149 moved the job to `runs-on: arc-happyvertical`.

The fix uses the tool the runner contract provides, and fails with a message naming the contract if it is ever absent, rather than silently reinstalling it. That matches how the actionlint step directly below fetches a pinned binary, and how `setup-environment` already treats image-provided ONNX dependencies. Pinning yamllint's version belongs in the image, beside the existing build-time check — not in this workflow.

This is a smaller fix than the issue proposed: #1164 suggested a pinned venv, written before I checked the image. Reading `images/arc-runner/Dockerfile` showed the install was unnecessary in the first place.

### Still open, not fixed here

- **#1163** — affected-mode CI fetches `fetch-depth: 2` but resolves the Turbo closure against `pull_request.base.sha`, which sits *N* commits back on an *N*-commit branch. This PR is squashed to one commit to work around it; the tree is byte-identical to the multi-commit version (`git diff` between them is empty). It will keep biting any multi-commit PR.
- **Shell injection surface in the same job.** `for file in ${{ steps.changed-files.outputs.all_changed_files }}` interpolates PR-controlled filenames straight into `run:`, in both the yamllint and actionlint steps. Reachable only by someone who can push a branch to this repo (the job is guarded to same-repository PRs), so it is not a fork vector — but it should be an `env:` binding. Left alone deliberately: it is a security change that deserves its own review, not a rider on this one.

## Rebased onto main `ab6e393`

Rebased from `9ff8e4f7` onto `ab6e393` to pick up a fresh `synchronize` event. Under `pull_request_target` the *base* copy of `on-pull-request.yml` grades this PR, so a `gh run rerun` replays the workflow captured at the original event and cannot pick up a newer base; only a new push can.

One genuine conflict, in the `Validate workflow syntax` step — main and this PR fix the same breakage differently:

- main (`ab6e393`) keeps the install and opts out of PEP 668: `pip install --user --break-system-packages yamllint`.
- this PR removes the install and uses the image-provided `yamllint`, failing closed if it is absent.

**Resolved in favour of this PR's version**, for three reasons. It is internally consistent — git had already taken this PR's bare `yamllint` call site outside the conflict, so main's side would additionally need `$HOME/.local/bin/` restored. It is the fix #1164 actually asks for: the install is redundant against an image that installs yamllint and verifies `which yamllint` at build time, so `--break-system-packages` makes a redundant install succeed rather than removing it. And it is validated before it can land — `validate-workflows` also runs on `merge_group`, where the workflow file comes from the merge commit, so the merge queue executes *this* PR's copy and `ALLGREEN` rejects it if the image does not provide `yamllint`.

Worth recording: main's `--break-system-packages` fix has never actually executed. The only run since it landed was the `pr-1160` merge group, where `Validate Workflow Files` reported success with the yamllint step **skipped** — #1160 changed no workflow files, so `changed-files` set `any_changed=false`. Neither fix had prior runtime evidence; this PR's is the one the merge queue will exercise.

`.github/CI.md` merged cleanly: main rewrote a neighbouring section (`ab6e393` added "Trusted-base public pull requests"), and this PR's store paragraphs re-sited above it without overlap.

Revalidated on the rebased tree: `select-pnpm-store` tests 7/7, `yamllint` and `actionlint` clean on both changed workflows, `shellcheck` clean on `select-pnpm-store.sh`.

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"claude","session":"4d153ad7-db62-4581-b06b-8f6d1fb27bf3","issue":"1156","linked_issue":"1164","policy_revision":"1.0.0","status":"complete","validation":["pnpm test:ci-scripts 27/27","pnpm agent:check clean","pnpm typecheck 20/20","pnpm lint clean","pnpm build 32/32","actionlint clean on node-runner-smoke.yml and on-pull-request.yml","yamllint clean on on-pull-request.yml against .github/.yamllint.yml","shellcheck clean on select-pnpm-store.sh","new test confirmed to FAIL against the old arc-happyvertical-node-* gate and pass against the fix","pnpm store path confirmed to append a store-version segment (/v11), so the smoke assertion is prefix-based not equality","trailing-slash PNPM_STORE_DIR case-glob defect found in review and fixed at both occurrences","PNPM_STORE_DIR confirmed absent from have-config docs/agents/runner-target-contract.md; confirmed exported by all arc-runners-happyvertical variants and the Landgraf broker provider in iac origin/main; Patdown has no env definition in iac","yamllint confirmed preinstalled and build-time verified in iac images/arc-runner/Dockerfile, making the workflow install redundant as well as broken","rebased onto #1149 and revalidated; squashed tree confirmed byte-identical to the multi-commit version","rebased onto main ab6e393; yamllint-step conflict resolved in favour of this PR's image-provided fix, which the merge_group run validates because validate-workflows runs from the merge commit","confirmed main's --break-system-packages fix has never executed: the pr-1160 merge group skipped the yamllint step because no workflow files changed","revalidated on the rebased tree: select-pnpm-store 7/7, yamllint + actionlint clean on both changed workflows, shellcheck clean on select-pnpm-store.sh"]}

