### PR TITLE
fix(ci): stop a second merge to main cancelling an in-flight publish

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -10,6 +10,13 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Pull-request validation: a newer push supersedes the older run. Keyed on the
+# pull-request number so successive pushes to the same Dependabot branch
+# collide instead of each holding a runner slot.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependabot:
     name: Dependabot Automation

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -7,8 +7,19 @@ on:
 concurrency:
   # Keep release-generated pushes from cancelling the original merge-to-main run
   # that created them. Those follow-up runs are intentionally skipped below.
+  # The github.sha key is deliberate here: it is unique per push, so a release
+  # commit lands in its own group and can never contend with anything.
   group: "${{ startsWith(github.event.head_commit.message, 'chore(release): v') && format('on-merge-main-release-{0}', github.sha) || 'on-merge-main' }}"
-  cancel-in-progress: true
+  # Never cancel a RUNNING release. This workflow orchestrates
+  # test -> build -> publish, so cancelling it can abort a release mid-flight —
+  # between `npm publish`, `git tag -f`, `git push origin HEAD:main`, and
+  # `gh release create` — and leave the registry or the tag half-written.
+  # Successive merges to main queue behind the running one instead; a slow
+  # release beats a torn one. Note GitHub still keeps only one *pending* run per
+  # group, so a third merge evicts the queued second one — that costs an
+  # intermediate commit its CI record, but the release itself is not lost,
+  # because changesets accumulate and the surviving run publishes from HEAD.
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
Closes #1175. Part of happyvertical/.github#104 — org-wide CI concurrency audit, cutting `arc-happyvertical` queue wait (77% of self-hosted CI wall time is queue wait against a ~12-slot pool).

## Headline finding

**`on-merge-main.yml` was cancelling its own releases.** It declared `cancel-in-progress: true` against a group that, for any ordinary commit, collapses to the constant string `'on-merge-main'`. Every non-release push to main therefore shared one group and cancelled its predecessor.

That workflow orchestrates test → build → publish through `shared-merge-orchestrator.yml`, so the cancelled run could be anywhere inside the release: between `npm publish` and `git tag -f`, or before `git push origin HEAD:main` and `gh release create`. Cancelling there leaves the registry or the tag half-written — the exact hazard that argues for queueing publish work. This is the "present but wrongly scoped" case the epic asked us to hunt for; it looked correct and was actively unsafe.

Now `cancel-in-progress: false`. The `github.sha` key in the release branch of the expression is **deliberate and left as-is** — a SHA is unique per push, which is precisely what gives a release commit its own group so it can never contend with the merge run that produced it. Only the cancellation policy was wrong.

Honest residual, recorded in the comment: GitHub keeps only one *pending* run per group, so a third merge evicts the queued second one. That costs an intermediate commit its CI record, but the release is not lost — the publish checks out the `refs/heads/main` tip and changesets accumulate, so the surviving run publishes from HEAD.

## Also

`dependabot-automation.yml` (`pull_request_target`) had no group; added one keyed on the pull-request number. Cancelling is safe: the job only approves, and merging still requires the full set of required checks.

## Workflow classification

All 16 workflows classified explicitly.

| Workflow | Triggers | Class | Action |
|---|---|---|---|
| `agent-policy.yml` | PR, merge_group, dispatch | validation-cancels | already correct |
| `dependabot-automation.yml` | pull_request_target | validation-cancels | **added** |
| `on-pull-request.yml` | pull_request_target, merge_group | validation-cancels | already correct |
| `on-merge-main.yml` | push main | mutating-queues | **fixed — was cancelling publishes** |
| `publish.yml` | workflow_call, dispatch | mutating-queues | already correct (job-level `release-publish-*`) |
| `build-json-native.yml` | workflow_call, dispatch | excluded (reusable) | none — gap filed as #1176 |
| `build.yml` | workflow_call, dispatch | excluded (reusable) | none |
| `postgres-tests.yml` | workflow_call, dispatch, schedule | excluded (reusable) | none |
| `publish-dry-run.yml` | workflow_call, dispatch | excluded (reusable) | none |
| `shared-direct-publish.yml` | workflow_call | excluded (reusable) | none |
| `shared-merge-orchestrator.yml` | workflow_call | excluded (reusable) | none |
| `shared-project-sync.yml` | workflow_call | excluded (reusable) | none |
| `test.yml` | workflow_call, dispatch | excluded (reusable) | none |
| `node-runner-smoke.yml` | dispatch | excluded (dispatch-only) | none |
| `on-issue-closed.yml` | issues | excluded (issue event) | none |
| `on-issue-opened.yml` | issues | excluded (issue event) | none |

Counts: 3 cancel (1 added, 2 already correct), 2 queue (1 fixed wrongly-scoped, 1 already correct), 11 excluded.

## Why reusable workflows are excluded

Nine of sixteen are `workflow_call`. A called workflow's top-level `concurrency` group is evaluated in the **caller's** context (`github.workflow` is the caller's name), so a `${{ github.workflow }}-${{ github.ref }}` group can resolve to the same string as its caller and deadlock — the callee queues behind a slot its own caller holds. Cancellation already propagates from caller to callee. Verified no deadlock for the changed caller: `on-merge-main`'s group is `on-merge-main`; its callees declare only the disjoint job-level `release-publish-*`.

## Found but deliberately not fixed here

Two publish paths mutate external state with no concurrency group — `publish.yml`'s `deploy-docs` (GitHub Pages; smrt already guards its equivalent with `group: 'pages'`) and `build-json-native.yml` (`npm publish`). Both are pre-existing, outside this issue's scope, and the second carries a behaviour change to error handling, so they are filed as **#1176** rather than bundled here.

## Validation

- `actionlint` on both changed files: clean.
- YAML parsed and the resolved `concurrency` mapping asserted.
- `commitlint` passed via the repo's lefthook `commit-msg` hook (scope `ci` is in this repo's `scope-enum`).

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude",
  "session": "dd233d07-ae14-43c0-bfec-b4f99514936a",
  "issue": "https://github.com/happyvertical/sdk/issues/1175",
  "policy_revision": "1.0.0",
  "validation": [
    "re-lifecycled after happyvertical/.github#105 repaired main; branch updated onto the fixed base",
    "actionlint on both changed files: clean",
    "yaml.safe_load parse + resolved concurrency assertion",
    "commitlint via lefthook commit-msg"
  ]
}
```

