### PR TITLE
fix(deps): resolve @happyvertical/pdf to 0.65.9 for pre-AVX2 safety

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^0.61.1
       version: 0.61.1
     '@happyvertical/pdf':
-      specifier: ^0.65
-      version: 0.65.5
+      specifier: ^0.65.9
+      version: 0.65.9
     '@happyvertical/spider':
       specifier: ^1.1
       version: 1.1.13
@@ -370,7 +370,7 @@ importers:
         version: 0.61.1(@types/node@24.12.2)
       '@happyvertical/pdf':
         specifier: 'catalog:'
-        version: 0.65.5(@types/node@24.12.2)
+        version: 0.65.9(@types/node@24.12.2)
       '@happyvertical/spider':
         specifier: 'catalog:'
         version: 1.1.13(@types/node@24.12.2)
@@ -3288,8 +3288,8 @@ packages:
     resolution: {integrity: sha512-MO5j/m5lec3Sj6PEkIqBWfyNUu0rX8tF8t+TDV0EQVtVrZnrWNJE5Xz02civa+4ZN1W5UXlTsysd7nOfn5Kr+Q==}
     engines: {node: '>=24', pnpm: '>=11.13.0'}
 
-  '@happyvertical/pdf@0.65.5':
-    resolution: {integrity: sha512-8XvncVUOFyYmsKgLWb1O1k9QLLr33QTDkRMo+2idAXvUfOb4zhNlGTzVm+QkJEoWiHLebc/licF9Qqbri6mFiw==}
+  '@happyvertical/pdf@0.65.9':
+    resolution: {integrity: sha512-FnyCI8N8YQeeuKUQdiiPoKkN4U4Hqgf/N+7Vw1HMAw0vmoliNGlPJBZcqzl6hX4N3ZdXYNP6pqiVHGmPiDiBhw==}
     engines: {node: '>=24', pnpm: '>=11.13.0'}
 
   '@happyvertical/spider@1.1.13':
@@ -7441,6 +7441,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
@@ -17429,7 +17430,7 @@ snapshots:
       - '@types/node'
       - encoding
 
-  '@happyvertical/pdf@0.65.5(@types/node@24.12.2)':
+  '@happyvertical/pdf@0.65.9(@types/node@24.12.2)':
     dependencies:
       '@happyvertical/ocr': 0.61.1(@types/node@24.12.2)
       '@happyvertical/utils': link:packages/utils

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,11 +27,11 @@ allowBuilds:
 # old SDK versions. The catalog + overrides below keep everything aligned.
 catalog:
   '@happyvertical/ocr': ^0.61.1
-  '@happyvertical/pdf': ^0.65
+  '@happyvertical/pdf': ^0.65.9
   '@happyvertical/spider': ^1.1
 
 minimumReleaseAgeExclude:
   - bullmq@5.80.4
   - '@happyvertical/ocr@0.61.1'
-  - '@happyvertical/pdf@0.65.5'
+  - '@happyvertical/pdf@0.65.9'
   - '@happyvertical/spider@1.1.13'

--- a/scripts/documents-dependency-contract.test.mjs
+++ b/scripts/documents-dependency-contract.test.mjs
@@ -75,7 +75,7 @@ test('Documents catalog ranges accept the audited released dependency family', (
   const catalog = readCatalog();
   const releasedDependencies = {
     '@happyvertical/ocr': '0.61.1',
-    '@happyvertical/pdf': '0.65.5',
+    '@happyvertical/pdf': '0.65.9',
     '@happyvertical/spider': '1.1.13',
   };
 


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude",
  "session": "c3807549-7e07-4869-8c8d-7b6bb779575a",
  "issue": "https://github.com/happyvertical/sdk/issues/1183",
  "policy_revision": "1.0.0",
  "validation": [
    "pnpm install --frozen-lockfile",
    "pnpm test:ci-scripts - 28/28 pass",
    "pnpm agent:check",
    "pnpm typecheck - 20/20 tasks",
    "pnpm lint - no errors",
    "pnpm build - 32/32 tasks"
  ]
}
```

Closes #1183

## What changed

`@happyvertical/pdf` now resolves to **0.65.9** instead of **0.65.5**.

| | before | after |
|---|---|---|
| catalog range | `^0.65` | `^0.65.9` |
| `minimumReleaseAgeExclude` | `@happyvertical/pdf@0.65.5` | `@happyvertical/pdf@0.65.9` |
| **resolved in `pnpm-lock.yaml`** | **0.65.5** | **0.65.9** |
| audited family in dependency contract test | `0.65.5` | `0.65.9` |

## Why

`@happyvertical/pdf` owns the only `import('@kreuzberg/node')`. That prebuilt
native module executes AVX2 at module load. Versions before 0.65.7 load it
unconditionally, so on an x86-64-v2 (pre-AVX2) host the process traps:

```
traps: MainThread[136968] trap invalid opcode
  in kreuzberg-node.linux-x64-gnu.node[...]
```

The forked process dies with `SIGILL` / **exit 132**. This is deterministic on a
pre-AVX2 CPU, not intermittent — it looks runner-specific only because `patdown`
(Xeon X5650 Westmere) is the fleet's sole x86-64-v2 machine.

Note: this is **not** the `Worker exited unexpectedly` vitest-worker fault. That
is a separate, still-unexplained condition documented in
`willgriffin/nixos-config` (`hosts/patdown/default.nix`), which states outright
that the two must not be conflated. Do not treat this bump as a fix for it.

v0.65.7 added `src/node/cpu-baseline.ts`, which probes the CPU baseline before
loading the native module and falls back.

The range was never the problem — `^0.65` already admitted 0.65.7+. The
`minimumReleaseAgeExclude` entry naming the exact version `0.65.5` is what held
the lockfile on the broken release, which is why this survived looking fixed.

## Note on the contract test

`scripts/documents-dependency-contract.test.mjs` asserts the catalog range
accepts an audited released version, hardcoded at `0.65.5`. Tightening the range
to `^0.65.9` correctly stops accepting 0.65.5, so the audited family moves to
`0.65.9` in the same change. Keeping 0.65.5 as the audited version would assert
that a SIGILL-prone release must remain installable.

## Downstream consequence worth a reviewer's attention

`packages/documents` declares `"@happyvertical/pdf": "catalog:"`, and pnpm
substitutes the catalog value at publish time. So this change also tightens what
`@happyvertical/documents` publishes:

| | range published by `documents` |
|---|---|
| today (0.85.3) | `^0.65` |
| after this lands | `^0.65.9` |

That is intended and is the useful half of the fix — `documents` is the transitive
vector by which pre-0.65.7 `pdf` reached other repositories, and `^0.65` let their
lockfiles sit on 0.65.3 indefinitely. `^0.65.9` makes a fresh resolve land on a
guarded version.

It is still a narrowing of a published range, so it is called out rather than
buried in the lockfile diff. It does not affect already-published `documents`
versions.

## Validation

All green locally on this head:

- `pnpm install --frozen-lockfile`
- `pnpm test:ci-scripts` — 28/28 pass
- `pnpm agent:check`
- `pnpm typecheck` — 20/20 tasks
- `pnpm lint` — no errors (3 pre-existing warnings in `@happyvertical/json`)
- `pnpm build` — 32/32 tasks
