### PR TITLE
fix(sql): serialize sibling nested savepoints

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -170,7 +170,9 @@ Two consequences worth knowing:
   connection its own caller is holding.
 
 PostgreSQL pools its connections, so transactions there run concurrently and
-never queue.
+never queue. Nested scopes on one PostgreSQL transaction use savepoints; if
+sibling nested scopes are started concurrently, they serialize so PostgreSQL's
+stack-ordered savepoint lifecycle remains intact.
 
 ### Identifiers
 

--- a/packages/sql/src/postgres-nested-transaction.spec.ts
+++ b/packages/sql/src/postgres-nested-transaction.spec.ts
@@ -209,6 +209,45 @@ describe('postgres nested transactions', () => {
     expect(rows.rows.map((r) => r.id)).toEqual([1, 2]);
   }, 30000);
 
+  it('drains a queued sibling before rolling the outer transaction back', async () => {
+    if (!postgresAvailable) return;
+
+    let startSecond!: () => void;
+    let continueSecond!: () => void;
+    const secondStarted = new Promise<void>((resolve) => {
+      startSecond = resolve;
+    });
+    const allowSecond = new Promise<void>((resolve) => {
+      continueSecond = resolve;
+    });
+    let outerSettled = false;
+
+    const outer = txOf(db)(async (tx) => {
+      const first = txOf(tx)(async () => {
+        throw new Error('__first_sibling_failed__');
+      });
+      const second = txOf(tx)(async (later) => {
+        startSecond();
+        await allowSecond;
+        await later.query(`INSERT INTO ${table} VALUES (2, 'second')`);
+      });
+      await Promise.all([first, second]);
+    });
+    void outer.catch(() => {
+      outerSettled = true;
+    });
+
+    await secondStarted;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(outerSettled).toBe(false);
+
+    continueSecond();
+    await expect(outer).rejects.toThrow('__first_sibling_failed__');
+
+    const rows = await db.query(`SELECT id FROM ${table}`);
+    expect(rows.rows).toHaveLength(0);
+  }, 30000);
+
   it('nests on a beginTransaction handle without checking out a second connection', async () => {
     if (!postgresAvailable || !db.beginTransaction) return;
 

--- a/packages/sql/src/postgres-nested-transaction.spec.ts
+++ b/packages/sql/src/postgres-nested-transaction.spec.ts
@@ -171,6 +171,44 @@ describe('postgres nested transactions', () => {
     expect(rows.rows.map((r) => r.id)).toEqual([1, 2, 3]);
   }, 30000);
 
+  it('serializes overlapping nested scopes on the enclosing client', async () => {
+    if (!postgresAvailable) return;
+
+    await txOf(db)(async (tx) => {
+      await Promise.all([
+        txOf(tx)(async (first) => {
+          await first.query(`INSERT INTO ${table} VALUES (1, 'first')`);
+        }),
+        txOf(tx)(async (second) => {
+          await second.query(`INSERT INTO ${table} VALUES (2, 'second')`);
+        }),
+      ]);
+    });
+
+    const rows = await db.query(`SELECT id FROM ${table} ORDER BY id`);
+    expect(rows.rows.map((r) => r.id)).toEqual([1, 2]);
+  }, 30000);
+
+  it('serializes siblings started from within a nested scope', async () => {
+    if (!postgresAvailable) return;
+
+    await txOf(db)(async (tx) => {
+      await txOf(tx)(async (parent) => {
+        await Promise.all([
+          txOf(parent)(async (first) => {
+            await first.query(`INSERT INTO ${table} VALUES (1, 'first')`);
+          }),
+          txOf(parent)(async (second) => {
+            await second.query(`INSERT INTO ${table} VALUES (2, 'second')`);
+          }),
+        ]);
+      });
+    });
+
+    const rows = await db.query(`SELECT id FROM ${table} ORDER BY id`);
+    expect(rows.rows.map((r) => r.id)).toEqual([1, 2]);
+  }, 30000);
+
   it('nests on a beginTransaction handle without checking out a second connection', async () => {
     if (!postgresAvailable || !db.beginTransaction) return;
 

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -2009,10 +2009,16 @@ async function createDatabase(
     interface NestedScope {
       tail: Promise<void>;
     }
+    type NestedTransaction = (<T>(
+      callback: (tx: DatabaseInterface) => Promise<T>,
+    ) => Promise<T>) & {
+      drain: () => Promise<void>;
+    };
     const nestedScope = new AsyncLocalStorage<NestedScope>();
     const rootScope: NestedScope = { tail: Promise.resolve() };
 
     const runScope = async <T>(
+      scope: NestedScope,
       callback: (tx: DatabaseInterface) => Promise<T>,
     ): Promise<T> => {
       savepointSequence += 1;
@@ -2020,9 +2026,15 @@ async function createDatabase(
       await txClient.query(`SAVEPOINT ${name}`);
       try {
         const result = await callback(scopeFor());
+        // A callback may start nested work without awaiting it. Its savepoint
+        // must remain open until that work is finished.
+        await scope.tail;
         await txClient.query(`RELEASE SAVEPOINT ${name}`);
         return result;
       } catch (error) {
+        // Promise.all rejects as soon as one sibling fails, but queued siblings
+        // are still tied to this savepoint. Let them finish before unwinding.
+        await scope.tail;
         try {
           // ROLLBACK TO leaves the savepoint defined, so release it too or it
           // accumulates for the life of the transaction.
@@ -2036,12 +2048,13 @@ async function createDatabase(
       }
     };
 
-    return async <T>(
+    const transaction: NestedTransaction = async <T>(
       callback: (tx: DatabaseInterface) => Promise<T>,
     ): Promise<T> => {
       const parentScope = nestedScope.getStore() ?? rootScope;
+      const scope: NestedScope = { tail: Promise.resolve() };
       const current = parentScope.tail.then(() =>
-        nestedScope.run({ tail: Promise.resolve() }, () => runScope(callback)),
+        nestedScope.run(scope, () => runScope(scope, callback)),
       );
       parentScope.tail = current.then(
         () => undefined,
@@ -2049,6 +2062,8 @@ async function createDatabase(
       );
       return current;
     };
+    transaction.drain = () => rootScope.tail;
+    return transaction;
   };
 
   /**
@@ -2064,22 +2079,31 @@ async function createDatabase(
     // Get a client from the pool for the transaction
     const txClient = await acquireTxClient();
 
+    let nestedTransaction:
+      | ReturnType<typeof createNestedTransaction>
+      | undefined;
     try {
       await txClient.query('BEGIN');
 
       // Create a transaction-scoped database interface
-      const txDb: DatabaseInterface = {
+      let txDb!: DatabaseInterface;
+      nestedTransaction = createNestedTransaction(txClient, () => txDb);
+      txDb = {
         url,
         client: txClient,
         ...createClientMethods(txClient, true, passThroughRecord),
-        transaction: createNestedTransaction(txClient, () => txDb),
+        transaction: nestedTransaction,
       };
 
       const result = await callback(txDb);
+      await nestedTransaction.drain();
       await txClient.query('COMMIT');
       releaseTxClient(txClient);
       return result;
     } catch (error) {
+      // Promise.all may reject before queued nested scopes finish. Do not
+      // release this client until their savepoint work has drained.
+      await nestedTransaction?.drain();
       // Never let a failing ROLLBACK replace the caller's error. On a dead
       // connection the rollback throws "Connection terminated unexpectedly",
       // which would otherwise be the only thing the caller ever sees.
@@ -2112,6 +2136,9 @@ async function createDatabase(
     }
 
     let active = true;
+    let nestedTransaction:
+      | ReturnType<typeof createNestedTransaction>
+      | undefined;
 
     // COMMIT and ROLLBACK both throw in ordinary operation — deferred
     // constraint violations, serialization failures, a connection lost at
@@ -2123,6 +2150,7 @@ async function createDatabase(
         throw new DatabaseError('Transaction already ended', {});
       }
       try {
+        await nestedTransaction?.drain();
         await txClient.query(command);
         active = false;
         releaseTxClient(txClient);
@@ -2143,11 +2171,13 @@ async function createDatabase(
     const isActive = (): boolean => active;
 
     // Create a transaction-scoped database interface with commit/rollback
-    const txHandle: TransactionHandle = {
+    let txHandle!: TransactionHandle;
+    nestedTransaction = createNestedTransaction(txClient, () => txHandle);
+    txHandle = {
       url,
       client: txClient,
       ...createClientMethods(txClient, true, passThroughRecord),
-      transaction: createNestedTransaction(txClient, () => txHandle),
+      transaction: nestedTransaction,
       commit,
       rollback,
       isActive,

--- a/packages/sql/src/postgres.ts
+++ b/packages/sql/src/postgres.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { DatabaseError, loadEnvConfig } from '@happyvertical/utils';
 import { Pool, type PoolClient } from 'pg';
 import { DatabaseSchemaManager } from './schema-manager';
@@ -2000,7 +2001,18 @@ async function createDatabase(
     txClient: PoolClient,
     scopeFor: () => DatabaseInterface,
   ) => {
-    return async <T>(
+    // PostgreSQL permits nested savepoints, but a sibling savepoint cannot be
+    // released while a later sibling is still open: releasing the earlier one
+    // implicitly discards the later savepoint. Each scope gets its own queue:
+    // child scopes are queued behind their parent, while work inside a child
+    // gets a fresh queue for its own children.
+    interface NestedScope {
+      tail: Promise<void>;
+    }
+    const nestedScope = new AsyncLocalStorage<NestedScope>();
+    const rootScope: NestedScope = { tail: Promise.resolve() };
+
+    const runScope = async <T>(
       callback: (tx: DatabaseInterface) => Promise<T>,
     ): Promise<T> => {
       savepointSequence += 1;
@@ -2022,6 +2034,20 @@ async function createDatabase(
         }
         throw error;
       }
+    };
+
+    return async <T>(
+      callback: (tx: DatabaseInterface) => Promise<T>,
+    ): Promise<T> => {
+      const parentScope = nestedScope.getStore() ?? rootScope;
+      const current = parentScope.tail.then(() =>
+        nestedScope.run({ tail: Promise.resolve() }, () => runScope(callback)),
+      );
+      parentScope.tail = current.then(
+        () => undefined,
+        () => undefined,
+      );
+      return current;
     };
   };
 

--- a/packages/sql/src/shared/types.ts
+++ b/packages/sql/src/shared/types.ts
@@ -1073,7 +1073,9 @@ export interface DatabaseInterface {
    * queued call that waits longer than `transactionQueueTimeout` (30s by
    * default) rejects rather than stalling indefinitely. Re-entrant calls do not
    * queue — they take the savepoint or refusal path described above.
-   * PostgreSQL pools, so its transactions run concurrently and never queue.
+   * PostgreSQL pools, so top-level transactions run concurrently. Nested scopes
+   * on one PostgreSQL transaction use a scope-local queue: concurrently started
+   * siblings serialize, while each child gets its own queue for further nesting.
    *
    * @param callback - Function to execute within transaction
    * @returns Promise resolving to callback result


### PR DESCRIPTION
## Summary

- serialize sibling nested PostgreSQL savepoint scopes per enclosing scope
- drain queued nested siblings before releasing a savepoint or transaction client
- cover direct, inherited-context, and failed-sibling regressions

Closes #1190
Refs happyvertical/happyvertical.com#171

## Validation

- `CI_POSTGRES_BASE_URL=… pnpm --filter @happyvertical/sql test:postgres` (225 tests)
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec biome check packages/sql/src/postgres.ts packages/sql/src/postgres-nested-transaction.spec.ts`
- `pnpm agent:check`

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-1190-lifecycle-repair-20260809","issue":"1190","policy_revision":"1.0.0","validation":["sql postgres: 225 tests","build","test","typecheck","lint","biome","agent context"]}
```