### PR TITLE
docs(ci): state the fork pull request policy and the supported route for external contributions

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -27,12 +27,17 @@ never restored through GitHub Actions.
 
 ## Trusted-base public pull requests
 
-The brokered PR, lifecycle, and Dependabot workflows use
-`pull_request_target`, so GitHub loads runner selection from the trusted base
-branch rather than contributor-controlled merge YAML. Only a same-repository
-PR explicitly checks out `github.event.pull_request.head.sha`; that SHA is
-passed into reusable validation workflows as `checkout_ref`. Merge groups use
-their synthetic `github.sha` normally.
+The brokered PR and Dependabot workflows use `pull_request_target`, so GitHub
+loads runner selection from the trusted base branch rather than
+contributor-controlled merge YAML. Only a same-repository PR explicitly checks
+out `github.event.pull_request.head.sha`; that SHA is passed into reusable
+validation workflows as `checkout_ref`. Merge groups use their synthetic
+`github.sha` normally.
+
+The lifecycle workflow stays on plain `pull_request` by design — the agent
+policy audits `on.pull_request.types` and rejects a narrowed trigger set — and
+is hosted, so it never reaches brokered capacity. See "External fork pull
+requests" for what that means on a fork.
 
 An external fork never gets an `arc-happyvertical` job: each job is guarded by
 the same-repository test before GitHub allocates a runner, and fork code is
@@ -71,7 +76,8 @@ coverage rules to a package `vitest.config.ts`, not to its test command.
 `Required CI` is always present for trusted PR and merge-group work. It rejects
 failed, cancelled, or unexpectedly skipped jobs using an explicit job set.
 `pull_request_target` runs cancel superseded commits; merge-group runs do not
-cancel each other.
+cancel each other. External fork pull requests are the designed exception, and
+cannot pass it; see "External fork pull requests".
 
 Observe `Required CI` alongside the existing required checks for ten successful
 representative pull requests before changing repository rules. The

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -85,6 +85,66 @@ repository-settings cutover is manual:
 When merge-queue mode is enabled, the post-merge orchestrator skips validation
 already proven by the merge group and performs release/deployment work only.
 
+## External fork pull requests
+
+A pull request opened from a fork receives no validation of its code, by
+design, and `Required CI` can never pass on one. Every protected job is guarded
+by the same-repository test described under "Trusted-base public pull
+requests", so on a fork pull request all of them skip; `required-ci` is a
+hosted `always()` fan-in that rejects a skipped result, so it fails. The runner
+target contract independently fixes `public_fork_pull_requests: "deny"` as a
+schema constant — not a tunable default — so untrusted fork code is never
+admitted to the root-capable pool even if a job-level guard were removed. The
+contract ships in the agent-policy artifact as
+`contracts/runner-target-contract-v2.json`.
+
+`Required CI` is the fork guard, and it is the check that fails here.
+`lifecycle`, the other required check, is hosted, triggers on plain
+`pull_request`, and is deliberately not guarded, so it still runs on a fork
+pull request — but it validates claim and pull-request lifecycle state rather
+than the code, so it is no part of the fork guard and ordinarily passes. If it
+does fail, read it on its own terms: most often a commit message carries a
+closing keyword the pull request body does not declare, or the change edits
+managed policy files. Its message says what to correct.
+
+A red `Required CI` here is the policy working as intended, not a CI fault. Do
+not report it as broken infrastructure, and do not weaken the guard to make it
+pass. Two things look like workarounds and are not:
+
+- "Allow edits by maintainers" does not help. Pushing to the contributor's
+  fork branch leaves `github.event.pull_request.head.repo.full_name` pointing
+  at the fork, so the pull request is still a fork pull request and the
+  same-repository test still excludes it.
+- Admin bypass is not the answer. Merging past the required check lands fork
+  code that nothing has built, tested, or scanned, which is precisely what the
+  required check exists to prevent.
+
+The supported route is to bring an accepted outside change into this
+repository, where it is no longer untrusted:
+
+1. Review the fork diff as ordinary content, and tell the contributor that the
+   failing check is policy rather than a defect in their change.
+2. Open and claim a tracker issue, as `AGENTS.md` requires for any other
+   implementation work in this repository.
+3. Re-create the branch inside `happyvertical/sdk` — push the reviewed commits
+   to a repository branch, rewording or squashing them to satisfy
+   `validate-commits` — or re-author the change.
+4. Credit the original author with a `Co-authored-by:` trailer on any commit
+   whose original authorship the rewording would otherwise drop.
+5. Add the changeset the change needs, or apply `skip-changeset`; an outside
+   contributor will usually not have supplied one.
+6. Open the in-repo pull request, which validates normally, then close the
+   fork pull request with a pointer to it.
+
+If external contributions are ever wanted with automation attached, the
+follow-on is a maintainer-triggered re-validation path: a label or
+`workflow_dispatch` that validates one specific, reviewed fork SHA, still
+resolving workflow definitions from the trusted base ref. That keeps trusting a
+commit an explicit maintainer action rather than an automatic consequence of
+opening a pull request, and it is why the invariant above is scoped to the fork
+pull-request event rather than to fork commits in general. That path does not
+exist today; until it does, in-repo re-creation is the only supported option.
+
 ## PostgreSQL isolation
 
 PostgreSQL-sensitive packages register one `test:postgres` script. The wrapper

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -367,7 +367,11 @@ jobs:
           files="${{ steps.changed-files.outputs.all_changed_files }}"
           echo "Changed files: $files"
 
