### PR TITLE
feat(ai): add async video-generation jobs across providers

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,6 +1,6 @@
 # @happyvertical/ai
 
-Unified interface for AI model interactions across multiple providers. Supports OpenAI, LiteLLM, Bifrost, Ollama, Anthropic Claude, Google Gemini, AWS Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS with a consistent API for chat, completions, embeddings, streaming, function calling, image operations, text-to-speech, and gateway admin provisioning where available.
+Unified interface for AI model interactions across multiple providers. Supports OpenAI, LiteLLM, Bifrost, Ollama, Anthropic Claude, Google Gemini, AWS Bedrock, Hugging Face, Claude CLI, Qwen3-TTS, and video-generation providers (Gemini Veo, BytePlus ModelArk/Seedance, OpenAI-compatible `/v1/videos` gateways) with a consistent API for chat, completions, embeddings, streaming, function calling, image operations, asynchronous video generation, text-to-speech, and gateway admin provisioning where available.
 
 ## Installation
 
@@ -99,7 +99,86 @@ const cli = await getAI({ type: 'claude-cli', defaultModel: 'sonnet' });
 
 // Qwen3-TTS (text-to-speech only)
 const tts = await getAI({ type: 'qwen3-tts', endpoint: 'http://localhost:8880' });
+
+// BytePlus ModelArk / Seedance (video generation only)
+const modelark = await getAI({
+  type: 'byteplus-modelark',
+  apiKey: process.env.MODELARK_API_KEY!, // or ARK_API_KEY
+});
+
+// OpenAI-compatible /v1/videos gateway (video generation only)
+const video = await getAI({
+  type: 'openai-compat-video',
+  baseUrl: process.env.OPENAI_COMPAT_VIDEO_BASE_URL || 'https://llm.happyvertical.com/v1',
+  apiKey: process.env.OPENAI_COMPAT_VIDEO_API_KEY!,
+});
 ```
+
+## Video Generation
+
+Video generation is asynchronous: `submitVideoGenerationJob` returns a JSON-serializable
+handle immediately, and the render itself runs as a provider-side job that you poll with
+`getVideoGenerationJob`. Persist the handle (it has no closures or client instances) to
+resume polling after a restart, and always call `cancelVideoGenerationJob` on abort so you
+are not billed for orphaned renders.
+
+```typescript
+const ai = await getAI({ type: 'gemini', apiKey: process.env.GEMINI_API_KEY! });
+
+const job = await ai.submitVideoGenerationJob({
+  prompt: 'A drone shot flying over a coastal cliff at sunrise',
+  durationSeconds: 8,
+  resolution: '1080p',
+  aspectRatio: '16:9',
+});
+
+// Persist `job` (plain JSON) and resume polling later, even after a process restart.
+let status = await ai.getVideoGenerationJob(job);
+while (status.status === 'queued' || status.status === 'running') {
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  status = await ai.getVideoGenerationJob(job);
+}
+
+if (status.status === 'succeeded') {
+  const result = await ai.fetchVideoGenerationResult(job);
+  if (result.data) fs.writeFileSync('output.mp4', result.data);
+}
+
+// On abort/step cancellation (best-effort — see below):
+await ai.cancelVideoGenerationJob(job).catch((error) => {
+  console.warn('Could not cancel video job', job.jobId, error);
+});
+```
+
+Supported providers: `gemini` (Veo, via `@google/genai` long-running operations),
+`byteplus-modelark` (Seedance, raw-HTTP ModelArk task API), and `openai-compat-video`
+(thin adapter over a `/v1/videos`-shaped REST surface — LiteLLM's Veo passthrough,
+Sora-shaped gateways). Providers without video support throw `NOT_IMPLEMENTED`, and
+`ai.getCapabilities()` reports `videoGeneration: false` for them.
+
+**Cancellation is best-effort, not a guarantee.** Gemini has no cancel endpoint for
+video-generation operations at all and always throws; ModelArk can only cancel a task
+that hasn't started rendering yet (`queued`) and rejects cancellation of a `running`
+one. Callers must catch and tolerate a `cancelVideoGenerationJob` failure rather than
+treating it as fatal.
+
+`byteplus-modelark` locally throttles `submitVideoGenerationJob` to approximate
+Seedance's documented account limits (QPS 2, small burst / 3 concurrent
+*submissions* — pass `rateLimit: { requestsPerMinute, maxConcurrent }` to override the
+defaults). This limiter is shared across provider instances constructed with the same
+`apiKey`, since a fresh instance is often constructed per pipeline step. It bounds
+concurrent submit HTTP requests, not the lifetime of the render tasks those
+submissions create — ModelArk doesn't expose a way to observe when a task actually
+finishes rendering, so task-lifetime concurrency isn't tracked. `submitVideoGenerationJob`
+is also registered with the shared [rate-limit pacing wrapper](#opt-in-rate-limit-pacing),
+so `rateLimit.enabled` works the same way it does for `chat`.
+
+Every provider exposes a cheap `validateVideoGenerationAccess()` auth-shaped check
+(a low-cost call — the exact shape is provider-specific: a model/task list for
+Gemini/ModelArk, a single-resource probe for `openai-compat-video` since LiteLLM's
+list route requires a parameter this generic adapter can't supply). It is not free —
+callers on a hot path must cache the result themselves rather than calling it on every
+iteration.
 
 ## Gateway Admin
 
@@ -300,6 +379,8 @@ for (const site of sites) {
 - `GEMINI_API_KEY`, `GOOGLE_API_KEY`
 - `HF_TOKEN`
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`
+- `MODELARK_API_KEY` / `ARK_API_KEY`, `MODELARK_BASE_URL`
+- `OPENAI_COMPAT_VIDEO_BASE_URL`, `OPENAI_COMPAT_VIDEO_API_KEY`
 
 ## API Overview
 
@@ -322,6 +403,11 @@ All providers implement `AIInterface`:
 | `embedImage(image, options?)` | Image embeddings (Gemini and Bedrock native, OpenAI and Ollama via describe-then-embed) |
 | `describeImage(image, prompt?, options?)` | Image description via vision models |
 | `generateImage(prompt, options?)` | Image generation (DALL-E, Imagen, Titan Image Generator, Ollama-compatible image models) |
+| `submitVideoGenerationJob(options)` | Submit an async video-generation job, returning a serializable handle |
+| `getVideoGenerationJob(handle)` | Poll job status (`queued`\|`running`\|`succeeded`\|`failed`\|`cancelled`) |
+| `fetchVideoGenerationResult(handle)` | Fetch the generated video once the job has succeeded |
+| `cancelVideoGenerationJob(handle)` | Cancel an in-flight video-generation job |
+| `validateVideoGenerationAccess()` | Cheap auth-shaped check for video-generation access (cache the result) |
 | `countTokens(text)` | Token count estimation |
 | `getModels()` | List available models |
 | `getCapabilities()` | Query provider capabilities |

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./node": {
+      "import": "./dist/node.js",
+      "types": "./dist/node.d.ts"
     }
   },
   "bin": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@happyvertical/ai",
   "version": "0.85.4",
-  "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, and Qwen3-TTS",
+  "description": "Standardized AI interface supporting OpenAI, LiteLLM, Bifrost, Ollama, Anthropic, Gemini, Bedrock, Hugging Face, Claude CLI, Qwen3-TTS, and async video generation (Veo, Seedance, OpenAI-compatible)",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ai/src/byteplus-modelark.integration.test.ts
+++ b/packages/ai/src/byteplus-modelark.integration.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Live integration tests for the BytePlus ModelArk (Seedance) video-generation
+ * provider.
+ *
+ * The endpoint paths, request/response field names, and the
+ * `queued|running|cancelled|succeeded|failed|expired` status enum used by
+ * `byteplus-modelark.ts` were confirmed against BytePlus's own published
+ * docs and blog examples, but the `expired` status, the list query params,
+ * and the DELETE-as-cancel-or-delete semantics have not been exercised
+ * against a live account by the rest of this package's test suite (which
+ * mocks `fetch`). These tests corroborate the parts that are cheap and safe
+ * to exercise for real — access validation, task creation, status
+ * retrieval, and cancelling a still-queued task — without waiting for or
+ * paying for a full render.
+ *
+ * Skipped unless `MODELARK_API_KEY` (or `ARK_API_KEY`) is available in the
+ * environment, matching this package's existing skipped-integration-test
+ * pattern (see `litellm.integration.test.ts`, `ollama.integration.test.ts`).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getAI } from './index';
+
+const apiKey = process.env.MODELARK_API_KEY || process.env.ARK_API_KEY;
+const baseUrl = process.env.MODELARK_BASE_URL;
+
+describe('BytePlus ModelArk Integration Tests', () => {
+  it.skipIf(!apiKey)(
+    'should validate access against the real ModelArk task-list endpoint',
+    async () => {
+      const client = await getAI({
+        type: 'byteplus-modelark',
+        apiKey,
+        baseUrl,
+      });
+
+      await expect(client.validateVideoGenerationAccess()).resolves.toBe(true);
+    },
+    30000,
+  );
+
+  it.skipIf(!apiKey)(
+    'should submit a task, retrieve its status, and cancel it while still queued',
+    async () => {
+      const client = await getAI({
+        type: 'byteplus-modelark',
+        apiKey,
+        baseUrl,
+      });
+
+      // Cheapest supported configuration: short duration, small resolution.
+      const job = await client.submitVideoGenerationJob({
+        prompt: '@happyvertical/ai integration test — safe to discard',
+        durationSeconds: 4,
+        resolution: '480p',
+      });
+
+      expect(job.jobId).toBeTruthy();
+      expect(job.provider).toBe('byteplus-modelark');
+
+      const status = await client.getVideoGenerationJob(job);
+      expect(['queued', 'running', 'succeeded']).toContain(status.status);
+
+      // Cancellation is best-effort: ModelArk only cancels a task that is
+      // still queued and rejects cancellation of one that has already
+      // started rendering, so tolerate either outcome rather than
+      // asserting cancellation always succeeds.
+      try {
+        await client.cancelVideoGenerationJob(job);
+      } catch (_error) {
+        // Acceptable: the task had already moved past 'queued' by the
+        // time cancellation was attempted.
+      }
+    },
+    30000,
+  );
+});

