### PR TITLE
test(weather): serve Environment Canada specs from recorded fixtures

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -60,6 +60,22 @@ from silently using Vitest's 5-second default on a contended runner.
 plain and locally overridden package configs. Add package-specific discovery or
 coverage rules to a package `vitest.config.ts`, not to its test command.
 
+## Network isolation in the default suites
+
+CI runs `test` and `test:optional` in the same step, so neither may depend on
+live egress. A suite that calls a real service must gate itself on an explicit
+opt-in and skip when it is absent — an API key where one exists
+(`OPENWEATHER_API_KEY`, `KANIDM_SERVER_URL`), otherwise a named flag
+(`ENVIRONMENT_CANADA_INTEGRATION`, `OLLAMA_INTEGRATION`, `MATOMO_INTEGRATION`),
+in the same spirit as `CI_POSTGRES_ENABLED`. Naming a file `*.optional.test.ts`
+is not itself a gate.
+
+Everything else stubs the transport. Record the upstream payload into a fixture
+beside the suite and serve it through `vi.stubGlobal('fetch', ...)`; the
+repository intentionally carries no `nock` or `msw` dependency. An unmocked
+suite fails whenever the runner's egress is blocked or the upstream rate-limits,
+which reads as a defect in whatever pull request happened to be running.
+
 ## Pull requests, merge groups, and Required CI
 
 `CI_MERGE_QUEUE_ENABLED` stages the cutover:

