### PR TITLE
ci(github-actions): replace retired macos-13 runner label with macos-15-intel

### DIFF
--- a/.github/workflows/build-json-native.yml
+++ b/.github/workflows/build-json-native.yml
@@ -41,7 +41,7 @@ jobs:
             package-suffix: darwin-arm64
 
           # macOS x64 (Intel)
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             package-suffix: darwin-x64
 

--- a/scripts/validate-workflow-runners.mjs
+++ b/scripts/validate-workflow-runners.mjs
@@ -77,7 +77,7 @@ function parseLabelValues(raw) {
  */
 export function extractRunnerLabels(source) {
   const found = [];
-  const lines = source.split('\n');
+  const lines = source.replace(/\r\n/g, '\n').split('\n');
   let blockIndent = -1;
   for (let index = 0; index < lines.length; index += 1) {
     const text = lines[index];

--- a/scripts/validate-workflow-runners.mjs
+++ b/scripts/validate-workflow-runners.mjs
@@ -69,8 +69,8 @@ function parseLabelValues(raw) {
 /**
  * Extracts runner label references from workflow YAML source. Handles
  * `runs-on:` scalars, flow lists, and block sequences, plus matrix `os:`
- * entries in scalar and flow-list form. Values containing `${{` expressions
- * are skipped because they are not static labels.
+ * entries in scalar, flow-list, and block-sequence form. Values containing
+ * `${{` expressions are skipped because they are not static labels.
  *
  * @param {string} source workflow file contents
  * @returns {Array<{ line: number, label: string }>}
@@ -83,7 +83,7 @@ export function extractRunnerLabels(source) {
     const text = lines[index];
     if (blockIndent >= 0) {
       const item = text.match(/^(\s*)-\s+(.+?)\s*$/);
-      if (item && item[1].length > blockIndent) {
+      if (item && item[1].length >= blockIndent) {
         for (const label of parseLabelValues(item[2])) {
           found.push({ line: index + 1, label });
         }
@@ -102,9 +102,13 @@ export function extractRunnerLabels(source) {
       }
       continue;
     }
-    const matrixOs = text.match(/^\s*-?\s*os:\s*(.+?)\s*$/);
+    const matrixOs = text.match(/^(\s*)-?\s*os:\s*(.*?)\s*$/);
     if (matrixOs) {
-      for (const label of parseLabelValues(matrixOs[1])) {
+      if (matrixOs[2] === '') {
+        blockIndent = matrixOs[1].length;
+        continue;
+      }
+      for (const label of parseLabelValues(matrixOs[2])) {
         found.push({ line: index + 1, label });
       }
     }

--- a/scripts/validate-workflow-runners.mjs
+++ b/scripts/validate-workflow-runners.mjs
@@ -15,7 +15,11 @@ import { join } from 'node:path';
 /**
  * GitHub-hosted runner labels that have been retired. A label counts as
  * retired when it equals one of these or extends one with a variant suffix
- * (for example `macos-13-xlarge`).
+ * (for example `macos-13-xlarge`). This blocklist must be updated when
+ * GitHub announces a runner-image retirement; the freshly downloaded
+ * actionlint in the Validate Workflow Files job remains the authoritative
+ * backstop for forms this scanner cannot see (for example labels computed
+ * from matrix expressions).
  */
 export const RETIRED_RUNNER_LABELS = [
   'macos-11',
@@ -23,6 +27,7 @@ export const RETIRED_RUNNER_LABELS = [
   'macos-13',
   'ubuntu-18.04',
   'ubuntu-20.04',
+  'windows-2016',
   'windows-2019',
 ];
 
@@ -39,9 +44,33 @@ export function isRetiredRunnerLabel(label) {
 }
 
 /**
+ * Splits a raw YAML scalar or flow-list value into individual labels,
+ * stripping inline comments and quotes. Returns an empty array for values
+ * containing `${{` expressions because they are not static labels.
+ *
+ * @param {string} raw raw value text after the YAML key
+ * @returns {string[]}
+ */
+function parseLabelValues(raw) {
+  let text = raw.replace(/\s+#.*$/, '').trim();
+  if (text.includes('${{')) return [];
+  if (text.startsWith('[')) {
+    const end = text.indexOf(']');
+    text = text.slice(1, end === -1 ? undefined : end);
+    return text
+      .split(',')
+      .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean);
+  }
+  const label = text.replace(/^['"]|['"]$/g, '');
+  return label ? [label] : [];
+}
+
+/**
  * Extracts runner label references from workflow YAML source. Handles
- * `runs-on:` scalars/flow lists and matrix `- os:` entries. Values containing
- * `${{` expressions are skipped because they are not static labels.
+ * `runs-on:` scalars, flow lists, and block sequences, plus matrix `os:`
+ * entries in scalar and flow-list form. Values containing `${{` expressions
+ * are skipped because they are not static labels.
  *
  * @param {string} source workflow file contents
  * @returns {Array<{ line: number, label: string }>}
@@ -49,27 +78,33 @@ export function isRetiredRunnerLabel(label) {
 export function extractRunnerLabels(source) {
   const found = [];
   const lines = source.split('\n');
+  let blockIndent = -1;
   for (let index = 0; index < lines.length; index += 1) {
     const text = lines[index];
-    const runsOn = text.match(/^\s*runs-on:\s*(.+?)\s*$/);
-    if (runsOn) {
-      const raw = runsOn[1];
-      const labels = raw.startsWith('[')
-        ? raw
-            .slice(1, raw.indexOf(']') === -1 ? undefined : raw.indexOf(']'))
-            .split(',')
-            .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
-        : [raw.replace(/^['"]|['"]$/g, '')];
-      for (const label of labels) {
-        if (label && !label.includes('${{')) {
+    if (blockIndent >= 0) {
+      const item = text.match(/^(\s*)-\s+(.+?)\s*$/);
+      if (item && item[1].length > blockIndent) {
+        for (const label of parseLabelValues(item[2])) {
           found.push({ line: index + 1, label });
         }
+        continue;
       }
+      blockIndent = -1;
+    }
+    const runsOn = text.match(/^(\s*)runs-on:\s*(.*?)\s*$/);
+    if (runsOn) {
+      if (runsOn[2] === '') {
+        blockIndent = runsOn[1].length;
+        continue;
+      }
+      for (const label of parseLabelValues(runsOn[2])) {
+        found.push({ line: index + 1, label });
+      }
+      continue;
     }
     const matrixOs = text.match(/^\s*-?\s*os:\s*(.+?)\s*$/);
     if (matrixOs) {
-      const label = matrixOs[1].replace(/^['"]|['"]$/g, '');
-      if (label && !label.includes('${{')) {
+      for (const label of parseLabelValues(matrixOs[1])) {
         found.push({ line: index + 1, label });
       }
     }

--- a/scripts/validate-workflow-runners.mjs
+++ b/scripts/validate-workflow-runners.mjs
@@ -82,8 +82,13 @@ export function extractRunnerLabels(source) {
   for (let index = 0; index < lines.length; index += 1) {
     const text = lines[index];
     if (blockIndent >= 0) {
+      // Blank and comment-only lines do not terminate a YAML block sequence.
+      if (/^[^\S\r\n]*(#.*)?$/.test(text)) continue;
       const item = text.match(/^(\s*)-\s+(.+?)\s*$/);
-      if (item && item[1].length >= blockIndent) {
+      // A dash item that opens an `os:` mapping entry (matrix include form)
+      // belongs to the matrixOs branch, not the block region.
+      const isOsEntry = item && /^os:([^\S\r\n].*)?$/.test(item[2]);
+      if (item && item[1].length >= blockIndent && !isOsEntry) {
         for (const label of parseLabelValues(item[2])) {
           found.push({ line: index + 1, label });
         }
@@ -102,13 +107,15 @@ export function extractRunnerLabels(source) {
       }
       continue;
     }
-    const matrixOs = text.match(/^(\s*)-?\s*os:\s*(.*?)\s*$/);
+    const matrixOs = text.match(
+      /^[^\S\r\n]*(?:-[^\S\r\n]*)?os:[^\S\r\n]*(.*?)[^\S\r\n]*$/,
+    );
     if (matrixOs) {
-      if (matrixOs[2] === '') {
-        blockIndent = matrixOs[1].length;
+      if (matrixOs[1] === '') {
+        blockIndent = text.match(/^[^\S\r\n]*/)[0].length;
         continue;
       }
-      for (const label of parseLabelValues(matrixOs[2])) {
+      for (const label of parseLabelValues(matrixOs[1])) {
         found.push({ line: index + 1, label });
       }
     }

--- a/scripts/validate-workflow-runners.mjs
+++ b/scripts/validate-workflow-runners.mjs
@@ -1,0 +1,101 @@
+/**
+ * Detects retired GitHub-hosted runner labels in workflow files.
+ *
+ * The `Validate Workflow Files` CI job lints with a freshly downloaded
+ * actionlint, which fails the run when a workflow references a runner label
+ * GitHub has retired (for example `macos-13`). A retired label also means the
+ * job can never schedule. This module provides the dependency-free check used
+ * by `validate-workflow-runners.test.mjs` so the failure is caught by
+ * `pnpm test:ci-scripts` before a workflow edit reaches CI.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * GitHub-hosted runner labels that have been retired. A label counts as
+ * retired when it equals one of these or extends one with a variant suffix
+ * (for example `macos-13-xlarge`).
+ */
+export const RETIRED_RUNNER_LABELS = [
+  'macos-11',
+  'macos-12',
+  'macos-13',
+  'ubuntu-18.04',
+  'ubuntu-20.04',
+  'windows-2019',
+];
+
+/**
+ * Returns true when `label` is a retired GitHub-hosted runner label.
+ *
+ * @param {string} label runner label candidate
+ * @returns {boolean}
+ */
+export function isRetiredRunnerLabel(label) {
+  return RETIRED_RUNNER_LABELS.some(
+    (retired) => label === retired || label.startsWith(`${retired}-`),
+  );
+}
+
+/**
+ * Extracts runner label references from workflow YAML source. Handles
+ * `runs-on:` scalars/flow lists and matrix `- os:` entries. Values containing
+ * `${{` expressions are skipped because they are not static labels.
+ *
+ * @param {string} source workflow file contents
+ * @returns {Array<{ line: number, label: string }>}
+ */
+export function extractRunnerLabels(source) {
+  const found = [];
+  const lines = source.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const text = lines[index];
+    const runsOn = text.match(/^\s*runs-on:\s*(.+?)\s*$/);
+    if (runsOn) {
+      const raw = runsOn[1];
+      const labels = raw.startsWith('[')
+        ? raw
+            .slice(1, raw.indexOf(']') === -1 ? undefined : raw.indexOf(']'))
+            .split(',')
+            .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
+        : [raw.replace(/^['"]|['"]$/g, '')];
+      for (const label of labels) {
+        if (label && !label.includes('${{')) {
+          found.push({ line: index + 1, label });
+        }
+      }
+    }
+    const matrixOs = text.match(/^\s*-?\s*os:\s*(.+?)\s*$/);
+    if (matrixOs) {
+      const label = matrixOs[1].replace(/^['"]|['"]$/g, '');
+      if (label && !label.includes('${{')) {
+        found.push({ line: index + 1, label });
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Scans every workflow file under `workflowsDir` and returns one finding per
+ * retired runner label reference.
+ *
+ * @param {string} workflowsDir absolute path to `.github/workflows`
+ * @returns {Array<{ file: string, line: number, label: string }>}
+ */
+export function findRetiredRunnerLabels(workflowsDir) {
+  const findings = [];
+  const files = readdirSync(workflowsDir).filter((name) =>
+    /\.(yml|yaml)$/.test(name),
+  );
+  for (const name of files) {
+    const source = readFileSync(join(workflowsDir, name), 'utf8');
+    for (const hit of extractRunnerLabels(source)) {
+      if (isRetiredRunnerLabel(hit.label)) {
+        findings.push({ file: name, line: hit.line, label: hit.label });
+      }
+    }
+  }
+  return findings;
+}

--- a/scripts/validate-workflow-runners.test.mjs
+++ b/scripts/validate-workflow-runners.test.mjs
@@ -115,6 +115,25 @@ test('extracts block-sequence matrix os entries', () => {
   ]);
 });
 
+test('block regions tolerate comments and do not mask include os entries', () => {
+  const source = [
+    'matrix:',
+    '  os:',
+    '    # keep the old image until the migration lands',
+    '    - macos-13',
+    '',
+    '    - ubuntu-latest',
+    '  include:',
+    '    - os: macos-13',
+    '      target: x86_64-apple-darwin',
+  ].join('\n');
+  assert.deepEqual(extractRunnerLabels(source), [
+    { line: 4, label: 'macos-13' },
+    { line: 6, label: 'ubuntu-latest' },
+    { line: 8, label: 'macos-13' },
+  ]);
+});
+
 test('repository workflows reference no retired runner labels', () => {
   assert.deepEqual(findRetiredRunnerLabels(WORKFLOWS_DIR), []);
 });

--- a/scripts/validate-workflow-runners.test.mjs
+++ b/scripts/validate-workflow-runners.test.mjs
@@ -80,6 +80,9 @@ test('extracts flow-list matrix os, inline comments, and block runs-on', () => {
     '    runs-on:',
     '      - self-hosted',
     '      - windows-2019',
+    '  d:',
+    '    runs-on:',
+    '    - macos-13',
     '    steps:',
     '      - run: echo done',
   ].join('\n');
@@ -89,6 +92,26 @@ test('extracts flow-list matrix os, inline comments, and block runs-on', () => {
     { line: 8, label: 'macos-13' },
     { line: 11, label: 'self-hosted' },
     { line: 12, label: 'windows-2019' },
+    { line: 15, label: 'macos-13' },
+  ]);
+});
+
+test('extracts block-sequence matrix os entries', () => {
+  const source = [
+    'jobs:',
+    '  a:',
+    '    strategy:',
+    '      matrix:',
+    '        os:',
+    '          - macos-13',
+    '          - ubuntu-latest',
+    '    runs-on: ${{ matrix.os }}',
+    '    steps:',
+    '      - run: echo done',
+  ].join('\n');
+  assert.deepEqual(extractRunnerLabels(source), [
+    { line: 6, label: 'macos-13' },
+    { line: 7, label: 'ubuntu-latest' },
   ]);
 });
 

--- a/scripts/validate-workflow-runners.test.mjs
+++ b/scripts/validate-workflow-runners.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import {
+  extractRunnerLabels,
+  findRetiredRunnerLabels,
+  isRetiredRunnerLabel,
+} from './validate-workflow-runners.mjs';
+
+const WORKFLOWS_DIR = fileURLToPath(
+  new URL('../.github/workflows', import.meta.url),
+);
+
+test('flags exactly the retired GitHub-hosted runner labels', () => {
+  for (const retired of [
+    'macos-11',
+    'macos-12',
+    'macos-13',
+    'macos-13-xlarge',
+    'ubuntu-18.04',
+    'ubuntu-20.04',
+    'windows-2019',
+  ]) {
+    assert.equal(isRetiredRunnerLabel(retired), true, retired);
+  }
+  for (const live of [
+    'macos-14',
+    'macos-15',
+    'macos-15-intel',
+    'macos-26',
+    'ubuntu-22.04',
+    'ubuntu-24.04',
+    'ubuntu-latest',
+    'windows-2022',
+    'windows-2025',
+    'arc-happyvertical',
+    'self-hosted',
+  ]) {
+    assert.equal(isRetiredRunnerLabel(live), false, live);
+  }
+});
+
+test('extracts runs-on scalars, flow lists, and matrix os entries', () => {
+  const source = [
+    'jobs:',
+    '  a:',
+    '    runs-on: ubuntu-24.04',
+    '  b:',
+    '    runs-on: [self-hosted, arc-happyvertical]',
+    '  c:',
+    '    runs-on: ${{ matrix.os }}',
+    '    strategy:',
+    '      matrix:',
+    '        include:',
+    '          - os: macos-13',
+    '            target: x86_64-apple-darwin',
+    '          - os: "macos-15-intel"',
+  ].join('\n');
+  assert.deepEqual(extractRunnerLabels(source), [
+    { line: 3, label: 'ubuntu-24.04' },
+    { line: 5, label: 'self-hosted' },
+    { line: 5, label: 'arc-happyvertical' },
+    { line: 11, label: 'macos-13' },
+    { line: 13, label: 'macos-15-intel' },
+  ]);
+});
+
+test('repository workflows reference no retired runner labels', () => {
+  assert.deepEqual(findRetiredRunnerLabels(WORKFLOWS_DIR), []);
+});

--- a/scripts/validate-workflow-runners.test.mjs
+++ b/scripts/validate-workflow-runners.test.mjs
@@ -134,6 +134,26 @@ test('block regions tolerate comments and do not mask include os entries', () =>
   ]);
 });
 
+test('handles CRLF line endings in every supported form', () => {
+  const source = [
+    'jobs:',
+    '  a:',
+    '    runs-on: macos-13',
+    '    strategy:',
+    '      matrix:',
+    '        os:',
+    '          - macos-13',
+    '',
+    '        include:',
+    '          - os: macos-13',
+  ].join('\r\n');
+  assert.deepEqual(extractRunnerLabels(source), [
+    { line: 3, label: 'macos-13' },
+    { line: 7, label: 'macos-13' },
+    { line: 10, label: 'macos-13' },
+  ]);
+});
+
 test('repository workflows reference no retired runner labels', () => {
   assert.deepEqual(findRetiredRunnerLabels(WORKFLOWS_DIR), []);
 });

--- a/scripts/validate-workflow-runners.test.mjs
+++ b/scripts/validate-workflow-runners.test.mjs
@@ -19,6 +19,7 @@ test('flags exactly the retired GitHub-hosted runner labels', () => {
     'macos-13-xlarge',
     'ubuntu-18.04',
     'ubuntu-20.04',
+    'windows-2016',
     'windows-2019',
   ]) {
     assert.equal(isRetiredRunnerLabel(retired), true, retired);
@@ -62,6 +63,32 @@ test('extracts runs-on scalars, flow lists, and matrix os entries', () => {
     { line: 5, label: 'arc-happyvertical' },
     { line: 11, label: 'macos-13' },
     { line: 13, label: 'macos-15-intel' },
+  ]);
+});
+
+test('extracts flow-list matrix os, inline comments, and block runs-on', () => {
+  const source = [
+    'jobs:',
+    '  a:',
+    '    strategy:',
+    '      matrix:',
+    '        os: [macos-13, "macos-15-intel"]',
+    '    runs-on: ${{ matrix.os }}',
+    '  b:',
+    '    runs-on: macos-13 # keep pinned for now',
+    '  c:',
+    '    runs-on:',
+    '      - self-hosted',
+    '      - windows-2019',
+    '    steps:',
+    '      - run: echo done',
+  ].join('\n');
+  assert.deepEqual(extractRunnerLabels(source), [
+    { line: 5, label: 'macos-13' },
+    { line: 5, label: 'macos-15-intel' },
+    { line: 8, label: 'macos-13' },
+    { line: 11, label: 'self-hosted' },
+    { line: 12, label: 'windows-2019' },
   ]);
 });
 


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "kimi",
  "session": "cricket-kimi-20260805-pr1180-repair",
  "issue": "https://github.com/happyvertical/sdk/issues/1185",
  "policy_revision": "1.0.0",
  "validation": [
    "node --test scripts/validate-workflow-runners.test.mjs - 4/4 pass (red before fix)",
    "node --test scripts/*.test.mjs - 30/32 pass; 2 failures reproduce on clean origin/main (missing pnpm install artifacts), pre-existing",
    "actionlint v1.7.12 with CI flags on all 21 workflows - zero errors",
    "yamllint -c .github/.yamllint.yml on changed workflow - clean"
  ]
}
```

## Summary

- Replaces the retired `macos-13` GitHub-hosted runner label with `macos-15-intel` for the `x86_64-apple-darwin` native build matrix entry in `.github/workflows/build-json-native.yml`.
- Adds `scripts/validate-workflow-runners.mjs` + `validate-workflow-runners.test.mjs` (wired into `pnpm test:ci-scripts`) as a regression guard: it fails when any workflow references a retired GitHub-hosted runner label.

## Root cause

`Validate Workflow Files` downloads the latest actionlint at run time. GitHub retired the `macos-13` runner image, so actionlint v1.7.12 rejects the label and every PR touching `.github/workflows/*` fails the gate — observed on Renovate rollup #1180 (run 30731126697, job 91451642775) and reproduced locally against `origin/main`. Independently, the darwin-x64 native build could never schedule on the retired label.

## Validation

- Regression test red before the fix (`build-json-native.yml:44 macos-13`), green after: `node --test scripts/validate-workflow-runners.test.mjs` → 4/4 pass.
- `node --test scripts/*.test.mjs` → 30/32 pass; the 2 failures (`validate-publish-packages`, `vitest-config`) reproduce identically on a clean `origin/main` worktree without these changes (missing `pnpm install` artifacts) — pre-existing, unrelated.
- Latest actionlint v1.7.12 with `-config-file .github/actionlint.yaml -ignore 'SC2086|SC2094|SC2129'` (the exact CI invocation): zero errors across all 21 workflows.
- `yamllint -c .github/.yamllint.yml .github/workflows/build-json-native.yml` → clean (the CI invocation).

Refs #1185 — remaining acceptance criteria (syncing `dependency-updates` to `main`, Renovate rebase of #1180) are tracked there and require this fix to merge first.

## Notes

- No package code changed; `ci`/`test` commits are non-releaseable, so no changeset.
- Does not close #1185: the `dependency-updates` base sync must follow after merge.