--- a/packages/ai/src/integration.test.ts
+++ b/packages/ai/src/integration.test.ts
@@ -116,6 +116,7 @@ describe('HuggingFace Provider Integration', () => {
       fineTuning: true,
       imageEmbeddings: false,
       imageGeneration: false,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,

--- a/packages/ai/src/node.ts
+++ b/packages/ai/src/node.ts
@@ -1,0 +1,28 @@
+/**
+ * Node.js-enhanced entry point for @happyvertical/ai
+ *
+ * Re-exports everything from the universal entry point (`.`), but replaces
+ * `getAIAuto` with the Node-aware version from `./node/factory`, which
+ * additionally auto-detects providers from process.env — including
+ * provider-specific variables the universal (`HAVE_AI_*`-only) `getAIAuto`
+ * does not check, such as `LITELLM_BASE_URL`, `BIFROST_BASE_URL`,
+ * `OLLAMA_HOST`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `HF_TOKEN`,
+ * `AWS_*`, `MODELARK_API_KEY` / `ARK_API_KEY`, and
+ * `OPENAI_COMPAT_VIDEO_BASE_URL`.
+ *
+ * The default `.` entry point stays universal/browser-safe (it must not
+ * reference `process.env` directly for provider-specific detection); import
+ * from `@happyvertical/ai/node` in Node.js contexts that want the fuller
+ * auto-detection.
+ *
+ * @example
+ * ```typescript
+ * import { getAIAuto } from '@happyvertical/ai/node';
+ *
+ * // Resolves to byteplus-modelark from MODELARK_API_KEY alone, which the
+ * // universal getAIAuto (imported from '@happyvertical/ai') cannot do.
+ * const client = await getAIAuto({});
+ * ```
+ */
+export * from './index';
+export { getAIAuto } from './node/factory';

--- a/packages/ai/src/node/factory.ts
+++ b/packages/ai/src/node/factory.ts
@@ -12,11 +12,13 @@ import type {
   AnthropicOptions,
   BedrockOptions,
   BifrostOptions,
+  ByteplusModelArkOptions,
   GeminiOptions,
   GetAIOptions,
   HuggingFaceOptions,
   LiteLLMOptions,
   OllamaOptions,
+  OpenAICompatVideoOptions,
   OpenAIOptions,
 } from '../shared/types';
 import { AI_PROVIDER_TYPES } from '../shared/types';
@@ -41,6 +43,15 @@ export { getAI } from '../shared/factory';
  * - GEMINI_API_KEY / GOOGLE_API_KEY → Gemini-specific key
  * - HF_TOKEN → Hugging Face token
  * - AWS_* → AWS Bedrock credentials
+ * - OPENAI_COMPAT_VIDEO_BASE_URL / OPENAI_COMPAT_VIDEO_API_KEY → openai-compat-video gateway config (checked last)
+ * - MODELARK_API_KEY / ARK_API_KEY / MODELARK_BASE_URL → BytePlus ModelArk (Seedance) config (checked last)
+ *
+ * The two video-only provider types above are intentionally checked *after*
+ * every general-purpose provider: they throw `NOT_IMPLEMENTED` for chat()
+ * and everything else, so their env signals must never hijack a bare
+ * `getAIAuto()` call away from a general-purpose provider. Prefer explicit
+ * `type: 'byteplus-modelark'` / `type: 'openai-compat-video'` when you want
+ * one of these on purpose.
  *
  * @param options - Configuration options that may contain provider-specific credentials
  * @returns Promise resolving to an AI provider instance
@@ -92,6 +103,25 @@ export async function getAIAuto(
 
   // If type is specified (either from options or env vars), use getAI directly
   if (config.type) {
+    if (config.type === 'byteplus-modelark') {
+      return getAIUniversal({
+        ...config,
+        apiKey:
+          config.apiKey ||
+          process.env.MODELARK_API_KEY ||
+          process.env.ARK_API_KEY,
+        baseUrl: config.baseUrl || process.env.MODELARK_BASE_URL,
+      } as ByteplusModelArkOptions);
+    }
+
+    if (config.type === 'openai-compat-video') {
+      return getAIUniversal({
+        ...config,
+        apiKey: config.apiKey || process.env.OPENAI_COMPAT_VIDEO_API_KEY,
+        baseUrl: config.baseUrl || process.env.OPENAI_COMPAT_VIDEO_BASE_URL,
+      } as OpenAICompatVideoOptions);
+    }
+
     if (config.type === 'bifrost') {
       const resolvedAdminUrl =
         callerAdminUrl ||
@@ -245,6 +275,45 @@ export async function getAIAuto(
     return getAIUniversal(bedrockOptions);
   }
 
+  // Video-only provider detection runs last, deliberately after every
+  // general-purpose provider check above: these providers throw
+  // NOT_IMPLEMENTED for chat() and every other non-video method, so a bare
+  // getAIAuto() must never let a video-only credential (e.g. MODELARK_API_KEY
+  // set alongside OPENAI_API_KEY for an unrelated pipeline step) hijack
+  // selection away from a general-purpose provider. Explicit
+  // `type: 'byteplus-modelark'` / `type: 'openai-compat-video'` selection is
+  // the intended way to reach these providers; auto-detection is a
+  // last-resort fallback for when nothing general-purpose matches.
+  const hasModelArkSignal = Boolean(
+    process.env.MODELARK_API_KEY ||
+      process.env.ARK_API_KEY ||
+      process.env.MODELARK_BASE_URL,
+  );
+  const hasOpenAICompatVideoSignal = Boolean(
+    process.env.OPENAI_COMPAT_VIDEO_BASE_URL,
+  );
+
+  if (hasModelArkSignal && !config.type) {
+    return getAIUniversal({
+      ...config,
+      type: 'byteplus-modelark',
+      apiKey:
+        config.apiKey ||
+        process.env.MODELARK_API_KEY ||
+        process.env.ARK_API_KEY,
+      baseUrl: config.baseUrl || process.env.MODELARK_BASE_URL,
+    } as ByteplusModelArkOptions);
+  }
+
+  if (hasOpenAICompatVideoSignal && !config.type) {
+    return getAIUniversal({
+      ...config,
+      type: 'openai-compat-video',
+      apiKey: config.apiKey || process.env.OPENAI_COMPAT_VIDEO_API_KEY,
+      baseUrl: config.baseUrl || process.env.OPENAI_COMPAT_VIDEO_BASE_URL,
+    } as OpenAICompatVideoOptions);
+  }
+
   throw new ValidationError(
     'Could not auto-detect AI provider from options or environment',
     {
@@ -267,6 +336,11 @@ export async function getAIAuto(
         'HF_TOKEN',
         'AWS_ACCESS_KEY_ID',
         'AWS_DEFAULT_REGION',
+        'OPENAI_COMPAT_VIDEO_BASE_URL',
+        'OPENAI_COMPAT_VIDEO_API_KEY',
+        'MODELARK_API_KEY',
+        'ARK_API_KEY',
+        'MODELARK_BASE_URL',
       ],
     },
   );

--- a/packages/ai/src/providers.test.ts
+++ b/packages/ai/src/providers.test.ts
@@ -66,6 +66,7 @@ describe('OpenAI Provider', () => {
       fineTuning: true,
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -129,6 +130,7 @@ describe('LiteLLM Provider', () => {
       fineTuning: false,
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -512,6 +514,7 @@ describe('Bifrost Provider', () => {
       fineTuning: false,
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -714,6 +717,7 @@ describe('Ollama Provider', () => {
       fineTuning: false,
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -1065,7 +1069,7 @@ describe('Ollama Provider', () => {
 
       expect(result.images).toHaveLength(1);
       expect(Buffer.isBuffer(result.images[0]?.data)).toBe(true);
-      expect((result.images[0]?.data as Buffer).toString()).toBe('image-bytes');
+      expect((result.images[0]!.data as Buffer).toString()).toBe('image-bytes');
     } finally {
       global.fetch = originalFetch;
     }
@@ -1164,6 +1168,7 @@ describe('Gemini Provider', () => {
       fineTuning: false,
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: true,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -1177,6 +1182,7 @@ describe('Gemini Provider', () => {
         'vision',
         'image_embedding',
         'image_generation',
+        'video_generation',
       ],
     });
   });
@@ -1302,6 +1308,7 @@ describe('Bedrock Provider', () => {
       fineTuning: true,
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -1541,6 +1548,7 @@ describe('Claude CLI Provider', () => {
       fineTuning: false,
       imageEmbeddings: false,
       imageGeneration: false,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,

--- a/packages/ai/src/shared/factory.ts
+++ b/packages/ai/src/shared/factory.ts
@@ -14,12 +14,14 @@ import type {
   AnthropicOptions,
   BedrockOptions,
   BifrostOptions,
+  ByteplusModelArkOptions,
   ClaudeCliOptions,
   GeminiOptions,
   GetAIOptions,
   HuggingFaceOptions,
   LiteLLMOptions,
   OllamaOptions,
+  OpenAICompatVideoOptions,
   OpenAIOptions,
   Qwen3TTSOptions,
 } from './types';
@@ -140,6 +142,28 @@ function isQwen3TTSOptions(
 }
 
 /**
+ * Checks if the options are for the OpenAI-compatible video-generation provider
+ * @param options - The AI provider options to check
+ * @returns True if options are for the openai-compat-video provider
+ */
+function isOpenAICompatVideoOptions(
+  options: GetAIOptions | AIClientOptions,
+): options is OpenAICompatVideoOptions {
+  return options.type === 'openai-compat-video';
+}
+
+/**
+ * Checks if the options are for the BytePlus ModelArk (Seedance) provider
+ * @param options - The AI provider options to check
+ * @returns True if options are for the byteplus-modelark provider
+ */
+function isByteplusModelArkOptions(
+  options: GetAIOptions | AIClientOptions,
+): options is ByteplusModelArkOptions {
+  return options.type === 'byteplus-modelark';
+}
+
+/**
  * Creates an AI provider instance based on the provided options.
  * Universal version that works in both browser and Node.js environments.
  *
@@ -253,6 +277,16 @@ export async function getAI(
   } else if (isQwen3TTSOptions(options)) {
     const { Qwen3TTSProvider } = await import('./providers/qwen-tts.js');
     client = new Qwen3TTSProvider(options);
+  } else if (isOpenAICompatVideoOptions(options)) {
+    const { OpenAICompatVideoProvider } = await import(
+      './providers/openai-compat-video.js'
+    );
+    client = new OpenAICompatVideoProvider(options);
+  } else if (isByteplusModelArkOptions(options)) {
+    const { ByteplusModelArkProvider } = await import(
+      './providers/byteplus-modelark.js'
+    );
+    client = new ByteplusModelArkProvider(options);
   } else {
     throw new ValidationError('Unsupported AI provider type', {
       supportedTypes: [...AI_PROVIDER_TYPES],

--- a/packages/ai/src/shared/providers/anthropic.ts
+++ b/packages/ai/src/shared/providers/anthropic.ts
@@ -32,6 +32,10 @@ import type {
   TokenUsage,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -540,6 +544,7 @@ export class AnthropicProvider implements AIInterface {
       fineTuning: false,
       imageEmbeddings: false,
       imageGeneration: false,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -552,6 +557,57 @@ export class AnthropicProvider implements AIInterface {
         'vision',
       ],
     };
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Not supported - use gemini, byteplus-modelark,
+  // or openai-compat-video provider)
+  // ============================================================================
+
+  async submitVideoGenerationJob(
+    _options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    throw new AIError(
+      'Video generation is not supported by Anthropic provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'anthropic',
+    );
+  }
+
+  async getVideoGenerationJob(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    throw new AIError(
+      'Video generation is not supported by Anthropic provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'anthropic',
+    );
+  }
+
+  async fetchVideoGenerationResult(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    throw new AIError(
+      'Video generation is not supported by Anthropic provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'anthropic',
+    );
+  }
+
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      'Video generation is not supported by Anthropic provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'anthropic',
+    );
+  }
+
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    throw new AIError(
+      'Video generation is not supported by Anthropic provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'anthropic',
+    );
   }
 
   // ============================================================================

--- a/packages/ai/src/shared/providers/bedrock.ts
+++ b/packages/ai/src/shared/providers/bedrock.ts
@@ -28,6 +28,10 @@ import type {
   TokenUsage,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -658,6 +662,7 @@ export class BedrockProvider implements AIInterface {
       fineTuning: true, // Via Bedrock fine-tuning
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -673,6 +678,57 @@ export class BedrockProvider implements AIInterface {
         'image_generation',
       ],
     };
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Not supported - use gemini, byteplus-modelark,
+  // or openai-compat-video provider)
+  // ============================================================================
+
+  async submitVideoGenerationJob(
+    _options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    throw new AIError(
+      'Video generation is not supported by Bedrock provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'bedrock',
+    );
+  }
+
+  async getVideoGenerationJob(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    throw new AIError(
+      'Video generation is not supported by Bedrock provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'bedrock',
+    );
+  }
+
+  async fetchVideoGenerationResult(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    throw new AIError(
+      'Video generation is not supported by Bedrock provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'bedrock',
+    );
+  }
+
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      'Video generation is not supported by Bedrock provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'bedrock',
+    );
+  }
+
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    throw new AIError(
+      'Video generation is not supported by Bedrock provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'bedrock',
+    );
   }
 
   // ============================================================================

--- a/packages/ai/src/shared/providers/bifrost.ts
+++ b/packages/ai/src/shared/providers/bifrost.ts
@@ -35,6 +35,7 @@ const BIFROST_CAPABILITIES: AICapabilities = {
   fineTuning: false,
   imageEmbeddings: true,
   imageGeneration: true,
+  videoGeneration: false,
   tts: false,
   voiceCloning: false,
   voiceDesign: false,

--- a/packages/ai/src/shared/providers/byteplus-modelark.ts
+++ b/packages/ai/src/shared/providers/byteplus-modelark.ts
@@ -105,6 +105,30 @@ interface ModelArkTaskResponse {
 }
 
 /**
+ * Resolve after `ms` milliseconds, or as soon as `signal` aborts —
+ * whichever comes first. Never rejects; callers re-check `signal.aborted`
+ * themselves immediately after, so a single check covers both "timed out
+ * normally" and "woke up early because of an abort."
+ */
+function delayOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
  * Local token-bucket + concurrency limiter for submit-time throttling.
  *
  * ModelArk documents Seedance account limits of QPS 2 / 3 *concurrent
@@ -140,7 +164,34 @@ class SubmitRateLimiter {
     this.maxConcurrent = options.maxConcurrent ?? 3;
   }
 
-  async acquire(): Promise<void> {
+  /**
+   * Acquire a submit slot + token, honoring `signal` throughout the wait.
+   *
+   * The concurrency slot and the token are checked and committed together
+   * in one synchronous section (no `await` between the check and the
+   * `tokens -=`/`activeRequests +=` mutations below), so a waiter can never
+   * observe a stale "slot available" snapshot from before another waiter's
+   * own commit — closing the TOCTOU window where two callers could both
+   * pass the checks and push `activeRequests` past `maxConcurrent`.
+   *
+   * An aborted `signal` — whether already aborted at entry or aborted
+   * while waiting for a slot/token — throws before any token is consumed
+   * or `activeRequests` is incremented, so an aborted submission never
+   * silently proceeds to create a billable job.
+   */
+  async acquire(signal?: AbortSignal): Promise<void> {
+    const throwIfAborted = () => {
+      if (signal?.aborted) {
+        throw new AIError(
+          'ModelArk submission aborted by caller while waiting for the rate limiter',
+          'AI_ABORTED',
+          'byteplus-modelark',
+        );
+      }
+    };
+
+    throwIfAborted();
+
     const now = Date.now();
     const elapsed = (now - this.lastRefill) / 1000;
     this.tokens = Math.min(
@@ -149,23 +200,31 @@ class SubmitRateLimiter {
     );
     this.lastRefill = now;
 
-    while (this.activeRequests >= this.maxConcurrent) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
+    for (;;) {
+      throwIfAborted();
 
-    while (this.tokens < 1) {
-      const waitTime = ((1 - this.tokens) / this.refillRate) * 1000;
-      await new Promise((resolve) => setTimeout(resolve, waitTime));
-      const elapsedNow = (Date.now() - this.lastRefill) / 1000;
-      this.tokens = Math.min(
-        this.maxTokens,
-        this.tokens + elapsedNow * this.refillRate,
-      );
-      this.lastRefill = Date.now();
-    }
+      if (this.activeRequests < this.maxConcurrent && this.tokens >= 1) {
+        this.tokens -= 1;
+        this.activeRequests += 1;
+        return;
+      }
 
-    this.tokens -= 1;
-    this.activeRequests += 1;
+      if (this.activeRequests >= this.maxConcurrent) {
+        await delayOrAbort(100, signal);
+      } else {
+        const waitTime = Math.max(
+          1,
+          ((1 - this.tokens) / this.refillRate) * 1000,
+        );
+        await delayOrAbort(waitTime, signal);
+        const elapsedNow = (Date.now() - this.lastRefill) / 1000;
+        this.tokens = Math.min(
+          this.maxTokens,
+          this.tokens + elapsedNow * this.refillRate,
+        );
+        this.lastRefill = Date.now();
+      }
+    }
   }
 
   release(): void {
@@ -281,6 +340,14 @@ export class ByteplusModelArkProvider implements AIInterface {
       timeout?: number;
     } = {},
   ): Promise<T> {
+    if (options.signal?.aborted) {
+      throw new AIError(
+        'ModelArk request aborted by caller',
+        'AI_ABORTED',
+        'byteplus-modelark',
+      );
+    }
+
     const url = new URL(`${this.baseUrl}${path}`);
     for (const [key, value] of Object.entries(options.query ?? {})) {
       url.searchParams.set(key, String(value));
@@ -295,8 +362,18 @@ export class ByteplusModelArkProvider implements AIInterface {
           controller.abort();
         }, timeoutMs)
       : undefined;
-    const onExternalAbort = () => controller.abort();
-    options.signal?.addEventListener('abort', onExternalAbort, { once: true });
+    // Mirrors `prepareRequestControls`'s pattern (packages/ai/src/shared/safety.ts):
+    // addEventListener on an already-aborted signal never fires, so an
+    // already-aborted `signal` must invoke the abort immediately instead of
+    // only listening for a future 'abort' event.
+    const onExternalAbort = () => controller.abort(options.signal?.reason);
+    if (options.signal?.aborted) {
+      onExternalAbort();
+    } else {
+      options.signal?.addEventListener('abort', onExternalAbort, {
+        once: true,
+      });
+    }
 
     try {
       let response: Response;
@@ -403,7 +480,7 @@ export class ByteplusModelArkProvider implements AIInterface {
     options: VideoGenerationOptions,
   ): Promise<VideoGenerationJob> {
     const startTime = Date.now();
-    await this.submitLimiter.acquire();
+    await this.submitLimiter.acquire(options.signal);
 
     try {
       const hasReferenceImages = (options.referenceImages?.length ?? 0) > 0;

--- a/packages/ai/src/shared/providers/byteplus-modelark.ts
+++ b/packages/ai/src/shared/providers/byteplus-modelark.ts
@@ -1,0 +1,786 @@
+/**
+ * BytePlus ModelArk (Seedance) video-generation provider implementation
+ *
+ * Raw-HTTP provider following the `qwen3-tts` precedent: no vendor SDK, just
+ * the ModelArk video-generation task API (create task / poll / fetch /
+ * cancel). This provider is video-generation only; it throws
+ * `NOT_IMPLEMENTED` for chat, embeddings, and other text/TTS operations.
+ *
+ * The base URL, endpoint paths (`/contents/generations/tasks`), request/
+ * response field names, and the `queued|running|cancelled|succeeded|failed|
+ * expired` status enum were confirmed directly against BytePlus's own
+ * published docs and blog examples at the time this was written (see the
+ * link below). The `expired` status, the `page_num`/`page_size`/`filter.*`
+ * list query params, and the DELETE-as-cancel-or-delete semantics
+ * (`queued` → cancelled, `running` → rejected, terminal → deleted) are
+ * corroborated from that same documentation but have not been exercised
+ * against a live ModelArk account by this package's test suite — see
+ * `packages/ai/src/byteplus-modelark.integration.test.ts` for an opt-in
+ * check (skipped unless `MODELARK_API_KEY` is set) that exercises those
+ * specifics against the real API.
+ *
+ * @see https://docs.byteplus.com/en/docs/ModelArk/Video_Generation_API
+ */
+
+import { extractRetryAfterSeconds } from '../rate-limit';
+import { normalizeBaseAIOptions } from '../safety';
+import type {
+  AICapabilities,
+  AIInterface,
+  AIMessage,
+  AIModel,
+  AIResponse,
+  ByteplusModelArkOptions,
+  ChatOptions,
+  CompletionOptions,
+  EmbeddingOptions,
+  EmbeddingResponse,
+  ImageDescriptionOptions,
+  ImageEmbeddingOptions,
+  ImageGenerationOptions,
+  ImageGenerationResponse,
+  MessageOptions,
+  TTSOptions,
+  TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationReferenceImage,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
+  Voice,
+  VoiceCloneOptions,
+  VoiceDesignOptions,
+  VoiceListOptions,
+} from '../types';
+import { AIError, AuthenticationError, RateLimitError } from '../types';
+import { emitUsage } from './usage';
+
+const DEFAULT_MODELARK_BASE_URL =
+  'https://ark.ap-southeast.bytepluses.com/api/v3';
+const DEFAULT_MODELARK_MODEL = 'seedance-1-0-lite-t2v-250428';
+const DEFAULT_MODELARK_I2V_MODEL = 'seedance-1-0-lite-i2v-250428';
+/** Burst capacity for the submit token bucket — see {@link SubmitRateLimiter}. */
+const SUBMIT_BURST_CAPACITY = 2;
+
+type ModelArkTaskStatus =
+  | 'queued'
+  | 'running'
+  | 'cancelled'
+  | 'succeeded'
+  | 'failed'
+  | 'expired';
+
+interface ModelArkContentItem {
+  type: 'text' | 'image_url';
+  text?: string;
+  image_url?: { url: string };
+  role?: string;
+}
+
+interface ModelArkCreateTaskRequest {
+  model: string;
+  content: ModelArkContentItem[];
+  resolution?: string;
+  ratio?: string;
+  duration?: number;
+  seed?: number;
+}
+
+interface ModelArkCreateTaskResponse {
+  id: string;
+}
+
+interface ModelArkTaskResponse {
+  id: string;
+  model: string;
+  status: ModelArkTaskStatus;
+  content?: { video_url?: string; last_frame_url?: string };
+  error?: { code: string; message: string } | null;
+  created_at: number;
+  updated_at: number;
+  seed?: number;
+  resolution?: string;
+  ratio?: string;
+  duration?: number;
+}
+
+/**
+ * Local token-bucket + concurrency limiter for submit-time throttling.
+ *
+ * ModelArk documents Seedance account limits of QPS 2 / 3 *concurrent
+ * submissions*; this only gates `submitVideoGenerationJob` (task creation
+ * HTTP calls), matching the "submit-time throttling" requirement — polling
+ * and cancellation are not subject to the same account-level task-creation
+ * limits. `maxConcurrent` bounds concurrent in-flight *submit HTTP
+ * requests*, not the lifetime of the provider-side render tasks those
+ * submissions create — this limiter has no way to observe when a task
+ * actually finishes rendering on ModelArk's infrastructure, so
+ * task-lifetime concurrency is not, and cannot be, tracked here.
+ *
+ * The bucket's burst capacity is capped at {@link SUBMIT_BURST_CAPACITY}
+ * (independent of `requestsPerMinute`) so the bucket doesn't start full —
+ * without this cap, a bucket sized to `requestsPerMinute` (e.g. 120) would
+ * start with 120 tokens and let the first 120 submits through instantly,
+ * defeating the QPS limit entirely.
+ */
+class SubmitRateLimiter {
+  private tokens: number;
+  private lastRefill: number;
+  private readonly maxTokens: number;
+  private readonly refillRate: number; // tokens per second
+  private activeRequests = 0;
+  private readonly maxConcurrent: number;
+
+  constructor(options: { requestsPerMinute?: number; maxConcurrent?: number }) {
+    const requestsPerMinute = options.requestsPerMinute ?? 120; // ~QPS 2
+    this.refillRate = requestsPerMinute / 60;
+    this.maxTokens = SUBMIT_BURST_CAPACITY;
+    this.tokens = this.maxTokens;
+    this.lastRefill = Date.now();
+    this.maxConcurrent = options.maxConcurrent ?? 3;
+  }
+
+  async acquire(): Promise<void> {
+    const now = Date.now();
+    const elapsed = (now - this.lastRefill) / 1000;
+    this.tokens = Math.min(
+      this.maxTokens,
+      this.tokens + elapsed * this.refillRate,
+    );
+    this.lastRefill = now;
+
+    while (this.activeRequests >= this.maxConcurrent) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    while (this.tokens < 1) {
+      const waitTime = ((1 - this.tokens) / this.refillRate) * 1000;
+      await new Promise((resolve) => setTimeout(resolve, waitTime));
+      const elapsedNow = (Date.now() - this.lastRefill) / 1000;
+      this.tokens = Math.min(
+        this.maxTokens,
+        this.tokens + elapsedNow * this.refillRate,
+      );
+      this.lastRefill = Date.now();
+    }
+
+    this.tokens -= 1;
+    this.activeRequests += 1;
+  }
+
+  release(): void {
+    this.activeRequests = Math.max(0, this.activeRequests - 1);
+  }
+}
+
+/**
+ * FNV-1a hash, used only to avoid retaining raw API keys as in-memory Map
+ * keys in {@link sharedSubmitLimiters}. Not cryptographic — collisions just
+ * mean two distinct keys share a rate-limit bucket, which is a pacing
+ * inefficiency, not a security issue.
+ */
+function hashKey(value: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * Submit-time limiters keyed by credential/config, shared module-wide.
+ *
+ * Provider instances are frequently constructed per pipeline step (a fresh
+ * `getAI({ type: 'byteplus-modelark', ... })` per job), so a limiter owned
+ * by a single provider instance would reset on every construction and never
+ * actually enforce the account-wide QPS/concurrency limits. Keying by the
+ * resolved credentials (or an explicit `rateLimit.key`) lets independently
+ * constructed instances that target the same ModelArk account share one
+ * bucket, mirroring how {@link createRateLimitedAI}'s budget coordinators
+ * are shared by `rateLimit.key`.
+ */
+const sharedSubmitLimiters = new Map<string, SubmitRateLimiter>();
+
+function getSharedSubmitLimiter(
+  options: ByteplusModelArkOptions,
+): SubmitRateLimiter {
+  const key =
+    options.rateLimit?.key?.trim() ||
+    `byteplus-modelark:${hashKey(options.apiKey || 'default')}`;
+
+  let limiter = sharedSubmitLimiters.get(key);
+  if (!limiter) {
+    limiter = new SubmitRateLimiter({
+      requestsPerMinute: options.rateLimit?.requestsPerMinute,
+      maxConcurrent: options.rateLimit?.maxConcurrent,
+    });
+    sharedSubmitLimiters.set(key, limiter);
+  }
+  return limiter;
+}
+
+/** @internal Test-only: clear shared submit limiters between test cases. */
+export function __resetByteplusModelArkRateLimitersForTests(): void {
+  sharedSubmitLimiters.clear();
+}
+
+/**
+ * BytePlus ModelArk provider implementation for asynchronous video
+ * generation (Seedance). Focuses on video-generation capabilities and
+ * throws `NOT_IMPLEMENTED` for text generation methods.
+ *
+ * @example
+ * ```typescript
+ * import { getAI } from '@happyvertical/ai';
+ *
+ * const modelark = await getAI({
+ *   type: 'byteplus-modelark',
+ *   apiKey: process.env.MODELARK_API_KEY!,
+ * });
+ *
+ * const job = await modelark.submitVideoGenerationJob({
+ *   prompt: 'A drone shot flying over a coastal cliff at sunrise',
+ *   durationSeconds: 5,
+ *   resolution: '720p',
+ *   aspectRatio: '16:9',
+ * });
+ *
+ * // Persist `job`, poll later (even after a restart):
+ * const status = await modelark.getVideoGenerationJob(job);
+ * ```
+ */
+export class ByteplusModelArkProvider implements AIInterface {
+  private options: ByteplusModelArkOptions;
+  private readonly submitLimiter: SubmitRateLimiter;
+
+  constructor(options: ByteplusModelArkOptions) {
+    // Note: deliberately no `defaultModel` fallback baked in here — the
+    // model-selection logic in submitVideoGenerationJob picks between the
+    // t2v and i2v defaults based on whether referenceImages are present,
+    // and an unconditional default here would always shadow that.
+    this.options = normalizeBaseAIOptions({ ...options });
+
+    this.submitLimiter = getSharedSubmitLimiter(this.options);
+  }
+
+  private get baseUrl(): string {
+    return (this.options.baseUrl || DEFAULT_MODELARK_BASE_URL).replace(
+      /\/+$/,
+      '',
+    );
+  }
+
+  private async request<T>(
+    path: string,
+    options: {
+      method?: 'GET' | 'POST' | 'DELETE';
+      body?: unknown;
+      query?: Record<string, string | number>;
+      signal?: AbortSignal;
+      timeout?: number;
+    } = {},
+  ): Promise<T> {
+    const url = new URL(`${this.baseUrl}${path}`);
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      url.searchParams.set(key, String(value));
+    }
+
+    const controller = new AbortController();
+    const timeoutMs = options.timeout ?? this.options.timeout;
+    let timedOut = false;
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, timeoutMs)
+      : undefined;
+    const onExternalAbort = () => controller.abort();
+    options.signal?.addEventListener('abort', onExternalAbort, { once: true });
+
+    try {
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: options.method || 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.options.apiKey ?? ''}`,
+            ...(this.options.headers || {}),
+          },
+          body: options.body ? JSON.stringify(options.body) : undefined,
+          signal: controller.signal,
+        });
+      } catch (error) {
+        // The fetch() call itself failed (network error, DNS failure,
+        // timeout/abort) — wrap it into the AIError taxonomy so callers get
+        // a consistent, retryable-vs-terminal-distinguishable error rather
+        // than a raw TypeError/DOMException.
+        if (timedOut) {
+          throw new AIError(
+            `ModelArk request to ${path} timed out after ${timeoutMs}ms`,
+            'AI_TIMEOUT',
+            'byteplus-modelark',
+            undefined,
+            true,
+          );
+        }
+        if (options.signal?.aborted) {
+          throw new AIError(
+            'ModelArk request aborted by caller',
+            'AI_ABORTED',
+            'byteplus-modelark',
+          );
+        }
+        throw new AIError(
+          `Network error calling ModelArk ${path}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          'NETWORK_ERROR',
+          'byteplus-modelark',
+          undefined,
+          true,
+        );
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text();
+
+        if (response.status === 401 || response.status === 403) {
+          throw new AuthenticationError('byteplus-modelark');
+        }
+        if (response.status === 429) {
+          throw new RateLimitError(
+            'byteplus-modelark',
+            extractRetryAfterSeconds({ headers: response.headers }),
+          );
+        }
+
+        throw new AIError(
+          `ModelArk request to ${path} failed: ${response.status} ${errorText}`,
+          'MODELARK_REQUEST_FAILED',
+          'byteplus-modelark',
+        );
+      }
+
+      if (response.status === 204) {
+        return {} as T;
+      }
+
+      const text = await response.text();
+      return text ? (JSON.parse(text) as T) : ({} as T);
+    } finally {
+      if (timer) clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onExternalAbort);
+    }
+  }
+
+  private toImageUrl(reference: VideoGenerationReferenceImage): string {
+    if (typeof reference.image === 'string') {
+      return reference.image;
+    }
+    const mimeType = reference.mimeType || 'image/png';
+    return `data:${mimeType};base64,${reference.image.toString('base64')}`;
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Implemented)
+  // ============================================================================
+
+  /**
+   * Submit an asynchronous Seedance video-generation task.
+   *
+   * Submission is locally throttled to approximate ModelArk's documented
+   * Seedance account limits (QPS 2, capped at {@link SUBMIT_BURST_CAPACITY}
+   * burst / 3 concurrent *submissions* — task-lifetime concurrency on
+   * ModelArk's infrastructure is not tracked; see {@link SubmitRateLimiter}).
+   *
+   * When `referenceImages` are supplied and no explicit `model` is chosen,
+   * this selects the image-to-video default model rather than silently
+   * generating text-to-video with the image ignored.
+   */
+  async submitVideoGenerationJob(
+    options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    const startTime = Date.now();
+    await this.submitLimiter.acquire();
+
+    try {
+      const hasReferenceImages = (options.referenceImages?.length ?? 0) > 0;
+      const model =
+        options.model ||
+        this.options.defaultModel ||
+        (hasReferenceImages
+          ? DEFAULT_MODELARK_I2V_MODEL
+          : DEFAULT_MODELARK_MODEL);
+
+      const content: ModelArkContentItem[] = [];
+      if (options.prompt) {
+        content.push({ type: 'text', text: options.prompt });
+      }
+      for (const reference of options.referenceImages ?? []) {
+        content.push({
+          type: 'image_url',
+          image_url: { url: this.toImageUrl(reference) },
+          role: reference.role || 'reference_image',
+        });
+      }
+
+      if (content.length === 0) {
+        throw new AIError(
+          'submitVideoGenerationJob requires a prompt or at least one reference image',
+          'INVALID_INPUT',
+          'byteplus-modelark',
+        );
+      }
+
+      const body: ModelArkCreateTaskRequest = {
+        model,
+        content,
+        resolution: options.resolution,
+        ratio: options.aspectRatio,
+        duration: options.durationSeconds,
+        seed: options.seed,
+      };
+      // Note: ModelArk's documented create-task schema has no negative_prompt
+      // or fps fields, so those VideoGenerationOptions are intentionally not
+      // forwarded for this provider.
+
+      const response = await this.request<ModelArkCreateTaskResponse>(
+        '/contents/generations/tasks',
+        {
+          method: 'POST',
+          body,
+          signal: options.signal,
+          timeout: options.timeout,
+        },
+      );
+
+      emitUsage(
+        this.options,
+        'byteplus-modelark',
+        'submitVideoGenerationJob',
+        model,
+        undefined,
+        startTime,
+        {
+          ...(options.durationSeconds !== undefined
+            ? { durationSeconds: String(options.durationSeconds) }
+            : {}),
+          ...(options.resolution ? { resolution: options.resolution } : {}),
+          ...(options.aspectRatio ? { aspectRatio: options.aspectRatio } : {}),
+          ...options.usageTags,
+        },
+      );
+
+      return {
+        jobId: response.id,
+        provider: 'byteplus-modelark',
+        model,
+        createdAt: new Date().toISOString(),
+      };
+    } finally {
+      this.submitLimiter.release();
+    }
+  }
+
+  /**
+   * Poll the status of a ModelArk video-generation task.
+   */
+  async getVideoGenerationJob(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    const task = await this.request<ModelArkTaskResponse>(
+      `/contents/generations/tasks/${handle.jobId}`,
+    );
+    return this.mapTask(task);
+  }
+
+  /**
+   * Fetch the result of a completed ModelArk video-generation task.
+   *
+   * @throws {AIError} When the job has not succeeded yet
+   */
+  async fetchVideoGenerationResult(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    const status = await this.getVideoGenerationJob(handle);
+    if (status.status !== 'succeeded' || !status.result) {
+      throw new AIError(
+        `ModelArk video-generation job ${handle.jobId} has not succeeded (status: ${status.status})`,
+        'VIDEO_JOB_NOT_READY',
+        'byteplus-modelark',
+        handle.model,
+      );
+    }
+    return status.result;
+  }
+
+  /**
+   * Cancel a ModelArk video-generation task.
+   *
+   * ModelArk's DELETE endpoint only transitions a `queued` task to
+   * `cancelled`; a task that is already `running` cannot be cancelled and
+   * the request fails with an {@link AIError} describing why. Terminal
+   * tasks (`succeeded`/`failed`/`expired`) are deleted instead.
+   */
+  async cancelVideoGenerationJob(handle: VideoGenerationJob): Promise<void> {
+    await this.request(`/contents/generations/tasks/${handle.jobId}`, {
+      method: 'DELETE',
+    });
+  }
+
+  /**
+   * Cheap auth-shaped check for ModelArk access: lists tasks with a page
+   * size of 1. Callers on a hot path must cache the result themselves.
+   */
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    await this.request('/contents/generations/tasks', {
+      query: { page_size: 1 },
+    });
+    return true;
+  }
+
+  private mapTask(task: ModelArkTaskResponse): VideoGenerationStatusResult {
+    switch (task.status) {
+      case 'queued':
+        return { status: 'queued' };
+      case 'running':
+        return { status: 'running' };
+      case 'cancelled':
+        return { status: 'cancelled' };
+      case 'expired':
+        return {
+          status: 'failed',
+          error: 'ModelArk task expired before the result was retrieved',
+        };
+      case 'failed':
+        return {
+          status: 'failed',
+          error: task.error?.message || 'ModelArk video generation failed',
+        };
+      case 'succeeded': {
+        if (!task.content?.video_url) {
+          return {
+            status: 'failed',
+            error: 'ModelArk reported success with no video_url',
+          };
+        }
+        return {
+          status: 'succeeded',
+          result: {
+            url: task.content.video_url,
+            mimeType: 'video/mp4',
+            durationSeconds: task.duration,
+          },
+        };
+      }
+      default:
+        // Never invent a terminal state for a status this package doesn't
+        // recognize (e.g. a future ModelArk status addition) — treat it as
+        // still in flight so a caller doesn't misread a mid-render job as
+        // failed, resubmit, and double-bill. The raw value is preserved for
+        // diagnostics.
+        return { status: 'running', rawStatus: task.status };
+    }
+  }
+
+  async getModels(): Promise<AIModel[]> {
+    return [
+      {
+        id: 'seedance-1-0-lite-t2v-250428',
+        name: 'Seedance 1.0 Lite (text-to-video)',
+        description: 'ModelArk Seedance 1.0 Lite text-to-video model',
+        contextLength: 0,
+        capabilities: ['video_generation'],
+        supportsFunctions: false,
+        supportsVision: false,
+      },
+      {
+        id: 'seedance-1-0-lite-i2v-250428',
+        name: 'Seedance 1.0 Lite (image-to-video)',
+        description: 'ModelArk Seedance 1.0 Lite image-to-video model',
+        contextLength: 0,
+        capabilities: ['video_generation'],
+        supportsFunctions: false,
+        supportsVision: true,
+      },
+    ];
+  }
+
+  async getCapabilities(): Promise<AICapabilities> {
+    return {
+      chat: false,
+      completion: false,
+      embeddings: false,
+      streaming: false,
+      functions: false,
+      vision: false,
+      fineTuning: false,
+      imageEmbeddings: false,
+      imageGeneration: false,
+      videoGeneration: true,
+      tts: false,
+      voiceCloning: false,
+      voiceDesign: false,
+      maxContextLength: 0,
+      supportedOperations: [
+        'submitVideoGenerationJob',
+        'getVideoGenerationJob',
+        'fetchVideoGenerationResult',
+        'cancelVideoGenerationJob',
+      ],
+    };
+  }
+
+  // ============================================================================
+  // Text Generation / TTS Methods (Not Implemented - Use another provider)
+  // ============================================================================
+
+  async chat(
+    _messages: AIMessage[],
+    _options?: ChatOptions,
+  ): Promise<AIResponse> {
+    throw new AIError(
+      'Chat is not supported by the BytePlus ModelArk provider. Use OpenAI, Anthropic, or another provider for text generation.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async complete(
+    _prompt: string,
+    _options?: CompletionOptions,
+  ): Promise<AIResponse> {
+    throw new AIError(
+      'Complete is not supported by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async message(_text: string, _options?: MessageOptions): Promise<string> {
+    throw new AIError(
+      'Message is not supported by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async embed(
+    _text: string | string[],
+    _options?: EmbeddingOptions,
+  ): Promise<EmbeddingResponse> {
+    throw new AIError(
+      'Embeddings are not supported by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async embedImage(
+    _image: string | Buffer,
+    _options?: ImageEmbeddingOptions,
+  ): Promise<EmbeddingResponse> {
+    throw new AIError(
+      'Image embeddings are not supported by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async describeImage(
+    _image: string | Buffer,
+    _prompt?: string,
+    _options?: ImageDescriptionOptions,
+  ): Promise<string> {
+    throw new AIError(
+      'Image description is not supported by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async generateImage(
+    _prompt: string,
+    _options?: ImageGenerationOptions,
+  ): Promise<ImageGenerationResponse> {
+    throw new AIError(
+      'Synchronous image generation is not yet implemented by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  stream(
+    _messages: AIMessage[],
+    _options?: ChatOptions,
+  ): AsyncIterable<string> {
+    const error = new AIError(
+      'Chat streaming is not supported by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.reject(error),
+      }),
+    };
+  }
+
+  async countTokens(_text: string): Promise<number> {
+    throw new AIError(
+      'Token counting is not supported by the BytePlus ModelArk provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async synthesizeSpeech(
+    _text: string,
+    _options?: TTSOptions,
+  ): Promise<TTSResponse> {
+    throw new AIError(
+      'TTS is not supported by the BytePlus ModelArk provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  streamSpeech(_text: string, _options?: TTSOptions): AsyncIterable<Buffer> {
+    const error = new AIError(
+      'TTS streaming is not supported by the BytePlus ModelArk provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.reject(error),
+      }),
+    };
+  }
+
+  async cloneVoice(_options: VoiceCloneOptions): Promise<Voice> {
+    throw new AIError(
+      'Voice cloning is not supported by the BytePlus ModelArk provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async designVoice(_options: VoiceDesignOptions): Promise<Voice> {
+    throw new AIError(
+      'Voice design is not supported by the BytePlus ModelArk provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+
+  async getVoices(_options?: VoiceListOptions): Promise<Voice[]> {
+    throw new AIError(
+      'Voice listing is not supported by the BytePlus ModelArk provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'byteplus-modelark',
+    );
+  }
+}

--- a/packages/ai/src/shared/providers/claude-cli.ts
+++ b/packages/ai/src/shared/providers/claude-cli.ts
@@ -34,6 +34,10 @@ import type {
   TokenUsage,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -775,12 +779,64 @@ export class ClaudeCliProvider implements AIInterface {
       fineTuning: false,
       imageEmbeddings: false,
       imageGeneration: false,
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
       maxContextLength: 200000,
       supportedOperations: ['chat', 'completion', 'streaming'],
     };
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Not supported - use gemini, byteplus-modelark,
+  // or openai-compat-video provider)
+  // ============================================================================
+
+  async submitVideoGenerationJob(
+    _options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    throw new AIError(
+      'Video generation is not supported by Claude CLI provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'claude-cli',
+    );
+  }
+
+  async getVideoGenerationJob(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    throw new AIError(
+      'Video generation is not supported by Claude CLI provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'claude-cli',
+    );
+  }
+
+  async fetchVideoGenerationResult(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    throw new AIError(
+      'Video generation is not supported by Claude CLI provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'claude-cli',
+    );
+  }
+
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      'Video generation is not supported by Claude CLI provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'claude-cli',
+    );
+  }
+
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    throw new AIError(
+      'Video generation is not supported by Claude CLI provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'claude-cli',
+    );
   }
 
   // ============================================================================

--- a/packages/ai/src/shared/providers/gemini.ts
+++ b/packages/ai/src/shared/providers/gemini.ts
@@ -3,6 +3,9 @@
  */
 
 import crypto from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { extractRetryAfterSeconds } from '../rate-limit';
 import {
   normalizeBaseAIOptions,
@@ -30,6 +33,10 @@ import type {
   TokenUsage,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -47,9 +54,30 @@ import { emitUsage } from './usage';
 // Note: This implementation uses the new @google/genai package
 // @google/generative-ai is deprecated - migrated to @google/genai
 
+/**
+ * Default Veo model for video generation. Veo 2 / Veo 3.0 are deprecated in
+ * favor of Veo 3.1 (still "preview" in its model id, but the current
+ * non-deprecated generation per Google's docs as of this writing). Veo 3.1
+ * supports the `resolution` config field this provider forwards; Veo 2 does
+ * not, so callers pinning back to Veo 2 should omit `resolution`.
+ */
+const DEFAULT_VEO_MODEL = 'veo-3.1-generate-preview';
+
+/**
+ * Type-only reference to the real `GenerateVideosOperation` class. The
+ * `@google/genai` SDK's `operations.getVideosOperation` calls
+ * `operation._fromAPIResponse(...)`, an instance method — passing a plain
+ * `{ name }` object literal throws at runtime. Typing the constructed
+ * operation against this type (rather than `any`) makes tsc reject a
+ * regression back to a plain literal, since `_fromAPIResponse` is a
+ * required member of the real class's public shape.
+ */
+type VideosOperation = import('@google/genai').GenerateVideosOperation;
+
 export class GeminiProvider implements AIInterface {
   private options: GeminiOptions;
   private client: any; // GoogleGenAI instance from @google/genai
+  private operationCtor?: new () => VideosOperation;
 
   constructor(options: GeminiOptions) {
     this.options = normalizeBaseAIOptions({
@@ -65,8 +93,9 @@ export class GeminiProvider implements AIInterface {
     try {
       // Dynamic import in constructor - this will work if the package is installed
       import('@google/genai')
-        .then(({ GoogleGenAI }) => {
+        .then(({ GoogleGenAI, GenerateVideosOperation }) => {
           this.client = new GoogleGenAI(this.buildClientConfig());
+          this.operationCtor = GenerateVideosOperation;
         })
         .catch(() => {
           // Client will be null and we'll handle it in methods
@@ -79,8 +108,11 @@ export class GeminiProvider implements AIInterface {
   private async ensureClient() {
     if (!this.client) {
       try {
-        const { GoogleGenAI } = await import('@google/genai');
+        const { GoogleGenAI, GenerateVideosOperation } = await import(
+          '@google/genai'
+        );
         this.client = new GoogleGenAI(this.buildClientConfig());
+        this.operationCtor = GenerateVideosOperation;
       } catch (_error) {
         throw new AIError(
           'Failed to initialize Gemini client. Make sure @google/genai is installed.',
@@ -357,15 +389,16 @@ export class GeminiProvider implements AIInterface {
   }
 
   /**
-   * Convert an image to Gemini inline format
-   * @param image - Image as URL, base64 data URL, or Buffer
-   * @returns Gemini inline data format
+   * Decode an image input (URL, base64 data URL, or Buffer) to raw bytes.
+   * Shared by the chat/vision inline-data format and the video-generation
+   * `imageBytes` format, which use different wrapper shapes around the same
+   * base64 payload.
    * @private
    */
-  private async imageToGeminiFormat(
+  private async decodeImageInput(
     image: string | Buffer,
     signal?: AbortSignal,
-  ): Promise<{ inlineData: { mimeType: string; data: string } }> {
+  ): Promise<{ mimeType: string; base64Data: string }> {
     let mimeType = 'image/png';
     let base64Data: string;
 
@@ -399,9 +432,45 @@ export class GeminiProvider implements AIInterface {
       mimeType = response.headers.get('content-type') || 'image/png';
     }
 
+    return { mimeType, base64Data };
+  }
+
+  /**
+   * Convert an image to Gemini's inline-data format, used by chat/vision
+   * `contents` parts (`generateContent`, `embedContent`).
+   * @param image - Image as URL, base64 data URL, or Buffer
+   * @returns Gemini inline data format
+   * @private
+   */
+  private async imageToGeminiFormat(
+    image: string | Buffer,
+    signal?: AbortSignal,
+  ): Promise<{ inlineData: { mimeType: string; data: string } }> {
+    const { mimeType, base64Data } = await this.decodeImageInput(image, signal);
     return {
       inlineData: { mimeType, data: base64Data },
     };
+  }
+
+  /**
+   * Convert a reference image to the shape `generateVideos`'s `image`
+   * parameter expects: `{ imageBytes, mimeType }` (or `{ gcsUri }` for a
+   * `gs://` URI in Vertex AI mode). This is a different shape than
+   * {@link imageToGeminiFormat}'s `{ inlineData: {...} }` — the SDK's video
+   * converters read `imageBytes`/`mimeType`/`gcsUri` directly and silently
+   * drop anything else, which previously caused image-to-video requests to
+   * convert to `{}` and fall back to text-to-video.
+   * @private
+   */
+  private async imageToGeminiVideoFormat(
+    image: string | Buffer,
+    signal?: AbortSignal,
+  ): Promise<{ imageBytes: string; mimeType: string } | { gcsUri: string }> {
+    if (typeof image === 'string' && image.startsWith('gs://')) {
+      return { gcsUri: image };
+    }
+    const { mimeType, base64Data } = await this.decodeImageInput(image, signal);
+    return { imageBytes: base64Data, mimeType };
   }
 
   /**
@@ -619,6 +688,390 @@ export class GeminiProvider implements AIInterface {
     }
   }
 
+  // ============================================================================
+  // Video Generation Methods (Veo, via long-running operations)
+  // ============================================================================
+
+  /**
+   * Submit an asynchronous video-generation job using Veo.
+   *
+   * Uses the same `@google/genai` client and credentials as {@link generateImage}.
+   * Returns a serializable handle immediately; the render itself runs as a
+   * long-running operation that callers poll via {@link getVideoGenerationJob}.
+   *
+   * @param options - Prompt, reference image(s), and generation parameters
+   * @returns Promise resolving to a serializable job handle
+   *
+   * @example
+   * ```typescript
+   * const job = await provider.submitVideoGenerationJob({
+   *   prompt: 'A neon hologram of a cat driving at top speed',
+   *   durationSeconds: 8,
+   * });
+   * ```
+   */
+  async submitVideoGenerationJob(
+    options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    const startTime = Date.now();
+    let controls: PreparedRequestControls | undefined;
+    try {
+      await this.ensureClient();
+
+      const model = options.model || DEFAULT_VEO_MODEL;
+      controls = prepareRequestControls(this.options, options);
+
+      let image:
+        | { imageBytes: string; mimeType: string }
+        | { gcsUri: string }
+        | undefined;
+      const firstReference = options.referenceImages?.[0];
+      if (firstReference) {
+        image = await this.imageToGeminiVideoFormat(
+          firstReference.image,
+          controls.signal,
+        );
+      }
+
+      const config = Object.fromEntries(
+        Object.entries({
+          abortSignal: controls.signal,
+          httpOptions: {
+            timeout: controls.timeout,
+            retryOptions: { attempts: (this.options.maxRetries || 0) + 1 },
+          },
+          numberOfVideos: 1,
+          durationSeconds: options.durationSeconds,
+          fps: options.fps,
+          seed: options.seed,
+          aspectRatio: options.aspectRatio,
+          resolution: options.resolution,
+          negativePrompt: options.negativePrompt,
+        }).filter(([, value]) => value !== undefined),
+      );
+
+      const operation = await this.client.models.generateVideos({
+        model,
+        prompt: options.prompt,
+        image,
+        config,
+      });
+
+      if (!operation.name) {
+        throw new AIError(
+          'Gemini did not return an operation name for the video-generation job',
+          'VIDEO_JOB_SUBMIT_FAILED',
+          'gemini',
+          model,
+        );
+      }
+
+      emitUsage(
+        this.options,
+        'gemini',
+        'submitVideoGenerationJob',
+        model,
+        undefined,
+        startTime,
+        {
+          ...(options.durationSeconds !== undefined
+            ? { durationSeconds: String(options.durationSeconds) }
+            : {}),
+          ...(options.resolution ? { resolution: options.resolution } : {}),
+          ...(options.aspectRatio ? { aspectRatio: options.aspectRatio } : {}),
+          ...options.usageTags,
+        },
+      );
+
+      return {
+        jobId: operation.name,
+        provider: 'gemini',
+        model,
+        createdAt: new Date().toISOString(),
+        raw: {
+          vertexai: Boolean(this.options.projectId && this.options.location),
+        },
+      };
+    } catch (error) {
+      if (controls?.didTimeout()) {
+        throw new AIError(
+          `AI request timed out after ${controls.timeout}ms`,
+          'AI_TIMEOUT',
+          'gemini',
+          options.model,
+        );
+      }
+      if (options.signal?.aborted) {
+        throw new AIError(
+          'AI request aborted by caller',
+          'AI_ABORTED',
+          'gemini',
+          options.model,
+        );
+      }
+      throw this.mapError(error);
+    } finally {
+      controls?.cleanup();
+    }
+  }
+
+  /**
+   * Build a real `GenerateVideosOperation` instance for polling, and assert
+   * the handle is being resumed against a provider configured in the same
+   * mode (Google AI Studio vs. Vertex AI) it was submitted in.
+   * @private
+   */
+  private buildVideoOperation(handle: VideoGenerationJob): VideosOperation {
+    if (!this.operationCtor) {
+      throw new AIError(
+        'Gemini client failed to initialize the video-operation constructor. Make sure @google/genai is installed.',
+        'INITIALIZATION_ERROR',
+        'gemini',
+        handle.model,
+      );
+    }
+    this.assertResumeModeMatches(handle);
+
+    const operation = new this.operationCtor();
+    operation.name = handle.jobId;
+    return operation;
+  }
+
+  /**
+   * A handle submitted in Vertex AI mode cannot be resumed against a
+   * provider configured for Google AI Studio (or vice versa): the SDK
+   * routes `operations.getVideosOperation` based on how *this* client was
+   * constructed, not how the job was submitted, so a mode mismatch would
+   * otherwise surface as a confusing 404 deep in the SDK.
+   * @private
+   */
+  private assertResumeModeMatches(handle: VideoGenerationJob): void {
+    const submittedVertexAI = handle.raw?.vertexai;
+    if (typeof submittedVertexAI !== 'boolean') {
+      // Unknown/legacy handle shape: best effort, let the request proceed.
+      return;
+    }
+
+    const currentVertexAI = Boolean(
+      this.options.projectId && this.options.location,
+    );
+    if (submittedVertexAI !== currentVertexAI) {
+      throw new AIError(
+        `Video-generation job ${handle.jobId} was submitted in ${
+          submittedVertexAI ? 'Vertex AI' : 'Google AI Studio'
+        } mode, but this provider instance is configured for ${
+          currentVertexAI ? 'Vertex AI' : 'Google AI Studio'
+        } mode. Resume with a provider configured the same way it was submitted.`,
+        'VIDEO_JOB_MODE_MISMATCH',
+        'gemini',
+        handle.model,
+      );
+    }
+  }
+
+  /**
+   * Poll the status of a Veo video-generation job.
+   *
+   * On success, `result` carries the provider's `url` (a `files/*:download`
+   * resource the caller cannot fetch directly without this provider's API
+   * key) plus `mimeType`, but not `data` — call
+   * {@link fetchVideoGenerationResult} to download the bytes.
+   *
+   * @param handle - The job handle returned by {@link submitVideoGenerationJob}
+   * @returns Promise resolving to the current status, and result once succeeded
+   */
+  async getVideoGenerationJob(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    try {
+      await this.ensureClient();
+      const operation = this.buildVideoOperation(handle);
+      const updated = await this.client.operations.getVideosOperation({
+        operation,
+      });
+      return this.mapVideoOperation(updated);
+    } catch (error) {
+      throw this.mapError(error);
+    }
+  }
+
+  /**
+   * Fetch the result of a completed Veo video-generation job, downloading
+   * the rendered bytes with this provider's API key (the `uri` Gemini
+   * returns is a `files/*:download` resource that requires the same
+   * credentials this provider already holds; a bare consumer cannot fetch
+   * it directly).
+   *
+   * @param handle - The job handle returned by {@link submitVideoGenerationJob}
+   * @returns Promise resolving to the generated video's bytes and metadata
+   * @throws {AIError} When the job has not succeeded yet
+   */
+  async fetchVideoGenerationResult(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    try {
+      await this.ensureClient();
+      const operation = this.buildVideoOperation(handle);
+      const updated = await this.client.operations.getVideosOperation({
+        operation,
+      });
+      const status = this.mapVideoOperation(updated);
+      if (status.status !== 'succeeded' || !status.result) {
+        throw new AIError(
+          `Gemini video-generation job ${handle.jobId} has not succeeded (status: ${status.status})`,
+          'VIDEO_JOB_NOT_READY',
+          'gemini',
+          handle.model,
+        );
+      }
+
+      const video = updated.response?.generatedVideos?.[0]?.video;
+      const mimeType = status.result.mimeType;
+
+      if (video?.videoBytes) {
+        // Already inline (e.g. Vertex AI bytesBase64Encoded) — no download needed.
+        return {
+          url: status.result.url,
+          data: Buffer.from(video.videoBytes, 'base64'),
+          mimeType,
+        };
+      }
+
+      return {
+        url: status.result.url,
+        data: await this.downloadGeneratedVideo(video),
+        mimeType,
+      };
+    } catch (error) {
+      throw this.mapError(error);
+    }
+  }
+
+  /**
+   * Download a generated video's bytes via `ai.files.download`, which
+   * resolves the `files/*:download` resource with this provider's API key
+   * (matching Google's own documented usage pattern). The SDK's `download`
+   * method only writes to a filesystem path, so this round-trips through a
+   * temporary file and reads it back into memory.
+   * @private
+   */
+  private async downloadGeneratedVideo(
+    video: { uri?: string; videoBytes?: string; mimeType?: string } | undefined,
+  ): Promise<Buffer> {
+    if (!video?.uri) {
+      throw new AIError(
+        'Gemini video-generation job succeeded with no downloadable output',
+        'VIDEO_JOB_NOT_READY',
+        'gemini',
+      );
+    }
+
+    const dir = await mkdtemp(join(tmpdir(), 'have-ai-veo-'));
+    const filePath = join(dir, 'video.mp4');
+    try {
+      await this.client.files.download({ file: video, downloadPath: filePath });
+      return await readFile(filePath);
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  /**
+   * Cancel an in-flight Veo video-generation job.
+   *
+   * **The Gemini API has no cancel endpoint for video-generation
+   * operations.** The generativelanguage v1beta discovery document only
+   * defines `batches.cancel` (unrelated to video jobs); there is no
+   * `models.operations.cancel`. This always throws — cancellation of a
+   * Veo render is unsupported by the provider itself, not merely by this
+   * client. Callers must treat cancellation as best-effort across all
+   * video-generation providers and tolerate this failure (e.g. by simply
+   * discarding the handle and not billing for further polling).
+   *
+   * @param handle - The job handle returned by {@link submitVideoGenerationJob}
+   * @throws {AIError} Always — cancellation is unsupported by the Gemini API
+   */
+  async cancelVideoGenerationJob(handle: VideoGenerationJob): Promise<void> {
+    if (this.options.projectId && this.options.location) {
+      throw new AIError(
+        'Cancelling Gemini video-generation jobs is not implemented for Vertex AI mode by this provider (it requires OAuth credentials this provider does not manage).',
+        'NOT_IMPLEMENTED',
+        'gemini',
+        handle.model,
+      );
+    }
+
+    throw new AIError(
+      'The Gemini API has no cancel endpoint for video-generation operations (only batches.cancel exists, which does not apply to Veo jobs). ' +
+        'cancelVideoGenerationJob cannot stop an in-flight Veo render on this provider; treat cancellation as best-effort and stop polling / discard the handle instead.',
+      'VIDEO_CANCEL_UNSUPPORTED',
+      'gemini',
+      handle.model,
+    );
+  }
+
+  /**
+   * Cheap auth-shaped check for Veo access: lists models with a page size
+   * of 1. Callers on a hot path must cache the result themselves.
+   *
+   * @returns Promise resolving to true when access looks valid
+   */
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    try {
+      await this.ensureClient();
+      await this.client.models.list({ config: { pageSize: 1 } });
+      return true;
+    } catch (error) {
+      throw this.mapError(error);
+    }
+  }
+
+  private mapVideoOperation(operation: {
+    done?: boolean;
+    error?: Record<string, unknown>;
+    response?: {
+      generatedVideos?: Array<{
+        video?: { uri?: string; videoBytes?: string; mimeType?: string };
+      }>;
+    };
+  }): VideoGenerationStatusResult {
+    if (!operation.done) {
+      return { status: 'running' };
+    }
+
+    if (operation.error) {
+      const errorInfo = operation.error as { code?: number; message?: unknown };
+      const message =
+        typeof errorInfo.message === 'string'
+          ? errorInfo.message
+          : JSON.stringify(operation.error);
+      // google.rpc.Code.CANCELLED === 1; fall back to a message regex for
+      // error shapes that don't carry a structured code.
+      const cancelled = errorInfo.code === 1 || /cancel/i.test(message);
+      return cancelled
+        ? { status: 'cancelled' }
+        : { status: 'failed', error: message };
+    }
+
+    const video = operation.response?.generatedVideos?.[0]?.video;
+    if (!video) {
+      return {
+        status: 'failed',
+        error:
+          'Gemini reported the video-generation job as done with no output',
+      };
+    }
+
+    // Metadata only here — `data` requires a separate authenticated
+    // download; see fetchVideoGenerationResult.
+    const result: VideoGenerationResult = {
+      url: video.uri,
+      mimeType: video.mimeType || 'video/mp4',
+    };
+
+    return { status: 'succeeded', result };
+  }
+
   async *stream(
     messages: AIMessage[],
     options: ChatOptions = {},
@@ -762,6 +1215,7 @@ export class GeminiProvider implements AIInterface {
       fineTuning: false,
       imageEmbeddings: true,
       imageGeneration: true,
+      videoGeneration: true,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
@@ -775,6 +1229,7 @@ export class GeminiProvider implements AIInterface {
         'vision',
         'image_embedding',
         'image_generation',
+        'video_generation',
       ],
     };
   }

--- a/packages/ai/src/shared/providers/huggingface.ts
+++ b/packages/ai/src/shared/providers/huggingface.ts
@@ -27,6 +27,10 @@ import type {
   TokenUsage,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -413,12 +417,64 @@ export class HuggingFaceProvider implements AIInterface {
       fineTuning: true, // Via Hugging Face training API
       imageEmbeddings: false,
       imageGeneration: false, // Stable Diffusion exists but not implemented
+      videoGeneration: false,
       tts: false,
       voiceCloning: false,
       voiceDesign: false,
       maxContextLength: 2048,
       supportedOperations: ['chat', 'completion', 'embedding', 'streaming'],
     };
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Not supported - use gemini, byteplus-modelark,
+  // or openai-compat-video provider)
+  // ============================================================================
+
+  async submitVideoGenerationJob(
+    _options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    throw new AIError(
+      'Video generation is not supported by HuggingFace provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'huggingface',
+    );
+  }
+
+  async getVideoGenerationJob(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    throw new AIError(
+      'Video generation is not supported by HuggingFace provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'huggingface',
+    );
+  }
+
+  async fetchVideoGenerationResult(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    throw new AIError(
+      'Video generation is not supported by HuggingFace provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'huggingface',
+    );
+  }
+
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      'Video generation is not supported by HuggingFace provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'huggingface',
+    );
+  }
+
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    throw new AIError(
+      'Video generation is not supported by HuggingFace provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'huggingface',
+    );
   }
 
   // ============================================================================

--- a/packages/ai/src/shared/providers/litellm.ts
+++ b/packages/ai/src/shared/providers/litellm.ts
@@ -31,6 +31,7 @@ const LITELLM_CAPABILITIES: AICapabilities = {
   fineTuning: false,
   imageEmbeddings: true,
   imageGeneration: true,
+  videoGeneration: false,
   tts: false,
   voiceCloning: false,
   voiceDesign: false,

--- a/packages/ai/src/shared/providers/ollama.ts
+++ b/packages/ai/src/shared/providers/ollama.ts
@@ -34,6 +34,10 @@ import type {
   TokenUsage,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -62,6 +66,7 @@ const OLLAMA_CAPABILITIES: AICapabilities = {
   fineTuning: false,
   imageEmbeddings: true,
   imageGeneration: true,
+  videoGeneration: false,
   tts: false,
   voiceCloning: false,
   voiceDesign: false,
@@ -1326,6 +1331,57 @@ export class OllamaProvider implements AIInterface {
 
   async getCapabilities(): Promise<AICapabilities> {
     return { ...OLLAMA_CAPABILITIES };
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Not supported - use gemini, byteplus-modelark,
+  // or openai-compat-video provider)
+  // ============================================================================
+
+  async submitVideoGenerationJob(
+    _options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    throw new AIError(
+      'Video generation is not supported by the Ollama provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'ollama',
+    );
+  }
+
+  async getVideoGenerationJob(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    throw new AIError(
+      'Video generation is not supported by the Ollama provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'ollama',
+    );
+  }
+
+  async fetchVideoGenerationResult(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    throw new AIError(
+      'Video generation is not supported by the Ollama provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'ollama',
+    );
+  }
+
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      'Video generation is not supported by the Ollama provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'ollama',
+    );
+  }
+
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    throw new AIError(
+      'Video generation is not supported by the Ollama provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'ollama',
+    );
   }
 
   async synthesizeSpeech(

--- a/packages/ai/src/shared/providers/openai-compat-video.ts
+++ b/packages/ai/src/shared/providers/openai-compat-video.ts
@@ -187,6 +187,14 @@ export class OpenAICompatVideoProvider implements AIInterface {
       allowNotFound?: boolean;
     } = {},
   ): Promise<Response> {
+    if (options.signal?.aborted) {
+      throw new AIError(
+        'openai-compat-video request aborted by caller',
+        'AI_ABORTED',
+        'openai-compat-video',
+      );
+    }
+
     const url = new URL(`${this.baseUrl}${path}`);
     for (const [key, value] of Object.entries(options.query ?? {})) {
       url.searchParams.set(key, String(value));
@@ -201,8 +209,18 @@ export class OpenAICompatVideoProvider implements AIInterface {
           controller.abort();
         }, timeoutMs)
       : undefined;
-    const onExternalAbort = () => controller.abort();
-    options.signal?.addEventListener('abort', onExternalAbort, { once: true });
+    // Mirrors `prepareRequestControls`'s pattern (packages/ai/src/shared/safety.ts):
+    // addEventListener on an already-aborted signal never fires, so an
+    // already-aborted `signal` must invoke the abort immediately instead of
+    // only listening for a future 'abort' event.
+    const onExternalAbort = () => controller.abort(options.signal?.reason);
+    if (options.signal?.aborted) {
+      onExternalAbort();
+    } else {
+      options.signal?.addEventListener('abort', onExternalAbort, {
+        once: true,
+      });
+    }
 
     try {
       const headers: Record<string, string> = {

--- a/packages/ai/src/shared/providers/openai-compat-video.ts
+++ b/packages/ai/src/shared/providers/openai-compat-video.ts
@@ -1,0 +1,683 @@
+/**
+ * OpenAI-compatible video-generation provider implementation
+ *
+ * Thin, raw-HTTP adapter over a `/v1/videos`-shaped REST surface (create /
+ * retrieve / cancel / download content) configured by base URL + key. This
+ * is the shape LiteLLM normalizes Veo behind, and the shape used by
+ * Sora-style gateways. The surface is young and still churning across
+ * vendors, so this adapter is deliberately thin: it forwards the fields the
+ * OpenAI `videos` API documents (model, prompt, seconds, size, a single
+ * image reference) and leaves everything else to the gateway's defaults.
+ *
+ * Only video-generation methods are implemented; use the `openai` or
+ * `litellm` provider types against the same gateway for chat/embeddings.
+ *
+ * Request bodies are sent as JSON, not the `multipart/form-data` the
+ * official `openai` npm package uses for `input_reference` uploads. This is
+ * a deliberate choice for this thin adapter: LiteLLM (the primary target
+ * gateway) accepts `input_reference.image_url` as a URL or base64 data URL
+ * in a JSON body, and staying JSON-only keeps this file a plain HTTP client
+ * with no multipart-encoding dependency. A raw OpenAI Sora endpoint that
+ * requires actual multipart file uploads is not supported by this adapter.
+ */
+
+import { ValidationError } from '@happyvertical/utils';
+import { extractRetryAfterSeconds } from '../rate-limit';
+import { normalizeBaseAIOptions } from '../safety';
+import type {
+  AICapabilities,
+  AIInterface,
+  AIMessage,
+  AIModel,
+  AIResponse,
+  ChatOptions,
+  CompletionOptions,
+  EmbeddingOptions,
+  EmbeddingResponse,
+  ImageDescriptionOptions,
+  ImageEmbeddingOptions,
+  ImageGenerationOptions,
+  ImageGenerationResponse,
+  MessageOptions,
+  OpenAICompatVideoOptions,
+  TTSOptions,
+  TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
+  Voice,
+  VoiceCloneOptions,
+  VoiceDesignOptions,
+  VoiceListOptions,
+} from '../types';
+import { AIError, AuthenticationError, RateLimitError } from '../types';
+import { emitUsage } from './usage';
+
+/** Raw video-job object shape, following the OpenAI `videos` API. */
+interface CompatVideoObject {
+  id: string;
+  status: string;
+  model: string;
+  progress?: number;
+  seconds?: string;
+  size?: string;
+  error?: { code?: string; message?: string } | null;
+  /** Some gateways (LiteLLM's Veo passthrough) include a direct download URL. */
+  url?: string;
+}
+
+function ensureOpenAICompatVideoOptions(
+  options: OpenAICompatVideoOptions,
+): OpenAICompatVideoOptions {
+  if (!options.baseUrl?.trim()) {
+    throw new ValidationError('openai-compat-video baseUrl is required', {
+      provider: 'openai-compat-video',
+      hint: 'Pass baseUrl like https://llm.happyvertical.com/v1 or set OPENAI_COMPAT_VIDEO_BASE_URL',
+    });
+  }
+
+  return {
+    ...options,
+    baseUrl: options.baseUrl.trim().replace(/\/+$/, ''),
+  };
+}
+
+function parseSize(size: string | undefined): {
+  width?: number;
+  height?: number;
+} {
+  const match = size?.match(/^(\d+)x(\d+)$/);
+  if (!match) return {};
+  return { width: Number(match[1]), height: Number(match[2]) };
+}
+
+/**
+ * Map a gateway's raw status string to our status enum.
+ *
+ * LiteLLM (the primary target gateway) documents `'processing'` as its
+ * mid-render status rather than OpenAI's own `'in_progress'`; both, plus
+ * `'pending'`, map to `'running'`. Only an explicit `'failed'` maps to a
+ * terminal failure — an unrecognized status is never assumed to be
+ * terminal, since misreading a mid-render job as failed would cause a
+ * caller to resubmit (and double-bill) a job that was actually still
+ * rendering. Unrecognized values map to `'running'` with the raw string
+ * preserved via `rawStatus` so callers can still see and log it.
+ */
+function mapStatus(status: string): {
+  status: VideoGenerationStatusResult['status'];
+  rawStatus?: string;
+} {
+  switch (status) {
+    case 'queued':
+      return { status: 'queued' };
+    case 'in_progress':
+    case 'processing':
+    case 'pending':
+      return { status: 'running' };
+    case 'completed':
+      return { status: 'succeeded' };
+    case 'failed':
+      return { status: 'failed' };
+    case 'cancelled':
+    case 'canceled':
+      return { status: 'cancelled' };
+    default:
+      return { status: 'running', rawStatus: status };
+  }
+}
+
+/**
+ * OpenAI-compatible video-generation provider for `/v1/videos`-shaped
+ * gateways (LiteLLM, Sora-shaped providers).
+ *
+ * @example
+ * ```typescript
+ * import { getAI } from '@happyvertical/ai';
+ *
+ * const video = await getAI({
+ *   type: 'openai-compat-video',
+ *   baseUrl: 'https://llm.happyvertical.com/v1',
+ *   apiKey: process.env.OPENAI_COMPAT_VIDEO_API_KEY!,
+ * });
+ *
+ * const job = await video.submitVideoGenerationJob({
+ *   prompt: 'A time-lapse of clouds over a mountain range',
+ *   durationSeconds: 8,
+ * });
+ * ```
+ */
+export class OpenAICompatVideoProvider implements AIInterface {
+  private options: OpenAICompatVideoOptions;
+
+  constructor(options: OpenAICompatVideoOptions) {
+    this.options = normalizeBaseAIOptions(
+      ensureOpenAICompatVideoOptions(options),
+    );
+  }
+
+  private get baseUrl(): string {
+    return this.options.baseUrl as string;
+  }
+
+  private async request<T>(
+    path: string,
+    options: {
+      method?: 'GET' | 'POST';
+      body?: unknown;
+      query?: Record<string, string | number>;
+      signal?: AbortSignal;
+      timeout?: number;
+    } = {},
+  ): Promise<T> {
+    const response = await this.rawRequest(path, options);
+    const text = await response.text();
+    return text ? (JSON.parse(text) as T) : ({} as T);
+  }
+
+  private async rawRequest(
+    path: string,
+    options: {
+      method?: 'GET' | 'POST';
+      body?: unknown;
+      query?: Record<string, string | number>;
+      signal?: AbortSignal;
+      timeout?: number;
+      /** When true, a 404 response is returned as-is instead of throwing. */
+      allowNotFound?: boolean;
+    } = {},
+  ): Promise<Response> {
+    const url = new URL(`${this.baseUrl}${path}`);
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      url.searchParams.set(key, String(value));
+    }
+
+    const controller = new AbortController();
+    const timeoutMs = options.timeout ?? this.options.timeout;
+    let timedOut = false;
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, timeoutMs)
+      : undefined;
+    const onExternalAbort = () => controller.abort();
+    options.signal?.addEventListener('abort', onExternalAbort, { once: true });
+
+    try {
+      const headers: Record<string, string> = {
+        ...(this.options.headers || {}),
+      };
+      if (this.options.apiKey) {
+        headers.Authorization = `Bearer ${this.options.apiKey}`;
+      }
+      if (options.body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: options.method || 'GET',
+          headers,
+          body:
+            options.body !== undefined
+              ? JSON.stringify(options.body)
+              : undefined,
+          signal: controller.signal,
+        });
+      } catch (error) {
+        // The fetch() call itself failed (network error, DNS failure,
+        // timeout/abort) — wrap it into the AIError taxonomy so callers get
+        // a consistent, retryable-vs-terminal-distinguishable error rather
+        // than a raw TypeError/DOMException.
+        if (timedOut) {
+          throw new AIError(
+            `openai-compat-video request to ${path} timed out after ${timeoutMs}ms`,
+            'AI_TIMEOUT',
+            'openai-compat-video',
+            undefined,
+            true,
+          );
+        }
+        if (options.signal?.aborted) {
+          throw new AIError(
+            'openai-compat-video request aborted by caller',
+            'AI_ABORTED',
+            'openai-compat-video',
+          );
+        }
+        throw new AIError(
+          `Network error calling openai-compat-video ${path}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          'NETWORK_ERROR',
+          'openai-compat-video',
+          undefined,
+          true,
+        );
+      }
+
+      if (!response.ok) {
+        if (response.status === 404 && options.allowNotFound) {
+          return response;
+        }
+
+        const errorText = await response.text();
+
+        if (response.status === 401 || response.status === 403) {
+          throw new AuthenticationError('openai-compat-video');
+        }
+        if (response.status === 429) {
+          throw new RateLimitError(
+            'openai-compat-video',
+            extractRetryAfterSeconds({ headers: response.headers }),
+          );
+        }
+
+        throw new AIError(
+          `openai-compat-video request to ${path} failed: ${response.status} ${errorText}`,
+          'OPENAI_COMPAT_VIDEO_REQUEST_FAILED',
+          'openai-compat-video',
+        );
+      }
+
+      return response;
+    } finally {
+      if (timer) clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onExternalAbort);
+    }
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Implemented)
+  // ============================================================================
+
+  /**
+   * Submit an asynchronous video-generation job.
+   *
+   * `resolution` is forwarded as the gateway's `size` field only when it is
+   * already in `WIDTHxHEIGHT` form (e.g. `'1280x720'`); other resolution
+   * labels (`'720p'`) are not translated and the gateway's default size
+   * applies instead — keeping this adapter thin rather than guessing a
+   * pixel size per vendor. `negativePrompt`, `seed`, and `fps` are not part
+   * of the documented OpenAI videos schema and are not forwarded.
+   */
+  async submitVideoGenerationJob(
+    options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    const startTime = Date.now();
+    const model = options.model || this.options.defaultModel || 'sora-2';
+
+    const body: Record<string, unknown> = {
+      model,
+      prompt: options.prompt,
+    };
+    if (options.durationSeconds !== undefined) {
+      body.seconds = String(options.durationSeconds);
+    }
+    if (options.resolution?.includes('x')) {
+      body.size = options.resolution;
+    }
+    const firstReference = options.referenceImages?.[0];
+    if (firstReference) {
+      body.input_reference = {
+        image_url:
+          typeof firstReference.image === 'string'
+            ? firstReference.image
+            : `data:${firstReference.mimeType || 'image/png'};base64,${firstReference.image.toString('base64')}`,
+      };
+    }
+
+    const video = await this.request<CompatVideoObject>('/videos', {
+      method: 'POST',
+      body,
+      signal: options.signal,
+      timeout: options.timeout,
+    });
+
+    emitUsage(
+      this.options,
+      'openai-compat-video',
+      'submitVideoGenerationJob',
+      video.model || model,
+      undefined,
+      startTime,
+      {
+        ...(options.durationSeconds !== undefined
+          ? { durationSeconds: String(options.durationSeconds) }
+          : {}),
+        ...(options.resolution ? { resolution: options.resolution } : {}),
+        ...(options.aspectRatio ? { aspectRatio: options.aspectRatio } : {}),
+        ...options.usageTags,
+      },
+    );
+
+    return {
+      jobId: video.id,
+      provider: 'openai-compat-video',
+      model: video.model || model,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Poll the status of a video-generation job.
+   *
+   * The gateway's status response does not include the video bytes, so
+   * `result` on a succeeded job carries only metadata (mimeType, duration,
+   * dimensions) plus a `url` when the gateway happens to include one
+   * directly. Call {@link fetchVideoGenerationResult} to download the bytes.
+   */
+  async getVideoGenerationJob(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    const video = await this.request<CompatVideoObject>(
+      `/videos/${handle.jobId}`,
+    );
+    return this.mapVideo(video);
+  }
+
+  /**
+   * Fetch the result of a completed video-generation job, downloading the
+   * rendered bytes from the gateway's content endpoint.
+   *
+   * @throws {AIError} When the job has not succeeded yet
+   */
+  async fetchVideoGenerationResult(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    const video = await this.request<CompatVideoObject>(
+      `/videos/${handle.jobId}`,
+    );
+    const status = this.mapVideo(video);
+    if (status.status !== 'succeeded') {
+      throw new AIError(
+        `openai-compat-video job ${handle.jobId} has not succeeded (status: ${status.status})`,
+        'VIDEO_JOB_NOT_READY',
+        'openai-compat-video',
+        handle.model,
+      );
+    }
+
+    if (video.url) {
+      return status.result as VideoGenerationResult;
+    }
+
+    const response = await this.rawRequest(`/videos/${handle.jobId}/content`);
+    const arrayBuffer = await response.arrayBuffer();
+    const { width, height } = parseSize(video.size);
+
+    return {
+      data: Buffer.from(arrayBuffer),
+      mimeType: response.headers.get('content-type') || 'video/mp4',
+      durationSeconds: video.seconds ? Number(video.seconds) : undefined,
+      width,
+      height,
+    };
+  }
+
+  /**
+   * Cancel a video-generation job. Cancellation of an in-flight Sora-shaped
+   * job is not part of the documented OpenAI `videos` API and is
+   * gateway-dependent (e.g. LiteLLM's Veo passthrough may support it); this
+   * attempts the conventional `/videos/{id}/cancel` REST call and surfaces
+   * an {@link AIError} if the gateway rejects or does not implement it.
+   */
+  async cancelVideoGenerationJob(handle: VideoGenerationJob): Promise<void> {
+    await this.rawRequest(`/videos/${handle.jobId}/cancel`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Cheap auth-shaped check for video-generation access.
+   *
+   * This probes `GET /videos/{sentinel-id}` rather than listing videos:
+   * LiteLLM (the primary target gateway) requires a `custom_llm_provider`
+   * parameter on its `GET /v1/videos` list route that this generic adapter
+   * has no context to supply, so a list-based check would fail with valid
+   * credentials on the flagship gateway. A single-resource GET works
+   * uniformly instead, classified as:
+   * - `401`/`403` → invalid credentials, throws {@link AuthenticationError}
+   * - `404` → authenticated successfully, the sentinel id just doesn't
+   *   exist — this is a **valid** result, not a failure
+   * - `2xx` → valid (the sentinel id coincidentally exists)
+   *
+   * Callers on a hot path must cache the result themselves.
+   */
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    const sentinelId = 'have-ai-validate-video-access';
+    const response = await this.rawRequest(`/videos/${sentinelId}`, {
+      allowNotFound: true,
+    });
+    return response.ok || response.status === 404;
+  }
+
+  private mapVideo(video: CompatVideoObject): VideoGenerationStatusResult {
+    const { status, rawStatus } = mapStatus(video.status);
+
+    if (status === 'failed') {
+      return {
+        status: 'failed',
+        error:
+          video.error?.message ||
+          `Video generation failed (status: ${video.status})`,
+      };
+    }
+
+    if (status !== 'succeeded') {
+      return { status, progress: video.progress, rawStatus };
+    }
+
+    const { width, height } = parseSize(video.size);
+    const result: VideoGenerationResult = {
+      url: video.url,
+      mimeType: 'video/mp4',
+      durationSeconds: video.seconds ? Number(video.seconds) : undefined,
+      width,
+      height,
+    };
+
+    return { status: 'succeeded', result };
+  }
+
+  async getModels(): Promise<AIModel[]> {
+    return [
+      {
+        id: 'sora-2',
+        name: 'Sora 2',
+        description: 'OpenAI-compatible Sora 2 video-generation model',
+        contextLength: 0,
+        capabilities: ['video_generation'],
+        supportsFunctions: false,
+        supportsVision: true,
+      },
+      {
+        id: 'sora-2-pro',
+        name: 'Sora 2 Pro',
+        description: 'OpenAI-compatible Sora 2 Pro video-generation model',
+        contextLength: 0,
+        capabilities: ['video_generation'],
+        supportsFunctions: false,
+        supportsVision: true,
+      },
+    ];
+  }
+
+  async getCapabilities(): Promise<AICapabilities> {
+    return {
+      chat: false,
+      completion: false,
+      embeddings: false,
+      streaming: false,
+      functions: false,
+      vision: false,
+      fineTuning: false,
+      imageEmbeddings: false,
+      imageGeneration: false,
+      videoGeneration: true,
+      tts: false,
+      voiceCloning: false,
+      voiceDesign: false,
+      maxContextLength: 0,
+      supportedOperations: [
+        'submitVideoGenerationJob',
+        'getVideoGenerationJob',
+        'fetchVideoGenerationResult',
+        'cancelVideoGenerationJob',
+      ],
+    };
+  }
+
+  // ============================================================================
+  // Text Generation / TTS Methods (Not Implemented - Use another provider)
+  // ============================================================================
+
+  async chat(
+    _messages: AIMessage[],
+    _options?: ChatOptions,
+  ): Promise<AIResponse> {
+    throw new AIError(
+      'Chat is not supported by the openai-compat-video provider. Use the openai or litellm provider for text generation.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async complete(
+    _prompt: string,
+    _options?: CompletionOptions,
+  ): Promise<AIResponse> {
+    throw new AIError(
+      'Complete is not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async message(_text: string, _options?: MessageOptions): Promise<string> {
+    throw new AIError(
+      'Message is not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async embed(
+    _text: string | string[],
+    _options?: EmbeddingOptions,
+  ): Promise<EmbeddingResponse> {
+    throw new AIError(
+      'Embeddings are not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async embedImage(
+    _image: string | Buffer,
+    _options?: ImageEmbeddingOptions,
+  ): Promise<EmbeddingResponse> {
+    throw new AIError(
+      'Image embeddings are not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async describeImage(
+    _image: string | Buffer,
+    _prompt?: string,
+    _options?: ImageDescriptionOptions,
+  ): Promise<string> {
+    throw new AIError(
+      'Image description is not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async generateImage(
+    _prompt: string,
+    _options?: ImageGenerationOptions,
+  ): Promise<ImageGenerationResponse> {
+    throw new AIError(
+      'Image generation is not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  stream(
+    _messages: AIMessage[],
+    _options?: ChatOptions,
+  ): AsyncIterable<string> {
+    const error = new AIError(
+      'Chat streaming is not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.reject(error),
+      }),
+    };
+  }
+
+  async countTokens(_text: string): Promise<number> {
+    throw new AIError(
+      'Token counting is not supported by the openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async synthesizeSpeech(
+    _text: string,
+    _options?: TTSOptions,
+  ): Promise<TTSResponse> {
+    throw new AIError(
+      'TTS is not supported by the openai-compat-video provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  streamSpeech(_text: string, _options?: TTSOptions): AsyncIterable<Buffer> {
+    const error = new AIError(
+      'TTS streaming is not supported by the openai-compat-video provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.reject(error),
+      }),
+    };
+  }
+
+  async cloneVoice(_options: VoiceCloneOptions): Promise<Voice> {
+    throw new AIError(
+      'Voice cloning is not supported by the openai-compat-video provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async designVoice(_options: VoiceDesignOptions): Promise<Voice> {
+    throw new AIError(
+      'Voice design is not supported by the openai-compat-video provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+
+  async getVoices(_options?: VoiceListOptions): Promise<Voice[]> {
+    throw new AIError(
+      'Voice listing is not supported by the openai-compat-video provider. Use Qwen3-TTS provider.',
+      'NOT_IMPLEMENTED',
+      'openai-compat-video',
+    );
+  }
+}

--- a/packages/ai/src/shared/providers/openai.ts
+++ b/packages/ai/src/shared/providers/openai.ts
@@ -36,6 +36,10 @@ import type {
   TokenUsage,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -81,6 +85,7 @@ const OPENAI_PROFILE: OpenAICompatibleProfile = {
     fineTuning: true,
     imageEmbeddings: true,
     imageGeneration: true,
+    videoGeneration: false,
     tts: false,
     voiceCloning: false,
     voiceDesign: false,
@@ -705,6 +710,57 @@ export class OpenAIProvider implements AIInterface {
     } finally {
       controls?.cleanup();
     }
+  }
+
+  // ============================================================================
+  // Video Generation Methods (Not supported - use gemini, byteplus-modelark,
+  // or openai-compat-video provider)
+  // ============================================================================
+
+  async submitVideoGenerationJob(
+    _options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    throw new AIError(
+      `Video generation is not supported by ${this.profile.providerLabel} provider. Use gemini, byteplus-modelark, or openai-compat-video provider.`,
+      'NOT_IMPLEMENTED',
+      this.profile.providerName,
+    );
+  }
+
+  async getVideoGenerationJob(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    throw new AIError(
+      `Video generation is not supported by ${this.profile.providerLabel} provider. Use gemini, byteplus-modelark, or openai-compat-video provider.`,
+      'NOT_IMPLEMENTED',
+      this.profile.providerName,
+    );
+  }
+
+  async fetchVideoGenerationResult(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    throw new AIError(
+      `Video generation is not supported by ${this.profile.providerLabel} provider. Use gemini, byteplus-modelark, or openai-compat-video provider.`,
+      'NOT_IMPLEMENTED',
+      this.profile.providerName,
+    );
+  }
+
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      `Video generation is not supported by ${this.profile.providerLabel} provider. Use gemini, byteplus-modelark, or openai-compat-video provider.`,
+      'NOT_IMPLEMENTED',
+      this.profile.providerName,
+    );
+  }
+
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    throw new AIError(
+      `Video generation is not supported by ${this.profile.providerLabel} provider. Use gemini, byteplus-modelark, or openai-compat-video provider.`,
+      'NOT_IMPLEMENTED',
+      this.profile.providerName,
+    );
   }
 
   /**

--- a/packages/ai/src/shared/providers/qwen-tts.ts
+++ b/packages/ai/src/shared/providers/qwen-tts.ts
@@ -28,6 +28,10 @@ import type {
   Qwen3TTSOptions,
   TTSOptions,
   TTSResponse,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
   Voice,
   VoiceCloneOptions,
   VoiceDesignOptions,
@@ -519,15 +523,66 @@ export class Qwen3TTSProvider implements AIInterface {
     );
   }
 
-  async *stream(
+  async submitVideoGenerationJob(
+    _options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    throw new AIError(
+      'Video generation is not supported by Qwen3-TTS provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'qwen3-tts',
+    );
+  }
+
+  async getVideoGenerationJob(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    throw new AIError(
+      'Video generation is not supported by Qwen3-TTS provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'qwen3-tts',
+    );
+  }
+
+  async fetchVideoGenerationResult(
+    _handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    throw new AIError(
+      'Video generation is not supported by Qwen3-TTS provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'qwen3-tts',
+    );
+  }
+
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      'Video generation is not supported by Qwen3-TTS provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'qwen3-tts',
+    );
+  }
+
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    throw new AIError(
+      'Video generation is not supported by Qwen3-TTS provider. Use gemini, byteplus-modelark, or openai-compat-video provider.',
+      'NOT_IMPLEMENTED',
+      'qwen3-tts',
+    );
+  }
+
+  stream(
     _messages: AIMessage[],
     _options?: ChatOptions,
   ): AsyncIterable<string> {
-    throw new AIError(
+    const error = new AIError(
       'Chat streaming is not supported by Qwen3-TTS provider.',
       'NOT_IMPLEMENTED',
       'qwen3-tts',
     );
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.reject(error),
+      }),
+    };
   }
 
   async countTokens(_text: string): Promise<number> {
@@ -572,6 +627,7 @@ export class Qwen3TTSProvider implements AIInterface {
       fineTuning: false,
       imageEmbeddings: false,
       imageGeneration: false,
+      videoGeneration: false,
       tts: true,
       voiceCloning: true,
       voiceDesign: true,

--- a/packages/ai/src/shared/rate-limit.ts
+++ b/packages/ai/src/shared/rate-limit.ts
@@ -15,6 +15,7 @@ const RATE_LIMITED_METHODS = new Set<keyof AIInterface>([
   'cloneVoice',
   'designVoice',
   'getVoices',
+  'submitVideoGenerationJob',
 ]);
 
 const MAX_BUDGET_COORDINATORS = 128;

--- a/packages/ai/src/shared/safety.ts
+++ b/packages/ai/src/shared/safety.ts
@@ -332,7 +332,8 @@ export function requestEventBase(options: {
     attempts: normalized.maxRetries + 1,
     requestedMaxOutputTokens: options.callOptions?.maxTokens,
     effectiveMaxOutputTokens:
-      options.operation === 'generateImage'
+      options.operation === 'generateImage' ||
+      VIDEO_GENERATION_OPERATIONS.has(options.operation)
         ? undefined
         : (options.effectiveMaxOutputTokens ??
           normalized.generationLimits.maxOutputTokens),
@@ -347,6 +348,29 @@ const OBSERVED_OPERATIONS = new Set<AIRequestOperation>([
   'describeImage',
   'generateImage',
   'stream',
+  'submitVideoGenerationJob',
+  'getVideoGenerationJob',
+  'fetchVideoGenerationResult',
+  'cancelVideoGenerationJob',
+]);
+
+/**
+ * `getVideoGenerationJob` / `fetchVideoGenerationResult` /
+ * `cancelVideoGenerationJob` take a `VideoGenerationJob` handle as their
+ * first (and only) argument rather than a chat-shaped `options` object as
+ * the second argument. The handle still carries a `model` field, so
+ * `callOptionsFor` reads it from the same position as `submitVideoGenerationJob`'s
+ * `options` (index 0) rather than index 1.
+ */
+const VIDEO_HANDLE_OPERATIONS = new Set<AIRequestOperation>([
+  'getVideoGenerationJob',
+  'fetchVideoGenerationResult',
+  'cancelVideoGenerationJob',
+]);
+
+const VIDEO_GENERATION_OPERATIONS = new Set<AIRequestOperation>([
+  'submitVideoGenerationJob',
+  ...VIDEO_HANDLE_OPERATIONS,
 ]);
 
 function callOptionsFor(
@@ -359,7 +383,13 @@ function callOptionsFor(
       usageTags?: Record<string, string>;
     })
   | undefined {
-  const index = operation === 'describeImage' ? 2 : 1;
+  const index =
+    operation === 'describeImage'
+      ? 2
+      : operation === 'submitVideoGenerationJob' ||
+          VIDEO_HANDLE_OPERATIONS.has(operation)
+        ? 0
+        : 1;
   const value = args[index];
   return value && typeof value === 'object'
     ? (value as AIRequestControls & {
@@ -386,13 +416,20 @@ function effectiveOutputTokens(
       })
     | undefined,
 ): number | undefined {
-  if (operation === 'generateImage') {
-    normalizeImageGenerationOptions(
-      providerOptions,
-      callOptions || {},
-      providerName(providerOptions),
-      callOptions?.model,
-    );
+  if (
+    operation === 'generateImage' ||
+    VIDEO_GENERATION_OPERATIONS.has(operation)
+  ) {
+    // maxTokens/reasoning concepts don't apply to video-generation jobs;
+    // avoid attaching a misleading chat-shaped token ceiling to the event.
+    if (operation === 'generateImage') {
+      normalizeImageGenerationOptions(
+        providerOptions,
+        callOptions || {},
+        providerName(providerOptions),
+        callOptions?.model,
+      );
+    }
     return undefined;
   }
 

--- a/packages/ai/src/shared/types.ts
+++ b/packages/ai/src/shared/types.ts
@@ -58,7 +58,11 @@ export type AIRequestOperation =
   | 'embedImage'
   | 'describeImage'
   | 'generateImage'
-  | 'stream';
+  | 'stream'
+  | 'submitVideoGenerationJob'
+  | 'getVideoGenerationJob'
+  | 'fetchVideoGenerationResult'
+  | 'cancelVideoGenerationJob';
 
 /** Terminal lifecycle state for a provider request. */
 export type AIRequestStatus =
@@ -100,6 +104,8 @@ export const AI_PROVIDER_TYPES = [
   'bedrock',
   'claude-cli',
   'qwen3-tts',
+  'openai-compat-video',
+  'byteplus-modelark',
 ] as const;
 
 /**
@@ -1090,6 +1096,12 @@ export interface AICapabilities {
   imageGeneration: boolean;
 
   /**
+   * Whether the provider supports asynchronous video-generation jobs
+   * (submitVideoGenerationJob / getVideoGenerationJob / fetchVideoGenerationResult / cancelVideoGenerationJob)
+   */
+  videoGeneration: boolean;
+
+  /**
    * Whether the provider supports text-to-speech synthesis
    */
   tts: boolean;
@@ -1400,6 +1412,123 @@ export interface AIInterface {
     options?: ImageGenerationOptions,
   ): Promise<ImageGenerationResponse>;
 
+  // ============================================================================
+  // Video Generation Methods (async job abstraction)
+  // ============================================================================
+
+  /**
+   * Submit an asynchronous video-generation job.
+   *
+   * Returns a JSON-serializable handle rather than the finished video: video
+   * generation runs as a long-lived provider-side job, so callers persist the
+   * handle and poll {@link AIInterface.getVideoGenerationJob} (optionally
+   * across process restarts) until the job completes.
+   *
+   * @param options - Prompt, reference media, and generation parameters
+   * @returns Promise resolving to a serializable job handle
+   * @throws {AIError} When video generation is not supported or the request fails
+   *
+   * @example
+   * ```typescript
+   * const job = await ai.submitVideoGenerationJob({
+   *   prompt: 'A drone shot flying over a coastal cliff at sunrise',
+   *   durationSeconds: 8,
+   *   resolution: '1080p',
+   * });
+   * // Persist `job` (it is plain JSON) and resume polling later, even after a restart.
+   * ```
+   */
+  submitVideoGenerationJob(
+    options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob>;
+
+  /**
+   * Check the status of a previously submitted video-generation job.
+   *
+   * @param handle - The job handle returned by {@link AIInterface.submitVideoGenerationJob}
+   * @returns Promise resolving to the current status, and the result once succeeded
+   * @throws {AIError} When video generation is not supported or the status check fails
+   *
+   * @example
+   * ```typescript
+   * const status = await ai.getVideoGenerationJob(job);
+   * if (status.status === 'succeeded') {
+   *   console.log(status.result?.url);
+   * }
+   * ```
+   */
+  getVideoGenerationJob(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult>;
+
+  /**
+   * Fetch the result of a completed video-generation job.
+   *
+   * @param handle - The job handle returned by {@link AIInterface.submitVideoGenerationJob}
+   * @returns Promise resolving to the generated video's location/bytes and metadata
+   * @throws {AIError} When video generation is not supported, the job has not
+   * succeeded yet, or the request fails
+   *
+   * @example
+   * ```typescript
+   * const result = await ai.fetchVideoGenerationResult(job);
+   * if (result.data) fs.writeFileSync('output.mp4', result.data);
+   * ```
+   */
+  fetchVideoGenerationResult(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult>;
+
+  /**
+   * Cancel an in-flight video-generation job.
+   *
+   * **Cancellation is best-effort across every provider, not a guarantee.**
+   * Consumers should call this on step abort or lease loss so they are not
+   * billed for orphaned renders, but must be prepared for it to fail and
+   * tolerate that failure rather than treating it as fatal:
+   * - Some providers have no cancel endpoint at all for video-generation
+   *   jobs (e.g. Gemini/Veo) and always throw.
+   * - Some providers can only cancel a job that hasn't started rendering
+   *   yet (e.g. ModelArk/Seedance can cancel a `queued` task but rejects
+   *   cancellation of a `running` one).
+   * - Some gateway-shaped providers may not implement cancellation at all,
+   *   depending on the backend they proxy to.
+   *
+   * In every failure case, implementations throw {@link AIError} describing
+   * why rather than silently succeeding.
+   *
+   * @param handle - The job handle returned by {@link AIInterface.submitVideoGenerationJob}
+   * @throws {AIError} When video generation is not supported, or cancellation
+   * is unsupported/rejected by the provider (best-effort — callers must
+   * tolerate this)
+   *
+   * @example
+   * ```typescript
+   * controller.signal.addEventListener('abort', () => {
+   *   ai.cancelVideoGenerationJob(job).catch((error) => {
+   *     // Best-effort: log and move on, don't treat this as fatal.
+   *     console.warn('Could not cancel video job', job.jobId, error);
+   *   });
+   * });
+   * ```
+   */
+  cancelVideoGenerationJob(handle: VideoGenerationJob): Promise<void>;
+
+  /**
+   * Perform a cheap, auth-shaped call to confirm video-generation access is
+   * configured correctly (e.g. a list-shaped API call), without submitting a
+   * billed generation job.
+   *
+   * This is intentionally minimal, not free: providers without a dedicated
+   * health endpoint reuse a low-cost listing call. Callers on a hot path
+   * (e.g. a capability check per task) must cache the result themselves
+   * rather than calling this on every iteration.
+   *
+   * @returns Promise resolving to true when access looks valid
+   * @throws {AIError} When video generation is not supported or credentials are invalid
+   */
+  validateVideoGenerationAccess(): Promise<boolean>;
+
   /**
    * Stream a chat completion, yielding text chunks as they arrive.
    *
@@ -1561,8 +1690,8 @@ export interface AIInterface {
  * The pacing wrapper activates only when one of the pacing fields
  * (`enabled`, `key`, `cooldownMs`, `initialDelayMs`, `maxAttempts`) is set.
  *
- * `qwen3-tts` also uses `requestsPerMinute` and `maxConcurrent` from this
- * object for its local token bucket limiter.
+ * `qwen3-tts` and `byteplus-modelark` also use `requestsPerMinute` and
+ * `maxConcurrent` from this object for their local token bucket limiters.
  */
 export interface AIRateLimitOptions {
   /**
@@ -1862,6 +1991,56 @@ export interface Qwen3TTSOptions extends BaseAIOptions {
 }
 
 /**
+ * OpenAI-compatible video-generation provider options.
+ *
+ * Thin adapter over a `/v1/videos`-shaped REST surface (create / retrieve /
+ * cancel / download content), the shape used by LiteLLM's video passthrough
+ * and Sora-shaped gateways. Only video-generation methods are implemented;
+ * chat, embeddings, and other operations throw `NOT_IMPLEMENTED` — use the
+ * `openai` or `litellm` provider types for those against the same gateway.
+ */
+export interface OpenAICompatVideoOptions extends BaseAIOptions {
+  type: 'openai-compat-video';
+  apiKey?: string;
+  /**
+   * Base URL for the gateway's OpenAI-compatible API root, e.g.
+   * `https://llm.happyvertical.com/v1`. Required (directly or via the
+   * `OPENAI_COMPAT_VIDEO_BASE_URL` environment variable).
+   */
+  baseUrl?: string;
+}
+
+/**
+ * BytePlus ModelArk (Seedance) video-generation provider options.
+ *
+ * Raw-HTTP provider following the `qwen3-tts` precedent: no vendor SDK, just
+ * the ModelArk video-generation task API (create task / poll / fetch).
+ */
+export interface ByteplusModelArkOptions extends BaseAIOptions {
+  type: 'byteplus-modelark';
+  /**
+   * ModelArk API key. Falls back to `MODELARK_API_KEY` or the
+   * BytePlus-documented `ARK_API_KEY` environment variable.
+   */
+  apiKey?: string;
+  /**
+   * ModelArk API root. Defaults to
+   * `https://ark.ap-southeast.bytepluses.com/api/v3`.
+   */
+  baseUrl?: string;
+  /**
+   * Rate limiting configuration for the local submit-time limiter, shared
+   * across provider instances constructed with the same `apiKey` (or the
+   * same explicit `rateLimit.key`). Reads `requestsPerMinute` /
+   * `maxConcurrent`. Defaults approximate the documented Seedance account
+   * limits of QPS 2 / 3 concurrent *submissions* — `maxConcurrent` bounds
+   * concurrent submit HTTP requests, not the lifetime of the render tasks
+   * they create, which this package has no way to observe.
+   */
+  rateLimit?: AIRateLimitOptions;
+}
+
+/**
  * Union type for all provider options
  */
 export type GetAIOptions =
@@ -1874,7 +2053,9 @@ export type GetAIOptions =
   | HuggingFaceOptions
   | BedrockOptions
   | ClaudeCliOptions
-  | Qwen3TTSOptions;
+  | Qwen3TTSOptions
+  | OpenAICompatVideoOptions
+  | ByteplusModelArkOptions;
 
 /**
  * Base error class for all AI operations.
@@ -1987,6 +2168,228 @@ export class ContentFilterError extends AIError {
     );
     this.name = 'ContentFilterError';
   }
+}
+
+// ============================================================================
+// Video Generation Types
+// ============================================================================
+
+/**
+ * Lifecycle status of an asynchronous video-generation job.
+ */
+export type VideoGenerationStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled';
+
+/**
+ * A reference image supplied to guide video generation (image-to-video,
+ * first/last frame, subject/style conditioning).
+ */
+export interface VideoGenerationReferenceImage {
+  /**
+   * Image as a URL, base64 data URL, or raw bytes.
+   */
+  image: string | Buffer;
+
+  /**
+   * MIME type of `image`, required when `image` is a Buffer.
+   */
+  mimeType?: string;
+
+  /**
+   * Provider-specific reference role, e.g. `'first_frame'`, `'last_frame'`,
+   * `'reference_image'`, `'style'`, or `'asset'`. Providers that don't
+   * recognize a role fall back to their default reference behavior.
+   */
+  role?: string;
+}
+
+/**
+ * Options for submitting an asynchronous video-generation job.
+ */
+export interface VideoGenerationOptions extends AIRequestControls {
+  /**
+   * Model to use for video generation (provider-specific id).
+   */
+  model?: string;
+
+  /**
+   * Text description of the desired video. Optional for providers that
+   * support pure image-to-video generation from `referenceImages` alone.
+   */
+  prompt?: string;
+
+  /**
+   * Explicit statement of what should NOT appear in the generated video.
+   * Support varies by provider; unsupported providers ignore this field.
+   */
+  negativePrompt?: string;
+
+  /**
+   * Reference image(s) for image-to-video or style/subject conditioning.
+   */
+  referenceImages?: VideoGenerationReferenceImage[];
+
+  /**
+   * Duration of the generated clip in seconds.
+   */
+  durationSeconds?: number;
+
+  /**
+   * Resolution label such as `'720p'` or `'1080p'` (provider-dependent).
+   */
+  resolution?: string;
+
+  /**
+   * Aspect ratio such as `'16:9'`, `'9:16'`, or `'1:1'`.
+   */
+  aspectRatio?: string;
+
+  /**
+   * Frames per second for the generated video. Support varies by provider.
+   */
+  fps?: number;
+
+  /**
+   * Random seed for deterministic generation where supported.
+   */
+  seed?: number;
+
+  /**
+   * Custom tags to attach to the usage event emitted for this job.
+   * Merged over any global `usageTags` from provider options.
+   */
+  usageTags?: Record<string, string>;
+}
+
+/**
+ * Serializable handle for an in-flight or completed video-generation job.
+ *
+ * Consumers persist this (e.g. as JSON in a database checkpoint) so they can
+ * resume polling after a process restart. Every field is plain
+ * JSON-serializable data — no closures, streams, or provider client
+ * instances — so the handle round-trips through `JSON.stringify` /
+ * `JSON.parse` unchanged.
+ *
+ * `jobId` and `provider` are the load-bearing fields every provider needs to
+ * resume polling; `raw` may carry provider-specific resume context (e.g.
+ * which auth mode a job was submitted under) that is opaque to callers but
+ * required for a provider to correctly service the resumed request.
+ * Consumers must persist and pass back the **whole** handle verbatim —
+ * reconstructing a handle from just `jobId` (dropping `raw`) is not
+ * guaranteed to work.
+ */
+export interface VideoGenerationJob {
+  /**
+   * Provider-assigned job or operation identifier.
+   */
+  jobId: string;
+
+  /**
+   * Provider that created the job (e.g. `'gemini'`, `'byteplus-modelark'`).
+   */
+  provider: string;
+
+  /**
+   * Model used for the job.
+   */
+  model: string;
+
+  /**
+   * ISO-8601 timestamp for when the job was submitted.
+   */
+  createdAt: string;
+
+  /**
+   * Provider-specific data needed to resume polling (e.g. an operation
+   * resource name shape, or routing hints). Opaque to callers; always
+   * JSON-serializable.
+   */
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * Result of a completed video-generation job.
+ */
+export interface VideoGenerationResult {
+  /**
+   * Temporary or permanent URL to the generated video, when the provider
+   * returns a downloadable link instead of inline bytes.
+   */
+  url?: string;
+
+  /**
+   * Raw generated video bytes, when the provider returns inline data
+   * instead of (or in addition to) a URL.
+   */
+  data?: Buffer;
+
+  /**
+   * MIME type of the generated video (e.g. `'video/mp4'`).
+   */
+  mimeType: string;
+
+  /**
+   * Duration of the generated video in seconds, where reported.
+   */
+  durationSeconds?: number;
+
+  /**
+   * Width of the generated video in pixels, where reported.
+   */
+  width?: number;
+
+  /**
+   * Height of the generated video in pixels, where reported.
+   */
+  height?: number;
+}
+
+/**
+ * Status snapshot for a video-generation job, as returned by
+ * {@link AIInterface.getVideoGenerationJob}.
+ */
+export interface VideoGenerationStatusResult {
+  /**
+   * Current lifecycle status of the job.
+   */
+  status: VideoGenerationStatus;
+
+  /**
+   * Provider-reported progress percentage (0-100), where available.
+   */
+  progress?: number;
+
+  /**
+   * Human-readable error message, populated when `status` is `'failed'`.
+   */
+  error?: string;
+
+  /**
+   * The provider's raw, unrecognized status string. Only set when the
+   * provider reported a status value this package doesn't have an explicit
+   * mapping for. Providers must never invent a terminal state (`'failed'`
+   * or `'succeeded'`) for a status they don't understand — an unrecognized
+   * value is mapped to `'running'` with the original string preserved here,
+   * so a mid-render status a provider adds later (e.g. a new gateway
+   * synonym for "processing") never gets misread as a failure that would
+   * cause a caller to resubmit and double-bill.
+   */
+  rawStatus?: string;
+
+  /**
+   * Populated once `status` is `'succeeded'`. For providers whose status
+   * endpoint returns the payload inline, this is equivalent to calling
+   * {@link AIInterface.fetchVideoGenerationResult} with the same handle.
+   * Providers whose result requires a separate download (e.g. large binary
+   * content behind its own endpoint) may populate metadata here (mimeType,
+   * durationSeconds, width, height) while leaving `url`/`data` unset until
+   * `fetchVideoGenerationResult` is called explicitly.
+   */
+  result?: VideoGenerationResult;
 }
 
 // ============================================================================

--- a/packages/ai/src/video-generation.test.ts
+++ b/packages/ai/src/video-generation.test.ts
@@ -1,0 +1,1441 @@
+/**
+ * Tests for the async video-generation job abstraction (issue #1181):
+ * handle serialization round-trip and resume, cancellation (best-effort),
+ * NOT_IMPLEMENTED throws on providers without video support, per-provider
+ * status mapping, reference-image submission, rate-limit behavior on
+ * submit, onRequest lifecycle events, and getAIAuto precedence.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { GenerateVideosOperation } from '@google/genai';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getAIAuto } from './node/factory';
+import {
+  __resetByteplusModelArkRateLimitersForTests,
+  ByteplusModelArkProvider,
+} from './shared/providers/byteplus-modelark';
+import { GeminiProvider } from './shared/providers/gemini';
+import { OpenAIProvider } from './shared/providers/openai';
+import { OpenAICompatVideoProvider } from './shared/providers/openai-compat-video';
+import { createRateLimitedAI } from './shared/rate-limit';
+import { createObservedAI } from './shared/safety';
+import {
+  AIError,
+  type AIInterface,
+  AuthenticationError,
+  type VideoGenerationJob,
+} from './shared/types';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+/**
+ * Construct a GeminiProvider with a mocked `@google/genai` client and a
+ * real `GenerateVideosOperation` constructor.
+ *
+ * The provider constructor fires a background `import('@google/genai')`
+ * that later assigns `this.client`/`this.operationCtor` asynchronously
+ * (see `initializeClientSync`). Since `@google/genai` is already loaded
+ * (statically imported at the top of this file), that background import
+ * resolves within a handful of microtask ticks — racing a same-tick
+ * `(provider as any).client = mock` assignment. Flushing past a macrotask
+ * boundary before assigning the mock guarantees the background write has
+ * already landed, so the mock assignment below is always the final,
+ * un-raced write.
+ */
+async function mockedGeminiProvider(
+  clientMock: Record<string, unknown>,
+  options: { apiKey?: string; projectId?: string; location?: string } = {},
+): Promise<GeminiProvider> {
+  const provider = new GeminiProvider({
+    type: 'gemini',
+    apiKey: options.apiKey ?? 'test-key',
+    projectId: options.projectId,
+    location: options.location,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  (provider as any).client = clientMock;
+  (provider as any).operationCtor = GenerateVideosOperation;
+  return provider;
+}
+
+describe('Video generation capability flag and NOT_IMPLEMENTED behavior', () => {
+  it('reports videoGeneration: false and throws NOT_IMPLEMENTED for a text-only provider', async () => {
+    const provider = new OpenAIProvider({ type: 'openai', apiKey: 'test-key' });
+
+    const capabilities = await provider.getCapabilities();
+    expect(capabilities.videoGeneration).toBe(false);
+
+    await expect(
+      provider.submitVideoGenerationJob({ prompt: 'a video' }),
+    ).rejects.toMatchObject({ name: 'AIError', code: 'NOT_IMPLEMENTED' });
+    await expect(
+      provider.getVideoGenerationJob({
+        jobId: 'x',
+        provider: 'openai',
+        model: 'gpt-4o',
+        createdAt: new Date().toISOString(),
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' });
+    await expect(
+      provider.fetchVideoGenerationResult({
+        jobId: 'x',
+        provider: 'openai',
+        model: 'gpt-4o',
+        createdAt: new Date().toISOString(),
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' });
+    await expect(
+      provider.cancelVideoGenerationJob({
+        jobId: 'x',
+        provider: 'openai',
+        model: 'gpt-4o',
+        createdAt: new Date().toISOString(),
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' });
+    await expect(
+      provider.validateVideoGenerationAccess(),
+    ).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' });
+  });
+});
+
+describe('Gemini video generation (Veo)', () => {
+  it('submits a job and returns a JSON-serializable handle', async () => {
+    const generateVideos = vi.fn().mockResolvedValue({
+      name: 'models/veo-3.1-generate-preview/operations/abc123',
+    });
+    const provider = await mockedGeminiProvider({ models: { generateVideos } });
+
+    const job = await provider.submitVideoGenerationJob({
+      prompt: 'A neon hologram of a cat driving at top speed',
+      durationSeconds: 8,
+      aspectRatio: '16:9',
+    });
+
+    expect(job).toEqual({
+      jobId: 'models/veo-3.1-generate-preview/operations/abc123',
+      provider: 'gemini',
+      model: 'veo-3.1-generate-preview',
+      createdAt: expect.any(String),
+      raw: { vertexai: false },
+    });
+    expect(generateVideos).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'veo-3.1-generate-preview',
+        prompt: 'A neon hologram of a cat driving at top speed',
+        config: expect.objectContaining({
+          durationSeconds: 8,
+          aspectRatio: '16:9',
+        }),
+      }),
+    );
+
+    // The handle must be plain JSON: no closures, functions, or class instances.
+    const serialized = JSON.parse(JSON.stringify(job));
+    expect(serialized).toEqual(job);
+  });
+
+  it('converts a URL reference image to the { imageBytes, mimeType } shape generateVideos expects (not inlineData)', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { 'content-type': 'image/jpeg' },
+      }),
+    ) as any;
+
+    const generateVideos = vi
+      .fn()
+      .mockResolvedValue({ name: 'operations/img2vid-url' });
+    const provider = await mockedGeminiProvider({ models: { generateVideos } });
+
+    try {
+      await provider.submitVideoGenerationJob({
+        prompt: 'animate this photo',
+        referenceImages: [{ image: 'https://example.com/first-frame.jpg' }],
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    expect(generateVideos).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: {
+          imageBytes: Buffer.from([1, 2, 3]).toString('base64'),
+          mimeType: 'image/jpeg',
+        },
+      }),
+    );
+    // Must NOT use the chat/vision inlineData wrapper shape — the SDK's
+    // video converters only read imageBytes/mimeType/gcsUri and silently
+    // drop anything else.
+    const call = generateVideos.mock.calls[0][0];
+    expect(call.image.inlineData).toBeUndefined();
+  });
+
+  it('converts a Buffer reference image to the { imageBytes, mimeType } shape', async () => {
+    const generateVideos = vi
+      .fn()
+      .mockResolvedValue({ name: 'operations/img2vid-buffer' });
+    const provider = await mockedGeminiProvider({ models: { generateVideos } });
+
+    const buf = Buffer.from([9, 9, 9]);
+    await provider.submitVideoGenerationJob({
+      prompt: 'animate this photo',
+      referenceImages: [{ image: buf, mimeType: 'image/png' }],
+    });
+
+    expect(generateVideos).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: { imageBytes: buf.toString('base64'), mimeType: 'image/png' },
+      }),
+    );
+  });
+
+  it('resumes polling from a handle round-tripped through JSON on a fresh provider instance, constructing a real GenerateVideosOperation', async () => {
+    const generateVideos = vi
+      .fn()
+      .mockResolvedValue({ name: 'operations/resume-me' });
+    const submitter = await mockedGeminiProvider({
+      models: { generateVideos },
+    });
+
+    const job = await submitter.submitVideoGenerationJob({ prompt: 'hello' });
+
+    // Simulate a process restart: persist as JSON, then rehydrate.
+    const persisted = JSON.stringify(job);
+    const resumedHandle: VideoGenerationJob = JSON.parse(persisted);
+
+    // A brand new provider instance with no memory of the original submit call.
+    const getVideosOperation = vi.fn().mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          {
+            video: {
+              uri: 'https://example.com/out.mp4',
+              mimeType: 'video/mp4',
+            },
+          },
+        ],
+      },
+    });
+    const resumer = await mockedGeminiProvider({
+      operations: { getVideosOperation },
+    });
+
+    const status = await resumer.getVideoGenerationJob(resumedHandle);
+
+    // The critical regression check: getVideosOperation must be called with
+    // a real GenerateVideosOperation instance, not a plain { name } literal
+    // — the SDK calls operation._fromAPIResponse(...), an instance method
+    // that doesn't exist on a plain object and throws at runtime.
+    const passedOperation = getVideosOperation.mock.calls[0][0].operation;
+    expect(passedOperation).toBeInstanceOf(GenerateVideosOperation);
+    expect(passedOperation.name).toBe(resumedHandle.jobId);
+
+    expect(status).toEqual({
+      status: 'succeeded',
+      result: {
+        url: 'https://example.com/out.mp4',
+        mimeType: 'video/mp4',
+      },
+    });
+  });
+
+  it('throws a mode-mismatch error when resuming a Vertex AI handle against an AI Studio provider', async () => {
+    const vertexHandle: VideoGenerationJob = {
+      jobId: 'projects/p/locations/l/operations/abc',
+      provider: 'gemini',
+      model: 'veo-3.1-generate-preview',
+      createdAt: new Date().toISOString(),
+      raw: { vertexai: true },
+    };
+
+    const provider = await mockedGeminiProvider({
+      operations: { getVideosOperation: vi.fn() },
+    });
+
+    await expect(
+      provider.getVideoGenerationJob(vertexHandle),
+    ).rejects.toMatchObject({ code: 'VIDEO_JOB_MODE_MISMATCH' });
+  });
+
+  it.each([
+    [{ done: false }, { status: 'running' }],
+    [
+      { done: true, error: { message: 'quota exceeded' } },
+      { status: 'failed', error: 'quota exceeded' },
+    ],
+    [
+      { done: true, error: { message: 'operation was cancelled by caller' } },
+      { status: 'cancelled' },
+    ],
+    [
+      // google.rpc.Code.CANCELLED === 1, preferred over the message regex.
+      { done: true, error: { code: 1, message: 'terminated' } },
+      { status: 'cancelled' },
+    ],
+  ])('maps operation shape %j to status %j', async (operation, expected) => {
+    const provider = await mockedGeminiProvider({
+      operations: {
+        getVideosOperation: vi.fn().mockResolvedValue(operation),
+      },
+    });
+
+    const status = await provider.getVideoGenerationJob({
+      jobId: 'operations/xyz',
+      provider: 'gemini',
+      model: 'veo-3.1-generate-preview',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(status).toMatchObject(expected);
+  });
+
+  it('fetchVideoGenerationResult throws when the job has not succeeded', async () => {
+    const provider = await mockedGeminiProvider({
+      operations: {
+        getVideosOperation: vi.fn().mockResolvedValue({ done: false }),
+      },
+    });
+
+    await expect(
+      provider.fetchVideoGenerationResult({
+        jobId: 'operations/xyz',
+        provider: 'gemini',
+        model: 'veo-3.1-generate-preview',
+        createdAt: new Date().toISOString(),
+      }),
+    ).rejects.toMatchObject({ code: 'VIDEO_JOB_NOT_READY' });
+  });
+
+  it('fetchVideoGenerationResult downloads bytes via ai.files.download for a succeeded job', async () => {
+    const download = vi.fn(
+      async ({ downloadPath }: { downloadPath: string }) => {
+        await writeFile(downloadPath, Buffer.from('fake-mp4-bytes'));
+      },
+    );
+    const provider = await mockedGeminiProvider({
+      operations: {
+        getVideosOperation: vi.fn().mockResolvedValue({
+          done: true,
+          response: {
+            generatedVideos: [
+              {
+                video: {
+                  uri: 'https://generativelanguage.googleapis.com/v1beta/files/abc123:download?alt=media',
+                  mimeType: 'video/mp4',
+                },
+              },
+            ],
+          },
+        }),
+      },
+      files: { download },
+    });
+
+    const result = await provider.fetchVideoGenerationResult({
+      jobId: 'operations/xyz',
+      provider: 'gemini',
+      model: 'veo-3.1-generate-preview',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(download).toHaveBeenCalledTimes(1);
+    expect(result.mimeType).toBe('video/mp4');
+    expect(result.url).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/files/abc123:download?alt=media',
+    );
+    expect(Buffer.from(result.data as Buffer).toString()).toBe(
+      'fake-mp4-bytes',
+    );
+  });
+
+  it('fetchVideoGenerationResult uses inline videoBytes directly, without downloading, when the provider returns them', async () => {
+    const download = vi.fn();
+    const inlineBytes = Buffer.from('inline-bytes').toString('base64');
+    const provider = await mockedGeminiProvider({
+      operations: {
+        getVideosOperation: vi.fn().mockResolvedValue({
+          done: true,
+          response: {
+            generatedVideos: [
+              {
+                video: { videoBytes: inlineBytes, mimeType: 'video/mp4' },
+              },
+            ],
+          },
+        }),
+      },
+      files: { download },
+    });
+
+    const result = await provider.fetchVideoGenerationResult({
+      jobId: 'operations/xyz',
+      provider: 'gemini',
+      model: 'veo-3.1-generate-preview',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(download).not.toHaveBeenCalled();
+    expect(Buffer.from(result.data as Buffer).toString()).toBe('inline-bytes');
+  });
+
+  describe('cancellation (unsupported by the Gemini API)', () => {
+    const originalFetch = global.fetch;
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('always throws in AI Studio mode without making any HTTP request (the API has no video-job cancel endpoint)', async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as any;
+
+      const provider = new GeminiProvider({
+        type: 'gemini',
+        apiKey: 'test-key',
+      });
+
+      await expect(
+        provider.cancelVideoGenerationJob({
+          jobId: 'operations/abc123',
+          provider: 'gemini',
+          model: 'veo-3.1-generate-preview',
+          createdAt: new Date().toISOString(),
+        }),
+      ).rejects.toMatchObject({ code: 'VIDEO_CANCEL_UNSUPPORTED' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws NOT_IMPLEMENTED in Vertex AI mode', async () => {
+      const provider = new GeminiProvider({
+        type: 'gemini',
+        apiKey: 'test-key',
+        projectId: 'my-project',
+        location: 'us-central1',
+      });
+
+      await expect(
+        provider.cancelVideoGenerationJob({
+          jobId: 'projects/p/locations/l/operations/abc',
+          provider: 'gemini',
+          model: 'veo-3.1-generate-preview',
+          createdAt: new Date().toISOString(),
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' });
+    });
+  });
+
+  it('validateVideoGenerationAccess performs a cheap list-shaped call', async () => {
+    const list = vi.fn().mockResolvedValue({});
+    const provider = await mockedGeminiProvider({ models: { list } });
+
+    await expect(provider.validateVideoGenerationAccess()).resolves.toBe(true);
+    expect(list).toHaveBeenCalledWith({ config: { pageSize: 1 } });
+  });
+});
+
+describe('BytePlus ModelArk video generation (Seedance)', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    __resetByteplusModelArkRateLimitersForTests();
+  });
+
+  it('submits a task with the documented ModelArk request shape', async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe(
+          'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks',
+        );
+        const headers = new Headers(init?.headers);
+        expect(headers.get('Authorization')).toBe('Bearer modelark-key-1');
+        const body = JSON.parse(String(init?.body));
+        expect(body).toEqual({
+          model: 'seedance-1-0-lite-t2v-250428',
+          content: [{ type: 'text', text: 'a cinematic drone shot' }],
+          resolution: '720p',
+          ratio: '16:9',
+          duration: 5,
+          seed: undefined,
+        });
+        return jsonResponse({ id: 'cgt-2025-abc' });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-1',
+    });
+
+    const job = await provider.submitVideoGenerationJob({
+      prompt: 'a cinematic drone shot',
+      resolution: '720p',
+      aspectRatio: '16:9',
+      durationSeconds: 5,
+    });
+
+    expect(job).toEqual({
+      jobId: 'cgt-2025-abc',
+      provider: 'byteplus-modelark',
+      model: 'seedance-1-0-lite-t2v-250428',
+      createdAt: expect.any(String),
+    });
+    expect(JSON.parse(JSON.stringify(job))).toEqual(job);
+  });
+
+  it('auto-selects the i2v default model when referenceImages are present and no model is given', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.model).toBe('seedance-1-0-lite-i2v-250428');
+        return jsonResponse({ id: 'cgt-i2v-auto' });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-i2v-auto',
+    });
+
+    const job = await provider.submitVideoGenerationJob({
+      prompt: 'animate this',
+      referenceImages: [{ image: 'https://example.com/ref.jpg' }],
+    });
+
+    expect(job.model).toBe('seedance-1-0-lite-i2v-250428');
+  });
+
+  it('submits a string-URL reference image as a content-array image_url entry with role', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.content).toEqual([
+          { type: 'text', text: 'animate' },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/ref.jpg' },
+            role: 'reference_image',
+          },
+        ]);
+        return jsonResponse({ id: 'cgt-ref-url' });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-ref-url',
+    });
+
+    await provider.submitVideoGenerationJob({
+      prompt: 'animate',
+      referenceImages: [{ image: 'https://example.com/ref.jpg' }],
+    });
+  });
+
+  it('submits a Buffer reference image as a base64 data URL content-array entry with role', async () => {
+    const buf = Buffer.from([1, 2, 3]);
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.content).toEqual([
+          { type: 'text', text: 'animate' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: `data:image/png;base64,${buf.toString('base64')}`,
+            },
+            role: 'reference_image',
+          },
+        ]);
+        return jsonResponse({ id: 'cgt-ref-buf' });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-ref-buf',
+    });
+
+    await provider.submitVideoGenerationJob({
+      prompt: 'animate',
+      referenceImages: [{ image: buf, mimeType: 'image/png' }],
+    });
+  });
+
+  it.each([
+    ['queued', {}, { status: 'queued' }],
+    ['running', {}, { status: 'running' }],
+    ['cancelled', {}, { status: 'cancelled' }],
+    [
+      'failed',
+      { error: { code: 'E', message: 'render failed' } },
+      { status: 'failed', error: 'render failed' },
+    ],
+    [
+      'expired',
+      {},
+      { status: 'failed', error: expect.stringContaining('expired') },
+    ],
+    [
+      'succeeded',
+      { content: { video_url: 'https://cdn.example.com/v.mp4' }, duration: 5 },
+      {
+        status: 'succeeded',
+        result: {
+          url: 'https://cdn.example.com/v.mp4',
+          mimeType: 'video/mp4',
+          durationSeconds: 5,
+        },
+      },
+    ],
+    [
+      // An unrecognized future status must never be read as terminal.
+      'a_future_status_this_package_does_not_know',
+      {},
+      {
+        status: 'running',
+        rawStatus: 'a_future_status_this_package_does_not_know',
+      },
+    ],
+  ])('maps ModelArk task status %s', async (status, extra, expected) => {
+    global.fetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        id: 'cgt-1',
+        model: 'seedance-1-0-lite-t2v-250428',
+        status,
+        created_at: 0,
+        updated_at: 0,
+        ...extra,
+      }),
+    ) as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-status',
+    });
+
+    const result = await provider.getVideoGenerationJob({
+      jobId: 'cgt-1',
+      provider: 'byteplus-modelark',
+      model: 'seedance-1-0-lite-t2v-250428',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(result).toEqual(expected);
+  });
+
+  it('fetchVideoGenerationResult succeeds and returns the video_url + duration for a succeeded task', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        id: 'cgt-success',
+        model: 'seedance-1-0-lite-t2v-250428',
+        status: 'succeeded',
+        content: { video_url: 'https://cdn.example.com/done.mp4' },
+        duration: 5,
+        created_at: 0,
+        updated_at: 0,
+      }),
+    ) as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-fetch-success',
+    });
+
+    const result = await provider.fetchVideoGenerationResult({
+      jobId: 'cgt-success',
+      provider: 'byteplus-modelark',
+      model: 'seedance-1-0-lite-t2v-250428',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(result).toEqual({
+      url: 'https://cdn.example.com/done.mp4',
+      mimeType: 'video/mp4',
+      durationSeconds: 5,
+    });
+  });
+
+  it('resumes polling from a JSON round-tripped handle on a fresh ModelArk provider instance', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ id: 'cgt-resume' })) as any;
+
+    const submitter = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-resume',
+    });
+    const job = await submitter.submitVideoGenerationJob({ prompt: 'x' });
+    const resumedHandle: VideoGenerationJob = JSON.parse(JSON.stringify(job));
+
+    const resumeFetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/cgt-resume',
+      );
+      return jsonResponse({
+        id: 'cgt-resume',
+        model: 'seedance-1-0-lite-t2v-250428',
+        status: 'succeeded',
+        content: { video_url: 'https://cdn.example.com/resumed.mp4' },
+        created_at: 0,
+        updated_at: 0,
+      });
+    });
+    global.fetch = resumeFetchMock as any;
+
+    // A brand new provider instance simulating a process restart.
+    const resumer = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-resume',
+    });
+    const status = await resumer.getVideoGenerationJob(resumedHandle);
+
+    expect(status.status).toBe('succeeded');
+    expect(status.result?.url).toBe('https://cdn.example.com/resumed.mp4');
+  });
+
+  it('cancels a queued task via DELETE', async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe(
+          'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/cgt-1',
+        );
+        expect(init?.method).toBe('DELETE');
+        return jsonResponse({});
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-cancel',
+    });
+
+    await expect(
+      provider.cancelVideoGenerationJob({
+        jobId: 'cgt-1',
+        provider: 'byteplus-modelark',
+        model: 'seedance-1-0-lite-t2v-250428',
+        createdAt: new Date().toISOString(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('surfaces a clear error when ModelArk refuses to cancel a running task (best-effort cancel)', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response('task is running and cannot be cancelled', {
+        status: 409,
+      }),
+    ) as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-cancel-blocked',
+    });
+
+    await expect(
+      provider.cancelVideoGenerationJob({
+        jobId: 'cgt-running',
+        provider: 'byteplus-modelark',
+        model: 'seedance-1-0-lite-t2v-250428',
+        createdAt: new Date().toISOString(),
+      }),
+    ).rejects.toBeInstanceOf(AIError);
+  });
+
+  it('maps a 401 response to AuthenticationError', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response('unauthorized', { status: 401 })) as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'bad-key',
+    });
+
+    await expect(
+      provider.validateVideoGenerationAccess(),
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('wraps a fetch()-level network failure into an AIError', async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError('fetch failed')) as any;
+
+    const provider = new ByteplusModelArkProvider({
+      type: 'byteplus-modelark',
+      apiKey: 'modelark-key-network-fail',
+    });
+
+    await expect(
+      provider.validateVideoGenerationAccess(),
+    ).rejects.toMatchObject({ code: 'NETWORK_ERROR', retryable: true });
+  });
+
+  describe('submit-time rate limiting', () => {
+    it('throttles concurrent submissions to the configured maxConcurrent', async () => {
+      let inFlight = 0;
+      let maxObservedInFlight = 0;
+      const releasers: Array<() => void> = [];
+
+      const fetchMock = vi.fn(async () => {
+        inFlight += 1;
+        maxObservedInFlight = Math.max(maxObservedInFlight, inFlight);
+        await new Promise<void>((resolve) => releasers.push(resolve));
+        inFlight -= 1;
+        return jsonResponse({ id: `task-${releasers.length}` });
+      });
+      global.fetch = fetchMock as any;
+
+      const provider = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-concurrency',
+        rateLimit: { maxConcurrent: 1 },
+      });
+
+      const first = provider.submitVideoGenerationJob({ prompt: 'first' });
+      const second = provider.submitVideoGenerationJob({ prompt: 'second' });
+
+      // Give both calls a chance to reach the limiter/fetch layer.
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(fetchMock).toHaveBeenCalledTimes(1); // second is still waiting
+
+      releasers.shift()?.();
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      releasers.shift()?.();
+
+      await Promise.all([first, second]);
+      expect(maxObservedInFlight).toBe(1);
+    });
+
+    it('caps burst capacity: a burst of 5 instant submits is paced, not all resolved at once', async () => {
+      const callTimestamps: number[] = [];
+      global.fetch = vi.fn(async () => {
+        callTimestamps.push(Date.now());
+        return jsonResponse({ id: `task-${callTimestamps.length}` });
+      }) as any;
+
+      const provider = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-burst',
+      });
+
+      const start = Date.now();
+      await Promise.all(
+        Array.from({ length: 5 }, (_, index) =>
+          provider.submitVideoGenerationJob({ prompt: `p${index}` }),
+        ),
+      );
+
+      expect(callTimestamps).toHaveLength(5);
+      // Burst capacity is capped at ~2 tokens with a ~2 req/s refill, so
+      // 5 submits cannot all clear instantly — the tail end must be
+      // paced. Under the old bug (bucket starting full at
+      // `requestsPerMinute`, e.g. 120), all 5 would resolve in the same
+      // tick and this would be ~0ms.
+      const elapsed = callTimestamps[4] - start;
+      expect(elapsed).toBeGreaterThan(500);
+    }, 10000);
+
+    it('shares the submit limiter across provider instances constructed with the same apiKey', async () => {
+      const callTimestamps: number[] = [];
+      global.fetch = vi.fn(async () => {
+        callTimestamps.push(Date.now());
+        return jsonResponse({ id: `task-${callTimestamps.length}` });
+      }) as any;
+
+      const providerA = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-shared',
+      });
+      const providerB = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-shared',
+      });
+
+      const start = Date.now();
+      await Promise.all([
+        providerA.submitVideoGenerationJob({ prompt: 'a1' }),
+        providerA.submitVideoGenerationJob({ prompt: 'a2' }),
+        // 3rd submission overall against the shared bucket (capacity ~2) —
+        // must wait for a token even though it's providerB's first call.
+        providerB.submitVideoGenerationJob({ prompt: 'b1' }),
+      ]);
+
+      expect(callTimestamps).toHaveLength(3);
+      expect(callTimestamps[2] - start).toBeGreaterThan(300);
+    }, 10000);
+
+    it('does NOT share the limiter across instances with different apiKeys', async () => {
+      const callTimestamps: number[] = [];
+      global.fetch = vi.fn(async () => {
+        callTimestamps.push(Date.now());
+        return jsonResponse({ id: `task-${callTimestamps.length}` });
+      }) as any;
+
+      const providerA = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-distinct-a',
+      });
+      const providerB = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-distinct-b',
+      });
+
+      // Both providers' buckets start full (capacity 2 each), so one
+      // submission from each should clear near-instantly.
+      const start = Date.now();
+      await Promise.all([
+        providerA.submitVideoGenerationJob({ prompt: 'a1' }),
+        providerB.submitVideoGenerationJob({ prompt: 'b1' }),
+      ]);
+
+      expect(callTimestamps).toHaveLength(2);
+      expect(Date.now() - start).toBeLessThan(300);
+    });
+  });
+
+  it('participates in the shared createRateLimitedAI submit-time pacing wrapper', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const callTimes: number[] = [];
+      const stub: Partial<AIInterface> = {
+        submitVideoGenerationJob: vi.fn(async () => {
+          callTimes.push(Date.now());
+          return {
+            jobId: `job-${callTimes.length}`,
+            provider: 'byteplus-modelark',
+            model: 'seedance-1-0-lite-t2v-250428',
+            createdAt: new Date().toISOString(),
+          };
+        }),
+      };
+
+      const ai = createRateLimitedAI(stub as AIInterface, {
+        type: 'byteplus-modelark',
+        apiKey: 'test-key',
+        rateLimit: { enabled: true, cooldownMs: 500, maxAttempts: 1 },
+      });
+
+      const first = ai.submitVideoGenerationJob({ prompt: 'first' });
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(first).resolves.toMatchObject({ jobId: 'job-1' });
+
+      const second = ai.submitVideoGenerationJob({ prompt: 'second' });
+      await vi.advanceTimersByTimeAsync(499);
+      expect(callTimes).toEqual([0]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(second).resolves.toMatchObject({ jobId: 'job-2' });
+      expect(callTimes).toEqual([0, 500]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('openai-compat-video provider', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('requires a baseUrl', () => {
+    expect(
+      () =>
+        new OpenAICompatVideoProvider({
+          type: 'openai-compat-video',
+          apiKey: 'key',
+        } as any),
+    ).toThrow(/baseUrl/i);
+  });
+
+  it('submits a job using the OpenAI videos request shape', async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe('https://gateway.example.com/v1/videos');
+        const headers = new Headers(init?.headers);
+        expect(headers.get('Authorization')).toBe('Bearer gw-key');
+        const body = JSON.parse(String(init?.body));
+        expect(body).toEqual({
+          model: 'sora-2',
+          prompt: 'a time-lapse of clouds',
+          seconds: '8',
+        });
+        return jsonResponse({
+          id: 'video_123',
+          status: 'queued',
+          model: 'sora-2',
+        });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    const job = await provider.submitVideoGenerationJob({
+      prompt: 'a time-lapse of clouds',
+      durationSeconds: 8,
+    });
+
+    expect(job).toEqual({
+      jobId: 'video_123',
+      provider: 'openai-compat-video',
+      model: 'sora-2',
+      createdAt: expect.any(String),
+    });
+    expect(JSON.parse(JSON.stringify(job))).toEqual(job);
+  });
+
+  it('submits a string-URL reference image as input_reference.image_url', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.input_reference).toEqual({
+          image_url: 'https://example.com/ref.jpg',
+        });
+        return jsonResponse({
+          id: 'video_ref_url',
+          status: 'queued',
+          model: 'sora-2',
+        });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    await provider.submitVideoGenerationJob({
+      prompt: 'p',
+      referenceImages: [{ image: 'https://example.com/ref.jpg' }],
+    });
+  });
+
+  it('submits a Buffer reference image as a base64 data URL input_reference.image_url', async () => {
+    const buf = Buffer.from([5, 6, 7]);
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.input_reference).toEqual({
+          image_url: `data:image/png;base64,${buf.toString('base64')}`,
+        });
+        return jsonResponse({
+          id: 'video_ref_buf',
+          status: 'queued',
+          model: 'sora-2',
+        });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    await provider.submitVideoGenerationJob({
+      prompt: 'p',
+      referenceImages: [{ image: buf, mimeType: 'image/png' }],
+    });
+  });
+
+  it.each([
+    ['queued', {}, { status: 'queued' }],
+    ['in_progress', { progress: 42 }, { status: 'running', progress: 42 }],
+    // LiteLLM (the primary target gateway) documents 'processing' as its
+    // mid-render status rather than OpenAI's own 'in_progress'.
+    ['processing', {}, { status: 'running' }],
+    ['pending', {}, { status: 'running' }],
+    [
+      'failed',
+      { error: { message: 'render error' } },
+      { status: 'failed', error: 'render error' },
+    ],
+    ['cancelled', {}, { status: 'cancelled' }],
+    [
+      // An unrecognized status must map to 'running', never a terminal
+      // state, so a caller never misreads a mid-render job as failed and
+      // resubmits (double-billing).
+      'some_future_status',
+      {},
+      { status: 'running', rawStatus: 'some_future_status' },
+    ],
+  ])('maps openai-compat-video status %s', async (status, extra, expected) => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ id: 'video_1', model: 'sora-2', status, ...extra }),
+      ) as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    const result = await provider.getVideoGenerationJob({
+      jobId: 'video_1',
+      provider: 'openai-compat-video',
+      model: 'sora-2',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(result).toMatchObject(expected);
+  });
+
+  it('downloads content bytes for a succeeded job when the gateway does not include a direct url', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/videos/video_1')) {
+        return jsonResponse({
+          id: 'video_1',
+          model: 'sora-2',
+          status: 'completed',
+          seconds: '8',
+          size: '1280x720',
+        });
+      }
+      if (url.endsWith('/videos/video_1/content')) {
+        return new Response(new Uint8Array([1, 2, 3]), {
+          headers: { 'Content-Type': 'video/mp4' },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    global.fetch = fetchMock as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    const result = await provider.fetchVideoGenerationResult({
+      jobId: 'video_1',
+      provider: 'openai-compat-video',
+      model: 'sora-2',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(result.mimeType).toBe('video/mp4');
+    expect(result.durationSeconds).toBe(8);
+    expect(result.width).toBe(1280);
+    expect(result.height).toBe(720);
+    expect(Buffer.from(result.data as Buffer)).toEqual(Buffer.from([1, 2, 3]));
+  });
+
+  it('returns the gateway-provided url directly without downloading content when present (fast path)', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/videos/video_2')) {
+        return jsonResponse({
+          id: 'video_2',
+          model: 'sora-2',
+          status: 'completed',
+          seconds: '4',
+          url: 'https://cdn.example.com/direct.mp4',
+        });
+      }
+      throw new Error(`Unexpected fetch (should not download content): ${url}`);
+    });
+    global.fetch = fetchMock as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    const result = await provider.fetchVideoGenerationResult({
+      jobId: 'video_2',
+      provider: 'openai-compat-video',
+      model: 'sora-2',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(result.url).toBe('https://cdn.example.com/direct.mp4');
+    expect(result.data).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // only the status GET
+  });
+
+  it('resumes polling from a JSON round-tripped handle on a fresh provider instance', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ id: 'video_resume', status: 'queued', model: 'sora-2' }),
+      ) as any;
+
+    const submitter = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+    const job = await submitter.submitVideoGenerationJob({ prompt: 'x' });
+    const resumedHandle: VideoGenerationJob = JSON.parse(JSON.stringify(job));
+
+    const resumeFetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'https://gateway.example.com/v1/videos/video_resume',
+      );
+      return jsonResponse({
+        id: 'video_resume',
+        model: 'sora-2',
+        status: 'completed',
+        url: 'https://cdn.example.com/resumed.mp4',
+      });
+    });
+    global.fetch = resumeFetchMock as any;
+
+    // A brand new provider instance simulating a process restart.
+    const resumer = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+    const status = await resumer.getVideoGenerationJob(resumedHandle);
+
+    expect(status.status).toBe('succeeded');
+    expect(status.result?.url).toBe('https://cdn.example.com/resumed.mp4');
+  });
+
+  it('fetchVideoGenerationResult throws when the job has not succeeded', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ id: 'video_1', model: 'sora-2', status: 'in_progress' }),
+      ) as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    await expect(
+      provider.fetchVideoGenerationResult({
+        jobId: 'video_1',
+        provider: 'openai-compat-video',
+        model: 'sora-2',
+        createdAt: new Date().toISOString(),
+      }),
+    ).rejects.toMatchObject({ code: 'VIDEO_JOB_NOT_READY' });
+  });
+
+  it('cancels a job via POST /videos/{id}/cancel (best-effort)', async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe(
+          'https://gateway.example.com/v1/videos/video_1/cancel',
+        );
+        expect(init?.method).toBe('POST');
+        return jsonResponse({ id: 'video_1', status: 'cancelled' });
+      },
+    );
+    global.fetch = fetchMock as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    await expect(
+      provider.cancelVideoGenerationJob({
+        jobId: 'video_1',
+        provider: 'openai-compat-video',
+        model: 'sora-2',
+        createdAt: new Date().toISOString(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  describe('validateVideoGenerationAccess (sentinel-id probe)', () => {
+    it('treats a 404 on the sentinel id as valid access (authenticated, resource just missing)', async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response('not found', { status: 404 })) as any;
+
+      const provider = new OpenAICompatVideoProvider({
+        type: 'openai-compat-video',
+        baseUrl: 'https://gateway.example.com/v1',
+        apiKey: 'gw-key',
+      });
+
+      await expect(provider.validateVideoGenerationAccess()).resolves.toBe(
+        true,
+      );
+    });
+
+    it('treats a 2xx on the sentinel id as valid access', async () => {
+      global.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          id: 'have-ai-validate-video-access',
+          model: 'sora-2',
+          status: 'queued',
+        }),
+      ) as any;
+
+      const provider = new OpenAICompatVideoProvider({
+        type: 'openai-compat-video',
+        baseUrl: 'https://gateway.example.com/v1',
+        apiKey: 'gw-key',
+      });
+
+      await expect(provider.validateVideoGenerationAccess()).resolves.toBe(
+        true,
+      );
+    });
+
+    it('throws AuthenticationError on 401', async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          new Response('unauthorized', { status: 401 }),
+        ) as any;
+
+      const provider = new OpenAICompatVideoProvider({
+        type: 'openai-compat-video',
+        baseUrl: 'https://gateway.example.com/v1',
+        apiKey: 'bad-key',
+      });
+
+      await expect(
+        provider.validateVideoGenerationAccess(),
+      ).rejects.toBeInstanceOf(AuthenticationError);
+    });
+  });
+
+  it('wraps a fetch()-level network failure into an AIError', async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError('fetch failed')) as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    await expect(
+      provider.validateVideoGenerationAccess(),
+    ).rejects.toMatchObject({ code: 'NETWORK_ERROR', retryable: true });
+  });
+});
+
+describe('onRequest lifecycle events for video-generation operations', () => {
+  it('fires onRequest for submitVideoGenerationJob and a handle-taking operation, without a chat-shaped token ceiling', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const stub: Partial<AIInterface> = {
+      submitVideoGenerationJob: vi.fn(async () => ({
+        jobId: 'job-1',
+        provider: 'gemini',
+        model: 'veo-3.1-generate-preview',
+        createdAt: new Date().toISOString(),
+      })),
+      getVideoGenerationJob: vi.fn(async () => ({
+        status: 'running' as const,
+      })),
+    };
+
+    const observed = createObservedAI(
+      stub as AIInterface,
+      {
+        type: 'gemini',
+        onRequest: (event: unknown) =>
+          events.push(event as Record<string, unknown>),
+      } as any,
+    );
+
+    await observed.submitVideoGenerationJob({
+      prompt: 'x',
+      model: 'veo-3.1-generate-preview',
+    });
+    await observed.getVideoGenerationJob({
+      jobId: 'job-1',
+      provider: 'gemini',
+      model: 'veo-3.1-generate-preview',
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      operation: 'submitVideoGenerationJob',
+      status: 'succeeded',
+      model: 'veo-3.1-generate-preview',
+    });
+    expect(events[0].effectiveMaxOutputTokens).toBeUndefined();
+    expect(events[1]).toMatchObject({
+      operation: 'getVideoGenerationJob',
+      status: 'succeeded',
+      model: 'veo-3.1-generate-preview',
+    });
+    expect(events[1].effectiveMaxOutputTokens).toBeUndefined();
+  });
+});
+
+describe('getAIAuto video-provider precedence', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('prefers a general-purpose provider over a video-only env signal', async () => {
+    delete process.env.HAVE_AI_PROVIDER;
+    delete process.env.HAVE_AI_TYPE;
+    delete process.env.HAVE_AI_API_KEY;
+    process.env.OPENAI_API_KEY = 'sk-precedence-test';
+    process.env.MODELARK_API_KEY = 'modelark-precedence-test';
+    process.env.OPENAI_COMPAT_VIDEO_BASE_URL = 'https://gateway.example.com/v1';
+
+    const client = await getAIAuto({});
+
+    expect(client).toBeInstanceOf(OpenAIProvider);
+  });
+
+  it('falls back to a video-only provider only when nothing general-purpose matches', async () => {
+    delete process.env.HAVE_AI_PROVIDER;
+    delete process.env.HAVE_AI_TYPE;
+    delete process.env.HAVE_AI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.HF_TOKEN;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_DEFAULT_REGION;
+    delete process.env.OLLAMA_HOST;
+    delete process.env.OLLAMA_BASE_URL;
+    delete process.env.OLLAMA_API_KEY;
+    delete process.env.LITELLM_BASE_URL;
+    delete process.env.LITELLM_API_KEY;
+    delete process.env.BIFROST_BASE_URL;
+    delete process.env.OPENAI_COMPAT_VIDEO_BASE_URL;
+    process.env.MODELARK_API_KEY = 'modelark-fallback-test';
+
+    const client = await getAIAuto({});
+
+    expect(client).toBeInstanceOf(ByteplusModelArkProvider);
+  });
+});