-          python3 -m pip install --user yamllint
+          # The brokered image marks its Python as externally managed (PEP 668),
+          # so a bare --user install is refused where the previous hosted runner
+          # allowed it. The runner is ephemeral and runs one job, so opting out
+          # of the guard for a --user install touches nothing that outlives it.
+          python3 -m pip install --user --break-system-packages yamllint
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo "  Checking $file..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,13 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
-          # Affected validation needs the PR merge commit plus its base/head parents.
-          # Neither mode needs every branch and tag from the repository history.
-          fetch-depth: ${{ inputs.mode == 'affected' && '2' || '1' }}
+          # Affected validation diffs against the PR base SHA, so that commit must
+          # be present. This checkout is pinned to the head ref, not the merge ref,
+          # so a shallow depth only reaches the base on a single-commit PR; depth 0
+          # is what keeps it reachable for any branch. Tested against 'full' rather
+          # than 'affected' so the '0' never lands in the middle of the
+          # short-circuit, where a falsy cast would silently select depth 1.
+          fetch-depth: ${{ inputs.mode == 'full' && '1' || '0' }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{"runtime":"claude","session":"claude-1158-fork-pr-policy","policy_revision":"1.0.0","validation":"bundles #1158 (docs) and #1166 (ci); rebased onto main after #1149 merged as 9ff8e4f and re-verified against it; hv-agent check-pr 1160 reports lifecycle passed; test.yml change validated by yamllint and act --list; pnpm agent:check clean, pnpm test:ci-scripts 20/20, pnpm lint clean (pre-existing @happyvertical/json warnings only); two-reviewer review-cycle to clean","schema":"hv-agent-run:v1","issue":"1158"}
```

Closes #1158
Closes #1166

## ⚠️ Merging this requires a one-time bypass — please read first

**Two checks are red, and neither can be made green from inside this PR.** That
is a bootstrap problem in the CI configuration itself, not a defect in this
change. Merging is what fixes it.

Under `pull_request_target`, GitHub loads the workflow — and any local
reusable workflow it calls with `./` — from the **base branch**, not from the
PR head. So the fixes in this PR are not the ones running against it:

| Red check | Runs base's | Why it fails here | Fixed by this PR |
| --- | --- | --- | --- |
| `Validate Changes / Run Tests` | `test.yml` | `fetch-depth: 2` cannot reach the base SHA; this PR has 4 commits | yes, `fetch-depth: 0` |
| `Validate Workflow Files` | `on-pull-request.yml` | `pip install --user` refused under PEP 668 on `arc-happyvertical`; fires because this PR changes workflow files | yes, `--break-system-packages` |

This was verified, not inferred: the failing run's log shows
`git ... fetch --depth=2 ...`, i.e. base's `test.yml` ran, ignoring the
`fetch-depth: 0` in this branch.

**The deadlock:** fixing either bug requires editing a workflow file, which
triggers `Validate Workflow Files`, whose definition comes from base and is
broken. No PR can currently carry a workflow fix through `Required CI`.

**What merging does:** both fixes land on `main`, and from the next PR onward
`Required CI` works normally for everyone — including multi-commit PRs and PRs
that touch workflows. One bypass, then the gate is healthy again.

**Note on the merge queue:** a `merge_group` run loads workflows from the queue
ref, which *contains* these fixes, and uses `mode: full` (no base diff). So the
merge-group run is expected to validate cleanly even though the PR-level run
cannot.

**Evidence this change is sound despite red CI:**

- `yamllint` and `actionlint` (`act --list`) pass on both workflow files via the
  pre-commit hook
- `hv-agent check-pr 1160` → `Agent Policy / lifecycle passed`
- `pnpm agent:check` clean, `pnpm test:ci-scripts` 20/20
- every other check on this PR is green
- the docs change is `.github/CI.md` only and touches no workspace input


## What this does

Two bundled changes.

**#1158 — the fork policy.** Adds an `## External fork pull requests` section to `.github/CI.md` recording
the fork policy that the trusted-base wrapper makes true but never states:
external fork pull requests get no validation of their code by design,
`Required CI` failing on them is expected rather than a CI fault, and the
supported route for accepting an outside contribution is in-repo re-creation —
not admin bypass.

**#1166 — a CI regression this PR tripped over.** Since #1149,
`Validate Changes / Run Tests` fails on *any* pull request more than one commit
ahead of its base:

```
Unable to query SCM: Git error: fatal: bad object 9ff8e4f76eb7809bf11b76de6fc8d237eb04848a
```

`.github/workflows/test.yml` diffs against `pull_request.base.sha` but checks
out shallow. Depth 2 was correct when `actions/checkout` defaulted to the
**merge ref**, whose two parents are the base and the head — the comment on
line 50 still said so. #1149 pinned the checkout to the head ref for
trusted-base reasons and left the depth: from the head, depth 2 reaches only
the head and its parent, so single-commit PRs pass and everything else fails.

Confirmed repo-wide on two branches with the identical missing object:
`claude/1158-fork-pr-policy` (run #2312) and `claude/1156-pnpm-store-reuse`
(run #2311). `test.yml` is the only workflow affected — every other reusable
workflow taking `checkout_ref` either already sets `fetch-depth: 0` or runs no
history diff.

The fix uses depth 0 for affected mode, and tests `inputs.mode == 'full'`
rather than `== 'affected'` so the `'0'` is never the middle operand of the
`&& ||` short circuit, where a falsy cast would silently select depth 1 —
quietly worse than the original bug.

## Merge ordering: satisfied

This documents the posture #1149 establishes, so it was ordered behind it.
**#1149 merged as `9ff8e4f` on 2026-07-28**, and this branch is now rebased on
top of it. Re-verified against merged `main`: the
`## Trusted-base public pull requests` section exists, `on-pull-request.yml`
uses `pull_request_target`, the `head.repo.full_name == github.repository`
guard appears 12 times, and `required-ci` is hosted `always()` with a comment
stating exactly the mechanism this section describes.

`hv-agent check-pr 1160` now reports **`Agent Policy / lifecycle passed`** — the
canonical `agent-policy.yml` re-vendor rode in with #1149, clearing the
pre-existing drift that had been failing `lifecycle` on every main-based PR.

## One correction to the issue's framing

The issue says a fork PR "can never pass `Required CI`" — correct — but the
section also had to account for the second required check. `lifecycle`
(`agent-policy.yml`) triggers on plain `pull_request`, runs on `ubuntu-latest`,
and is deliberately **not** guarded — #1149 does not change that, and the
policy runtime audits the workflow to keep exactly that unguarded trigger.

So a fork PR runs `lifecycle`, and it ordinarily **passes**: `check-pr`
short-circuits when the PR body has no `hv-agent-run:v1` marker unless the
branch matches `(?:codex|claude|hermes|zcode|copilot|agent)/`, a linked issue
has claim records, or `status: blocked` is set — none of which an outside
contributor's PR has. The section says so, because a green `lifecycle` beside a
red `Required CI` would otherwise read as "validation mostly succeeded".

It is stated as scope rather than as a count, deliberately. `lifecycle` *can*
fail on a fork PR on its own terms — `undeclared_closing_reference_errors`
(hv-agent:3203) and `audit_repository` (:3170) both run *before* that
short-circuit, so a contributor commit reading `Fixes #123` that the PR body
does not declare, or a change touching managed policy files, turns it red. A
doc promising "exactly one check fails" would then send the maintainer back to
the fork policy — the precise misread this section exists to prevent.

## Second commit: corrects an error #1149 merged

`#1149`'s trusted-base section states that "The brokered PR, **lifecycle**, and
Dependabot workflows use `pull_request_target`". The lifecycle workflow does
not: `agent-policy.yml` declares `on.pull_request` with all eight action types,
and only `on-pull-request.yml` and `dependabot-automation.yml` use
`pull_request_target`. The agent policy audits that exact trigger set
(`PULL_REQUEST_ACTIONS`, `hv_agent_lifecycle.py:67`, enforced at `:951`) and
rejects a narrowed one, so the lifecycle workflow *cannot* be converted without
failing its own audit.

Fixed here because the fork section directly depends on `lifecycle` being
unguarded and hosted, so leaving it would put two adjacent sections of the same
file in direct contradiction. One clause, no behaviour change.

The same commit adds the cross-reference a reviewer asked for: the
"Pull requests, merge groups, and Required CI" paragraph says the check is
always present and rejects skipped jobs, which is the first thing a maintainer
reads when a fork PR goes red, so the exception now names itself there. This
was deferred on the first pass only because #1149 was rewriting that exact
paragraph; with #1149 merged, the conflict risk is gone.

## Review notes

Two reviewers ran over the diff. Their material findings, all accepted:

- The first draft claimed fork PRs receive *no automated validation*; that was
  false on `main` and still over-claimed post-#1149 because of `lifecycle`.
  Scoped to validation *of the code*, with the `lifecycle` behaviour spelled
  out.
- The supported route was not followable as written. It now covers the tracker
  issue `AGENTS.md` requires, rewording commits for `validate-commits`,
  `Co-authored-by:` attribution, and the changeset / `skip-changeset`
  obligation an outside contributor will not have met.
- A later draft claimed "expect exactly one of the two required checks to
  fail". Both reviewers independently rejected it: `lifecycle` has its own
  failure paths, and the sentence's contrapositive ("a red `lifecycle` means
  the policy is not working") was itself the misread the section exists to
  prevent. Reworded to scope rather than count.
- Bold lead-ins were the only bold text in `CI.md`; removed.

One deliberate non-change:

- **`CONTRIBUTING.md` pointer not added.** `CONTRIBUTING.md` never mentions forks and
  reads throughout as though every contributor has push and label rights (it
  tells contributors to apply the `skip-changeset` label themselves). That is a
  real gap, but a pre-existing and broader one than this issue's acceptance
  criterion, which is scoped to `CI.md`. Worth a follow-up.

## Validation

Docs-only; no package source touched.

- `pnpm agent:check` — clean
- `pnpm test:ci-scripts` — 20/20
- `pnpm lint` — clean (pre-existing `@happyvertical/json` warnings only)
- `typecheck` / `build` not run: no workspace input changed
