### PR TITLE
fix(ci): repair canonical agent policy drift

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -9,6 +9,10 @@
     "repository": "happyvertical/sdk",
     "project_url": "https://github.com/orgs/happyvertical/projects/7"
   },
+  "forge": {
+    "provider": "github",
+    "repository": "happyvertical/sdk"
+  },
   "labels": {
     "claim": "agent: implementation",
     "blocked": "status: blocked",

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -13,6 +13,7 @@ on:
         type: number
 
 permissions:
+  actions: read
   contents: read
   issues: read
   pull-requests: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Agent Instructions
 
-<!-- hv-managed-policy:start revision=1.0.0 sha256=2524e6ee8f276434a25586757222674450e5d1c68802399b89ce69822684b2f6 -->
+<!-- hv-managed-policy:start revision=1.0.0 sha256=2b93cafed7454afd2d15e4c73c9f25cbbeac28eae0b313c8c6090b5367639f57 -->
 
 ## Shared development kernel
 
@@ -12,7 +12,7 @@
 - Patch-class work — small bug, doc, and improvement changes with no schema, contract, dependency, or breaking change — may bundle as one claimed patch train — member issues each claimed by this session, or one umbrella issue of listed micro-items — on one branch and pull request with one attributed commit per item. Other work stays one issue per pull request. An incidental patch-class fix of ten lines or fewer near files under edit ships in the same pull request as its own commit, ledgered under `Drive-by fixes` in the PR description; findings outside that envelope go to the train or tracker, never a new cycle.
 - Release intentionally: reauthenticate the payload owner, record immutable owner-attributed evidence on every exact PR head, then set `released_at` and the evidence digest on the existing claim comment before derived state changes. Identifiers are selectors, not credentials; issue closure ends authority, and any later push or reopen requires a new claimed cycle. Never delete claim history, backfill a release, or duplicate active claim comments.
 - Open pull requests only when reviewable, never as drafts, and keep them ready for review; exactly one valid, unexpired same-session claim per closing issue may coexist with a ready PR. Watch a ready PR until it is fully mergeable — no base conflicts, no unresolved review threads, required checks green (merge-queue-only checks may stay queued), release recorded — or report a concrete blocker.
-- Lifecycle-protected pull requests merge only through the managed merge queue, whose synthetic merge commit rechecks current claim state and requires every closing issue's `review` release from its exact cycle bound to the current PR head; never direct-merge or merge over a live, blocked, abandoned, expired, unbound, or stale release.
+- Fleet `required` pull requests merge only through the managed merge queue, whose synthetic merge commit rechecks current claim state and requires every closing issue's `review` release from its exact cycle bound to the current PR head. Private Team-plan fleet `local` pull requests use their strict local `lifecycle` and repository CI checks, and may direct-merge only after those checks are green on the current head and every closing issue has that exact `review` release. Never merge over a live, blocked, abandoned, expired, unbound, or stale release; a continuation with no new change reuses the released canonical PR session, while an edit requires an explicit handoff or new claim/release cycle.
 - Incomplete work remains ready with `status: blocked` and a concrete handoff. Review agents do not claim implementation.
 - Agents do not merge unless explicitly authorized in the current session.
 - Run documented validation and update affected docs before shipping.


### PR DESCRIPTION
## Summary

- regenerate the canonical hv-agent managed kernel block in `AGENTS.md`
- synchronize the canonical `.github/workflows/agent-policy.yml`
- refresh the generated `forge` selector in `.agents/project.yaml`

Refs #1194 (this policy repair unblocks its lifecycle).

## Validation

- `hv-agent audit --repo /private/tmp/sdk-policy-repair-worktree`
- `actionlint .github/workflows/agent-policy.yml`
- `yamllint -d relaxed .github/workflows/agent-policy.yml`
- `pnpm test:ci-scripts` (35 passed)
- `pnpm agent:check`
- `pnpm typecheck` (20 tasks)
- `pnpm lint` (green; 3 existing warnings)
- `pnpm build` (32 tasks)
- `pnpm test` (44 tasks; 655 passed / 4 skipped)

Closes #1195

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"765DFE15-1A63-4DF4-9588-191FB9D2DC50","issue":1195,"linked_issue":"https://github.com/happyvertical/sdk/issues/1195","policy_revision":"1.0.0","status":"review","validation":["hv-agent audit","actionlint agent-policy.yml","yamllint agent-policy.yml","pnpm test:ci-scripts (35 passed)","pnpm agent:check","pnpm typecheck (20 tasks)","pnpm lint","pnpm build (32 tasks)","pnpm test (655 passed / 4 skipped)"]}
```