--- a/packages/weather/README.md
+++ b/packages/weather/README.md
@@ -147,17 +147,24 @@ interface WeatherForecast {
 
 ## Testing
 
-The default suite is offline and deterministic. Provider responses come from
-recorded fixtures in `src/__tests__/fixtures/`, so no test in `test` reaches the
-network:
+The default suite is offline and deterministic, with one key-gated exception.
+Provider responses come from recorded fixtures in `src/__tests__/fixtures/`, so
+on a clean environment no test in `test` reaches the network:
 
 ```bash
 pnpm turbo run test --filter=@happyvertical/weather
 ```
 
-Coverage against the real services lives in `*.optional.test.ts` and is skipped
-unless you opt in. OpenWeatherMap gates on its API key; Environment Canada needs
-no key, so it gates on an explicit flag:
+The exception is `google-weather.spec.ts`. It gates on `GOOGLE_API_KEY`, per the
+repository rule that a suite needing a real service gates on a key where one
+exists — see "Network isolation in the default suites" in `.github/CI.md`. With
+the key unset, its live block skips and the offline guarantee holds; that is how
+CI runs it. With the key exported, it calls the live Google Weather API from
+`test`.
+
+Coverage against the other live services lives in `*.optional.test.ts` and is
+skipped unless you opt in. OpenWeatherMap gates on its API key; Environment
+Canada needs no key, so it gates on an explicit flag:
 
 ```bash
 ENVIRONMENT_CANADA_INTEGRATION=1 pnpm --filter @happyvertical/weather test:optional

--- a/packages/weather/README.md
+++ b/packages/weather/README.md
@@ -145,6 +145,28 @@ interface WeatherForecast {
 | `OPENWEATHER_API_KEY` | string | OpenWeatherMap API key |
 | `HAVE_WEATHER_TIMEOUT` | number | Request timeout (ms) |
 
+## Testing
+
+The default suite is offline and deterministic. Provider responses come from
+recorded fixtures in `src/__tests__/fixtures/`, so no test in `test` reaches the
+network:
+
+```bash
+pnpm turbo run test --filter=@happyvertical/weather
+```
+
+Coverage against the real services lives in `*.optional.test.ts` and is skipped
+unless you opt in. OpenWeatherMap gates on its API key; Environment Canada needs
+no key, so it gates on an explicit flag:
+
+```bash
+ENVIRONMENT_CANADA_INTEGRATION=1 pnpm --filter @happyvertical/weather test:optional
+```
+
+Run the live suite after re-recording a fixture, to confirm the upstream payload
+still matches the shape the offline suite asserts. See
+`src/__tests__/fixtures/README.md` for how each fixture was recorded.
+
 ## Provider Comparison
 
 | Feature | Environment Canada | OpenWeatherMap | OWM One Call |

--- a/packages/weather/src/__tests__/environment-canada.optional.test.ts
+++ b/packages/weather/src/__tests__/environment-canada.optional.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Optional Environment Canada provider integration tests
+ *
+ * These tests hit the real Environment Canada MSC Geomet API and are excluded
+ * from normal CI. The service needs no API key, so there is no key-shaped gate
+ * to fall back on: opt in explicitly with `ENVIRONMENT_CANADA_INTEGRATION=1`.
+ *
+ *   ENVIRONMENT_CANADA_INTEGRATION=1 \
+ *     pnpm --filter @happyvertical/weather test:optional
+ *
+ * Run these after re-recording `./fixtures/environment-canada-citypage-*.json`
+ * to confirm the live payload still matches the shape the offline suite in
+ * `environment-canada.spec.ts` asserts against.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getWeatherAdapter } from '../index';
+import type { IWeatherAdapter } from '../shared/types';
+import { InvalidLocationError } from '../shared/types';
+
+const optedIn = process.env.ENVIRONMENT_CANADA_INTEGRATION === '1';
+
+// Calgary, AB coordinates
+const calgaryLat = 51.0447;
+const calgaryLng = -114.0719;
+
+// New York coordinates (not in Canada)
+const newYorkLat = 40.7128;
+const newYorkLng = -74.006;
+
+describe.skipIf(!optedIn)('Environment Canada Provider (live API)', () => {
+  let adapter: IWeatherAdapter;
+
+  it('reaches the live service', async () => {
+    adapter = await getWeatherAdapter({
+      provider: 'environment-canada',
+      timeout: 15000,
+    });
+
+    await expect(adapter.testConnection()).resolves.toBe(true);
+  });
+
+  it('returns forecasts for Calgary in the recorded shape', async () => {
+    adapter = await getWeatherAdapter({
+      provider: 'environment-canada',
+      timeout: 15000,
+    });
+
+    const forecasts = await adapter.fetchForLocation(calgaryLat, calgaryLng);
+
+    expect(Array.isArray(forecasts)).toBe(true);
+    expect(forecasts.length).toBeGreaterThan(0);
+
+    const forecast = forecasts[0];
+    expect(forecast.timestamp).toBeInstanceOf(Date);
+    expect(typeof forecast.temperature).toBe('number');
+    expect(typeof forecast.humidity).toBe('number');
+    expect(typeof forecast.windSpeed).toBe('number');
+    expect(typeof forecast.conditions).toBe('string');
+    expect(forecast.raw).toBeDefined();
+    expect(forecast.raw.source).toBe('environment-canada-citypage');
+  }, 30000);
+
+  it('respects the limit option against live data', async () => {
+    adapter = await getWeatherAdapter({
+      provider: 'environment-canada',
+      timeout: 15000,
+    });
+
+    const forecasts = await adapter.fetchForLocation(calgaryLat, calgaryLng, {
+      limit: 3,
+    });
+
+    expect(forecasts.length).toBeLessThanOrEqual(3);
+  }, 30000);
+
+  it('rejects non-Canadian coordinates before calling the service', async () => {
+    adapter = await getWeatherAdapter({ provider: 'environment-canada' });
+
+    await expect(
+      adapter.fetchForLocation(newYorkLat, newYorkLng),
+    ).rejects.toThrow(InvalidLocationError);
+  });
+});

--- a/packages/weather/src/__tests__/environment-canada.spec.ts
+++ b/packages/weather/src/__tests__/environment-canada.spec.ts
@@ -1,11 +1,15 @@
 /**
- * Environment Canada Provider Integration Tests
+ * Environment Canada Provider Tests
  *
- * Tests the Environment Canada provider with real API calls.
- * No API key required - this is a public government service.
+ * These tests are offline and deterministic: every request is served from the
+ * recorded fixtures in `./fixtures`, so the suite never depends on runner
+ * egress or on the upstream service's rate limits.
+ *
+ * Coverage against the real API lives in `environment-canada.optional.test.ts`
+ * and is opt-in via `ENVIRONMENT_CANADA_INTEGRATION`.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getWeatherAdapter } from '../index';
 import type { IWeatherAdapter } from '../shared/types';
 import {
@@ -13,22 +17,68 @@ import {
   NoResultsError,
   WeatherError,
 } from '../shared/types';
+import citypageCalgary from './fixtures/environment-canada-citypage-calgary.json';
+
+// Calgary, AB coordinates
+const calgaryLat = 51.0447;
+const calgaryLng = -114.0719;
+
+// New York coordinates (not in Canada)
+const newYorkLat = 40.7128;
+const newYorkLng = -74.006;
+
+type FetchMock = ReturnType<typeof stubFetch>;
+
+/**
+ * Stub `fetch` with a fixed response and return the mock so tests can assert on
+ * the request the provider built.
+ */
+function stubFetch(response: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  body?: unknown;
+}) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok: response.ok ?? true,
+    status: response.status ?? 200,
+    statusText: response.statusText ?? 'OK',
+    json: async () => response.body,
+  }));
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  return fetchMock;
+}
+
+function stubCitypageFetch(): FetchMock {
+  return stubFetch({ body: citypageCalgary });
+}
+
+async function createAdapter(
+  options: { timeout?: number } = {},
+): Promise<IWeatherAdapter> {
+  return getWeatherAdapter({ provider: 'environment-canada', ...options });
+}
+
+/** Resolve to the rejection reason so its type and fields can both be checked. */
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => {
+      throw new Error('expected the call to reject');
+    },
+    (error) => error,
+  );
+}
 
 describe('Environment Canada Provider', () => {
-  let adapter: IWeatherAdapter;
-
-  // Calgary, AB coordinates
-  const calgaryLat = 51.0447;
-  const calgaryLng = -114.0719;
-
-  // New York coordinates (not in Canada)
-  const newYorkLat = 40.7128;
-  const newYorkLng = -74.006;
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
 
   it('should create adapter with default config', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-    });
+    const adapter = await createAdapter();
 
     expect(adapter).toBeDefined();
     expect(adapter.name).toBe('Environment Canada');
@@ -36,47 +86,76 @@ describe('Environment Canada Provider', () => {
   });
 
   it('should test connection successfully', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-    });
+    const fetchMock = stubCitypageFetch();
+    const adapter = await createAdapter();
 
-    const isConnected = await adapter.testConnection();
-    expect(isConnected).toBe(true);
+    await expect(adapter.testConnection()).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should report a failed connection without throwing', async () => {
+    stubFetch({ ok: false, status: 403, statusText: 'Forbidden', body: {} });
+    const adapter = await createAdapter();
+
+    await expect(adapter.testConnection()).resolves.toBe(false);
+  });
+
+  it('should report a failed connection when the request itself errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('fetch failed');
+      }),
+    );
+    const adapter = await createAdapter();
+
+    await expect(adapter.testConnection()).resolves.toBe(false);
   });
 
   it('should support Canadian locations', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-    });
+    const adapter = await createAdapter();
 
-    const isSupported = await adapter.supportsLocation(calgaryLat, calgaryLng);
-    expect(isSupported).toBe(true);
+    await expect(
+      adapter.supportsLocation(calgaryLat, calgaryLng),
+    ).resolves.toBe(true);
   });
 
   it('should not support non-Canadian locations', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-    });
+    const adapter = await createAdapter();
 
-    const isSupported = await adapter.supportsLocation(newYorkLat, newYorkLng);
-    expect(isSupported).toBe(false);
+    await expect(
+      adapter.supportsLocation(newYorkLat, newYorkLng),
+    ).resolves.toBe(false);
+  });
+
+  it('should query the citypage collection for the requested bounding box', async () => {
+    const fetchMock = stubCitypageFetch();
+    const adapter = await createAdapter();
+
+    await adapter.fetchForLocation(calgaryLat, calgaryLng);
+
+    const requested = new URL(fetchMock.mock.calls[0][0]);
+    expect(`${requested.origin}${requested.pathname}`).toBe(
+      'https://api.weather.gc.ca/collections/citypageweather-realtime/items',
+    );
+    expect(requested.searchParams.get('f')).toBe('json');
+    expect(requested.searchParams.get('limit')).toBe('1');
+    expect(requested.searchParams.get('bbox')).toBe(
+      `${calgaryLng - 1},${calgaryLat - 1},${calgaryLng + 1},${calgaryLat + 1}`,
+    );
   });
 
   it('should fetch weather forecasts for Calgary', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-      timeout: 15000, // 15 second timeout for API call
-    });
+    stubCitypageFetch();
+    const adapter = await createAdapter();
 
     const forecasts = await adapter.fetchForLocation(calgaryLat, calgaryLng);
 
-    expect(forecasts).toBeDefined();
     expect(Array.isArray(forecasts)).toBe(true);
-    expect(forecasts.length).toBeGreaterThan(0);
+    // One entry for current conditions plus one per recorded forecast period.
+    expect(forecasts).toHaveLength(14);
 
-    // Check first forecast structure
     const forecast = forecasts[0];
-    expect(forecast).toBeDefined();
     expect(forecast.timestamp).toBeInstanceOf(Date);
     expect(typeof forecast.temperature).toBe('number');
     expect(typeof forecast.humidity).toBe('number');
@@ -84,22 +163,56 @@ describe('Environment Canada Provider', () => {
     expect(typeof forecast.conditions).toBe('string');
     expect(forecast.raw).toBeDefined();
     expect(forecast.raw.source).toBe('environment-canada-citypage');
-  }, 30000); // 30 second timeout
+  });
+
+  it('should map recorded current conditions onto the standard shape', async () => {
+    stubCitypageFetch();
+    const adapter = await createAdapter();
+
+    const [current] = await adapter.fetchForLocation(calgaryLat, calgaryLng);
+
+    expect(current).toMatchObject({
+      timestamp: new Date('2026-07-28T12:00:00Z'),
+      temperature: 10.7,
+      humidity: 94,
+      // 101.4 kPa in the payload, hPa on the standard shape.
+      pressure: 1014,
+      confidence: 100,
+    });
+  });
+
+  it('should coerce a non-numeric wind speed to zero', async () => {
+    // The recording reports the string "calm" rather than a number.
+    stubCitypageFetch();
+    const adapter = await createAdapter();
+
+    const [current] = await adapter.fetchForLocation(calgaryLat, calgaryLng);
+
+    expect(current.windSpeed).toBe(0);
+  });
+
+  it('should fall back to Unknown when current conditions omit the condition', async () => {
+    stubCitypageFetch();
+    const adapter = await createAdapter();
+
+    const [current] = await adapter.fetchForLocation(calgaryLat, calgaryLng);
+
+    expect(current.conditions).toBe('Unknown');
+  });
 
   it('should throw InvalidLocationError for non-Canadian location', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-    });
+    const fetchMock = stubCitypageFetch();
+    const adapter = await createAdapter();
 
     await expect(
       adapter.fetchForLocation(newYorkLat, newYorkLng),
     ).rejects.toThrow(InvalidLocationError);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('should throw InvalidLocationError for invalid coordinates', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-    });
+    const fetchMock = stubCitypageFetch();
+    const adapter = await createAdapter();
 
     // Invalid latitude (> 90)
     await expect(adapter.fetchForLocation(100, -114.0719)).rejects.toThrow(
@@ -110,29 +223,70 @@ describe('Environment Canada Provider', () => {
     await expect(adapter.fetchForLocation(51.0447, -200)).rejects.toThrow(
       InvalidLocationError,
     );
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('should respect limit option', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-    });
+    stubCitypageFetch();
+    const adapter = await createAdapter();
 
     const forecasts = await adapter.fetchForLocation(calgaryLat, calgaryLng, {
       limit: 3,
     });
 
-    expect(forecasts).toBeDefined();
-    expect(forecasts.length).toBeLessThanOrEqual(3);
-  }, 30000); // 30 second timeout
+    expect(forecasts).toHaveLength(3);
+  });
 
-  it('should handle timeout option', async () => {
-    adapter = await getWeatherAdapter({
-      provider: 'environment-canada',
-      timeout: 1, // Very short timeout should fail
+  it('should surface a non-ok response as a WeatherError', async () => {
+    stubFetch({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      body: {},
     });
+    const adapter = await createAdapter();
+
+    const error = await rejection(
+      adapter.fetchForLocation(calgaryLat, calgaryLng),
+    );
+
+    expect(error).toBeInstanceOf(WeatherError);
+    expect((error as WeatherError).code).toBe('HTTP_503');
+  });
+
+  it('should throw NoResultsError when the bounding box matches no city', async () => {
+    stubFetch({ body: { type: 'FeatureCollection', features: [] } });
+    const adapter = await createAdapter();
 
     await expect(
       adapter.fetchForLocation(calgaryLat, calgaryLng),
-    ).rejects.toThrow(WeatherError);
+    ).rejects.toThrow(NoResultsError);
+  });
+
+  it('should handle timeout option', async () => {
+    // Never settles on its own; only the provider's abort signal ends it.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              const abortError = new Error('The operation was aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
+          }),
+      ),
+    );
+
+    const adapter = await createAdapter({ timeout: 1 });
+
+    const error = await rejection(
+      adapter.fetchForLocation(calgaryLat, calgaryLng),
+    );
+
+    expect(error).toBeInstanceOf(WeatherError);
+    expect((error as WeatherError).code).toBe('TIMEOUT');
   });
 });

--- a/packages/weather/src/__tests__/fixtures/README.md
+++ b/packages/weather/src/__tests__/fixtures/README.md
@@ -1,8 +1,8 @@
 # Environment Canada test fixtures
 
 Recorded responses from the MSC Geomet API, used so the Environment Canada
-provider specs run offline and deterministically. No live request is made by
-the default `test` task.
+provider specs run offline and deterministically — those specs make no live
+request from the default `test` task.
 
 ## `environment-canada-citypage-calgary.json`
 

--- a/packages/weather/src/__tests__/fixtures/README.md
+++ b/packages/weather/src/__tests__/fixtures/README.md
@@ -1,0 +1,32 @@
+# Environment Canada test fixtures
+
+Recorded responses from the MSC Geomet API, used so the Environment Canada
+provider specs run offline and deterministically. No live request is made by
+the default `test` task.
+
+## `environment-canada-citypage-calgary.json`
+
+The `citypageweather-realtime` collection response for the bounding box that
+`EnvironmentCanadaProvider.buildApiUrl` derives from Calgary, AB
+(51.0447, -114.0719).
+
+Recorded 2026-07-28 with:
+
+```bash
+curl -s 'https://api.weather.gc.ca/collections/citypageweather-realtime/items?f=json&bbox=-115.0719,50.0447,-113.0719,52.0447&limit=1'
+```
+
+Kept verbatim except for `properties.hourlyForecastGroup`, which the provider
+never reads and which accounted for roughly a third of the payload.
+
+The recording deliberately preserves two upstream quirks the transform has to
+survive, so do not "clean" them up:
+
+- `currentConditions.wind.speed.value.en` is the string `"calm"`, not a number.
+- `currentConditions` carries no `condition` field.
+
+## Re-recording
+
+Re-record only when the upstream schema changes, and re-run
+`ENVIRONMENT_CANADA_INTEGRATION=1 pnpm --filter @happyvertical/weather test:optional`
+afterwards to confirm the live service still matches the fixture's shape.

--- a/packages/weather/src/__tests__/fixtures/environment-canada-citypage-calgary.json
+++ b/packages/weather/src/__tests__/fixtures/environment-canada-citypage-calgary.json
@@ -1,0 +1,1658 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "lastUpdated": "2026-07-28T12:02:24Z",
+        "identifier": "ab-42",
+        "name": {
+          "en": "Bow Valley (Provincial Park)",
+          "fr": "Bow Valley (Parc provincial)"
+        },
+        "region": {
+          "en": "Kananaskis Improvement District near Kananaskis Village",
+          "fr": "district en voie d’organisation de Kananaskis près de Kananaskis Village"
+        },
+        "url": {
+          "en": "https://weather.gc.ca/en/location/index.html?coords=51.08,-115.07",
+          "fr": "https://meteo.gc.ca/fr/location/index.html?coords=51.08,-115.07"
+        },
+        "currentConditions": {
+          "iconCode": {
+            "format": "gif"
+          },
+          "timestamp": {
+            "en": "2026-07-28T12:00:00Z",
+            "fr": "2026-07-28T12:00:00Z"
+          },
+          "relativeHumidity": {
+            "units": {
+              "en": "%",
+              "fr": "%"
+            },
+            "qaValue": {
+              "en": 100,
+              "fr": 100
+            },
+            "value": {
+              "en": 94,
+              "fr": 94
+            }
+          },
+          "wind": {
+            "speed": {
+              "unitType": {
+                "en": "metric",
+                "fr": "metric"
+              },
+              "units": {
+                "en": "km/h",
+                "fr": "km/h"
+              },
+              "qaValue": {
+                "en": 100,
+                "fr": 100
+              },
+              "value": {
+                "en": "calm",
+                "fr": "calme"
+              }
+            },
+            "direction": {
+              "qaValue": {
+                "en": 100,
+                "fr": 100
+              },
+              "value": {
+                "en": "NNE",
+                "fr": "NNE"
+              }
+            },
+            "bearing": {
+              "units": {
+                "en": "degrees",
+                "fr": "degrees"
+              },
+              "qaValue": {
+                "en": 100,
+                "fr": 100
+              },
+              "value": {
+                "en": 29.3,
+                "fr": 29.3
+              }
+            },
+            "gust": {
+              "unitType": {
+                "en": "metric",
+                "fr": "metric"
+              },
+              "units": {
+                "en": "km/h",
+                "fr": "km/h"
+              },
+              "value": {
+                "en": 31,
+                "fr": 31
+              },
+              "qaValue": {
+                "en": 100,
+                "fr": 100
+              }
+            }
+          },
+          "pressure": {
+            "unitType": {
+              "en": "metric",
+              "fr": "metric"
+            },
+            "units": {
+              "en": "kPa",
+              "fr": "kPa"
+            },
+            "change": {
+              "en": 0.07,
+              "fr": 0.07
+            },
+            "tendency": {
+              "en": "falling",
+              "fr": "à la baisse"
+            },
+            "value": {
+              "en": 101.4,
+              "fr": 101.4
+            }
+          },
+          "temperature": {
+            "unitType": {
+              "en": "metric",
+              "fr": "metric"
+            },
+            "units": {
+              "en": "C",
+              "fr": "C"
+            },
+            "qaValue": {
+              "en": 100,
+              "fr": 100
+            },
+            "value": {
+              "en": 10.7,
+              "fr": 10.7
+            }
+          },
+          "dewpoint": {
+            "unitType": {
+              "en": "metric",
+              "fr": "metric"
+            },
+            "units": {
+              "en": "C",
+              "fr": "C"
+            },
+            "value": {
+              "en": 9.8,
+              "fr": 9.8
+            }
+          },
+          "station": {
+            "code": {
+              "en": "wxa",
+              "fr": "wxa"
+            },
+            "lat": {
+              "en": "51.08N",
+              "fr": "51.08N"
+            },
+            "lon": {
+              "en": "115.07W",
+              "fr": "115.07O"
+            },
+            "value": {
+              "en": "Bow Valley",
+              "fr": "Bow Valley"
+            }
+          },
+          "windChill": {
+            "unitType": {
+              "en": "metric",
+              "fr": "metric"
+            },
+            "value": {
+              "en": -3,
+              "fr": -3
+            },
+            "qaValue": {
+              "en": 100,
+              "fr": 100
+            }
+          }
+        },
+        "forecastGroup": {
+          "timestamp": {
+            "en": "2026-07-28T11:00:00Z",
+            "fr": "2026-07-28T11:00:00Z"
+          },
+          "regionalNormals": {
+            "textSummary": {
+              "en": "Low 7. High 22.",
+              "fr": "Minimum 7. Maximum 22."
+            },
+            "temperature": [
+              {
+                "unitType": {
+                  "en": "metric",
+                  "fr": "metric"
+                },
+                "units": {
+                  "en": "C",
+                  "fr": "C"
+                },
+                "class": {
+                  "en": "high",
+                  "fr": "high"
+                },
+                "value": {
+                  "en": 22,
+                  "fr": 22
+                }
+              },
+              {
+                "unitType": {
+                  "en": "metric",
+                  "fr": "metric"
+                },
+                "units": {
+                  "en": "C",
+                  "fr": "C"
+                },
+                "class": {
+                  "en": "low",
+                  "fr": "low"
+                },
+                "value": {
+                  "en": 7,
+                  "fr": 7
+                }
+              }
+            ]
+          },
+          "forecasts": [
+            {
+              "uv": {
+                "index": {
+                  "en": "7",
+                  "fr": "7"
+                },
+                "category": {
+                  "en": "high",
+                  "fr": "élevé"
+                },
+                "textSummary": {
+                  "en": "UV index 7 or high.",
+                  "fr": "Indice UV de 7 ou élevé."
+                }
+              },
+              "period": {
+                "textForecastName": {
+                  "en": "Today",
+                  "fr": "Aujourd'hui"
+                },
+                "value": {
+                  "en": "Tuesday",
+                  "fr": "mardi"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "high",
+                      "fr": "high"
+                    },
+                    "value": {
+                      "en": 29,
+                      "fr": 29
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "High 29.",
+                  "fr": "Maximum 29."
+                }
+              },
+              "winds": {
+                "periods": [
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 22,
+                        "fr": 22
+                      }
+                    },
+                    "index": {
+                      "en": 1,
+                      "fr": 1
+                    },
+                    "rank": {
+                      "en": "major",
+                      "fr": "major"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 15,
+                        "fr": 15
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 0,
+                        "fr": 0
+                      }
+                    },
+                    "direction": {
+                      "en": "SW",
+                      "fr": "SO"
+                    }
+                  },
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 99,
+                        "fr": 99
+                      }
+                    },
+                    "index": {
+                      "en": 2,
+                      "fr": 2
+                    },
+                    "rank": {
+                      "en": "minor",
+                      "fr": "minor"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 5,
+                        "fr": 5
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 0,
+                        "fr": 0
+                      }
+                    },
+                    "direction": {
+                      "en": "VR",
+                      "fr": "VR"
+                    }
+                  },
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 22,
+                        "fr": 22
+                      }
+                    },
+                    "index": {
+                      "en": 3,
+                      "fr": 3
+                    },
+                    "rank": {
+                      "en": "major",
+                      "fr": "major"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 30,
+                        "fr": 30
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 50,
+                        "fr": 50
+                      }
+                    },
+                    "direction": {
+                      "en": "SW",
+                      "fr": "SO"
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Wind becoming southwest 30 km/h gusting to 50 early this afternoon.",
+                  "fr": "Vents devenant du sud-ouest à 30 km/h avec rafales à 50 tôt cet après-midi."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Sunny. Becoming a mix of sun and cloud this afternoon.",
+                "fr": "Ensoleillé. Devenant alternance de soleil et de nuages cet après-midi."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 20,
+                  "fr": 20
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 1,
+                  "url": "https://weather.gc.ca/weathericons/01.gif"
+                },
+                "textSummary": {
+                  "en": "Mainly sunny",
+                  "fr": "Généralement ensoleillé"
+                }
+              },
+              "textSummary": {
+                "en": "Sunny. Becoming a mix of sun and cloud this afternoon. Wind becoming southwest 30 km/h gusting to 50 early this afternoon. High 29. UV index 7 or high.",
+                "fr": "Ensoleillé. Devenant alternance de soleil et de nuages cet après-midi. Vents devenant du sud-ouest à 30 km/h avec rafales à 50 tôt cet après-midi. Maximum 29. Indice UV de 7 ou élevé."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Tonight",
+                  "fr": "Ce soir et cette nuit"
+                },
+                "value": {
+                  "en": "Tuesday night",
+                  "fr": "ce soir et cette nuit"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "low",
+                      "fr": "low"
+                    },
+                    "value": {
+                      "en": 8,
+                      "fr": 8
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Low 8.",
+                  "fr": "Minimum 8."
+                }
+              },
+              "winds": {
+                "periods": [
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 22,
+                        "fr": 22
+                      }
+                    },
+                    "index": {
+                      "en": 1,
+                      "fr": 1
+                    },
+                    "rank": {
+                      "en": "major",
+                      "fr": "major"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 30,
+                        "fr": 30
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 50,
+                        "fr": 50
+                      }
+                    },
+                    "direction": {
+                      "en": "SW",
+                      "fr": "SO"
+                    }
+                  },
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 27,
+                        "fr": 27
+                      }
+                    },
+                    "index": {
+                      "en": 2,
+                      "fr": 2
+                    },
+                    "rank": {
+                      "en": "major",
+                      "fr": "major"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 15,
+                        "fr": 15
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 0,
+                        "fr": 0
+                      }
+                    },
+                    "direction": {
+                      "en": "W",
+                      "fr": "O"
+                    }
+                  },
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 27,
+                        "fr": 27
+                      }
+                    },
+                    "index": {
+                      "en": 3,
+                      "fr": 3
+                    },
+                    "rank": {
+                      "en": "minor",
+                      "fr": "minor"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 10,
+                        "fr": 10
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 0,
+                        "fr": 0
+                      }
+                    },
+                    "direction": {
+                      "en": "W",
+                      "fr": "O"
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Wind southwest 30 km/h gusting to 50 becoming light this evening.",
+                  "fr": "Vents du sud-ouest de 30 km/h avec rafales à 50 devenant légers ce soir."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Partly cloudy. Becoming clear this evening.",
+                "fr": "Partiellement nuageux. Devenant dégagé ce soir."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 80,
+                  "fr": 80
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 31,
+                  "url": "https://weather.gc.ca/weathericons/31.gif"
+                },
+                "textSummary": {
+                  "en": "A few clouds",
+                  "fr": "Quelques nuages"
+                }
+              },
+              "textSummary": {
+                "en": "Partly cloudy. Becoming clear this evening. Wind southwest 30 km/h gusting to 50 becoming light this evening. Low 8.",
+                "fr": "Partiellement nuageux. Devenant dégagé ce soir. Vents du sud-ouest de 30 km/h avec rafales à 50 devenant légers ce soir. Minimum 8."
+              }
+            },
+            {
+              "uv": {
+                "index": {
+                  "en": "7",
+                  "fr": "7"
+                },
+                "category": {
+                  "en": "high",
+                  "fr": "élevé"
+                },
+                "textSummary": {
+                  "en": "UV index 7 or high.",
+                  "fr": "Indice UV de 7 ou élevé."
+                }
+              },
+              "period": {
+                "textForecastName": {
+                  "en": "Wednesday",
+                  "fr": "Mercredi"
+                },
+                "value": {
+                  "en": "Wednesday",
+                  "fr": "mercredi"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "high",
+                      "fr": "high"
+                    },
+                    "value": {
+                      "en": 27,
+                      "fr": 27
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "High 27.",
+                  "fr": "Maximum 27."
+                }
+              },
+              "winds": {
+                "periods": [
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 27,
+                        "fr": 27
+                      }
+                    },
+                    "index": {
+                      "en": 1,
+                      "fr": 1
+                    },
+                    "rank": {
+                      "en": "major",
+                      "fr": "major"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 10,
+                        "fr": 10
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 0,
+                        "fr": 0
+                      }
+                    },
+                    "direction": {
+                      "en": "W",
+                      "fr": "O"
+                    }
+                  },
+                  {
+                    "bearing": {
+                      "units": {
+                        "en": "degrees",
+                        "fr": "degrees"
+                      },
+                      "value": {
+                        "en": 99,
+                        "fr": 99
+                      }
+                    },
+                    "index": {
+                      "en": 2,
+                      "fr": 2
+                    },
+                    "rank": {
+                      "en": "major",
+                      "fr": "major"
+                    },
+                    "speed": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 5,
+                        "fr": 5
+                      }
+                    },
+                    "gust": {
+                      "unitType": {
+                        "en": "metric",
+                        "fr": "metric"
+                      },
+                      "units": {
+                        "en": "km/h",
+                        "fr": "km/h"
+                      },
+                      "value": {
+                        "en": 0,
+                        "fr": 0
+                      }
+                    },
+                    "direction": {
+                      "en": "VR",
+                      "fr": "VR"
+                    }
+                  }
+                ]
+              },
+              "cloudPrecip": {
+                "en": "Sunny.",
+                "fr": "Ensoleillé."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 25,
+                  "fr": 25
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 0,
+                  "url": "https://weather.gc.ca/weathericons/00.gif"
+                },
+                "textSummary": {
+                  "en": "Sunny",
+                  "fr": "Ensoleillé"
+                }
+              },
+              "textSummary": {
+                "en": "Sunny. High 27. UV index 7 or high.",
+                "fr": "Ensoleillé. Maximum 27. Indice UV de 7 ou élevé."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Wednesday night",
+                  "fr": "Mercredi soir et nuit"
+                },
+                "value": {
+                  "en": "Wednesday night",
+                  "fr": "mercredi soir et nuit"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "low",
+                      "fr": "low"
+                    },
+                    "value": {
+                      "en": 9,
+                      "fr": 9
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Low 9.",
+                  "fr": "Minimum 9."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Clear.",
+                "fr": "Dégagé."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 95,
+                  "fr": 95
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 30,
+                  "url": "https://weather.gc.ca/weathericons/30.gif"
+                },
+                "textSummary": {
+                  "en": "Clear",
+                  "fr": "Dégagé"
+                }
+              },
+              "textSummary": {
+                "en": "Clear. Low 9.",
+                "fr": "Dégagé. Minimum 9."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Thursday",
+                  "fr": "Jeudi"
+                },
+                "value": {
+                  "en": "Thursday",
+                  "fr": "jeudi"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "high",
+                      "fr": "high"
+                    },
+                    "value": {
+                      "en": 28,
+                      "fr": 28
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "High 28.",
+                  "fr": "Maximum 28."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Sunny.",
+                "fr": "Ensoleillé."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 15,
+                  "fr": 15
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 0,
+                  "url": "https://weather.gc.ca/weathericons/00.gif"
+                },
+                "textSummary": {
+                  "en": "Sunny",
+                  "fr": "Ensoleillé"
+                }
+              },
+              "textSummary": {
+                "en": "Sunny. High 28.",
+                "fr": "Ensoleillé. Maximum 28."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Thursday night",
+                  "fr": "Jeudi soir et nuit"
+                },
+                "value": {
+                  "en": "Thursday night",
+                  "fr": "jeudi soir et nuit"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "low",
+                      "fr": "low"
+                    },
+                    "value": {
+                      "en": 11,
+                      "fr": 11
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Low 11.",
+                  "fr": "Minimum 11."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Clear.",
+                "fr": "Dégagé."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 45,
+                  "fr": 45
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 30,
+                  "url": "https://weather.gc.ca/weathericons/30.gif"
+                },
+                "textSummary": {
+                  "en": "Clear",
+                  "fr": "Dégagé"
+                }
+              },
+              "textSummary": {
+                "en": "Clear. Low 11.",
+                "fr": "Dégagé. Minimum 11."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Friday",
+                  "fr": "Vendredi"
+                },
+                "value": {
+                  "en": "Friday",
+                  "fr": "vendredi"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "high",
+                      "fr": "high"
+                    },
+                    "value": {
+                      "en": 30,
+                      "fr": 30
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "High 30.",
+                  "fr": "Maximum 30."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Sunny.",
+                "fr": "Ensoleillé."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 15,
+                  "fr": 15
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 0,
+                  "url": "https://weather.gc.ca/weathericons/00.gif"
+                },
+                "textSummary": {
+                  "en": "Sunny",
+                  "fr": "Ensoleillé"
+                }
+              },
+              "textSummary": {
+                "en": "Sunny. High 30.",
+                "fr": "Ensoleillé. Maximum 30."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Friday night",
+                  "fr": "Vendredi soir et nuit"
+                },
+                "value": {
+                  "en": "Friday night",
+                  "fr": "vendredi soir et nuit"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "low",
+                      "fr": "low"
+                    },
+                    "value": {
+                      "en": 11,
+                      "fr": 11
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Low 11.",
+                  "fr": "Minimum 11."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Clear.",
+                "fr": "Dégagé."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 55,
+                  "fr": 55
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 30,
+                  "url": "https://weather.gc.ca/weathericons/30.gif"
+                },
+                "textSummary": {
+                  "en": "Clear",
+                  "fr": "Dégagé"
+                }
+              },
+              "textSummary": {
+                "en": "Clear. Low 11.",
+                "fr": "Dégagé. Minimum 11."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Saturday",
+                  "fr": "Samedi"
+                },
+                "value": {
+                  "en": "Saturday",
+                  "fr": "samedi"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "high",
+                      "fr": "high"
+                    },
+                    "value": {
+                      "en": 32,
+                      "fr": 32
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "High 32.",
+                  "fr": "Maximum 32."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Sunny.",
+                "fr": "Ensoleillé."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 20,
+                  "fr": 20
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 0,
+                  "url": "https://weather.gc.ca/weathericons/00.gif"
+                },
+                "textSummary": {
+                  "en": "Sunny",
+                  "fr": "Ensoleillé"
+                }
+              },
+              "textSummary": {
+                "en": "Sunny. High 32.",
+                "fr": "Ensoleillé. Maximum 32."
+              }
+            },
+            {
+              "precipitation": {
+                "precipPeriods": [
+                  {
+                    "start": {
+                      "en": 126,
+                      "fr": 126
+                    },
+                    "end": {
+                      "en": 132,
+                      "fr": 132
+                    },
+                    "value": {
+                      "en": "rain",
+                      "fr": "pluie"
+                    }
+                  }
+                ]
+              },
+              "period": {
+                "textForecastName": {
+                  "en": "Saturday night",
+                  "fr": "Samedi soir et nuit"
+                },
+                "value": {
+                  "en": "Saturday night",
+                  "fr": "samedi soir et nuit"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "low",
+                      "fr": "low"
+                    },
+                    "value": {
+                      "en": 11,
+                      "fr": 11
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Low 11.",
+                  "fr": "Minimum 11."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Cloudy periods with 40 percent chance of showers.",
+                "fr": "Passages nuageux avec 40 pour cent de probabilité d'averses."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 55,
+                  "fr": 55
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 36,
+                  "url": "https://weather.gc.ca/weathericons/36.gif"
+                },
+                "textSummary": {
+                  "en": "Chance of showers",
+                  "fr": "Possibilité d'averses"
+                }
+              },
+              "textSummary": {
+                "en": "Cloudy periods with 40 percent chance of showers. Low 11.",
+                "fr": "Passages nuageux avec 40 pour cent de probabilité d'averses. Minimum 11."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Sunday",
+                  "fr": "Dimanche"
+                },
+                "value": {
+                  "en": "Sunday",
+                  "fr": "dimanche"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "high",
+                      "fr": "high"
+                    },
+                    "value": {
+                      "en": 18,
+                      "fr": 18
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "High 18.",
+                  "fr": "Maximum 18."
+                }
+              },
+              "cloudPrecip": {
+                "en": "A mix of sun and cloud.",
+                "fr": "Alternance de soleil et de nuages."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 25,
+                  "fr": 25
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 2,
+                  "url": "https://weather.gc.ca/weathericons/02.gif"
+                },
+                "textSummary": {
+                  "en": "A mix of sun and cloud",
+                  "fr": "Alternance de soleil et de nuages"
+                }
+              },
+              "textSummary": {
+                "en": "A mix of sun and cloud. High 18.",
+                "fr": "Alternance de soleil et de nuages. Maximum 18."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Sunday night",
+                  "fr": "Dimanche soir et nuit"
+                },
+                "value": {
+                  "en": "Sunday night",
+                  "fr": "dimanche soir et nuit"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "low",
+                      "fr": "low"
+                    },
+                    "value": {
+                      "en": 6,
+                      "fr": 6
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "Low 6.",
+                  "fr": "Minimum 6."
+                }
+              },
+              "cloudPrecip": {
+                "en": "Cloudy periods.",
+                "fr": "Passages nuageux."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 65,
+                  "fr": 65
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 32,
+                  "url": "https://weather.gc.ca/weathericons/32.gif"
+                },
+                "textSummary": {
+                  "en": "Cloudy periods",
+                  "fr": "Passages nuageux"
+                }
+              },
+              "textSummary": {
+                "en": "Cloudy periods. Low 6.",
+                "fr": "Passages nuageux. Minimum 6."
+              }
+            },
+            {
+              "period": {
+                "textForecastName": {
+                  "en": "Monday",
+                  "fr": "Lundi"
+                },
+                "value": {
+                  "en": "Monday",
+                  "fr": "lundi"
+                }
+              },
+              "temperatures": {
+                "temperature": [
+                  {
+                    "unitType": {
+                      "en": "metric",
+                      "fr": "metric"
+                    },
+                    "units": {
+                      "en": "C",
+                      "fr": "C"
+                    },
+                    "class": {
+                      "en": "high",
+                      "fr": "high"
+                    },
+                    "value": {
+                      "en": 20,
+                      "fr": 20
+                    }
+                  }
+                ],
+                "textSummary": {
+                  "en": "High 20.",
+                  "fr": "Maximum 20."
+                }
+              },
+              "cloudPrecip": {
+                "en": "A mix of sun and cloud.",
+                "fr": "Alternance de soleil et de nuages."
+              },
+              "relativeHumidity": {
+                "units": {
+                  "en": "%",
+                  "fr": "%"
+                },
+                "value": {
+                  "en": 30,
+                  "fr": 30
+                }
+              },
+              "abbreviatedForecast": {
+                "icon": {
+                  "format": "gif",
+                  "value": 2,
+                  "url": "https://weather.gc.ca/weathericons/02.gif"
+                },
+                "textSummary": {
+                  "en": "A mix of sun and cloud",
+                  "fr": "Alternance de soleil et de nuages"
+                }
+              },
+              "textSummary": {
+                "en": "A mix of sun and cloud. High 20.",
+                "fr": "Alternance de soleil et de nuages. Maximum 20."
+              }
+            }
+          ]
+        },
+        "warnings": [],
+        "riseSet": {
+          "disclaimer": {
+            "en": "The information provided here, for the times of the rise and set of the sun, is an estimate included as a convenience to our clients. Values shown here may differ from the official sunrise/sunset data available from (http://hia-iha.nrc-cnrc.gc.ca/sunrise_e.html)",
+            "fr": "Les heures de lever et coucher du soleil sont une estimation seulement et peuvent être différentes des heures officielles de lever et coucher du soleil disponibles ici ( http://hia-iha.nrc-cnrc.gc.ca/sunrise_f.html )"
+          },
+          "sunrise": {
+            "en": "2026-07-28T12:00:00Z",
+            "fr": "2026-07-28T12:00:00Z"
+          },
+          "sunset": {
+            "en": "2026-07-29T03:33:00Z",
+            "fr": "2026-07-29T03:33:00Z"
+          }
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -115.07,
+          51.08
+        ]
+      },
+      "id": "ab-42"
+    }
+  ],
+  "numberMatched": 11,
+  "numberReturned": 1,
+  "links": [
+    {
+      "type": "application/geo+json",
+      "rel": "self",
+      "title": "This document as GeoJSON",
+      "href": "https://api.weather.gc.ca/collections/citypageweather-realtime/items?f=json&bbox=-115.0719,50.0447,-113.0719,52.0447&limit=1"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/ld+json",
+      "title": "This document as RDF (JSON-LD)",
+      "href": "https://api.weather.gc.ca/collections/citypageweather-realtime/items?f=jsonld&bbox=-115.0719,50.0447,-113.0719,52.0447&limit=1"
+    },
+    {
+      "type": "text/html",
+      "rel": "alternate",
+      "title": "This document as HTML",
+      "href": "https://api.weather.gc.ca/collections/citypageweather-realtime/items?f=html&bbox=-115.0719,50.0447,-113.0719,52.0447&limit=1"
+    },
+    {
+      "type": "application/geo+json",
+      "rel": "next",
+      "title": "Items (next)",
+      "href": "https://api.weather.gc.ca/collections/citypageweather-realtime/items?offset=1&bbox=-115.0719,50.0447,-113.0719,52.0447&limit=1"
+    },
+    {
+      "type": "application/json",
+      "title": "City Page Weather [experimental]",
+      "rel": "collection",
+      "href": "https://api.weather.gc.ca/collections/citypageweather-realtime"
+    }
+  ],
+  "timeStamp": "2026-07-28T12:12:47.233146Z"
+}


### PR DESCRIPTION
Resolves #1165

## What was wrong

`environment-canada.spec.ts` had no mocking layer. It called
`adapter.testConnection()` and `adapter.fetchForLocation(...)` straight against
`https://api.weather.gc.ca`, so `@happyvertical/weather#test` failed whenever
the runner's egress was blocked or the upstream rate-limited — on pull requests
that changed no package source.

Environment Canada needs no API key, which is why this file was the only
default-`test` suite in the repo reaching a live service unconditionally: every
sibling gates on a key (`OPENWEATHER_API_KEY`, `KANIDM_SERVER_URL`) or a named
flag (`OLLAMA_INTEGRATION`, `MATOMO_INTEGRATION`), and this one had nothing
key-shaped to gate on.

## What changed

**`environment-canada.spec.ts` is now offline and deterministic.** Requests are
served from `src/__tests__/fixtures/environment-canada-citypage-calgary.json`,
recorded off the live API on 2026-07-28 and stubbed in with
`vi.stubGlobal('fetch', ...)` — the same shape `historical-weather.spec.ts`
already uses for this provider. The repo carries no `nock`/`msw` dependency and
this does not add one.

The recording deliberately keeps two upstream quirks the transform has to
survive: `wind.speed.value.en` is the string `"calm"`, and `currentConditions`
carries no `condition` field. Both now have explicit tests.

Mocking also bought coverage the live call could not produce on demand:

| New case | Asserted |
| --- | --- |
| Non-ok response | `WeatherError` with `code: 'HTTP_503'` |
| Empty feature collection | `NoResultsError` |
| Abort | `WeatherError` with `code: 'TIMEOUT'` |
| Request shape | `f`, `limit`, and the derived `bbox` |
| Invalid/foreign coordinates | reject *without* calling `fetch` |

9 tests → 17, and the file drops from a network round trip to 6 ms.

**Live coverage moves to `environment-canada.optional.test.ts`,** opt-in via
`ENVIRONMENT_CANADA_INTEGRATION=1`. Worth noting for review: CI runs `test` and
`test:optional` in the *same* step, so naming a file `*.optional.test.ts` is not
by itself a gate — the `describe.skipIf` is what keeps it out of default CI.

Docs: a Testing section in the weather README, a fixtures README recording how
the payload was captured and what was trimmed, and a "Network isolation in the
default suites" section in `.github/CI.md` stating the rule for future suites.

## Validation

Ran under a Node preload that throws on every non-loopback `net.Socket.connect`,
`net.connect`, `tls.connect`, and DNS lookup. Loopback stays open, so packages
that spin up their own fixture server (`speech`, `files`) are not false
positives — an earlier pass that blocked loopback too flagged both, and both are
hermetic.

Harness self-check — the pre-change spec under the same conditions reproduces
the exact CI failure from #1165:

```
× should test connection successfully
× should fetch weather forecasts for Calgary
× should respect limit option
Tests  3 failed | 6 passed (9)
```

After:

```
pnpm turbo run test --filter=@happyvertical/weather      # 32 passed | 20 skipped, network blocked
VITEST_INCLUDE_OPTIONAL=true …                           # 25 skipped, network blocked
ENVIRONMENT_CANADA_INTEGRATION=1 … test:optional         # 4 passed against the live API
pnpm test:ci-scripts                                     # 20 passed
pnpm agent:check                                         # clean
pnpm typecheck                                           # 20 tasks
pnpm build                                               # 32 tasks
biome check (changed files)                              # clean
```

## Sibling audit

Full suite with the network blocked: of the 32 package `test` tasks plus
weather's `test:optional`, **only `@happyvertical/translator` still fails
offline** — filed as #1167.

`@happyvertical/documents` was flagged as a suspect on the issue but is not one:
its PDF tests read local `file://` testdata under `packages/documents/testdata/`
and are already `it.skipIf(process.env.CI === 'true')`. It passes offline
(19 passed, 1 skipped).

## Review follow-up

`chatgpt-codex-connector` correctly flagged the new Testing section as
overstated. `google-weather.spec.ts` is a plain `*.spec.ts`, so it runs under
`test`, and its `describeWithKey` block calls `testConnection()` and the
forecast endpoint against the live Google Weather API whenever `GOOGLE_API_KEY`
is exported — which makes both "no test in `test` reaches the network" and "all
live coverage lives in `*.optional.test.ts`" false in that environment.

Fixed in the prose rather than by moving the file. A key-gated live suite in the
default `test` task is the convention this PR itself documents in `.github/CI.md`
("gate on a key where one exists"), the same way `OPENWEATHER_API_KEY` and
`KANIDM_SERVER_URL` gate their suites; the defect was the claim, not the
placement. `src/__tests__/fixtures/README.md` carried the same unqualified
sentence and is now scoped to the Environment Canada specs it documents.

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"claude","session":"4d153ad7-db62-4581-b06b-8f6d1fb27bf3","issue":"1165","policy_revision":"1.0.0","status":"complete","validation":["pnpm turbo run test --filter=@happyvertical/weather","pnpm test:ci-scripts","pnpm agent:check","pnpm typecheck","pnpm build","node scripts/sync-agent-context.js --check (review follow-up)"]}
