### PR TITLE
feat(repos): buzz forge transport for Work #171

### DIFF
--- a/.changeset/buzz-forge-adapter.md
+++ b/.changeset/buzz-forge-adapter.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/repos": minor
+---
+
+Add buzz/Nostr forge transport: kind 30617/30618/1617/1630–1633/7 normalization into provider-neutral ForgeEventEnvelope, signature verification, relay client, and deterministic convergence fixtures for Work #171.

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -1076,7 +1076,8 @@
         ],
         "externalHappyVertical": [],
         "external": [
-          "js-yaml"
+          "js-yaml",
+          "nostr-tools"
         ]
       },
       "dependents": [

--- a/packages/repos/AGENT.md
+++ b/packages/repos/AGENT.md
@@ -27,7 +27,7 @@ pnpm --filter @happyvertical/repos clean
 ## Ecosystem Relationships
 - Provides: Standardized repository interface for GitHub, GitLab, Bitbucket, and Azure DevOps
 - Implements: none
-- Requires: @happyvertical/graphql, js-yaml
+- Requires: @happyvertical/graphql, js-yaml, nostr-tools
 - Stability: stable (Primary package surface is described as implemented and production-oriented.)
 <!-- END AGENT:GENERATED -->
 

--- a/packages/repos/README.md
+++ b/packages/repos/README.md
@@ -123,6 +123,27 @@ an observation. The exported `createGitHubWebhookFixture()` helper creates exact
 deterministic bytes and signatures for duplicate, redelivery, delayed, and
 out-of-order integration scenarios.
 
+### Buzz forge relay
+
+`BuzzRelayClient` polls configured Buzz/Nostr relays and normalizes supported
+forge kinds into provider-neutral `ForgeEventEnvelope` values. Production
+events are verified with `nostr-tools` before normalization; the
+`allowUnverifiedFixtures` option is solely for deterministic test fixtures.
+When `channelIds` is set, accepted events must have a matching `channel` or
+`h` tag. Kind-7 approvals need pull-request metadata or their referenced
+kind-1617 patch; pass a kind-39002 members event and `roleFloor` to enforce
+channel roles.
+
+```typescript
+import { BuzzRelayClient } from '@happyvertical/repos';
+
+const buzz = new BuzzRelayClient({
+  relays: ['https://relay.example/buzz'],
+  channelIds: ['channel-hv'],
+});
+const events = await buzz.pollOnce();
+```
+
 ### Errors and provider metadata
 
 New forge APIs throw `ForgeError`, which exposes `code`, `provider`, `status`,

--- a/packages/repos/metadata.json
+++ b/packages/repos/metadata.json
@@ -16,7 +16,8 @@
     ],
     "externalHappyVertical": [],
     "external": [
-      "js-yaml"
+      "js-yaml",
+      "nostr-tools"
     ]
   },
   "dependents": [

--- a/packages/repos/package.json
+++ b/packages/repos/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@happyvertical/graphql": "workspace:*",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "nostr-tools": "^2.23.3"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/repos/src/buzz/events.test.ts
+++ b/packages/repos/src/buzz/events.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { ForgeError, ForgeSignatureError } from '../forge/errors.js';
+import {
+  computeNostrEventId,
+  normalizeBuzzEvent,
+  resolveBuzzChannelRole,
+  roleMeetsFloor,
+  verifyAndNormalizeBuzzEvent,
+  verifyNostrEventSignature,
+} from './events.js';
+import {
+  createApprovalFixture,
+  createBuzzConvergenceSequences,
+  createMembersFixture,
+  createPatchFixture,
+  createRefUpdateFixture,
+  createRepositoryAnnouncementFixture,
+  createStatusFixture,
+} from './fixtures.js';
+import { BuzzRelayClient } from './relay.js';
+import { BUZZ_FORGE_KINDS } from './types.js';
+
+describe('buzz forge normalize', () => {
+  it('normalizes kind:30617 repository announcements', () => {
+    const event = createRepositoryAnnouncementFixture();
+    const envelope = normalizeBuzzEvent(event);
+    expect(envelope.provider).toBe('buzz');
+    expect(envelope.deliveryId).toBe(event.id);
+    expect(envelope.observation).toMatchObject({
+      kind: 'repository',
+      repository: {
+        name: 'happyvertical.com',
+      },
+    });
+  });
+
+  it('normalizes kind:30618 ref updates as push observations with before/after SHA', () => {
+    const event = createRefUpdateFixture({
+      head: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      previous: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      ref: 'refs/heads/main',
+    });
+    const envelope = normalizeBuzzEvent(event);
+    expect(envelope.observation).toEqual({
+      kind: 'push',
+      ref: 'refs/heads/main',
+      beforeSha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      afterSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      forced: false,
+      created: false,
+      deleted: false,
+    });
+  });
+
+  it('normalizes kind:1617 patches as pull_request observations', () => {
+    const event = createPatchFixture({ number: 12, headSha: 'c'.repeat(40) });
+    const envelope = normalizeBuzzEvent(event);
+    expect(envelope.observation).toMatchObject({
+      kind: 'pull_request',
+      pullRequest: {
+        number: 12,
+        headSha: 'c'.repeat(40),
+        state: 'open',
+      },
+    });
+  });
+
+  it('normalizes kinds 1630–1633 into check or merge observations', () => {
+    const open = normalizeBuzzEvent(
+      createStatusFixture({
+        kind: BUZZ_FORGE_KINDS.statusOpen,
+        conclusion: 'success',
+      }),
+    );
+    expect(open.observation.kind).toBe('check');
+
+    const merged = normalizeBuzzEvent(
+      createStatusFixture({ kind: BUZZ_FORGE_KINDS.statusApplied }),
+    );
+    expect(merged.observation.kind).toBe('merge');
+  });
+
+  it('normalizes kind:7 approvals with kind:39002 role floors', () => {
+    const members = createMembersFixture();
+    const approval = createApprovalFixture();
+    const envelope = normalizeBuzzEvent(approval, new Date(), {
+      membersEvent: members,
+      roleFloor: 'admin',
+    });
+    expect(envelope.observation).toMatchObject({
+      kind: 'review',
+      review: { state: 'APPROVED' },
+    });
+    const role = resolveBuzzChannelRole(members, approval.pubkey);
+    expect(role?.role).toBe('admin');
+    expect(roleMeetsFloor('admin', 'member')).toBe(true);
+    expect(roleMeetsFloor('guest', 'admin')).toBe(false);
+  });
+
+  it('rejects events whose id does not match the NIP-01 digest', () => {
+    const event = createRefUpdateFixture();
+    expect(() =>
+      verifyNostrEventSignature(
+        { ...event, id: '0'.repeat(64) },
+        { allowUnverifiedFixtures: true },
+      ),
+    ).toThrow(ForgeSignatureError);
+  });
+
+  it('accepts fixture events with matching digests when allowUnverifiedFixtures is set', () => {
+    const event = createRefUpdateFixture();
+    expect(computeNostrEventId(event)).toBe(event.id);
+    const envelope = verifyAndNormalizeBuzzEvent(event, new Date(), {
+      allowUnverifiedFixtures: true,
+    });
+    expect(envelope.observation.kind).toBe('push');
+  });
+
+  it('requires schnorr verification outside the fixture path when nostr-tools is absent', () => {
+    const event = createRefUpdateFixture();
+    try {
+      verifyNostrEventSignature(event);
+      // If nostr-tools is installed and verifies the placeholder, that is fine.
+    } catch (error) {
+      expect(error).toBeInstanceOf(ForgeError);
+    }
+  });
+});
+
+describe('buzz forge fixtures and relay ingest', () => {
+  it('produces stable convergence sequences', () => {
+    const a = createBuzzConvergenceSequences();
+    const b = createBuzzConvergenceSequences();
+    expect(a.canonical.map((e) => e.id)).toEqual(b.canonical.map((e) => e.id));
+    expect(a.duplicate.length).toBe(a.canonical.length * 2);
+    expect(a.outOfOrder.map((e) => e.id)).not.toEqual(a.canonical.map((e) => e.id));
+    expect(a.replay.length).toBe(a.canonical.length * 2);
+  });
+
+  it('dedupes event ids on ingest', () => {
+    const client = new BuzzRelayClient({
+      relays: ['https://relay.example/http'],
+    });
+    const sequences = createBuzzConvergenceSequences();
+    const first = client.ingestEvents(sequences.duplicate, {
+      allowUnverifiedFixtures: true,
+    });
+    const second = client.ingestEvents(sequences.canonical, {
+      allowUnverifiedFixtures: true,
+    });
+    expect(first.length).toBe(sequences.canonical.length);
+    expect(second.length).toBe(0);
+  });
+});

--- a/packages/repos/src/buzz/events.test.ts
+++ b/packages/repos/src/buzz/events.test.ts
@@ -86,6 +86,9 @@ describe('buzz forge normalize', () => {
     const envelope = normalizeBuzzEvent(approval, new Date(), {
       membersEvent: members,
       roleFloor: 'admin',
+      referencedPatchEvent: createPatchFixture({
+        id: 'merge-request-event-id',
+      }),
     });
     expect(envelope.observation).toMatchObject({
       kind: 'review',
@@ -116,14 +119,31 @@ describe('buzz forge normalize', () => {
     expect(envelope.observation.kind).toBe('push');
   });
 
-  it('requires schnorr verification outside the fixture path when nostr-tools is absent', () => {
+  it('requires a valid Schnorr signature outside the explicit fixture path', () => {
     const event = createRefUpdateFixture();
     try {
       verifyNostrEventSignature(event);
-      // If nostr-tools is installed and verifies the placeholder, that is fine.
+      // Placeholder fixture signatures must not pass production verification.
     } catch (error) {
       expect(error).toBeInstanceOf(ForgeError);
     }
+  });
+
+  it('rejects an approval actor missing from a supplied member list', () => {
+    expect(() =>
+      normalizeBuzzEvent(createApprovalFixture(), new Date(), {
+        membersEvent: createMembersFixture({ members: [] }),
+        referencedPatchEvent: createPatchFixture({
+          id: 'merge-request-event-id',
+        }),
+      }),
+    ).toThrow(ForgeError);
+  });
+
+  it('requires pull-request metadata or the referenced patch for reactions', () => {
+    expect(() => normalizeBuzzEvent(createApprovalFixture())).toThrow(
+      ForgeError,
+    );
   });
 });
 
@@ -133,7 +153,9 @@ describe('buzz forge fixtures and relay ingest', () => {
     const b = createBuzzConvergenceSequences();
     expect(a.canonical.map((e) => e.id)).toEqual(b.canonical.map((e) => e.id));
     expect(a.duplicate.length).toBe(a.canonical.length * 2);
-    expect(a.outOfOrder.map((e) => e.id)).not.toEqual(a.canonical.map((e) => e.id));
+    expect(a.outOfOrder.map((e) => e.id)).not.toEqual(
+      a.canonical.map((e) => e.id),
+    );
     expect(a.replay.length).toBe(a.canonical.length * 2);
   });
 
@@ -150,5 +172,17 @@ describe('buzz forge fixtures and relay ingest', () => {
     });
     expect(first.length).toBe(sequences.canonical.length);
     expect(second.length).toBe(0);
+  });
+
+  it('requires an explicit matching channel tag when channels are configured', () => {
+    const client = new BuzzRelayClient({
+      relays: ['https://relay.example/http'],
+      channelIds: ['channel-hv'],
+    });
+    expect(
+      client.ingestEvents([createRefUpdateFixture()], {
+        allowUnverifiedFixtures: true,
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/repos/src/buzz/events.ts
+++ b/packages/repos/src/buzz/events.ts
@@ -1,0 +1,480 @@
+import { createHash } from 'node:crypto';
+import { ForgeError, ForgeSignatureError } from '../forge/errors.js';
+import type {
+  CheckRun,
+  ForgeActor,
+  ForgeEventEnvelope,
+  ForgeObservation,
+  ForgePullRequestRef,
+  ForgeRepositoryRef,
+} from '../forge/types.js';
+import {
+  BUZZ_FORGE_KINDS,
+  type BuzzChannelRole,
+  type BuzzRoleResolution,
+  type NostrForgeEvent,
+} from './types.js';
+
+const ROLE_RANK: Record<BuzzChannelRole, number> = {
+  owner: 40,
+  admin: 30,
+  member: 20,
+  guest: 10,
+  bot: 5,
+};
+
+/**
+ * Compute the NIP-01 event id for a Nostr event (sha256 of serialized fields).
+ * Used by fixtures and verification when the caller supplies an unsigned skeleton.
+ */
+export function computeNostrEventId(
+  event: Omit<NostrForgeEvent, 'id' | 'sig'>,
+): string {
+  const serialized = JSON.stringify([
+    0,
+    event.pubkey,
+    event.created_at,
+    event.kind,
+    event.tags,
+    event.content,
+  ]);
+  return createHash('sha256').update(serialized).digest('hex');
+}
+
+function tagValue(event: NostrForgeEvent, name: string): string | undefined {
+  for (const tag of event.tags) {
+    if (tag[0] === name && typeof tag[1] === 'string' && tag[1] !== '') {
+      return tag[1];
+    }
+  }
+  return undefined;
+}
+
+function allTagValues(event: NostrForgeEvent, name: string): string[] {
+  const values: string[] = [];
+  for (const tag of event.tags) {
+    if (tag[0] === name && typeof tag[1] === 'string' && tag[1] !== '') {
+      values.push(tag[1]);
+    }
+  }
+  return values;
+}
+
+function optionalJson(content: string): Record<string, unknown> {
+  if (!content) return {};
+  try {
+    const parsed: unknown = JSON.parse(content);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function actorFromPubkey(pubkey: string): ForgeActor {
+  return {
+    id: pubkey,
+    login: pubkey,
+    type: 'User',
+  };
+}
+
+function repositoryFromEvent(event: NostrForgeEvent): ForgeRepositoryRef {
+  const owner =
+    tagValue(event, 'p') ??
+    tagValue(event, 'owner') ??
+    event.pubkey;
+  const name =
+    tagValue(event, 'd') ??
+    tagValue(event, 'repo') ??
+    tagValue(event, 'name') ??
+    'unknown';
+  const fullName =
+    tagValue(event, 'a')?.replace(/^30617:/, '') ?? `${owner}/${name}`;
+  return {
+    id: tagValue(event, 'repo-id') ?? fullName,
+    owner,
+    name: name.includes('/') ? (name.split('/').pop() ?? name) : name,
+    fullName: fullName.includes('/') ? fullName : `${owner}/${name}`,
+    url: tagValue(event, 'clone') ?? tagValue(event, 'url'),
+  };
+}
+
+function pullRequestFromEvent(event: NostrForgeEvent): ForgePullRequestRef {
+  const body = optionalJson(event.content);
+  const numberRaw =
+    tagValue(event, 't') ??
+    tagValue(event, 'pr') ??
+    (typeof body.number === 'number' || typeof body.number === 'string'
+      ? String(body.number)
+      : '0');
+  const number = Number.parseInt(numberRaw, 10);
+  const headSha =
+    tagValue(event, 'commit') ??
+    tagValue(event, 'head') ??
+    (typeof body.headSha === 'string' ? body.headSha : '') ??
+    (typeof body.head_sha === 'string' ? body.head_sha : '') ??
+    '';
+  const stateTag = tagValue(event, 'status') ?? tagValue(event, 'state');
+  const state =
+    stateTag === 'closed' || stateTag === 'merged' || event.kind === BUZZ_FORGE_KINDS.statusClosed
+      ? 'closed'
+      : 'open';
+  return {
+    id: event.id,
+    number: Number.isFinite(number) && number > 0 ? number : 0,
+    state,
+    headSha,
+    headRef: tagValue(event, 'head-ref') ?? tagValue(event, 'branch'),
+    baseSha: tagValue(event, 'base') ?? tagValue(event, 'base-sha'),
+    baseRef: tagValue(event, 'base-ref') ?? 'refs/heads/main',
+    merged:
+      event.kind === BUZZ_FORGE_KINDS.statusApplied ||
+      stateTag === 'merged' ||
+      body.merged === true,
+    mergeCommitSha:
+      typeof body.mergeCommitSha === 'string'
+        ? body.mergeCommitSha
+        : tagValue(event, 'merge-commit'),
+    url: tagValue(event, 'url'),
+  };
+}
+
+function checkFromStatusEvent(event: NostrForgeEvent): CheckRun {
+  const body = optionalJson(event.content);
+  const context =
+    tagValue(event, 'context') ??
+    tagValue(event, 'l') ??
+    (typeof body.context === 'string' ? body.context : 'ci');
+  const conclusionRaw =
+    tagValue(event, 'conclusion') ??
+    (typeof body.conclusion === 'string' ? body.conclusion : undefined) ??
+    (typeof body.state === 'string' ? body.state : undefined);
+  let conclusion: CheckRun['conclusion'];
+  let status: CheckRun['status'] = 'completed';
+  if (
+    conclusionRaw === 'success' ||
+    conclusionRaw === 'failure' ||
+    conclusionRaw === 'neutral' ||
+    conclusionRaw === 'cancelled' ||
+    conclusionRaw === 'skipped' ||
+    conclusionRaw === 'timed_out' ||
+    conclusionRaw === 'action_required' ||
+    conclusionRaw === 'stale' ||
+    conclusionRaw === 'startup_failure'
+  ) {
+    conclusion = conclusionRaw;
+  } else if (event.kind === BUZZ_FORGE_KINDS.statusApplied) {
+    conclusion = 'success';
+  } else if (event.kind === BUZZ_FORGE_KINDS.statusClosed) {
+    conclusion = 'cancelled';
+  } else if (event.kind === BUZZ_FORGE_KINDS.statusDraft) {
+    status = 'in_progress';
+    conclusion = undefined;
+  } else {
+    status = 'queued';
+    conclusion = undefined;
+  }
+  return {
+    id: event.id,
+    name: context,
+    headSha:
+      tagValue(event, 'commit') ??
+      tagValue(event, 'head') ??
+      (typeof body.headSha === 'string' ? body.headSha : '') ??
+      '',
+    status,
+    conclusion,
+    detailsUrl: tagValue(event, 'url'),
+    startedAt: new Date(event.created_at * 1000),
+    completedAt: status === 'completed' ? new Date(event.created_at * 1000) : undefined,
+    raw: event as unknown as Record<string, unknown>,
+  };
+}
+
+/**
+ * Resolve a reactor's channel role from a kind:39002 members list.
+ * Returns null when the pubkey is absent from the membership event.
+ */
+export function resolveBuzzChannelRole(
+  membersEvent: NostrForgeEvent,
+  pubkey: string,
+): BuzzRoleResolution | null {
+  if (membersEvent.kind !== BUZZ_FORGE_KINDS.channelMembers) {
+    throw new ForgeError(
+      'Role resolution requires a kind:39002 members event',
+      'INVALID_INPUT',
+      { provider: 'buzz' },
+    );
+  }
+  for (const tag of membersEvent.tags) {
+    if (tag[0] !== 'p' || tag[1] !== pubkey) continue;
+    const roleRaw = (tag[2] ?? 'member').toLowerCase();
+    const role: BuzzChannelRole =
+      roleRaw === 'owner' ||
+      roleRaw === 'admin' ||
+      roleRaw === 'member' ||
+      roleRaw === 'guest' ||
+      roleRaw === 'bot'
+        ? roleRaw
+        : 'member';
+    return { pubkey, role };
+  }
+  return null;
+}
+
+/** True when the reactor's role rank is at or above the configured floor. */
+export function roleMeetsFloor(
+  role: BuzzChannelRole,
+  floor: BuzzChannelRole,
+): boolean {
+  return ROLE_RANK[role] >= ROLE_RANK[floor];
+}
+
+/**
+ * Normalize one already-verified Nostr forge event into a provider-neutral
+ * envelope. Signature verification is the caller's responsibility (or use
+ * {@link verifyAndNormalizeBuzzEvent}).
+ */
+export function normalizeBuzzEvent(
+  event: NostrForgeEvent,
+  receivedAt = new Date(),
+  options: {
+    roleFloor?: BuzzChannelRole;
+    membersEvent?: NostrForgeEvent;
+  } = {},
+): ForgeEventEnvelope {
+  const repository = repositoryFromEvent(event);
+  const actor = actorFromPubkey(event.pubkey);
+  const observation = normalizeObservation(event, options);
+  return {
+    provider: 'buzz',
+    deliveryId: event.id,
+    event: String(event.kind),
+    action: tagValue(event, 'action'),
+    occurredAt: new Date(event.created_at * 1000),
+    receivedAt,
+    repository,
+    actor,
+    observation,
+    raw: event,
+  };
+}
+
+function normalizeObservation(
+  event: NostrForgeEvent,
+  options: {
+    roleFloor?: BuzzChannelRole;
+    membersEvent?: NostrForgeEvent;
+  },
+): ForgeObservation {
+  switch (event.kind) {
+    case BUZZ_FORGE_KINDS.repositoryAnnouncement:
+      return {
+        kind: 'repository',
+        repository: repositoryFromEvent(event),
+      };
+    case BUZZ_FORGE_KINDS.refUpdate: {
+      const body = optionalJson(event.content);
+      const ref =
+        tagValue(event, 'ref') ??
+        (typeof body.ref === 'string' ? body.ref : 'refs/heads/main');
+      const afterSha =
+        tagValue(event, 'commit') ??
+        tagValue(event, 'head') ??
+        (typeof body.head === 'string' ? body.head : '') ??
+        (typeof body.after === 'string' ? body.after : '') ??
+        '';
+      const beforeSha =
+        tagValue(event, 'previous') ??
+        tagValue(event, 'before') ??
+        (typeof body.before === 'string' ? body.before : undefined) ??
+        (typeof body.previous === 'string' ? body.previous : undefined);
+      return {
+        kind: 'push',
+        ref,
+        beforeSha,
+        afterSha,
+        forced: body.forced === true,
+        created: body.created === true,
+        deleted: body.deleted === true || afterSha === '' || afterSha === '0'.repeat(40),
+      };
+    }
+    case BUZZ_FORGE_KINDS.patch:
+      return {
+        kind: 'pull_request',
+        pullRequest: pullRequestFromEvent(event),
+      };
+    case BUZZ_FORGE_KINDS.statusOpen:
+    case BUZZ_FORGE_KINDS.statusDraft:
+      return {
+        kind: 'check',
+        check: checkFromStatusEvent(event),
+      };
+    case BUZZ_FORGE_KINDS.statusClosed:
+      return {
+        kind: 'check',
+        check: checkFromStatusEvent(event),
+      };
+    case BUZZ_FORGE_KINDS.statusApplied: {
+      // kind:1631 is posted after a coordinator merge (ADR-002).
+      const pullRequest = pullRequestFromEvent(event);
+      return {
+        kind: 'merge',
+        pullRequest: { ...pullRequest, state: 'closed', merged: true },
+        mergeCommitSha: pullRequest.mergeCommitSha ?? pullRequest.headSha,
+      };
+    }
+    case BUZZ_FORGE_KINDS.reaction: {
+      const body = optionalJson(event.content);
+      const content = event.content.trim() || (typeof body.content === 'string' ? body.content : '');
+      const isApproval =
+        content === '✅' ||
+        content === '+' ||
+        content.toLowerCase() === 'approved' ||
+        body.approved === true;
+      const commitSha =
+        tagValue(event, 'commit') ??
+        tagValue(event, 'e') ??
+        (typeof body.commitSha === 'string' ? body.commitSha : undefined);
+      let author = actorFromPubkey(event.pubkey);
+      if (options.membersEvent) {
+        const resolved = resolveBuzzChannelRole(options.membersEvent, event.pubkey);
+        if (resolved) {
+          author = {
+            ...author,
+            type: `role:${resolved.role}`,
+          };
+          const floor = options.roleFloor ?? 'member';
+          if (!roleMeetsFloor(resolved.role, floor)) {
+            return {
+              kind: 'review',
+              pullRequest: pullRequestFromEvent(event),
+              review: {
+                id: event.id,
+                state: 'COMMENTED',
+                body: content,
+                commitSha,
+                submittedAt: new Date(event.created_at * 1000),
+                author,
+              },
+            };
+          }
+        }
+      }
+      return {
+        kind: 'review',
+        pullRequest: pullRequestFromEvent(event),
+        review: {
+          id: event.id,
+          state: isApproval ? 'APPROVED' : 'COMMENTED',
+          body: content,
+          commitSha,
+          submittedAt: new Date(event.created_at * 1000),
+          author,
+        },
+      };
+    }
+    default:
+      return { kind: 'unknown' };
+  }
+}
+
+/**
+ * Structural signature verification for Nostr events.
+ *
+ * When `nostr-tools` is available it performs full Schnorr verification.
+ * Otherwise it fails closed unless `allowUnverifiedFixtures` is set (tests
+ * that inject pre-trusted fixture events with matching id digests).
+ */
+export function verifyNostrEventSignature(
+  event: NostrForgeEvent,
+  options: { allowUnverifiedFixtures?: boolean } = {},
+): void {
+  if (!event.id || !event.pubkey || !event.sig) {
+    throw new ForgeSignatureError('Buzz forge event is missing id, pubkey, or sig');
+  }
+  const expectedId = computeNostrEventId({
+    pubkey: event.pubkey,
+    created_at: event.created_at,
+    kind: event.kind,
+    tags: event.tags,
+    content: event.content,
+  });
+  if (expectedId !== event.id) {
+    throw new ForgeSignatureError('Buzz forge event id does not match NIP-01 digest');
+  }
+  // Dynamic import path is resolved at call time so the package remains
+  // usable when optional schnorr verification is not installed.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nostrTools = requireNostrTools();
+    if (nostrTools && typeof nostrTools.verifyEvent === 'function') {
+      const ok = nostrTools.verifyEvent(event as never);
+      if (!ok) {
+        throw new ForgeSignatureError('Buzz forge event Schnorr signature is invalid');
+      }
+      return;
+    }
+  } catch (error) {
+    if (error instanceof ForgeSignatureError) throw error;
+  }
+  if (options.allowUnverifiedFixtures) {
+    // Fixture path: id digest already matched; signature bytes are placeholders.
+    if (event.sig.length < 64) {
+      throw new ForgeSignatureError('Buzz forge fixture signature is malformed');
+    }
+    return;
+  }
+  throw new ForgeError(
+    'Schnorr verification requires the optional nostr-tools dependency',
+    'CONFIGURATION_ERROR',
+    { provider: 'buzz', retryable: false },
+  );
+}
+
+function requireNostrTools(): { verifyEvent?: (event: unknown) => boolean } | null {
+  try {
+    // Optional peer: present when the consumer installs nostr-tools.
+    // Use Function to avoid bundlers rewriting the require.
+    // eslint-disable-next-line no-new-func
+    const req = new Function('m', 'return require(m)') as (m: string) => {
+      verifyEvent?: (event: unknown) => boolean;
+    };
+    return req('nostr-tools');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify then normalize a buzz forge event. Rejects invalid signatures without
+ * producing an observation.
+ */
+export function verifyAndNormalizeBuzzEvent(
+  event: NostrForgeEvent,
+  receivedAt = new Date(),
+  options: {
+    roleFloor?: BuzzChannelRole;
+    membersEvent?: NostrForgeEvent;
+    allowUnverifiedFixtures?: boolean;
+  } = {},
+): ForgeEventEnvelope {
+  verifyNostrEventSignature(event, {
+    allowUnverifiedFixtures: options.allowUnverifiedFixtures,
+  });
+  return normalizeBuzzEvent(event, receivedAt, {
+    roleFloor: options.roleFloor,
+    membersEvent: options.membersEvent,
+  });
+}
+
+/** Extract a channel id from common buzz tags when present. */
+export function channelIdFromEvent(event: NostrForgeEvent): string | undefined {
+  return (
+    tagValue(event, 'channel') ??
+    tagValue(event, 'h') ??
+    allTagValues(event, 'e')[0]
+  );
+}

--- a/packages/repos/src/buzz/events.ts
+++ b/packages/repos/src/buzz/events.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { verifyEvent } from 'nostr-tools';
 import { ForgeError, ForgeSignatureError } from '../forge/errors.js';
 import type {
   CheckRun,
@@ -50,16 +51,6 @@ function tagValue(event: NostrForgeEvent, name: string): string | undefined {
   return undefined;
 }
 
-function allTagValues(event: NostrForgeEvent, name: string): string[] {
-  const values: string[] = [];
-  for (const tag of event.tags) {
-    if (tag[0] === name && typeof tag[1] === 'string' && tag[1] !== '') {
-      values.push(tag[1]);
-    }
-  }
-  return values;
-}
-
 function optionalJson(content: string): Record<string, unknown> {
   if (!content) return {};
   try {
@@ -82,9 +73,7 @@ function actorFromPubkey(pubkey: string): ForgeActor {
 
 function repositoryFromEvent(event: NostrForgeEvent): ForgeRepositoryRef {
   const owner =
-    tagValue(event, 'p') ??
-    tagValue(event, 'owner') ??
-    event.pubkey;
+    tagValue(event, 'p') ?? tagValue(event, 'owner') ?? event.pubkey;
   const name =
     tagValue(event, 'd') ??
     tagValue(event, 'repo') ??
@@ -118,7 +107,9 @@ function pullRequestFromEvent(event: NostrForgeEvent): ForgePullRequestRef {
     '';
   const stateTag = tagValue(event, 'status') ?? tagValue(event, 'state');
   const state =
-    stateTag === 'closed' || stateTag === 'merged' || event.kind === BUZZ_FORGE_KINDS.statusClosed
+    stateTag === 'closed' ||
+    stateTag === 'merged' ||
+    event.kind === BUZZ_FORGE_KINDS.statusClosed
       ? 'closed'
       : 'open';
   return {
@@ -139,6 +130,27 @@ function pullRequestFromEvent(event: NostrForgeEvent): ForgePullRequestRef {
         : tagValue(event, 'merge-commit'),
     url: tagValue(event, 'url'),
   };
+}
+
+function pullRequestForReaction(
+  event: NostrForgeEvent,
+  referencedPatchEvent?: NostrForgeEvent,
+): ForgePullRequestRef {
+  const pullRequest = pullRequestFromEvent(event);
+  if (pullRequest.number > 0) return pullRequest;
+  const targetId = tagValue(event, 'e');
+  if (
+    targetId &&
+    referencedPatchEvent?.id === targetId &&
+    referencedPatchEvent.kind === BUZZ_FORGE_KINDS.patch
+  ) {
+    return pullRequestFromEvent(referencedPatchEvent);
+  }
+  throw new ForgeError(
+    'Buzz approval reaction must include pull-request metadata or its referenced patch event',
+    'INVALID_INPUT',
+    { provider: 'buzz' },
+  );
 }
 
 function checkFromStatusEvent(event: NostrForgeEvent): CheckRun {
@@ -188,7 +200,8 @@ function checkFromStatusEvent(event: NostrForgeEvent): CheckRun {
     conclusion,
     detailsUrl: tagValue(event, 'url'),
     startedAt: new Date(event.created_at * 1000),
-    completedAt: status === 'completed' ? new Date(event.created_at * 1000) : undefined,
+    completedAt:
+      status === 'completed' ? new Date(event.created_at * 1000) : undefined,
     raw: event as unknown as Record<string, unknown>,
   };
 }
@@ -243,6 +256,7 @@ export function normalizeBuzzEvent(
   options: {
     roleFloor?: BuzzChannelRole;
     membersEvent?: NostrForgeEvent;
+    referencedPatchEvent?: NostrForgeEvent;
   } = {},
 ): ForgeEventEnvelope {
   const repository = repositoryFromEvent(event);
@@ -267,6 +281,7 @@ function normalizeObservation(
   options: {
     roleFloor?: BuzzChannelRole;
     membersEvent?: NostrForgeEvent;
+    referencedPatchEvent?: NostrForgeEvent;
   },
 ): ForgeObservation {
   switch (event.kind) {
@@ -298,7 +313,10 @@ function normalizeObservation(
         afterSha,
         forced: body.forced === true,
         created: body.created === true,
-        deleted: body.deleted === true || afterSha === '' || afterSha === '0'.repeat(40),
+        deleted:
+          body.deleted === true ||
+          afterSha === '' ||
+          afterSha === '0'.repeat(40),
       };
     }
     case BUZZ_FORGE_KINDS.patch:
@@ -328,7 +346,9 @@ function normalizeObservation(
     }
     case BUZZ_FORGE_KINDS.reaction: {
       const body = optionalJson(event.content);
-      const content = event.content.trim() || (typeof body.content === 'string' ? body.content : '');
+      const content =
+        event.content.trim() ||
+        (typeof body.content === 'string' ? body.content : '');
       const isApproval =
         content === '✅' ||
         content === '+' ||
@@ -339,33 +359,42 @@ function normalizeObservation(
         tagValue(event, 'e') ??
         (typeof body.commitSha === 'string' ? body.commitSha : undefined);
       let author = actorFromPubkey(event.pubkey);
+      const pullRequest = pullRequestForReaction(
+        event,
+        options.referencedPatchEvent,
+      );
       if (options.membersEvent) {
-        const resolved = resolveBuzzChannelRole(options.membersEvent, event.pubkey);
-        if (resolved) {
-          author = {
-            ...author,
-            type: `role:${resolved.role}`,
+        const resolved = resolveBuzzChannelRole(
+          options.membersEvent,
+          event.pubkey,
+        );
+        if (!resolved) {
+          throw new ForgeError(
+            'Buzz approval actor is not a member of the configured channel',
+            'AUTHORITY_MISMATCH',
+            { provider: 'buzz' },
+          );
+        }
+        author = { ...author, type: `role:${resolved.role}` };
+        const floor = options.roleFloor ?? 'member';
+        if (!roleMeetsFloor(resolved.role, floor)) {
+          return {
+            kind: 'review',
+            pullRequest,
+            review: {
+              id: event.id,
+              state: 'COMMENTED',
+              body: content,
+              commitSha,
+              submittedAt: new Date(event.created_at * 1000),
+              author,
+            },
           };
-          const floor = options.roleFloor ?? 'member';
-          if (!roleMeetsFloor(resolved.role, floor)) {
-            return {
-              kind: 'review',
-              pullRequest: pullRequestFromEvent(event),
-              review: {
-                id: event.id,
-                state: 'COMMENTED',
-                body: content,
-                commitSha,
-                submittedAt: new Date(event.created_at * 1000),
-                author,
-              },
-            };
-          }
         }
       }
       return {
         kind: 'review',
-        pullRequest: pullRequestFromEvent(event),
+        pullRequest,
         review: {
           id: event.id,
           state: isApproval ? 'APPROVED' : 'COMMENTED',
@@ -393,7 +422,9 @@ export function verifyNostrEventSignature(
   options: { allowUnverifiedFixtures?: boolean } = {},
 ): void {
   if (!event.id || !event.pubkey || !event.sig) {
-    throw new ForgeSignatureError('Buzz forge event is missing id, pubkey, or sig');
+    throw new ForgeSignatureError(
+      'Buzz forge event is missing id, pubkey, or sig',
+    );
   }
   const expectedId = computeNostrEventId({
     pubkey: event.pubkey,
@@ -403,48 +434,23 @@ export function verifyNostrEventSignature(
     content: event.content,
   });
   if (expectedId !== event.id) {
-    throw new ForgeSignatureError('Buzz forge event id does not match NIP-01 digest');
-  }
-  // Dynamic import path is resolved at call time so the package remains
-  // usable when optional schnorr verification is not installed.
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const nostrTools = requireNostrTools();
-    if (nostrTools && typeof nostrTools.verifyEvent === 'function') {
-      const ok = nostrTools.verifyEvent(event as never);
-      if (!ok) {
-        throw new ForgeSignatureError('Buzz forge event Schnorr signature is invalid');
-      }
-      return;
-    }
-  } catch (error) {
-    if (error instanceof ForgeSignatureError) throw error;
+    throw new ForgeSignatureError(
+      'Buzz forge event id does not match NIP-01 digest',
+    );
   }
   if (options.allowUnverifiedFixtures) {
     // Fixture path: id digest already matched; signature bytes are placeholders.
     if (event.sig.length < 64) {
-      throw new ForgeSignatureError('Buzz forge fixture signature is malformed');
+      throw new ForgeSignatureError(
+        'Buzz forge fixture signature is malformed',
+      );
     }
     return;
   }
-  throw new ForgeError(
-    'Schnorr verification requires the optional nostr-tools dependency',
-    'CONFIGURATION_ERROR',
-    { provider: 'buzz', retryable: false },
-  );
-}
-
-function requireNostrTools(): { verifyEvent?: (event: unknown) => boolean } | null {
-  try {
-    // Optional peer: present when the consumer installs nostr-tools.
-    // Use Function to avoid bundlers rewriting the require.
-    // eslint-disable-next-line no-new-func
-    const req = new Function('m', 'return require(m)') as (m: string) => {
-      verifyEvent?: (event: unknown) => boolean;
-    };
-    return req('nostr-tools');
-  } catch {
-    return null;
+  if (!verifyEvent(event as never)) {
+    throw new ForgeSignatureError(
+      'Buzz forge event Schnorr signature is invalid',
+    );
   }
 }
 
@@ -458,6 +464,7 @@ export function verifyAndNormalizeBuzzEvent(
   options: {
     roleFloor?: BuzzChannelRole;
     membersEvent?: NostrForgeEvent;
+    referencedPatchEvent?: NostrForgeEvent;
     allowUnverifiedFixtures?: boolean;
   } = {},
 ): ForgeEventEnvelope {
@@ -467,14 +474,11 @@ export function verifyAndNormalizeBuzzEvent(
   return normalizeBuzzEvent(event, receivedAt, {
     roleFloor: options.roleFloor,
     membersEvent: options.membersEvent,
+    referencedPatchEvent: options.referencedPatchEvent,
   });
 }
 
 /** Extract a channel id from common buzz tags when present. */
 export function channelIdFromEvent(event: NostrForgeEvent): string | undefined {
-  return (
-    tagValue(event, 'channel') ??
-    tagValue(event, 'h') ??
-    allTagValues(event, 'e')[0]
-  );
+  return tagValue(event, 'channel') ?? tagValue(event, 'h');
 }

--- a/packages/repos/src/buzz/fixtures.ts
+++ b/packages/repos/src/buzz/fixtures.ts
@@ -1,0 +1,263 @@
+import { computeNostrEventId } from './events.js';
+import { BUZZ_FORGE_KINDS, type NostrForgeEvent } from './types.js';
+
+const FIXTURE_PUBKEY =
+  '2ad53df8aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4f05';
+const FIXTURE_ATTESTOR =
+  'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const FIXTURE_REACTOR =
+  'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const PLACEHOLDER_SIG = 'a'.repeat(128);
+
+export interface BuzzFixtureOptions {
+  /** Override event id after computing the NIP-01 digest (duplicate/replay cases). */
+  id?: string;
+  pubkey?: string;
+  created_at?: number;
+  tags?: readonly (readonly string[])[];
+  content?: string;
+  sig?: string;
+}
+
+/**
+ * Build a deterministic unsigned-then-id-bound Nostr event for tests.
+ * Signature bytes are placeholders; pair with `allowUnverifiedFixtures: true`.
+ */
+export function createBuzzFixtureEvent(
+  kind: number,
+  options: BuzzFixtureOptions = {},
+): NostrForgeEvent {
+  const skeleton = {
+    pubkey: options.pubkey ?? FIXTURE_PUBKEY,
+    created_at: options.created_at ?? 1_725_000_000,
+    kind,
+    tags: options.tags ?? [],
+    content: options.content ?? '',
+  };
+  const id = options.id ?? computeNostrEventId(skeleton);
+  return {
+    ...skeleton,
+    id,
+    sig: options.sig ?? PLACEHOLDER_SIG,
+  };
+}
+
+export function createRepositoryAnnouncementFixture(
+  options: BuzzFixtureOptions & {
+    owner?: string;
+    repoId?: string;
+    channelId?: string;
+  } = {},
+): NostrForgeEvent {
+  const owner = options.owner ?? FIXTURE_PUBKEY;
+  const repoId = options.repoId ?? 'happyvertical.com';
+  return createBuzzFixtureEvent(BUZZ_FORGE_KINDS.repositoryAnnouncement, {
+    ...options,
+    pubkey: owner,
+    tags: options.tags ?? [
+      ['d', repoId],
+      ['p', owner],
+      ['channel', options.channelId ?? 'channel-hv'],
+      ['clone', `https://buzz.happyvertical.com/git/${owner}/${repoId}.git`],
+    ],
+  });
+}
+
+export function createRefUpdateFixture(
+  options: BuzzFixtureOptions & {
+    ref?: string;
+    head?: string;
+    previous?: string;
+    repoId?: string;
+    owner?: string;
+  } = {},
+): NostrForgeEvent {
+  const head =
+    options.head ?? '1111111111111111111111111111111111111111';
+  const previous =
+    options.previous ?? '0000000000000000000000000000000000000000';
+  const owner = options.owner ?? FIXTURE_PUBKEY;
+  const repoId = options.repoId ?? 'happyvertical.com';
+  return createBuzzFixtureEvent(BUZZ_FORGE_KINDS.refUpdate, {
+    ...options,
+    tags: options.tags ?? [
+      ['d', repoId],
+      ['p', owner],
+      ['ref', options.ref ?? 'refs/heads/main'],
+      ['commit', head],
+      ['previous', previous],
+    ],
+    content:
+      options.content ??
+      JSON.stringify({ ref: options.ref ?? 'refs/heads/main', head, before: previous }),
+  });
+}
+
+export function createPatchFixture(
+  options: BuzzFixtureOptions & {
+    headSha?: string;
+    number?: number;
+    repoId?: string;
+  } = {},
+): NostrForgeEvent {
+  const headSha =
+    options.headSha ?? '2222222222222222222222222222222222222222';
+  return createBuzzFixtureEvent(BUZZ_FORGE_KINDS.patch, {
+    ...options,
+    tags: options.tags ?? [
+      ['d', options.repoId ?? 'happyvertical.com'],
+      ['p', FIXTURE_PUBKEY],
+      ['commit', headSha],
+      ['t', String(options.number ?? 1)],
+      ['head-ref', 'refs/heads/feature'],
+      ['base-ref', 'refs/heads/main'],
+    ],
+    content:
+      options.content ??
+      JSON.stringify({ number: options.number ?? 1, headSha }),
+  });
+}
+
+export function createStatusFixture(
+  options: BuzzFixtureOptions & {
+    kind?:
+      | typeof BUZZ_FORGE_KINDS.statusOpen
+      | typeof BUZZ_FORGE_KINDS.statusApplied
+      | typeof BUZZ_FORGE_KINDS.statusClosed
+      | typeof BUZZ_FORGE_KINDS.statusDraft;
+    context?: string;
+    headSha?: string;
+    conclusion?: string;
+  } = {},
+): NostrForgeEvent {
+  const kind = options.kind ?? BUZZ_FORGE_KINDS.statusOpen;
+  const headSha =
+    options.headSha ?? '2222222222222222222222222222222222222222';
+  return createBuzzFixtureEvent(kind, {
+    ...options,
+    pubkey: options.pubkey ?? FIXTURE_ATTESTOR,
+    tags: options.tags ?? [
+      ['d', 'happyvertical.com'],
+      ['p', FIXTURE_PUBKEY],
+      ['commit', headSha],
+      ['context', options.context ?? 'ci'],
+      ...(options.conclusion ? ([['conclusion', options.conclusion]] as const) : []),
+    ],
+    content:
+      options.content ??
+      JSON.stringify({
+        context: options.context ?? 'ci',
+        conclusion: options.conclusion ?? 'success',
+        headSha,
+      }),
+  });
+}
+
+export function createApprovalFixture(
+  options: BuzzFixtureOptions & {
+    content?: string;
+    headSha?: string;
+  } = {},
+): NostrForgeEvent {
+  return createBuzzFixtureEvent(BUZZ_FORGE_KINDS.reaction, {
+    ...options,
+    pubkey: options.pubkey ?? FIXTURE_REACTOR,
+    tags: options.tags ?? [
+      ['e', 'merge-request-event-id'],
+      ['p', FIXTURE_PUBKEY],
+      ['commit', options.headSha ?? '2222222222222222222222222222222222222222'],
+    ],
+    content: options.content ?? '✅',
+  });
+}
+
+export function createMembersFixture(
+  options: BuzzFixtureOptions & {
+    members?: readonly { pubkey: string; role: string }[];
+  } = {},
+): NostrForgeEvent {
+  const members = options.members ?? [
+    { pubkey: FIXTURE_PUBKEY, role: 'owner' },
+    { pubkey: FIXTURE_REACTOR, role: 'admin' },
+    { pubkey: FIXTURE_ATTESTOR, role: 'bot' },
+  ];
+  return createBuzzFixtureEvent(BUZZ_FORGE_KINDS.channelMembers, {
+    ...options,
+    tags: options.tags ?? [
+      ['d', 'channel-hv'],
+      ...members.map((m) => ['p', m.pubkey, m.role] as const),
+    ],
+  });
+}
+
+/**
+ * Deterministic sequences for convergence suites (duplicate / delayed /
+ * out-of-order / replay). Each sequence is an ordered list of Nostr events;
+ * consumers may reshuffle delivery while asserting identical projection state.
+ */
+export function createBuzzConvergenceSequences(): {
+  canonical: NostrForgeEvent[];
+  duplicate: NostrForgeEvent[];
+  delayed: NostrForgeEvent[];
+  outOfOrder: NostrForgeEvent[];
+  replay: NostrForgeEvent[];
+} {
+  const repo = createRepositoryAnnouncementFixture({ created_at: 1_725_000_000 });
+  const pushH1 = createRefUpdateFixture({
+    created_at: 1_725_000_010,
+    head: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    previous: '0000000000000000000000000000000000000000',
+  });
+  const patch = createPatchFixture({
+    created_at: 1_725_000_020,
+    headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    number: 7,
+  });
+  const ci = createStatusFixture({
+    created_at: 1_725_000_030,
+    headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    conclusion: 'success',
+  });
+  const approval = createApprovalFixture({
+    created_at: 1_725_000_040,
+    headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  });
+  const merge = createStatusFixture({
+    kind: BUZZ_FORGE_KINDS.statusApplied,
+    created_at: 1_725_000_050,
+    headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  });
+  const pushH2 = createRefUpdateFixture({
+    created_at: 1_725_000_060,
+    head: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    previous: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  });
+
+  const canonical = [repo, pushH1, patch, ci, approval, merge, pushH2];
+  return {
+    canonical,
+    // Same events delivered twice in order.
+    duplicate: [...canonical, ...canonical],
+    // Same events with a multi-second gap encoded via created_at only (delivery delay).
+    delayed: canonical.map((event, index) =>
+      createBuzzFixtureEvent(event.kind, {
+        id: event.id,
+        pubkey: event.pubkey,
+        created_at: event.created_at,
+        tags: event.tags,
+        content: event.content,
+        sig: event.sig,
+      }),
+    ),
+    // Later push arrives before CI/approval/merge for the prior head.
+    outOfOrder: [repo, pushH1, pushH2, patch, ci, approval, merge],
+    // Full replay of the canonical sequence after completion.
+    replay: [...canonical, ...canonical.map((e) => ({ ...e }))],
+  };
+}
+
+export const BUZZ_FIXTURE_PUBKEYS = {
+  owner: FIXTURE_PUBKEY,
+  attestor: FIXTURE_ATTESTOR,
+  reactor: FIXTURE_REACTOR,
+} as const;

--- a/packages/repos/src/buzz/fixtures.ts
+++ b/packages/repos/src/buzz/fixtures.ts
@@ -72,8 +72,7 @@ export function createRefUpdateFixture(
     owner?: string;
   } = {},
 ): NostrForgeEvent {
-  const head =
-    options.head ?? '1111111111111111111111111111111111111111';
+  const head = options.head ?? '1111111111111111111111111111111111111111';
   const previous =
     options.previous ?? '0000000000000000000000000000000000000000';
   const owner = options.owner ?? FIXTURE_PUBKEY;
@@ -89,7 +88,11 @@ export function createRefUpdateFixture(
     ],
     content:
       options.content ??
-      JSON.stringify({ ref: options.ref ?? 'refs/heads/main', head, before: previous }),
+      JSON.stringify({
+        ref: options.ref ?? 'refs/heads/main',
+        head,
+        before: previous,
+      }),
   });
 }
 
@@ -100,8 +103,7 @@ export function createPatchFixture(
     repoId?: string;
   } = {},
 ): NostrForgeEvent {
-  const headSha =
-    options.headSha ?? '2222222222222222222222222222222222222222';
+  const headSha = options.headSha ?? '2222222222222222222222222222222222222222';
   return createBuzzFixtureEvent(BUZZ_FORGE_KINDS.patch, {
     ...options,
     tags: options.tags ?? [
@@ -131,8 +133,7 @@ export function createStatusFixture(
   } = {},
 ): NostrForgeEvent {
   const kind = options.kind ?? BUZZ_FORGE_KINDS.statusOpen;
-  const headSha =
-    options.headSha ?? '2222222222222222222222222222222222222222';
+  const headSha = options.headSha ?? '2222222222222222222222222222222222222222';
   return createBuzzFixtureEvent(kind, {
     ...options,
     pubkey: options.pubkey ?? FIXTURE_ATTESTOR,
@@ -141,7 +142,9 @@ export function createStatusFixture(
       ['p', FIXTURE_PUBKEY],
       ['commit', headSha],
       ['context', options.context ?? 'ci'],
-      ...(options.conclusion ? ([['conclusion', options.conclusion]] as const) : []),
+      ...(options.conclusion
+        ? ([['conclusion', options.conclusion]] as const)
+        : []),
     ],
     content:
       options.content ??
@@ -157,13 +160,14 @@ export function createApprovalFixture(
   options: BuzzFixtureOptions & {
     content?: string;
     headSha?: string;
+    targetEventId?: string;
   } = {},
 ): NostrForgeEvent {
   return createBuzzFixtureEvent(BUZZ_FORGE_KINDS.reaction, {
     ...options,
     pubkey: options.pubkey ?? FIXTURE_REACTOR,
     tags: options.tags ?? [
-      ['e', 'merge-request-event-id'],
+      ['e', options.targetEventId ?? 'merge-request-event-id'],
       ['p', FIXTURE_PUBKEY],
       ['commit', options.headSha ?? '2222222222222222222222222222222222222222'],
     ],
@@ -202,7 +206,9 @@ export function createBuzzConvergenceSequences(): {
   outOfOrder: NostrForgeEvent[];
   replay: NostrForgeEvent[];
 } {
-  const repo = createRepositoryAnnouncementFixture({ created_at: 1_725_000_000 });
+  const repo = createRepositoryAnnouncementFixture({
+    created_at: 1_725_000_000,
+  });
   const pushH1 = createRefUpdateFixture({
     created_at: 1_725_000_010,
     head: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -221,6 +227,7 @@ export function createBuzzConvergenceSequences(): {
   const approval = createApprovalFixture({
     created_at: 1_725_000_040,
     headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    targetEventId: patch.id,
   });
   const merge = createStatusFixture({
     kind: BUZZ_FORGE_KINDS.statusApplied,

--- a/packages/repos/src/buzz/index.ts
+++ b/packages/repos/src/buzz/index.ts
@@ -1,0 +1,30 @@
+export {
+  channelIdFromEvent,
+  computeNostrEventId,
+  normalizeBuzzEvent,
+  resolveBuzzChannelRole,
+  roleMeetsFloor,
+  verifyAndNormalizeBuzzEvent,
+  verifyNostrEventSignature,
+} from './events.js';
+export {
+  BUZZ_FIXTURE_PUBKEYS,
+  createApprovalFixture,
+  createBuzzConvergenceSequences,
+  createBuzzFixtureEvent,
+  createMembersFixture,
+  createPatchFixture,
+  createRefUpdateFixture,
+  createRepositoryAnnouncementFixture,
+  createStatusFixture,
+} from './fixtures.js';
+export { BuzzRelayClient } from './relay.js';
+export {
+  BUZZ_FORGE_KINDS,
+  type BuzzChannelRole,
+  type BuzzForgeKind,
+  type BuzzRelayClientOptions,
+  type BuzzRelaySubscription,
+  type BuzzRoleResolution,
+  type NostrForgeEvent,
+} from './types.js';

--- a/packages/repos/src/buzz/relay.ts
+++ b/packages/repos/src/buzz/relay.ts
@@ -1,0 +1,234 @@
+import { ForgeError } from '../forge/errors.js';
+import type { ForgeEventEnvelope } from '../forge/types.js';
+import {
+  channelIdFromEvent,
+  normalizeBuzzEvent,
+  verifyAndNormalizeBuzzEvent,
+} from './events.js';
+import {
+  BUZZ_FORGE_KINDS,
+  type BuzzRelayClientOptions,
+  type BuzzRelaySubscription,
+  type NostrForgeEvent,
+} from './types.js';
+
+const DEFAULT_KINDS: readonly number[] = [
+  BUZZ_FORGE_KINDS.repositoryAnnouncement,
+  BUZZ_FORGE_KINDS.refUpdate,
+  BUZZ_FORGE_KINDS.patch,
+  BUZZ_FORGE_KINDS.statusOpen,
+  BUZZ_FORGE_KINDS.statusApplied,
+  BUZZ_FORGE_KINDS.statusClosed,
+  BUZZ_FORGE_KINDS.statusDraft,
+  BUZZ_FORGE_KINDS.reaction,
+  BUZZ_FORGE_KINDS.channelMembers,
+];
+
+function isNostrForgeEvent(value: unknown): value is NostrForgeEvent {
+  if (!value || typeof value !== 'object') return false;
+  const event = value as Record<string, unknown>;
+  return (
+    typeof event.id === 'string' &&
+    typeof event.pubkey === 'string' &&
+    typeof event.created_at === 'number' &&
+    typeof event.kind === 'number' &&
+    Array.isArray(event.tags) &&
+    typeof event.content === 'string' &&
+    typeof event.sig === 'string'
+  );
+}
+
+/**
+ * Minimal buzz relay client: HTTP REQ polling plus an injectable event source
+ * for tests and WebSocket adapters.
+ *
+ * The client never mutates process-global state. Each subscribe/poll call is
+ * scoped to the constructed options.
+ */
+export class BuzzRelayClient {
+  private readonly relays: readonly string[];
+  private readonly kinds: readonly number[];
+  private readonly channelIds: readonly string[] | undefined;
+  private readonly fetchImpl: typeof fetch;
+  private readonly pollIntervalMs: number;
+  private readonly seenIds = new Set<string>();
+
+  constructor(options: BuzzRelayClientOptions) {
+    if (!options.relays.length) {
+      throw new ForgeError('Buzz relay client requires at least one relay', 'CONFIGURATION_ERROR', {
+        provider: 'buzz',
+      });
+    }
+    this.relays = options.relays;
+    this.kinds = options.kinds ?? DEFAULT_KINDS;
+    this.channelIds = options.channelIds;
+    this.fetchImpl = options.fetch ?? fetch;
+    this.pollIntervalMs = options.pollIntervalMs ?? 5000;
+  }
+
+  /**
+   * Poll every configured relay once with a NIP-01-style HTTP REQ body and
+   * return newly observed, verified envelopes (deduped by event id).
+   */
+  async pollOnce(
+    options: {
+      since?: number;
+      allowUnverifiedFixtures?: boolean;
+      membersEvent?: NostrForgeEvent;
+    } = {},
+  ): Promise<ForgeEventEnvelope[]> {
+    const envelopes: ForgeEventEnvelope[] = [];
+    for (const relay of this.relays) {
+      const events = await this.fetchEvents(relay, options.since);
+      for (const event of events) {
+        if (this.seenIds.has(event.id)) continue;
+        if (!this.kinds.includes(event.kind)) continue;
+        if (this.channelIds?.length) {
+          const channelId = channelIdFromEvent(event);
+          if (channelId && !this.channelIds.includes(channelId)) continue;
+        }
+        try {
+          const envelope = verifyAndNormalizeBuzzEvent(event, new Date(), {
+            allowUnverifiedFixtures: options.allowUnverifiedFixtures,
+            membersEvent: options.membersEvent,
+          });
+          this.seenIds.add(event.id);
+          envelopes.push(envelope);
+        } catch {
+          // Fail closed per event; continue scanning the rest of the batch.
+        }
+      }
+    }
+    return envelopes;
+  }
+
+  /**
+   * Poll on an interval until `close()` is called. Useful for long-running
+   * Aedile adapters. Returns a subscription handle.
+   */
+  subscribe(
+    onEvent: (envelope: ForgeEventEnvelope) => void | Promise<void>,
+    options: {
+      since?: number;
+      allowUnverifiedFixtures?: boolean;
+      membersEvent?: NostrForgeEvent;
+      onError?: (error: unknown) => void;
+    } = {},
+  ): BuzzRelaySubscription {
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      if (stopped) return;
+      try {
+        const envelopes = await this.pollOnce(options);
+        for (const envelope of envelopes) {
+          await onEvent(envelope);
+        }
+      } catch (error) {
+        options.onError?.(error);
+      }
+      if (!stopped) {
+        timer = setTimeout(() => {
+          void tick();
+        }, this.pollIntervalMs);
+      }
+    };
+
+    void tick();
+
+    return {
+      close() {
+        stopped = true;
+        clearTimeout(timer);
+      },
+    };
+  }
+
+  /**
+   * Normalize a pre-fetched event list (tests / custom transports) without
+   * contacting a relay. Applies the same kind/channel filters and id dedupe.
+   */
+  ingestEvents(
+    events: readonly NostrForgeEvent[],
+    options: {
+      allowUnverifiedFixtures?: boolean;
+      membersEvent?: NostrForgeEvent;
+      verify?: boolean;
+    } = {},
+  ): ForgeEventEnvelope[] {
+    const envelopes: ForgeEventEnvelope[] = [];
+    for (const event of events) {
+      if (this.seenIds.has(event.id)) continue;
+      if (!this.kinds.includes(event.kind)) continue;
+      if (this.channelIds?.length) {
+        const channelId = channelIdFromEvent(event);
+        if (channelId && !this.channelIds.includes(channelId)) continue;
+      }
+      const envelope =
+        options.verify === false
+          ? normalizeBuzzEvent(event, new Date(), {
+              membersEvent: options.membersEvent,
+            })
+          : verifyAndNormalizeBuzzEvent(event, new Date(), {
+              allowUnverifiedFixtures: options.allowUnverifiedFixtures ?? true,
+              membersEvent: options.membersEvent,
+            });
+      this.seenIds.add(event.id);
+      envelopes.push(envelope);
+    }
+    return envelopes;
+  }
+
+  /** Forget delivered ids (operator replay). */
+  resetSeen(): void {
+    this.seenIds.clear();
+  }
+
+  private async fetchEvents(relay: string, since?: number): Promise<NostrForgeEvent[]> {
+    const filter: Record<string, unknown> = { kinds: [...this.kinds] };
+    if (since !== undefined) filter.since = since;
+    if (this.channelIds?.length) filter['#channel'] = [...this.channelIds];
+
+    // HTTP REQ convention used by HappyVertical relay helpers: POST JSON array.
+    const body = JSON.stringify(['REQ', 'buzz-forge', filter]);
+    let response: Response;
+    try {
+      response = await this.fetchImpl(relay, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+      });
+    } catch (error) {
+      throw new ForgeError('Buzz relay transport failed', 'TRANSPORT_ERROR', {
+        provider: 'buzz',
+        cause: error,
+        retryable: true,
+      });
+    }
+    if (!response.ok) {
+      throw new ForgeError(
+        `Buzz relay returned HTTP ${response.status}`,
+        'PROVIDER_ERROR',
+        { provider: 'buzz', status: response.status, retryable: response.status >= 500 },
+      );
+    }
+    const payload: unknown = await response.json();
+    return extractEvents(payload);
+  }
+}
+
+function extractEvents(payload: unknown): NostrForgeEvent[] {
+  if (!Array.isArray(payload)) return [];
+  const events: NostrForgeEvent[] = [];
+  for (const item of payload) {
+    if (Array.isArray(item) && item[0] === 'EVENT' && isNostrForgeEvent(item[2])) {
+      events.push(item[2]);
+      continue;
+    }
+    if (isNostrForgeEvent(item)) {
+      events.push(item);
+    }
+  }
+  return events;
+}

--- a/packages/repos/src/buzz/relay.ts
+++ b/packages/repos/src/buzz/relay.ts
@@ -55,9 +55,13 @@ export class BuzzRelayClient {
 
   constructor(options: BuzzRelayClientOptions) {
     if (!options.relays.length) {
-      throw new ForgeError('Buzz relay client requires at least one relay', 'CONFIGURATION_ERROR', {
-        provider: 'buzz',
-      });
+      throw new ForgeError(
+        'Buzz relay client requires at least one relay',
+        'CONFIGURATION_ERROR',
+        {
+          provider: 'buzz',
+        },
+      );
     }
     this.relays = options.relays;
     this.kinds = options.kinds ?? DEFAULT_KINDS;
@@ -75,22 +79,31 @@ export class BuzzRelayClient {
       since?: number;
       allowUnverifiedFixtures?: boolean;
       membersEvent?: NostrForgeEvent;
+      referencedPatchEvent?: NostrForgeEvent;
     } = {},
   ): Promise<ForgeEventEnvelope[]> {
     const envelopes: ForgeEventEnvelope[] = [];
     for (const relay of this.relays) {
       const events = await this.fetchEvents(relay, options.since);
+      const patches = new Map(
+        events
+          .filter((event) => event.kind === BUZZ_FORGE_KINDS.patch)
+          .map((event) => [event.id, event]),
+      );
       for (const event of events) {
         if (this.seenIds.has(event.id)) continue;
         if (!this.kinds.includes(event.kind)) continue;
         if (this.channelIds?.length) {
           const channelId = channelIdFromEvent(event);
-          if (channelId && !this.channelIds.includes(channelId)) continue;
+          if (!channelId || !this.channelIds.includes(channelId)) continue;
         }
         try {
           const envelope = verifyAndNormalizeBuzzEvent(event, new Date(), {
             allowUnverifiedFixtures: options.allowUnverifiedFixtures,
             membersEvent: options.membersEvent,
+            referencedPatchEvent:
+              options.referencedPatchEvent ??
+              patches.get(event.tags.find((tag) => tag[0] === 'e')?.[1] ?? ''),
           });
           this.seenIds.add(event.id);
           envelopes.push(envelope);
@@ -112,6 +125,7 @@ export class BuzzRelayClient {
       since?: number;
       allowUnverifiedFixtures?: boolean;
       membersEvent?: NostrForgeEvent;
+      referencedPatchEvent?: NostrForgeEvent;
       onError?: (error: unknown) => void;
     } = {},
   ): BuzzRelaySubscription {
@@ -154,25 +168,41 @@ export class BuzzRelayClient {
     options: {
       allowUnverifiedFixtures?: boolean;
       membersEvent?: NostrForgeEvent;
+      referencedPatchEvent?: NostrForgeEvent;
       verify?: boolean;
     } = {},
   ): ForgeEventEnvelope[] {
     const envelopes: ForgeEventEnvelope[] = [];
+    const patches = new Map(
+      events
+        .filter((event) => event.kind === BUZZ_FORGE_KINDS.patch)
+        .map((event) => [event.id, event]),
+    );
     for (const event of events) {
       if (this.seenIds.has(event.id)) continue;
       if (!this.kinds.includes(event.kind)) continue;
       if (this.channelIds?.length) {
         const channelId = channelIdFromEvent(event);
-        if (channelId && !this.channelIds.includes(channelId)) continue;
+        if (!channelId || !this.channelIds.includes(channelId)) continue;
       }
       const envelope =
         options.verify === false
           ? normalizeBuzzEvent(event, new Date(), {
               membersEvent: options.membersEvent,
+              referencedPatchEvent:
+                options.referencedPatchEvent ??
+                patches.get(
+                  event.tags.find((tag) => tag[0] === 'e')?.[1] ?? '',
+                ),
             })
           : verifyAndNormalizeBuzzEvent(event, new Date(), {
-              allowUnverifiedFixtures: options.allowUnverifiedFixtures ?? true,
+              allowUnverifiedFixtures: options.allowUnverifiedFixtures,
               membersEvent: options.membersEvent,
+              referencedPatchEvent:
+                options.referencedPatchEvent ??
+                patches.get(
+                  event.tags.find((tag) => tag[0] === 'e')?.[1] ?? '',
+                ),
             });
       this.seenIds.add(event.id);
       envelopes.push(envelope);
@@ -185,7 +215,10 @@ export class BuzzRelayClient {
     this.seenIds.clear();
   }
 
-  private async fetchEvents(relay: string, since?: number): Promise<NostrForgeEvent[]> {
+  private async fetchEvents(
+    relay: string,
+    since?: number,
+  ): Promise<NostrForgeEvent[]> {
     const filter: Record<string, unknown> = { kinds: [...this.kinds] };
     if (since !== undefined) filter.since = since;
     if (this.channelIds?.length) filter['#channel'] = [...this.channelIds];
@@ -210,7 +243,11 @@ export class BuzzRelayClient {
       throw new ForgeError(
         `Buzz relay returned HTTP ${response.status}`,
         'PROVIDER_ERROR',
-        { provider: 'buzz', status: response.status, retryable: response.status >= 500 },
+        {
+          provider: 'buzz',
+          status: response.status,
+          retryable: response.status >= 500,
+        },
       );
     }
     const payload: unknown = await response.json();
@@ -222,7 +259,11 @@ function extractEvents(payload: unknown): NostrForgeEvent[] {
   if (!Array.isArray(payload)) return [];
   const events: NostrForgeEvent[] = [];
   for (const item of payload) {
-    if (Array.isArray(item) && item[0] === 'EVENT' && isNostrForgeEvent(item[2])) {
+    if (
+      Array.isArray(item) &&
+      item[0] === 'EVENT' &&
+      isNostrForgeEvent(item[2])
+    ) {
       events.push(item[2]);
       continue;
     }

--- a/packages/repos/src/buzz/types.ts
+++ b/packages/repos/src/buzz/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Buzz/Nostr forge event kinds verified live against desktop-v0.5.3 (ADR-002).
+ * Kind numbers are load-bearing and must match the deployed relay.
+ */
+export const BUZZ_FORGE_KINDS = {
+  repositoryAnnouncement: 30617,
+  refUpdate: 30618,
+  patch: 1617,
+  statusOpen: 1630,
+  statusApplied: 1631,
+  statusClosed: 1632,
+  statusDraft: 1633,
+  reaction: 7,
+  channelMembers: 39002,
+} as const;
+
+export type BuzzForgeKind =
+  (typeof BUZZ_FORGE_KINDS)[keyof typeof BUZZ_FORGE_KINDS];
+
+/** Minimal Nostr event shape consumed by the buzz forge adapter. */
+export interface NostrForgeEvent {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: readonly (readonly string[])[];
+  content: string;
+  sig: string;
+}
+
+/** Channel role floor used when validating kind:7 approvals (ADR-002). */
+export type BuzzChannelRole = 'owner' | 'admin' | 'member' | 'guest' | 'bot';
+
+export interface BuzzRoleResolution {
+  pubkey: string;
+  role: BuzzChannelRole;
+}
+
+export interface BuzzRelayClientOptions {
+  /** WebSocket or HTTP relay endpoints. */
+  relays: readonly string[];
+  /** Optional filter limiting which kinds are accepted. */
+  kinds?: readonly number[];
+  /** Bound channel ids watched for forge activity. */
+  channelIds?: readonly string[];
+  /** Fetch implementation override for tests. */
+  fetch?: typeof fetch;
+  /** Poll interval in ms when using HTTP REQ polling. Default 5000. */
+  pollIntervalMs?: number;
+}
+
+export interface BuzzRelaySubscription {
+  close(): void;
+}

--- a/packages/repos/src/index.ts
+++ b/packages/repos/src/index.ts
@@ -30,6 +30,34 @@ export {
   ForgeError,
   ForgeSignatureError,
 } from './forge/errors.js';
+export {
+  BuzzRelayClient,
+  BUZZ_FIXTURE_PUBKEYS,
+  BUZZ_FORGE_KINDS,
+  channelIdFromEvent,
+  computeNostrEventId,
+  createApprovalFixture,
+  createBuzzConvergenceSequences,
+  createBuzzFixtureEvent,
+  createMembersFixture,
+  createPatchFixture,
+  createRefUpdateFixture,
+  createRepositoryAnnouncementFixture,
+  createStatusFixture,
+  normalizeBuzzEvent,
+  resolveBuzzChannelRole,
+  roleMeetsFloor,
+  verifyAndNormalizeBuzzEvent,
+  verifyNostrEventSignature,
+} from './buzz/index.js';
+export type {
+  BuzzChannelRole,
+  BuzzForgeKind,
+  BuzzRelayClientOptions,
+  BuzzRelaySubscription,
+  BuzzRoleResolution,
+  NostrForgeEvent,
+} from './buzz/index.js';
 export type {
   CheckRun,
   CheckRunOutput,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 20.5.0
       '@jpisnice/shadcn-ui-mcp-server':
         specifier: 1.1.4
-        version: 1.1.4
+        version: 1.1.4(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -55,7 +55,7 @@ importers:
         version: 17.3.10
       express:
         specifier: ^5.2.1
-        version: 5.2.1
+        version: 5.2.1(supports-color@8.1.1)
       lefthook:
         specifier: 2.1.10
         version: 2.1.10
@@ -82,28 +82,28 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   docs:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/plugin-ideal-image':
         specifier: ^3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(jimp@1.6.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(jimp@1.6.1(supports-color@8.1.1))(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/plugin-pwa':
         specifier: ^3.10.0
-        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/preset-classic':
         specifier: ^3.10.0
-        version: 3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/theme-mermaid':
         specifier: ^3.10.0
-        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -122,13 +122,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.10.0
-        version: 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@docusaurus/tsconfig':
         specifier: ^3.10.0
         version: 3.10.0
       '@docusaurus/types':
         specifier: ^3.10.0
-        version: 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -158,7 +158,7 @@ importers:
         version: link:../utils
       intuit-oauth:
         specifier: ^4.2.3
-        version: 4.2.3
+        version: 4.2.3(debug@4.4.3(supports-color@8.1.1))
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -171,10 +171,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/ai:
     dependencies:
@@ -186,7 +186,7 @@ importers:
         version: 3.1034.0
       '@google/genai':
         specifier: 1.50.1
-        version: 1.50.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+        version: 1.50.1(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)
       '@happyvertical/utils':
         specifier: workspace:*
         version: link:../utils
@@ -205,10 +205,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/analytics:
     dependencies:
@@ -217,7 +217,7 @@ importers:
         version: link:../utils
       googleapis:
         specifier: ^170.1.0
-        version: 170.1.0
+        version: 170.1.0(supports-color@8.1.1)
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -230,10 +230,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/auth:
     dependencies:
@@ -255,10 +255,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
     optionalDependencies:
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3.1034.0
@@ -293,10 +293,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/comfyui:
     dependencies:
@@ -318,10 +318,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/directory:
     dependencies:
@@ -355,10 +355,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/documents:
     dependencies:
@@ -373,7 +373,7 @@ importers:
         version: 0.65.9(@types/node@24.12.2)
       '@happyvertical/spider':
         specifier: 'catalog:'
-        version: 1.1.13(@types/node@24.12.2)
+        version: 1.1.13(@types/node@24.12.2)(supports-color@8.1.1)
       '@happyvertical/utils':
         specifier: workspace:*
         version: link:../utils
@@ -392,7 +392,7 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/email:
     dependencies:
@@ -404,10 +404,10 @@ importers:
         version: link:../utils
       google-auth-library:
         specifier: ^10.6.2
-        version: 10.6.2
+        version: 10.6.2(supports-color@8.1.1)
       googleapis:
         specifier: ^170.1.0
-        version: 170.1.0
+        version: 170.1.0(supports-color@8.1.1)
       imapflow:
         specifier: ^1.3.2
         version: 1.3.2
@@ -441,10 +441,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/encryption:
     dependencies:
@@ -478,10 +478,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/files:
     dependencies:
@@ -493,10 +493,10 @@ importers:
         version: link:../utils
       google-auth-library:
         specifier: ^9.15.1
-        version: 9.15.1
+        version: 9.15.1(supports-color@8.1.1)
       googleapis:
         specifier: ^144.0.0
-        version: 144.0.0
+        version: 144.0.0(supports-color@8.1.1)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 6.9.1
@@ -512,7 +512,7 @@ importers:
         version: 20.9.0
       jsdom:
         specifier: 27.4.0
-        version: 27.4.0(@noble/hashes@2.0.1)
+        version: 27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -521,16 +521,16 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/geo:
     dependencies:
       '@googlemaps/google-maps-services-js':
         specifier: ^3.4.2
-        version: 3.4.2
+        version: 3.4.2(debug@4.4.3(supports-color@8.1.1))
       '@happyvertical/cache':
         specifier: workspace:*
         version: link:../cache
@@ -549,10 +549,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/github-actions:
     dependencies:
@@ -574,10 +574,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/graphql:
     devDependencies:
@@ -592,10 +592,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/images:
     dependencies:
@@ -611,7 +611,7 @@ importers:
         version: 24.12.2
       jimp:
         specifier: ^1.6.1
-        version: 1.6.1
+        version: 1.6.1(supports-color@8.1.1)
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@24.12.2)
@@ -623,10 +623,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/jobs:
     dependencies:
@@ -642,19 +642,19 @@ importers:
         version: 3.1034.0
       '@google-cloud/tasks':
         specifier: ^6.2.1
-        version: 6.2.1
+        version: 6.2.1(supports-color@8.1.1)
       '@types/bull':
         specifier: ^4.10.4
-        version: 4.10.4
+        version: 4.10.4(supports-color@8.1.1)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
       bull:
         specifier: ^4.16.5
-        version: 4.16.5
+        version: 4.16.5(supports-color@8.1.1)
       bullmq:
         specifier: ^5.80.4
-        version: 5.80.4(redis@5.12.1(@opentelemetry/api@1.9.1))
+        version: 5.80.4(redis@5.12.1(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -663,16 +663,16 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/json:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.6.2
-        version: 3.6.2(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(node-addon-api@6.1.0)
+        version: 3.6.2(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(node-addon-api@6.1.0)(supports-color@8.1.1)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -684,10 +684,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/logger:
     dependencies:
@@ -697,7 +697,7 @@ importers:
     devDependencies:
       '@sentry/node':
         specifier: ^10.49.0
-        version: 10.49.0
+        version: 10.49.0(supports-color@8.1.1)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -709,7 +709,7 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/messages:
     dependencies:
@@ -724,7 +724,7 @@ importers:
         version: link:../utils
       '@slack/web-api':
         specifier: ^7.15.1
-        version: 7.15.1
+        version: 7.15.1(debug@4.4.3(supports-color@8.1.1))
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -737,10 +737,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/payments:
     devDependencies:
@@ -767,10 +767,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/projects:
     dependencies:
@@ -792,10 +792,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/repos:
     dependencies:
@@ -805,6 +805,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      nostr-tools:
+        specifier: ^2.23.3
+        version: 2.23.3(typescript@5.9.3)
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -820,10 +823,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/sdk-mcp:
     dependencies:
@@ -838,7 +841,7 @@ importers:
         version: link:../utils
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(supports-color@8.1.1)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -851,10 +854,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/secrets:
     dependencies:
@@ -876,10 +879,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/signatures:
     devDependencies:
@@ -897,10 +900,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/social:
     dependencies:
@@ -922,10 +925,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/speech:
     devDependencies:
@@ -940,10 +943,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/sql:
     dependencies:
@@ -983,16 +986,16 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/translator:
     dependencies:
       '@google-cloud/translate':
         specifier: ^9.3.0
-        version: 9.3.0
+        version: 9.3.0(supports-color@8.1.1)
       '@happyvertical/cache':
         specifier: workspace:*
         version: link:../cache
@@ -1001,7 +1004,7 @@ importers:
         version: link:../utils
       deepl-node:
         specifier: ^1.26.0
-        version: 1.26.0
+        version: 1.26.0(debug@4.4.3(supports-color@8.1.1))
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -1014,10 +1017,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/utils:
     dependencies:
@@ -1048,10 +1051,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/video:
     dependencies:
@@ -1079,10 +1082,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/weather:
     dependencies:
@@ -1107,10 +1110,10 @@ importers:
         version: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
 packages:
 
@@ -7452,6 +7455,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -14612,20 +14616,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14652,32 +14656,32 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -14685,26 +14689,26 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5':
+  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.28.6(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14714,27 +14718,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/helper-wrap-function': 7.28.6(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -14745,10 +14749,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helper-wrap-function@7.28.6':
+  '@babel/helper-wrap-function@7.28.6(supports-color@8.1.1)':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -14766,569 +14770,569 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.0(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@8.1.1))
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.48.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
 
-  '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-react@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15340,7 +15344,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -15348,7 +15352,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15685,14 +15689,14 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@crawlee/basic@3.17.0':
+  '@crawlee/basic@3.17.0(supports-color@8.1.1)':
     dependencies:
       '@apify/log': 2.5.32
       '@apify/timeout': 0.3.2
       '@apify/utilities': 2.25.4
-      '@crawlee/core': 3.17.0
+      '@crawlee/core': 3.17.0(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       csv-stringify: 6.6.0
       fs-extra: 11.3.3
       got-scraping: 4.2.1
@@ -15703,11 +15707,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser-pool@3.17.0(playwright@1.61.1)':
+  '@crawlee/browser-pool@3.17.0(playwright@1.61.1)(supports-color@8.1.1)':
     dependencies:
       '@apify/log': 2.5.32
       '@apify/timeout': 0.3.2
-      '@crawlee/core': 3.17.0
+      '@crawlee/core': 3.17.0(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
       fingerprint-generator: 2.1.80
       fingerprint-injector: 2.1.80(playwright@1.61.1)
@@ -15715,7 +15719,7 @@ snapshots:
       nanoid: 3.3.16
       ow: 0.28.2
       p-limit: 3.1.0
-      proxy-chain: 2.7.1
+      proxy-chain: 2.7.1(supports-color@8.1.1)
       quick-lru: 5.1.1
       tiny-typed-emitter: 2.1.0
       tslib: 2.8.1
@@ -15724,13 +15728,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser@3.17.0(playwright@1.61.1)':
+  '@crawlee/browser@3.17.0(playwright@1.61.1)(supports-color@8.1.1)':
     dependencies:
       '@apify/timeout': 0.3.2
-      '@crawlee/basic': 3.17.0
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)
+      '@crawlee/basic': 3.17.0(supports-color@8.1.1)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       ow: 0.28.2
       tslib: 2.8.1
       type-fest: 4.41.0
@@ -15739,11 +15743,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/cheerio@3.17.0':
+  '@crawlee/cheerio@3.17.0(supports-color@8.1.1)':
     dependencies:
-      '@crawlee/http': 3.17.0
+      '@crawlee/http': 3.17.0(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       cheerio: 1.0.0-rc.12
       htmlparser2: 9.1.0
       tslib: 2.8.1
@@ -15762,7 +15766,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@crawlee/core@3.17.0':
+  '@crawlee/core@3.17.0(supports-color@8.1.1)':
     dependencies:
       '@apify/consts': 2.51.0
       '@apify/datastructures': 2.0.3
@@ -15772,7 +15776,7 @@ snapshots:
       '@apify/utilities': 2.25.4
       '@crawlee/memory-storage': 3.17.0
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       '@sapphire/async-queue': 1.5.5
       '@vladfrangu/async_event_emitter': 2.4.7
       csv-stringify: 6.6.0
@@ -15789,13 +15793,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/http@3.17.0':
+  '@crawlee/http@3.17.0(supports-color@8.1.1)':
     dependencies:
       '@apify/timeout': 0.3.2
       '@apify/utilities': 2.25.4
-      '@crawlee/basic': 3.17.0
+      '@crawlee/basic': 3.17.0(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       '@types/content-type': 1.1.9
       cheerio: 1.0.0-rc.12
       content-type: 1.0.5
@@ -15808,16 +15812,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/jsdom@3.17.0':
+  '@crawlee/jsdom@3.17.0(supports-color@8.1.1)':
     dependencies:
       '@apify/timeout': 0.3.2
       '@apify/utilities': 2.25.4
-      '@crawlee/http': 3.17.0
+      '@crawlee/http': 3.17.0(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       '@types/jsdom': 21.1.7
       cheerio: 1.0.0-rc.12
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
       ow: 0.28.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -15826,11 +15830,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@crawlee/linkedom@3.17.0':
+  '@crawlee/linkedom@3.17.0(supports-color@8.1.1)':
     dependencies:
       '@apify/timeout': 0.3.2
       '@apify/utilities': 2.25.4
-      '@crawlee/http': 3.17.0
+      '@crawlee/http': 3.17.0(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
       linkedom: 0.18.12
       ow: 0.28.2
@@ -15853,16 +15857,16 @@ snapshots:
       proper-lockfile: 4.1.2
       tslib: 2.8.1
 
-  '@crawlee/playwright@3.17.0(playwright@1.61.1)':
+  '@crawlee/playwright@3.17.0(playwright@1.61.1)(supports-color@8.1.1)':
     dependencies:
       '@apify/datastructures': 2.0.3
       '@apify/log': 2.5.32
       '@apify/timeout': 0.3.2
-      '@crawlee/browser': 3.17.0(playwright@1.61.1)
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)
-      '@crawlee/core': 3.17.0
+      '@crawlee/browser': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
+      '@crawlee/core': 3.17.0(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       cheerio: 1.0.0-rc.12
       jquery: 3.7.1
       lodash.isequal: 4.5.0
@@ -15877,14 +15881,14 @@ snapshots:
       - puppeteer
       - supports-color
 
-  '@crawlee/puppeteer@3.17.0(playwright@1.61.1)':
+  '@crawlee/puppeteer@3.17.0(playwright@1.61.1)(supports-color@8.1.1)':
     dependencies:
       '@apify/datastructures': 2.0.3
       '@apify/log': 2.5.32
-      '@crawlee/browser': 3.17.0(playwright@1.61.1)
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)
+      '@crawlee/browser': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
       '@crawlee/types': 3.17.0
-      '@crawlee/utils': 3.17.0
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       cheerio: 1.0.0-rc.12
       devtools-protocol: 0.0.1638949
       jquery: 3.7.1
@@ -15908,14 +15912,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@crawlee/utils@3.17.0':
+  '@crawlee/utils@3.17.0(supports-color@8.1.1)':
     dependencies:
       '@apify/log': 2.5.32
       '@apify/ps-tree': 1.2.0
       '@crawlee/types': 3.17.0
       '@types/sax': 1.2.7
       cheerio: 1.0.0-rc.12
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@8.1.1)
       got-scraping: 4.2.1
       ow: 0.28.2
       robots-parser: 3.0.1
@@ -16286,19 +16290,19 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/babel@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.1
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.3
       tslib: 2.8.1
@@ -16311,19 +16315,19 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/bundler@3.10.0(csso@5.0.5)(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@docusaurus/babel': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@docusaurus/cssnano-preset': 3.10.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.27.3))
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      babel-loader: 9.2.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.2(esbuild@0.27.3))
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.105.2(esbuild@0.27.3))
       css-loader: 6.11.0(webpack@5.105.2(esbuild@0.27.3))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(webpack@5.105.2(esbuild@0.27.3))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.27.3)(lightningcss@1.32.0)(webpack@5.105.2(esbuild@0.27.3))
       cssnano: 6.1.2(postcss@8.5.6)
       file-loader: 6.2.0(webpack@5.105.2(esbuild@0.27.3))
       html-minifier-terser: 7.2.0
@@ -16352,15 +16356,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/bundler': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@docusaurus/babel': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/bundler': 3.10.0(csso@5.0.5)(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -16369,7 +16373,7 @@ snapshots:
       combine-promises: 1.2.0
       commander: 5.1.0
       core-js: 3.48.0
-      detect-port: 1.6.1
+      detect-port: 1.6.1(supports-color@8.1.1)
       escape-html: 1.0.3
       eta: 2.2.0
       eval: 0.1.8
@@ -16397,7 +16401,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.105.2(esbuild@0.27.3)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
+      webpack-dev-server: 5.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -16440,27 +16444,27 @@ snapshots:
       - react-native-b4a
       - webpack
 
-  '@docusaurus/mdx-loader@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/mdx-loader@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@mdx-js/mdx': 3.1.1
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
       file-loader: 6.2.0(webpack@5.105.2(esbuild@0.27.3))
       fs-extra: 11.3.3
       image-size: 2.0.2
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@8.1.1)
       mdast-util-to-string: 4.0.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       rehype-raw: 7.0.0
-      remark-directive: 3.0.1
+      remark-directive: 3.0.1(supports-color@8.1.1)
       remark-emoji: 4.0.1
-      remark-frontmatter: 5.0.0
-      remark-gfm: 4.0.1
+      remark-frontmatter: 5.0.0(supports-color@8.1.1)
+      remark-gfm: 4.0.1(supports-color@8.1.1)
       stringify-object: 3.3.0
       tslib: 2.8.1
       unified: 11.0.5
@@ -16475,9 +16479,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/module-type-aliases@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -16493,17 +16497,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -16535,17 +16539,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.3
@@ -16575,13 +16579,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       fs-extra: 11.3.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -16605,12 +16609,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -16632,11 +16636,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       fs-extra: 11.3.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -16660,11 +16664,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -16686,11 +16690,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@types/gtag.js': 0.0.20
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -16713,11 +16717,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -16739,21 +16743,21 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-ideal-image@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(jimp@1.6.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-ideal-image@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(jimp@1.6.1(supports-color@8.1.1))(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/lqip-loader': 3.10.0(webpack@5.105.2(esbuild@0.27.3))
-      '@docusaurus/responsive-loader': 1.7.1(jimp@1.6.1)(sharp@0.32.6)
+      '@docusaurus/responsive-loader': 1.7.1(jimp@1.6.1(supports-color@8.1.1))(sharp@0.32.6)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       sharp: 0.32.6
       tslib: 2.8.1
       webpack: 5.105.2(esbuild@0.27.3)
     optionalDependencies:
-      jimp: 1.6.1
+      jimp: 1.6.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -16775,19 +16779,19 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-pwa@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-pwa@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
-      '@docusaurus/bundler': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@docusaurus/bundler': 3.10.0(csso@5.0.5)(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.27.3))
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      babel-loader: 9.2.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.2(esbuild@0.27.3))
       clsx: 2.1.1
       core-js: 3.48.0
       react: 19.2.5
@@ -16795,7 +16799,7 @@ snapshots:
       tslib: 2.8.1
       webpack: 5.105.2(esbuild@0.27.3)
       webpack-merge: 5.10.0
-      workbox-build: 7.4.0
+      workbox-build: 7.4.0(supports-color@8.1.1)
       workbox-precaching: 7.4.0
       workbox-window: 7.4.0
     transitivePeerDependencies:
@@ -16818,14 +16822,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       fs-extra: 11.3.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -16849,14 +16853,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/webpack': 8.1.0(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/webpack': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -16879,23 +16883,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/theme-classic': 3.10.0(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/theme-classic': 3.10.0(@types/react@19.2.14)(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -16924,28 +16928,28 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  '@docusaurus/responsive-loader@1.7.1(jimp@1.6.1)(sharp@0.32.6)':
+  '@docusaurus/responsive-loader@1.7.1(jimp@1.6.1(supports-color@8.1.1))(sharp@0.32.6)':
     dependencies:
       loader-utils: 2.0.4
     optionalDependencies:
-      jimp: 1.6.1
+      jimp: 1.6.1(supports-color@8.1.1)
       sharp: 0.32.6
 
-  '@docusaurus/theme-classic@3.10.0(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/theme-classic@3.10.0(@types/react@19.2.14)(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -16979,13 +16983,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -17003,13 +17007,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+  '@docusaurus/theme-mermaid@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       mermaid: 11.12.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -17033,17 +17037,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.2(@algolia/client-search@5.49.1)(algoliasearch@5.49.1)(search-insights@2.17.3)
       '@docsearch/react': 4.6.0(@algolia/client-search@5.49.1)(@types/react@19.2.14)(algoliasearch@5.49.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.3)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@5.9.3))(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       algoliasearch: 5.49.1
       algoliasearch-helper: 3.27.1(algoliasearch@5.49.1)
       clsx: 2.1.1
@@ -17082,9 +17086,9 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.0': {}
 
-  '@docusaurus/types@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/types@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
-      '@mdx-js/mdx': 3.1.1
+      '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       '@types/history': 4.7.11
       '@types/mdast': 4.0.4
       '@types/react': 19.2.14
@@ -17103,9 +17107,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-common@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -17116,11 +17120,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-validation@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       fs-extra: 11.3.3
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -17135,11 +17139,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils@3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       file-loader: 6.2.0(webpack@5.105.2(esbuild@0.27.3))
@@ -17308,11 +17312,11 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
-  '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
+  '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       minimatch: 10.2.5
     transitivePeerDependencies:
@@ -17326,17 +17330,17 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@google-cloud/common@6.0.0':
+  '@google-cloud/common@6.0.0(supports-color@8.1.1)':
     dependencies:
       '@google-cloud/projectify': 4.0.0
       '@google-cloud/promisify': 4.1.0
       arrify: 2.0.1
       duplexify: 4.1.3
       extend: 3.0.2
-      google-auth-library: 10.6.2
+      google-auth-library: 10.6.2(supports-color@8.1.1)
       html-entities: 2.6.0
-      retry-request: 8.0.2
-      teeny-request: 10.1.0
+      retry-request: 8.0.2(supports-color@8.1.1)
+      teeny-request: 10.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17346,43 +17350,43 @@ snapshots:
 
   '@google-cloud/promisify@5.0.0': {}
 
-  '@google-cloud/tasks@6.2.1':
+  '@google-cloud/tasks@6.2.1(supports-color@8.1.1)':
     dependencies:
-      google-gax: 5.0.6
+      google-gax: 5.0.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/translate@9.3.0':
+  '@google-cloud/translate@9.3.0(supports-color@8.1.1)':
     dependencies:
-      '@google-cloud/common': 6.0.0
+      '@google-cloud/common': 6.0.0(supports-color@8.1.1)
       '@google-cloud/promisify': 5.0.0
       arrify: 2.0.1
       extend: 3.0.2
-      google-gax: 5.0.6
+      google-gax: 5.0.6(supports-color@8.1.1)
       is-html: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
+  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)':
     dependencies:
-      google-auth-library: 10.6.2
+      google-auth-library: 10.6.2(supports-color@8.1.1)
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.19.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@8.1.1)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@googlemaps/google-maps-services-js@3.4.2':
+  '@googlemaps/google-maps-services-js@3.4.2(debug@4.4.3(supports-color@8.1.1))':
     dependencies:
       '@googlemaps/url-signature': 1.0.40
       agentkeepalive: 4.6.0
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.3(supports-color@8.1.1))
       query-string: 7.1.3
-      retry-axios: 2.6.0(axios@1.15.0)
+      retry-axios: 2.6.0(axios@1.15.0(debug@4.4.3(supports-color@8.1.1)))
     transitivePeerDependencies:
       - debug
 
@@ -17450,12 +17454,12 @@ snapshots:
       - utf-8-validate
       - yauzl
 
-  '@happyvertical/spider@1.1.13(@types/node@24.12.2)':
+  '@happyvertical/spider@1.1.13(@types/node@24.12.2)(supports-color@8.1.1)':
     dependencies:
       '@happyvertical/cache': link:packages/cache
       '@happyvertical/utils': link:packages/utils
       cheerio: 1.2.0
-      crawlee: 3.17.0(@types/node@24.12.2)(playwright@1.61.1)
+      crawlee: 3.17.0(@types/node@24.12.2)(playwright@1.61.1)(supports-color@8.1.1)
       happy-dom: 20.10.6
       playwright: 1.61.1
       undici: 8.7.0
@@ -17742,21 +17746,21 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@jimp/core@1.6.1':
+  '@jimp/core@1.6.1(supports-color@8.1.1)':
     dependencies:
       '@jimp/file-ops': 1.6.1
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       await-to-js: 3.0.0
       exif-parser: 0.1.12
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@8.1.1)
       mime: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/diff@1.6.1':
+  '@jimp/diff@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/plugin-resize': 1.6.1
+      '@jimp/plugin-resize': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       pixelmatch: 5.3.0
@@ -17765,43 +17769,43 @@ snapshots:
 
   '@jimp/file-ops@1.6.1': {}
 
-  '@jimp/js-bmp@1.6.1':
+  '@jimp/js-bmp@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       bmp-ts: 1.0.9
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/js-gif@1.6.1':
+  '@jimp/js-gif@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       gifwrap: 0.10.1
       omggif: 1.0.10
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/js-jpeg@1.6.1':
+  '@jimp/js-jpeg@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       jpeg-js: 0.4.4
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/js-png@1.6.1':
+  '@jimp/js-png@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       pngjs: 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/js-tiff@1.6.1':
+  '@jimp/js-tiff@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       utif2: 4.1.0
     transitivePeerDependencies:
@@ -17813,9 +17817,9 @@ snapshots:
       '@jimp/utils': 1.6.1
       zod: 3.25.76
 
-  '@jimp/plugin-blur@1.6.1':
+  '@jimp/plugin-blur@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/utils': 1.6.1
     transitivePeerDependencies:
       - supports-color
@@ -17825,9 +17829,9 @@ snapshots:
       '@jimp/types': 1.6.1
       zod: 3.25.76
 
-  '@jimp/plugin-color@1.6.1':
+  '@jimp/plugin-color@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       tinycolor2: 1.6.0
@@ -17835,30 +17839,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/plugin-contain@1.6.1':
+  '@jimp/plugin-contain@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/plugin-blit': 1.6.1
-      '@jimp/plugin-resize': 1.6.1
+      '@jimp/plugin-resize': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/plugin-cover@1.6.1':
+  '@jimp/plugin-cover@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
-      '@jimp/plugin-crop': 1.6.1
-      '@jimp/plugin-resize': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-crop': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-resize': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/plugin-crop@1.6.1':
+  '@jimp/plugin-crop@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       zod: 3.25.76
@@ -17886,15 +17890,15 @@ snapshots:
       '@jimp/types': 1.6.1
       zod: 3.25.76
 
-  '@jimp/plugin-hash@1.6.1':
+  '@jimp/plugin-hash@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
-      '@jimp/js-bmp': 1.6.1
-      '@jimp/js-jpeg': 1.6.1
-      '@jimp/js-png': 1.6.1
-      '@jimp/js-tiff': 1.6.1
-      '@jimp/plugin-color': 1.6.1
-      '@jimp/plugin-resize': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-bmp': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-jpeg': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-png': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-tiff': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-color': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-resize': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       any-base: 1.1.0
@@ -17906,11 +17910,11 @@ snapshots:
       '@jimp/types': 1.6.1
       zod: 3.25.76
 
-  '@jimp/plugin-print@1.6.1':
+  '@jimp/plugin-print@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
-      '@jimp/js-jpeg': 1.6.1
-      '@jimp/js-png': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-jpeg': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-png': 1.6.1(supports-color@8.1.1)
       '@jimp/plugin-blit': 1.6.1
       '@jimp/types': 1.6.1
       parse-bmfont-ascii: 1.0.6
@@ -17926,30 +17930,30 @@ snapshots:
       image-q: 4.0.0
       zod: 3.25.76
 
-  '@jimp/plugin-resize@1.6.1':
+  '@jimp/plugin-resize@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/plugin-rotate@1.6.1':
+  '@jimp/plugin-rotate@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
-      '@jimp/plugin-crop': 1.6.1
-      '@jimp/plugin-resize': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-crop': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-resize': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@jimp/plugin-threshold@1.6.1':
+  '@jimp/plugin-threshold@1.6.1(supports-color@8.1.1)':
     dependencies:
-      '@jimp/core': 1.6.1
-      '@jimp/plugin-color': 1.6.1
-      '@jimp/plugin-hash': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-color': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-hash': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       zod: 3.25.76
@@ -17965,13 +17969,13 @@ snapshots:
       '@jimp/types': 1.6.1
       tinycolor2: 1.6.0
 
-  '@jpisnice/shadcn-ui-mcp-server@1.1.4':
+  '@jpisnice/shadcn-ui-mcp-server@1.1.4(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      axios: 1.15.0
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@8.1.1)(zod@3.25.76)
+      axios: 1.15.0(debug@4.4.3(supports-color@8.1.1))
       cheerio: 1.2.0
       cors: 2.8.6
-      express: 4.22.1
+      express: 4.22.1(supports-color@8.1.1)
       joi: 17.13.3
       uuid: 10.0.0
       winston: 3.19.0
@@ -18239,7 +18243,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mdx-js/mdx@3.1.1':
+  '@mdx-js/mdx@3.1.1(supports-color@8.1.1)':
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -18251,14 +18255,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
+      rehype-recma: 1.0.0(supports-color@8.1.1)
+      remark-mdx: 3.1.1(supports-color@8.1.1)
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -18315,7 +18319,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -18325,8 +18329,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.2.1(express@5.2.1(supports-color@8.1.1))
       hono: 4.12.2
       jose: 6.2.2
       json-schema-typed: 8.0.2
@@ -18468,10 +18472,10 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 1.0.2
     optional: true
 
-  '@napi-rs/cli@3.6.2(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(node-addon-api@6.1.0)':
+  '@napi-rs/cli@3.6.2(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(node-addon-api@6.1.0)(supports-color@8.1.1)':
     dependencies:
       '@inquirer/prompts': 8.3.0(@types/node@24.12.2)
-      '@napi-rs/cross-toolchain': 1.0.3
+      '@napi-rs/cross-toolchain': 1.0.3(supports-color@8.1.1)
       '@napi-rs/wasm-tools': 1.0.1
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
@@ -18499,11 +18503,11 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3':
+  '@napi-rs/cross-toolchain@1.0.3(supports-color@8.1.1)':
     dependencies:
       '@napi-rs/lzma': 1.4.5
       '@napi-rs/tar': 1.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18722,8 +18726,7 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@noble/ciphers@2.1.1':
-    optional: true
+  '@noble/ciphers@2.1.1': {}
 
   '@noble/curves@2.0.1':
     dependencies:
@@ -18832,154 +18835,154 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/connect': 3.4.38
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-http@0.214.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-http@0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-ioredis@0.62.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-ioredis@0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/redis-common': 0.38.2
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/mysql': 2.15.27
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
       '@types/pg': 8.15.6
@@ -18987,57 +18990,57 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-redis@0.62.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-redis@0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/redis-common': 0.38.2
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/tedious': 4.0.14
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-undici@0.24.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation-undici@0.24.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.207.0
       import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.212.0
       import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.214.0
       import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19188,10 +19191,10 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
+  '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19347,10 +19350,10 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(rollup@4.60.2)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0(supports-color@8.1.1))(rollup@4.60.2)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@rollup/pluginutils': 3.1.0(rollup@4.60.2)
       rollup: 4.60.2
     transitivePeerDependencies:
@@ -19547,7 +19550,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
       '@scure/base': 2.0.0
-    optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -19558,7 +19560,7 @@ snapshots:
 
   '@sentry/core@10.49.0': {}
 
-  '@sentry/node-core@10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/node-core@10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@sentry/core': 10.49.0
       '@sentry/opentelemetry': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
@@ -19566,42 +19568,42 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@sentry/node@10.49.0':
+  '@sentry/node@10.49.0(supports-color@8.1.1)':
     dependencies:
-      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
+      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-undici': 0.24.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation-undici': 0.24.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
-      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
+      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@sentry/core': 10.49.0
-      '@sentry/node-core': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/node-core': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/opentelemetry': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
@@ -19669,13 +19671,13 @@ snapshots:
 
   '@slack/types@2.20.1': {}
 
-  '@slack/web-api@7.15.1':
+  '@slack/web-api@7.15.1(debug@4.4.3(supports-color@8.1.1))':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.20.1
       '@types/node': 24.12.2
       '@types/retry': 0.12.0
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.3(supports-color@8.1.1))
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -20117,54 +20119,54 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -20177,35 +20179,35 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@8.1.0(typescript@5.9.3)':
+  '@svgr/webpack@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/preset-env': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20247,11 +20249,11 @@ snapshots:
       svelte: 5.53.3
     optionalDependencies:
       vite: 8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@8.1.1)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -20303,9 +20305,9 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
-  '@types/bull@4.10.4':
+  '@types/bull@4.10.4(supports-color@8.1.1)':
     dependencies:
-      bull: 4.16.5
+      bull: 4.16.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20669,7 +20671,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -20891,9 +20893,9 @@ snapshots:
 
   adm-zip@0.5.16: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21084,9 +21086,9 @@ snapshots:
 
   await-to-js@3.0.0: {}
 
-  axios@1.15.0:
+  axios@1.15.0(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -21096,9 +21098,9 @@ snapshots:
 
   b4a@1.8.0: {}
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.27.3)):
+  babel-loader@9.2.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.2(esbuild@0.27.3)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
       webpack: 5.105.2(esbuild@0.27.3)
@@ -21107,35 +21109,35 @@ snapshots:
     dependencies:
       object.assign: 4.1.7
 
-  babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.48.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.0(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.14.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.48.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.6(@babel/core@7.29.0):
+  babel-plugin-polyfill-regenerator@0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21217,11 +21219,11 @@ snapshots:
 
   bmp-ts@1.0.9: {}
 
-  body-parser@1.20.4:
+  body-parser@1.20.4(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -21234,11 +21236,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -21313,11 +21315,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bull@4.16.5:
+  bull@4.16.5(supports-color@8.1.1):
     dependencies:
       cron-parser: 4.9.0
       get-port: 5.1.1
-      ioredis: 5.10.1
+      ioredis: 5.10.1(supports-color@8.1.1)
       lodash: 4.17.23
       msgpackr: 1.11.8
       semver: 7.7.4
@@ -21325,10 +21327,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bullmq@5.80.4(redis@5.12.1(@opentelemetry/api@1.9.1)):
+  bullmq@5.80.4(redis@5.12.1(@opentelemetry/api@1.9.1))(supports-color@8.1.1):
     dependencies:
       cron-parser: 4.9.0
-      ioredis: 5.11.1
+      ioredis: 5.11.1(supports-color@8.1.1)
       msgpackr: 2.0.4
       node-abort-controller: 3.1.1
       semver: 7.8.5
@@ -21651,11 +21653,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1:
+  compression@1.8.1(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -21784,20 +21786,20 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  crawlee@3.17.0(@types/node@24.12.2)(playwright@1.61.1):
+  crawlee@3.17.0(@types/node@24.12.2)(playwright@1.61.1)(supports-color@8.1.1):
     dependencies:
-      '@crawlee/basic': 3.17.0
-      '@crawlee/browser': 3.17.0(playwright@1.61.1)
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)
-      '@crawlee/cheerio': 3.17.0
+      '@crawlee/basic': 3.17.0(supports-color@8.1.1)
+      '@crawlee/browser': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
+      '@crawlee/cheerio': 3.17.0(supports-color@8.1.1)
       '@crawlee/cli': 3.17.0(@types/node@24.12.2)
-      '@crawlee/core': 3.17.0
-      '@crawlee/http': 3.17.0
-      '@crawlee/jsdom': 3.17.0
-      '@crawlee/linkedom': 3.17.0
-      '@crawlee/playwright': 3.17.0(playwright@1.61.1)
-      '@crawlee/puppeteer': 3.17.0(playwright@1.61.1)
-      '@crawlee/utils': 3.17.0
+      '@crawlee/core': 3.17.0(supports-color@8.1.1)
+      '@crawlee/http': 3.17.0(supports-color@8.1.1)
+      '@crawlee/jsdom': 3.17.0(supports-color@8.1.1)
+      '@crawlee/linkedom': 3.17.0(supports-color@8.1.1)
+      '@crawlee/playwright': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
+      '@crawlee/puppeteer': 3.17.0(playwright@1.61.1)(supports-color@8.1.1)
+      '@crawlee/utils': 3.17.0(supports-color@8.1.1)
       import-local: 3.2.0
       tslib: 2.8.1
     optionalDependencies:
@@ -21876,7 +21878,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.105.2(esbuild@0.27.3)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(webpack@5.105.2(esbuild@0.27.3)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.27.3)(lightningcss@1.32.0)(webpack@5.105.2(esbuild@0.27.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.6)
@@ -21887,7 +21889,9 @@ snapshots:
       webpack: 5.105.2(esbuild@0.27.3)
     optionalDependencies:
       clean-css: 5.3.3
+      csso: 5.0.5
       esbuild: 0.27.3
+      lightningcss: 1.32.0
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.6):
     dependencies:
@@ -22237,13 +22241,17 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js@10.6.0: {}
 
@@ -22263,11 +22271,11 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
-  deepl-node@1.26.0:
+  deepl-node@1.26.0(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       '@types/node': 24.12.2
       adm-zip: 0.5.16
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 3.0.4
       loglevel: 1.9.2
       uuid: 8.3.2
@@ -22350,10 +22358,10 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detect-port@1.6.1:
+  detect-port@1.6.1(supports-color@8.1.1):
     dependencies:
       address: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22788,26 +22796,26 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.2.1(express@5.2.1):
+  express-rate-limit@8.2.1(express@5.2.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       ip-address: 10.0.1
 
-  express@4.22.1:
+  express@4.22.1(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.4
+      body-parser: 1.20.4(supports-color@8.1.1)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
+      finalhandler: 1.3.2(supports-color@8.1.1)
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -22819,8 +22827,8 @@ snapshots:
       qs: 6.14.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2
-      serve-static: 1.16.3
+      send: 0.19.2(supports-color@8.1.1)
+      serve-static: 1.16.3(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -22829,20 +22837,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@8.1.1)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -22853,9 +22861,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.0
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -22953,9 +22961,9 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.2(esbuild@0.27.3)
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@8.1.1):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@8.1.1)
       strtok3: 10.3.4
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -22972,9 +22980,9 @@ snapshots:
 
   filter-obj@1.1.0: {}
 
-  finalhandler@1.3.2:
+  finalhandler@1.3.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -22984,9 +22992,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -23031,7 +23039,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.15.11(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -23132,10 +23142,10 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  gaxios@6.7.1:
+  gaxios@6.7.1(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-stream: 2.0.1
       node-fetch: 2.7.0
       uuid: 9.0.1
@@ -23143,26 +23153,26 @@ snapshots:
       - encoding
       - supports-color
 
-  gaxios@7.1.4:
+  gaxios@7.1.4(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@6.1.1:
+  gcp-metadata@6.1.1(supports-color@8.1.1):
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@8.1.1)
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  gcp-metadata@8.1.2:
+  gcp-metadata@8.1.2(supports-color@8.1.1):
     dependencies:
-      gaxios: 7.1.4
+      gaxios: 7.1.4(supports-color@8.1.1)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -23302,41 +23312,41 @@ snapshots:
       merge2: 1.4.1
       slash: 4.0.0
 
-  google-auth-library@10.6.2:
+  google-auth-library@10.6.2(supports-color@8.1.1):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.4
-      gcp-metadata: 8.1.2
+      gaxios: 7.1.4(supports-color@8.1.1)
+      gcp-metadata: 8.1.2(supports-color@8.1.1)
       google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@9.15.1:
+  google-auth-library@9.15.1(supports-color@8.1.1):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1
-      gcp-metadata: 6.1.1
-      gtoken: 7.1.0
+      gaxios: 6.7.1(supports-color@8.1.1)
+      gcp-metadata: 6.1.1(supports-color@8.1.1)
+      gtoken: 7.1.0(supports-color@8.1.1)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-gax@5.0.6:
+  google-gax@5.0.6(supports-color@8.1.1):
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.8.0
       duplexify: 4.1.3
-      google-auth-library: 10.6.2
+      google-auth-library: 10.6.2(supports-color@8.1.1)
       google-logging-utils: 1.1.3
       node-fetch: 3.3.2
       object-hash: 3.0.0
       proto3-json-serializer: 3.0.4
       protobufjs: 7.5.4
-      retry-request: 8.0.2
+      retry-request: 8.0.2(supports-color@8.1.1)
       rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
@@ -23345,11 +23355,11 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0:
+  googleapis-common@7.2.0(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
-      gaxios: 6.7.1
-      google-auth-library: 9.15.1
+      gaxios: 6.7.1(supports-color@8.1.1)
+      google-auth-library: 9.15.1(supports-color@8.1.1)
       qs: 6.15.0
       url-template: 2.0.8
       uuid: 9.0.1
@@ -23357,28 +23367,28 @@ snapshots:
       - encoding
       - supports-color
 
-  googleapis-common@8.0.1:
+  googleapis-common@8.0.1(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
-      gaxios: 7.1.4
-      google-auth-library: 10.6.2
+      gaxios: 7.1.4(supports-color@8.1.1)
+      google-auth-library: 10.6.2(supports-color@8.1.1)
       qs: 6.15.0
       url-template: 2.0.8
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@144.0.0:
+  googleapis@144.0.0(supports-color@8.1.1):
     dependencies:
-      google-auth-library: 9.15.1
-      googleapis-common: 7.2.0
+      google-auth-library: 9.15.1(supports-color@8.1.1)
+      googleapis-common: 7.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  googleapis@170.1.0:
+  googleapis@170.1.0(supports-color@8.1.1):
     dependencies:
-      google-auth-library: 10.6.2
-      googleapis-common: 8.0.1
+      google-auth-library: 10.6.2(supports-color@8.1.1)
+      googleapis-common: 8.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23434,9 +23444,9 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  gtoken@7.1.0:
+  gtoken@7.1.0(supports-color@8.1.1):
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@8.1.1)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -23534,7 +23544,7 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
-  hast-util-to-estree@3.1.3:
+  hast-util-to-estree@3.1.3(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -23544,9 +23554,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -23555,7 +23565,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.8
       '@types/hast': 3.0.4
@@ -23564,9 +23574,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -23738,25 +23748,25 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -23765,10 +23775,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@8.1.1))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -23778,17 +23788,17 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23939,10 +23949,10 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  intuit-oauth@4.2.3:
+  intuit-oauth@4.2.3(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       atob: 2.1.2
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.3(supports-color@8.1.1))
       csrf: 3.1.0
       jsonwebtoken: 9.0.3
       query-string: 6.14.1
@@ -23955,11 +23965,11 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis@5.10.1:
+  ioredis@5.10.1(supports-color@8.1.1):
     dependencies:
       '@ioredis/commands': 1.5.1
       cluster-key-slot: 1.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -23969,11 +23979,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ioredis@5.11.1:
+  ioredis@5.11.1(supports-color@8.1.1):
     dependencies:
       '@ioredis/commands': 1.10.0
       cluster-key-slot: 1.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       redis-errors: 1.2.0
       redis-parser: 3.0.0
@@ -24276,33 +24286,33 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jimp@1.6.1:
+  jimp@1.6.1(supports-color@8.1.1):
     dependencies:
-      '@jimp/core': 1.6.1
-      '@jimp/diff': 1.6.1
-      '@jimp/js-bmp': 1.6.1
-      '@jimp/js-gif': 1.6.1
-      '@jimp/js-jpeg': 1.6.1
-      '@jimp/js-png': 1.6.1
-      '@jimp/js-tiff': 1.6.1
+      '@jimp/core': 1.6.1(supports-color@8.1.1)
+      '@jimp/diff': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-bmp': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-gif': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-jpeg': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-png': 1.6.1(supports-color@8.1.1)
+      '@jimp/js-tiff': 1.6.1(supports-color@8.1.1)
       '@jimp/plugin-blit': 1.6.1
-      '@jimp/plugin-blur': 1.6.1
+      '@jimp/plugin-blur': 1.6.1(supports-color@8.1.1)
       '@jimp/plugin-circle': 1.6.1
-      '@jimp/plugin-color': 1.6.1
-      '@jimp/plugin-contain': 1.6.1
-      '@jimp/plugin-cover': 1.6.1
-      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-color': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-contain': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-cover': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-crop': 1.6.1(supports-color@8.1.1)
       '@jimp/plugin-displace': 1.6.1
       '@jimp/plugin-dither': 1.6.1
       '@jimp/plugin-fisheye': 1.6.1
       '@jimp/plugin-flip': 1.6.1
-      '@jimp/plugin-hash': 1.6.1
+      '@jimp/plugin-hash': 1.6.1(supports-color@8.1.1)
       '@jimp/plugin-mask': 1.6.1
-      '@jimp/plugin-print': 1.6.1
+      '@jimp/plugin-print': 1.6.1(supports-color@8.1.1)
       '@jimp/plugin-quantize': 1.6.1
-      '@jimp/plugin-resize': 1.6.1
-      '@jimp/plugin-rotate': 1.6.1
-      '@jimp/plugin-threshold': 1.6.1
+      '@jimp/plugin-resize': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-rotate': 1.6.1(supports-color@8.1.1)
+      '@jimp/plugin-threshold': 1.6.1(supports-color@8.1.1)
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
     transitivePeerDependencies:
@@ -24345,14 +24355,14 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -24372,7 +24382,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@27.4.0(@noble/hashes@2.0.1):
+  jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
@@ -24381,8 +24391,8 @@ snapshots:
       data-urls: 6.0.1
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -24860,13 +24870,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdast-util-directive@3.1.0:
+  mdast-util-directive@3.1.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -24881,14 +24891,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -24898,12 +24908,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-frontmatter@2.0.1:
+  mdast-util-frontmatter@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -24917,67 +24927,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@8.1.1)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-table: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -24985,7 +24995,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -24994,23 +25004,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0:
+  mdast-util-mdx@3.0.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -25385,10 +25395,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -25635,10 +25645,8 @@ snapshots:
       nostr-wasm: 0.1.0
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
-  nostr-wasm@0.1.0:
-    optional: true
+  nostr-wasm@0.1.0: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -26671,10 +26679,10 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-chain@2.7.1:
+  proxy-chain@2.7.1(supports-color@8.1.1):
     dependencies:
       socks: 2.8.7
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -26979,20 +26987,20 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0:
+  rehype-recma@1.0.0(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.8
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3
+      hast-util-to-estree: 3.1.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   relateurl@0.2.7: {}
 
-  remark-directive@3.0.1:
+  remark-directive@3.0.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-directive: 3.1.0
+      mdast-util-directive: 3.1.0(supports-color@8.1.1)
       micromark-extension-directive: 3.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -27006,37 +27014,37 @@ snapshots:
       node-emoji: 2.2.0
       unified: 11.0.5
 
-  remark-frontmatter@5.0.0:
+  remark-frontmatter@5.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-frontmatter: 2.0.1
+      mdast-util-frontmatter: 2.0.1(supports-color@8.1.1)
       micromark-extension-frontmatter: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@8.1.1)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(supports-color@8.1.1):
     dependencies:
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@8.1.1)
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -27070,9 +27078,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -27112,14 +27120,14 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.15.0):
+  retry-axios@2.6.0(axios@1.15.0(debug@4.4.3(supports-color@8.1.1))):
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.3(supports-color@8.1.1))
 
-  retry-request@8.0.2:
+  retry-request@8.0.2(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
-      teeny-request: 10.1.0
+      teeny-request: 10.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27198,9 +27206,9 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -27335,9 +27343,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2:
+  send@0.19.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -27353,9 +27361,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -27387,11 +27395,11 @@ snapshots:
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
 
-  serve-index@1.9.2:
+  serve-index@1.9.2(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       escape-html: 1.0.3
       http-errors: 1.8.1
       mime-types: 2.1.35
@@ -27399,21 +27407,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.3:
+  serve-static@1.16.3(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2
+      send: 0.19.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27597,10 +27605,10 @@ snapshots:
       uuid: 8.3.2
       websocket-driver: 0.7.4
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -27640,9 +27648,9 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -27651,13 +27659,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27951,10 +27959,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  teeny-request@10.1.0:
+  teeny-request@10.1.0(supports-color@8.1.1):
     dependencies:
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 5.0.0(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       node-fetch: 3.3.2
       stream-events: 1.0.5
     transitivePeerDependencies:
@@ -28437,14 +28445,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-dts@4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)):
+  vite-plugin-dts@4.5.4(@types/node@24.12.2)(rollup@4.60.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.57.5(@types/node@24.12.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -28471,7 +28479,7 @@ snapshots:
       terser: 5.46.0
       yaml: 2.8.3
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
@@ -28498,11 +28506,11 @@ snapshots:
       '@types/node': 24.12.2
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.10.6
-      jsdom: 27.4.0(@noble/hashes@2.0.1)
+      jsdom: 27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1))(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
@@ -28529,7 +28537,7 @@ snapshots:
       '@types/node': 24.12.2
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.9.0
-      jsdom: 27.4.0(@noble/hashes@2.0.1)
+      jsdom: 27.4.0(@noble/hashes@2.0.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - msw
 
@@ -28616,7 +28624,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3)):
+  webpack-dev-server@5.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -28630,20 +28638,20 @@ snapshots:
       bonjour-service: 1.3.0
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.1
+      compression: 1.8.1(supports-color@8.1.1)
       connect-history-api-fallback: 2.0.0
-      express: 4.22.1
+      express: 4.22.1(supports-color@8.1.1)
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
       ipaddr.js: 2.3.0
       launch-editor: 2.13.1
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3
       selfsigned: 5.5.0
-      serve-index: 1.9.2
+      serve-index: 1.9.2(supports-color@8.1.1)
       sockjs: 0.3.24
-      spdy: 4.0.2
+      spdy: 4.0.2(supports-color@8.1.1)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
       ws: 8.19.0
     optionalDependencies:
@@ -28842,13 +28850,13 @@ snapshots:
     dependencies:
       workbox-core: 7.4.0
 
-  workbox-build@7.4.0:
+  workbox-build@7.4.0(supports-color@8.1.1):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.18.0)
-      '@babel/core': 7.29.0
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.28.6
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.29.0)(rollup@4.60.2)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.29.0(supports-color@8.1.1))(rollup@4.60.2)(supports-color@8.1.1)
       '@rollup/plugin-node-resolve': 15.3.1(rollup@4.60.2)
       '@rollup/plugin-replace': 2.4.2(rollup@4.60.2)
       '@rollup/plugin-terser': 0.4.4(rollup@4.60.2)


### PR DESCRIPTION
## Summary
Adds a Buzz/Nostr forge adapter to `@happyvertical/repos`: verified relay polling, provider-neutral normalization, deterministic convergence fixtures, role-floor approval handling, and public configuration documentation.

## Links
- Closes #1187
- Parent: happyvertical/happyvertical.com#171

## Validation
- `pnpm exec vitest --config vitest.package.config.ts run packages/repos/src/buzz/events.test.ts` — 13 passed
- Full package test/typecheck locally blocked by unrelated unbuilt `@happyvertical/graphql` workspace export under Node 22; CI runs the complete supported environment.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-171-sdk-policy-review","issue":1187,"policy_revision":"1.0.0","validation":"Buzz focused suite: 13 passed"}
```