--- a/packages/ai/src/video-generation.test.ts
+++ b/packages/ai/src/video-generation.test.ts
@@ -904,6 +904,173 @@ describe('BytePlus ModelArk video generation (Seedance)', () => {
       expect(callTimestamps).toHaveLength(2);
       expect(Date.now() - start).toBeLessThan(300);
     });
+
+    it('never lets activeRequests exceed maxConcurrent under contention that interleaves the slot-wait and token-wait loops (TOCTOU)', async () => {
+      let inFlight = 0;
+      let maxObservedInFlight = 0;
+      const releasers: Array<() => void> = [];
+
+      const fetchMock = vi.fn(async () => {
+        inFlight += 1;
+        maxObservedInFlight = Math.max(maxObservedInFlight, inFlight);
+        await new Promise<void>((resolve) => releasers.push(resolve));
+        inFlight -= 1;
+        return jsonResponse({ id: `task-${releasers.length}` });
+      });
+      global.fetch = fetchMock as any;
+
+      const provider = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-toctou',
+        // Only 2 burst tokens and only 2 concurrent slots for 5 submitters:
+        // callers 3-5 must wait on BOTH the slot-wait loop and the
+        // token-wait loop, and slots free up (via the release loop below)
+        // while other callers are still mid-wait for a token — exactly the
+        // interleaving window the TOCTOU bug required.
+        rateLimit: { maxConcurrent: 2, requestsPerMinute: 120 },
+      });
+
+      const submissionCount = 5;
+      const submissions = Array.from({ length: submissionCount }, (_, index) =>
+        provider.submitVideoGenerationJob({ prompt: `p${index}` }),
+      );
+
+      // Release fetches as they actually arrive rather than on a fixed
+      // schedule: under heavy rate-limit contention, later callers may not
+      // reach fetch() until well after earlier ones have been released, so
+      // a fixed-cadence release loop can run out of scheduled releases
+      // before a late caller ever starts (and then hang forever waiting on
+      // a release that never comes). Polling for a releaser to appear
+      // instead makes this robust to however long the limiter makes each
+      // caller wait.
+      let released = 0;
+      const releaseLoop = (async () => {
+        while (released < submissionCount) {
+          if (releasers.length > 0) {
+            releasers.shift()?.();
+            released += 1;
+            // Hold each response open briefly so multiple submissions can
+            // genuinely overlap in-flight (exercising real concurrency),
+            // rather than releasing so fast that submissions never overlap.
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          } else {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+        }
+      })();
+
+      await Promise.all([...submissions, releaseLoop]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(submissionCount);
+      // The core assertion: at no point did more than maxConcurrent (2)
+      // submissions have an in-flight fetch simultaneously.
+      expect(maxObservedInFlight).toBeLessThanOrEqual(2);
+    }, 15000);
+  });
+
+  describe('abort-signal handling', () => {
+    it('honors an already-aborted signal at submit time: no fetch call, and the limiter slot/token is not consumed', async () => {
+      const fetchMock = vi.fn(async () => jsonResponse({ id: 'ok' }));
+      global.fetch = fetchMock as any;
+
+      const provider = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-preaborted',
+      });
+
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        provider.submitVideoGenerationJob({
+          prompt: 'x',
+          signal: controller.signal,
+        }),
+      ).rejects.toMatchObject({ code: 'AI_ABORTED' });
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      // The burst-capacity bucket (2 tokens) must still be full — the
+      // aborted attempt must not have consumed a token or a concurrency
+      // slot. Two legitimate submits right after should both clear
+      // near-instantly, proving nothing was consumed.
+      const start = Date.now();
+      await provider.submitVideoGenerationJob({ prompt: 'y' });
+      await provider.submitVideoGenerationJob({ prompt: 'z' });
+      expect(Date.now() - start).toBeLessThan(300);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('aborting while waiting for a concurrency slot never calls fetch', async () => {
+      let releaseFirst: (() => void) | undefined;
+      const blockingFetch = vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            releaseFirst = () => resolve(jsonResponse({ id: 'blocking' }));
+          }),
+      );
+      global.fetch = blockingFetch as any;
+
+      const provider = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-abort-slot-wait',
+        rateLimit: { maxConcurrent: 1 },
+      });
+
+      // Occupy the single concurrency slot with a submission whose fetch
+      // never resolves, forcing the next submission to wait in
+      // acquire()'s slot-wait loop.
+      const first = provider.submitVideoGenerationJob({ prompt: 'first' });
+      await vi.waitFor(() => expect(blockingFetch).toHaveBeenCalledTimes(1));
+
+      const controller = new AbortController();
+      const second = provider.submitVideoGenerationJob({
+        prompt: 'second',
+        signal: controller.signal,
+      });
+
+      // Let the second call enter the slot-wait loop, then abort it while
+      // it is still waiting for a concurrency slot (well before the
+      // loop's own 100ms poll interval would naturally wake it).
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      controller.abort();
+
+      await expect(second).rejects.toMatchObject({ code: 'AI_ABORTED' });
+      expect(blockingFetch).toHaveBeenCalledTimes(1); // second never reached fetch
+
+      releaseFirst?.();
+      await first;
+    });
+
+    it('aborting while waiting for a token refill never calls fetch', async () => {
+      const fetchMock = vi.fn(async () => jsonResponse({ id: 'ok' }));
+      global.fetch = fetchMock as any;
+
+      const provider = new ByteplusModelArkProvider({
+        type: 'byteplus-modelark',
+        apiKey: 'modelark-key-abort-token-wait',
+        // No slot contention (maxConcurrent is generous); the bottleneck
+        // is the 2-token burst bucket refilling slowly.
+        rateLimit: { requestsPerMinute: 12, maxConcurrent: 10 },
+      });
+
+      // Drain the burst capacity with two quick, unaborted submits.
+      await provider.submitVideoGenerationJob({ prompt: 'first' });
+      await provider.submitVideoGenerationJob({ prompt: 'second' });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      // A third submission now has to wait for a token refill (~5s at
+      // this rate); abort it while it is still waiting.
+      const controller = new AbortController();
+      const third = provider.submitVideoGenerationJob({
+        prompt: 'third',
+        signal: controller.signal,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      controller.abort();
+
+      await expect(third).rejects.toMatchObject({ code: 'AI_ABORTED' });
+      expect(fetchMock).toHaveBeenCalledTimes(2); // third never reached fetch
+    });
   });
 
   it('participates in the shared createRateLimitedAI submit-time pacing wrapper', async () => {
@@ -960,6 +1127,28 @@ describe('openai-compat-video provider', () => {
           apiKey: 'key',
         } as any),
     ).toThrow(/baseUrl/i);
+  });
+
+  it('honors an already-aborted signal at submit time: no fetch call', async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as any;
+
+    const provider = new OpenAICompatVideoProvider({
+      type: 'openai-compat-video',
+      baseUrl: 'https://gateway.example.com/v1',
+      apiKey: 'gw-key',
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ code: 'AI_ABORTED' });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('submits a job using the OpenAI videos request shape', async () => {

--- a/packages/ai/vite.config.ts
+++ b/packages/ai/vite.config.ts
@@ -1,3 +1,10 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
-export default createPackageConfig('ai');
+// `node` is a separate entry (published as the `@happyvertical/ai/node`
+// subpath, see package.json `exports`) so the Node-aware `getAIAuto` —
+// which additionally checks provider-specific environment variables
+// (LITELLM_*, BIFROST_*, OLLAMA_*, MODELARK_*, ARK_API_KEY,
+// OPENAI_COMPAT_VIDEO_*, etc.) — is actually reachable by published-package
+// consumers. The default `.` entry point stays universal/browser-safe and
+// only exports the `HAVE_AI_*`-only `getAIAuto`.
+export default createPackageConfig('ai', { node: 'src/node.ts' });


### PR DESCRIPTION
## Summary

Adds an async video-generation job abstraction to `@happyvertical/ai`, following the package's TTS modality precedent: five new `AIInterface` methods (`submitVideoGenerationJob`, `getVideoGenerationJob`, `fetchVideoGenerationResult`, `cancelVideoGenerationJob`, `validateVideoGenerationAccess`), an `AICapabilities.videoGeneration` flag, and three providers.

Closes #1181.

First consumer: happyvertical/ergot.io#322 (cloud generator runtime adapter), which persists the serializable job handle in step-run checkpoints and resumes polling across process restarts.

## Providers

- **gemini** — Veo via `@google/genai` long-running operations (same client/key as the existing Imagen support). Resume rehydrates a real `GenerateVideosOperation` instance; results download bytes via `ai.files.download()`. Default model `veo-3.1-generate-preview` (Veo 2/3.0 are deprecated upstream).
- **byteplus-modelark** — Seedance via the ModelArk task API (raw-HTTP, qwen-tts precedent). Module-shared submit limiter keyed by credential: QPS 2 with burst capacity 2 and 3 concurrent submissions (task-lifetime concurrency is not trackable — documented). Auto-selects the i2v model variant when reference images are present. Includes an opt-in live integration test (skipped without `MODELARK_API_KEY`).
- **openai-compat-video** — thin `/v1/videos` adapter configured by base URL + key; covers LiteLLM (primary target) and Sora-shaped gateways. Unknown/`processing` statuses map to `running` with `rawStatus` preserved — never inventing a terminal state.

## Design notes

- **Serializable handles**: `VideoGenerationJob` is plain data; a fresh provider instance in a new process resumes from a `JSON.parse`'d handle (tested per provider). `jobId`/`provider` are load-bearing; consumers persist the whole handle verbatim.
- **Cancellation is best-effort** (documented in interface TSDoc + README): the Gemini API exposes no video-operation cancel (typed `VIDEO_CANCEL_UNSUPPORTED`; verified against the live v1beta discovery document), and ModelArk only cancels queued tasks. Issue acceptance amended accordingly (see issue comment).
- **`getAIAuto`**: video-only provider env detection ranks strictly after all general-purpose providers, so setting `MODELARK_API_KEY` cannot hijack bare `getAIAuto()` chat callers.
- Usage events fire once per submit (not per poll) with model/duration/resolution dimensions; `OBSERVED_OPERATIONS` extended so `onRequest` lifecycle events fire for video ops (includes a fix for a token-ceiling misattribution on non-chat events).

## Validation

- `pnpm --filter @happyvertical/ai test` — 230 passed, 26 skipped (integration tests needing live credentials); video suite run 3× for determinism (61/61 each)
- `pnpm --filter @happyvertical/ai build` — clean; `tsc --noEmit` clean
- Repo-wide `pnpm typecheck` — 20/20; consumer builds (`sdk-mcp`, `analytics`, `github-actions`) green against the extended interface
- Breaking-change audit: no `implements AIInterface`/`AICapabilities` usage outside `packages/ai`
- Review: 2-lens roster (contract correctness vs pinned SDK dist + live vendor docs; tests/consistency), 2 rounds; 10 material findings fixed; final verdicts CLEAN ×2

## Drive-by fixes

Two pre-existing biome errors surfaced by the lefthook pre-commit gate on touched files, fixed minimally in the same commit (both verified pre-existing on `main` via baseline diff):

- `packages/ai/src/shared/providers/qwen-tts.ts` — `useYield` error on the legacy `stream()` stub; converted to the non-generator rejecting-`AsyncIterable` pattern the sibling providers already use.
- `packages/ai/src/providers.test.ts` — `noUnsafeOptionalChaining` error; one-line `?.`→`!` matching the file's existing post-assertion idiom.

## Caveats for release

ModelArk's `expired` status and DELETE-semantics for running tasks are corroborated from third-party clients but unverified against a live account — the opt-in integration test covers create/status/cancel-while-queued. A live smoke with real credentials is recommended before the first production use.

<!-- hv-agent-run:v1 -->
<!--
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude",
  "session": "c54627d4-d970-4897-8c77-4b46690b8a50",
  "issue": "https://github.com/happyvertical/sdk/issues/1181",
  "policy_revision": "1.0.0",
  "validation": "ai test 230P/26S x3; ai build clean; tsc --noEmit clean; repo typecheck 20/20; consumer builds green; review-cycle 2 rounds, final CLEAN x2"
}
-->
