### PR TITLE
fix(cache): await cache directory creation before the first file write

### DIFF
--- a/packages/cache/src/env-config.integration.test.ts
+++ b/packages/cache/src/env-config.integration.test.ts
@@ -2,6 +2,9 @@
  * Integration tests for environment variable configuration in @happyvertical/cache
  */
 
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getCache } from './index';
 import type { CacheAdapter } from './shared/types';
@@ -10,18 +13,28 @@ describe('Cache Environment Variable Configuration', () => {
   // Store original env to restore after tests
   const originalEnv = { ...process.env };
 
-  beforeEach(() => {
+  // Each test gets its own directory outside the repository, so a failed
+  // assertion cannot leave a cache directory in the working tree and tests
+  // cannot collide over a shared cwd-relative path.
+  let scratchDir: string;
+  const cacheDir = (name: string) => join(scratchDir, name);
+
+  beforeEach(async () => {
     // Clear cache-related env vars before each test
     for (const key of Object.keys(process.env)) {
       if (key.startsWith('HAVE_CACHE_')) {
         delete process.env[key];
       }
     }
+
+    scratchDir = await mkdtemp(join(tmpdir(), 'have-cache-env-'));
   });
 
   afterEach(async () => {
     // Restore original env
     process.env = { ...originalEnv };
+
+    await rm(scratchDir, { recursive: true, force: true });
   });
 
   describe('memory provider configuration', () => {
@@ -98,15 +111,16 @@ describe('Cache Environment Variable Configuration', () => {
 
   describe('file provider configuration', () => {
     it('should create file cache from environment variables', async () => {
+      const dir = cacheDir('test-cache-env');
       process.env.HAVE_CACHE_PROVIDER = 'file';
-      process.env.HAVE_CACHE_CACHE_DIR = './test-cache-env';
+      process.env.HAVE_CACHE_CACHE_DIR = dir;
       process.env.HAVE_CACHE_NAMESPACE = 'file-test';
       process.env.HAVE_CACHE_COMPRESSION = 'true';
       process.env.HAVE_CACHE_DEFAULT_TTL = '300';
 
       const cache = await getCache({
         provider: 'file',
-        cacheDir: './test-cache-env',
+        cacheDir: dir,
       });
 
       await cache.set('file-key', { data: 'file-value' });
@@ -114,10 +128,6 @@ describe('Cache Environment Variable Configuration', () => {
       expect(result).toEqual({ data: 'file-value' });
 
       await cache.close();
-
-      // Cleanup
-      const fs = await import('node:fs/promises');
-      await fs.rm('./test-cache-env', { recursive: true, force: true });
     });
 
     it('should merge env vars with user options for file cache', async () => {
@@ -126,7 +136,7 @@ describe('Cache Environment Variable Configuration', () => {
 
       const cache = await getCache({
         provider: 'file',
-        cacheDir: './test-cache-merge',
+        cacheDir: cacheDir('test-cache-merge'),
         namespace: 'merge-test',
       });
 
@@ -134,10 +144,6 @@ describe('Cache Environment Variable Configuration', () => {
       expect(await cache.get('merge-key')).toBe('merge-value');
 
       await cache.close();
-
-      // Cleanup
-      const fs = await import('node:fs/promises');
-      await fs.rm('./test-cache-merge', { recursive: true, force: true });
     });
   });
 
@@ -197,17 +203,13 @@ describe('Cache Environment Variable Configuration', () => {
 
       const cache = await getCache({
         provider: 'file',
-        cacheDir: './test-cache-bool',
+        cacheDir: cacheDir('test-cache-bool'),
       });
 
       await cache.set('bool-test', 'bool-data');
       expect(await cache.get('bool-test')).toBe('bool-data');
 
       await cache.close();
-
-      // Cleanup
-      const fs = await import('node:fs/promises');
-      await fs.rm('./test-cache-bool', { recursive: true, force: true });
     });
 
     it('should handle false boolean values', async () => {
@@ -215,17 +217,13 @@ describe('Cache Environment Variable Configuration', () => {
 
       const cache = await getCache({
         provider: 'file',
-        cacheDir: './test-cache-no-compress',
+        cacheDir: cacheDir('test-cache-no-compress'),
       });
 
       await cache.set('no-compress', 'data');
       expect(await cache.get('no-compress')).toBe('data');
 
       await cache.close();
-
-      // Cleanup
-      const fs = await import('node:fs/promises');
-      await fs.rm('./test-cache-no-compress', { recursive: true, force: true });
     });
   });
 
@@ -349,24 +347,21 @@ describe('Cache Environment Variable Configuration', () => {
     });
 
     it('should support development file cache configuration', async () => {
+      const dir = cacheDir('dev-cache');
       process.env.HAVE_CACHE_PROVIDER = 'file';
-      process.env.HAVE_CACHE_CACHE_DIR = './dev-cache';
+      process.env.HAVE_CACHE_CACHE_DIR = dir;
       process.env.HAVE_CACHE_COMPRESSION = 'false'; // Fast dev mode
       process.env.HAVE_CACHE_DEFAULT_TTL = '300'; // 5 minutes
 
       const cache = await getCache({
         provider: 'file',
-        cacheDir: './dev-cache',
+        cacheDir: dir,
       });
 
       await cache.set('dev-key', { debug: true, data: 'test' });
       expect(await cache.get('dev-key')).toEqual({ debug: true, data: 'test' });
 
       await cache.close();
-
-      // Cleanup
-      const fs = await import('node:fs/promises');
-      await fs.rm('./dev-cache', { recursive: true, force: true });
     });
   });
 });

--- a/packages/cache/src/file.integration.test.ts
+++ b/packages/cache/src/file.integration.test.ts
@@ -2,18 +2,24 @@
  * Integration tests for File cache provider
  */
 
-import { rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getCache } from './index';
 import type { ICacheAdapter } from './shared/types';
 
 describe('File Cache Provider Integration', () => {
   let cache: ICacheAdapter;
-  const testCacheDir = './test-cache';
+  // Kept outside the repository so a failed assertion cannot leave a cache
+  // directory in the working tree.
+  let testRoot: string;
+  let testCacheDir: string;
 
   beforeEach(async () => {
-    // Clean up test directory
-    await rm(testCacheDir, { recursive: true, force: true });
+    testRoot = await mkdtemp(join(tmpdir(), 'have-cache-file-'));
+    testCacheDir = join(testRoot, 'test-cache');
 
     cache = await getCache({
       provider: 'file',
@@ -27,7 +33,7 @@ describe('File Cache Provider Integration', () => {
   afterEach(async () => {
     await cache.close();
     // Clean up test directory
-    await rm(testCacheDir, { recursive: true, force: true });
+    await rm(testRoot, { recursive: true, force: true });
   });
 
   describe('basic operations', () => {
@@ -89,7 +95,6 @@ describe('File Cache Provider Integration', () => {
       expect(result).toEqual(largeValue);
 
       await compressedCache.close();
-      await rm(`${testCacheDir}-compressed`, { recursive: true, force: true });
     });
   });
 
@@ -107,6 +112,117 @@ describe('File Cache Provider Integration', () => {
       expect(results.get('key1')).toBe('value1');
       expect(results.get('key2')).toBe('value2');
       expect(results.get('key3')).toBe('value3');
+    });
+  });
+
+  describe('cache directory initialization', () => {
+    it('creates the cache directory before the first write', async () => {
+      // The provider cannot await directory creation in its constructor, so a
+      // write issued immediately after must still wait for it.
+      //
+      // The nesting is load-bearing, and not because deeper paths are "slow":
+      // mkdir({recursive}) costs one round trip per missing level, while set()
+      // costs two before it writes (the readdir under evictIfNeeded, then
+      // writeFile). At one level mkdir wins the race and this test passes even
+      // with the bug present; at two or more it loses every time. Keep the
+      // depth here, or this stops testing anything.
+      const nested = join(testRoot, 'a', 'b', 'c', 'dev-cache');
+
+      const provider = await getCache({
+        provider: 'file',
+        cacheDir: nested,
+        compression: false,
+      });
+
+      try {
+        await provider.set('dev-key', { debug: true, data: 'test' });
+        expect(await provider.get('dev-key')).toEqual({
+          debug: true,
+          data: 'test',
+        });
+      } finally {
+        await provider.close();
+      }
+    });
+
+    it('surfaces a failed directory creation and retries once it clears', async () => {
+      // A path underneath a regular file can never be created (ENOTDIR). The
+      // constructor starts that mkdir and nothing awaits it, so without a
+      // handler the rejection escapes and Node terminates the process.
+      const obstruction = join(testRoot, 'obstruction');
+      await writeFile(obstruction, 'not a directory');
+
+      const provider = await getCache({
+        provider: 'file',
+        cacheDir: join(obstruction, 'cache'),
+        compression: false,
+      });
+
+      try {
+        await expect(provider.set('key', 'value')).rejects.toMatchObject({
+          code: 'INIT_ERROR',
+        });
+
+        // A failed creation must not latch: once the obstruction is gone the
+        // provider has to retry rather than replay the settled rejection.
+        await rm(obstruction, { force: true });
+
+        await provider.set('key', 'value');
+        expect(await provider.get('key')).toBe('value');
+      } finally {
+        await provider.close();
+      }
+    });
+
+    it('resolves a relative cache directory once, at construction', async () => {
+      // Every other test passes an absolute path. Round-tripping a value
+      // through a relative one is not enough to pin this: fs resolves a
+      // relative path against cwd on every call, so it behaves identically
+      // until cwd moves. What the constructor's resolve() actually buys is a
+      // path that stops depending on cwd, so assert the resolved path itself.
+      const dir = join(testRoot, 'relative-cache');
+
+      const provider = await getCache({
+        provider: 'file',
+        cacheDir: relative(process.cwd(), dir),
+        compression: false,
+      });
+
+      try {
+        await provider.set('relative-key', 'value');
+        expect(await provider.get('relative-key')).toBe('value');
+
+        const stats = await provider.getStats();
+        expect(stats.backend?.cacheDir).toBe(dir);
+      } finally {
+        await provider.close();
+      }
+
+      // Written through the relative path, readable at the absolute one.
+      expect(existsSync(dir)).toBe(true);
+    });
+
+    it('recreates the cache directory after clear removes it', async () => {
+      const dir = join(testRoot, 'cleared-cache');
+
+      const provider = await getCache({
+        provider: 'file',
+        cacheDir: dir,
+        compression: false,
+      });
+
+      try {
+        await provider.set('before', 'value');
+        await provider.clear();
+
+        // clear() deletes the directory itself, so the provider has to create
+        // it again rather than reusing its memoized initialization.
+        await provider.set('after', 'value');
+        expect(await provider.get('after')).toBe('value');
+        expect(await provider.get('before')).toBeUndefined();
+      } finally {
+        await provider.close();
+      }
     });
   });
 });

--- a/packages/cache/src/providers/file.ts
+++ b/packages/cache/src/providers/file.ts
@@ -53,6 +53,7 @@ export class FileProvider implements CacheProvider {
   private fileExtension: string;
   private checkPeriod: number;
   private checkInterval?: NodeJS.Timeout;
+  private cacheDirReady?: Promise<void>;
   private stats: {
     hits: number;
     misses: number;
@@ -73,7 +74,9 @@ export class FileProvider implements CacheProvider {
       evictions: 0,
     };
 
-    // Ensure cache directory exists
+    // Start creating the cache directory now so the first operation rarely has
+    // to wait. Every filesystem operation still awaits it, because the
+    // constructor cannot.
     this.ensureCacheDir();
 
     // Start background cleanup
@@ -133,6 +136,17 @@ export class FileProvider implements CacheProvider {
     if (!isValidKey(key)) {
       throw new CacheKeyError(key, 'file');
     }
+
+    // The only operation that creates a file from nothing, so the only one
+    // that can outrun directory creation. Reads tolerate a missing directory,
+    // and the write-backs in get()/touch() only run after a successful read,
+    // which already proves the directory exists. Any new operation that writes
+    // without reading first must await this too.
+    //
+    // This settles initialization, not the directory's continued existence:
+    // once creation has succeeded the memo is fulfilled, so a directory
+    // deleted externally afterwards is not recreated here.
+    await this.ensureCacheDir();
 
     const fullKey = formatKey(this.namespace, key);
     const filePath = this.getFilePath(fullKey);
@@ -234,6 +248,10 @@ export class FileProvider implements CacheProvider {
       // Clear all cache files
       try {
         await rm(this.cacheDir, { recursive: true, force: true });
+
+        // The directory this provider memoized no longer exists, so drop the
+        // memo and create it again rather than awaiting the settled promise.
+        this.cacheDirReady = undefined;
         await this.ensureCacheDir();
         this.stats.hits = 0;
         this.stats.misses = 0;
@@ -416,9 +434,30 @@ export class FileProvider implements CacheProvider {
   }
 
   /**
-   * Ensures cache directory exists
+   * Ensures cache directory exists.
+   *
+   * Creation is started once and memoized, so concurrent operations share a
+   * single `mkdir` and every caller awaits the same result. The constructor
+   * cannot await, so operations must: otherwise a write issued right after
+   * construction can reach `writeFile` before the directory exists and fail
+   * with ENOENT.
    */
-  private async ensureCacheDir(): Promise<void> {
+  private ensureCacheDir(): Promise<void> {
+    if (!this.cacheDirReady) {
+      this.cacheDirReady = this.createCacheDir();
+
+      // Keep a failed creation from surfacing as an unhandled rejection when
+      // the constructor kicks it off, and let a later operation retry it.
+      // Callers awaiting this promise still observe the error.
+      this.cacheDirReady.catch(() => {
+        this.cacheDirReady = undefined;
+      });
+    }
+
+    return this.cacheDirReady;
+  }
+
+  private async createCacheDir(): Promise<void> {
     try {
       await mkdir(this.cacheDir, { recursive: true });
     } catch (error: any) {
@@ -558,7 +597,9 @@ export class FileProvider implements CacheProvider {
    */
   private startCleanup(): void {
     this.checkInterval = setInterval(() => {
-      this.removeExpiredFiles();
+      // Background sweep: nothing awaits this, so swallow failures rather than
+      // letting them surface as an unhandled rejection in an unrelated caller.
+      this.removeExpiredFiles().catch(() => {});
     }, this.checkPeriod);
 
     // Don't block process exit


### PR DESCRIPTION
Resolves #1169

## What was wrong

`FileProvider`'s constructor started `ensureCacheDir()` but never awaited it
(`packages/cache/src/providers/file.ts:77`), so `new FileProvider(...)` returned
with an in-flight `mkdir`. `set()` performs exactly one awaited I/O op before it
writes:

```
set() -> evictIfNeeded() -> getStats() -> getAllFiles() -> readdir(cacheDir)  // ENOENT -> [], fast
      -> writeEntry() -> writeFile(filePath)                                   // ENOENT if mkdir has not landed
```

`getAllFiles()` swallows `ENOENT` and returns `[]`, so the race window is a
single fast-failing `readdir` round trip. Under contended I/O the unawaited
`mkdir` loses and the write fails with `ENOENT`.

That is the intermittent `@happyvertical/cache#test` failure that ejected
unrelated PRs from the merge queue. When it fires, `github-merge-queue[bot]`
removes the PR with no review comment, so it reads as that PR's own defect — it
cost #1168 a full queue cycle. It is merge-queue-only because the exhaustive
release-confidence suite runs many packages concurrently; the PR-level run only
covers Turbo's affected closure.

Ruled out: a shared adapter (`getCache` builds a fresh provider per call), a
sibling test removing the directory (`./dev-cache` was used by one test, and
`resolve()` snapshots the path at construction), and parallel execution
(`vitest.shared.ts` sets `fileParallelism: false`, `maxWorkers: 1`).

Reproduced deterministically at 200/200 with the byte-identical error message.

## What changed

Memoize the directory-creation promise and await it in `set()` — the only
operation that creates a file without first reading one. Reads already tolerate
a missing directory, and the write-backs in `get()`/`touch()` run only after a
successful `readFile`, which already proves the directory exists.

`clear()` deletes the cache directory itself, so it drops the memo before
recreating it rather than awaiting the settled promise.

Two fire-and-forget rejections are now handled: the constructor's floating
`ensureCacheDir()` and the unawaited `removeExpiredFiles()` in `startCleanup()`.
Both could surface as unhandled rejections that Vitest attributes to whichever
unrelated test was running; under Node's default `--unhandled-rejections=throw`
the former terminated the process.

Tests move from cwd-relative cache directories to per-test `os.tmpdir()` ones,
so a failed assertion can no longer leave a cache directory in the working tree.

### Behavior changes

- `set()`/`setMany()` on a directory that cannot be created now throw
  `CacheError` `INIT_ERROR`, replacing `LIST_ERROR` under ENOTDIR and
  `CacheSerializationError` under EACCES. `INIT_ERROR` is not new — the
  constructor previously turned it into an unhandled rejection instead of
  surfacing it, and the README documents `CacheSerializationError` as a
  serialize/deserialize failure, which a filesystem error never was.
- A provider whose first `mkdir` failed is no longer permanently unable to
  write; it retries once the condition clears.

Every read-path error code is unchanged, verified pre- vs post-fix across seven
filesystem scenarios: `get`→`READ_ERROR`, `has`→`CHECK_ERROR`,
`keys`/`getStats`→`LIST_ERROR`, `delete`→`DELETE_ERROR`, `clear`→`CLEAR_ERROR`,
`touch`→`TOUCH_ERROR`. `FileProvider` is not exported, so there is no public API
change.

An earlier revision of this fix awaited in all eight filesystem methods. That
changed those read-path codes to `INIT_ERROR` without fixing anything, so it was
narrowed to `set()` alone.

## Tests

Every part of the fix is pinned by a test that fails without it:

| Removed from the fix | Failing tests |
|---|---|
| the whole change | 2 |
| `set()`'s `await ensureCacheDir()` | 2 |
| the `.catch()` guard | 1 |
| `clear()`'s memo invalidation | 1 |
| `resolve(options.cacheDir)` | 1 |

The race test's directory nesting is load-bearing and commented as such: `mkdir`
costs one round trip per missing level against `set()`'s two before `writeFile`,
so at one level the test passes even with the bug present (measured 0/50 and
1/200 in two independent runs), and at two or more it fails every time. The
depth must not be trimmed.

## Validation

```
pnpm turbo run test --filter=@happyvertical/cache   # 46 passed, 14 skipped
pnpm test:ci-scripts                                # 28 passed
pnpm agent:check
pnpm typecheck                                      # 20/20
pnpm lint
pnpm build                                          # 32/32
```

Biome reports the same 34 warnings before and after the change.

## Follow-up

`s3.ts` and `redis.ts` guard lazy init with a boolean set only after the awaited
work, so concurrent first calls each run initialization — a first `getMany()`
on a fresh S3 provider leaks clients, and two concurrent first Redis ops fail
with "Socket already opened". Out of scope here; filed separately.

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"claude","session":"858ed521-febe-45e3-9289-ea902474ff25","issue":"1169","policy_revision":"1.0.0","status":"complete","validation":["pnpm turbo run test --filter=@happyvertical/cache","pnpm test:ci-scripts","pnpm agent:check","pnpm typecheck","pnpm lint","pnpm build"]}
