### PR TITLE
ci: migrate actions to Node 24 runtimes

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -123,7 +123,7 @@ runs:
 
     - name: Setup pnpm
       if: steps.pnpm-check.outputs.skip != 'true'
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       with:
         version: ${{ steps.pnpm-check.outputs.required-version }}
         run_install: false

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       # cosign-installer v4 shells out to envsubst, which is not part of the
       # provider-neutral general runner contract. Download the publisher-
       # compatible cosign v3 binary directly and verify its pinned SHA-256 so

--- a/.github/workflows/build-json-native.yml
+++ b/.github/workflows/build-json-native.yml
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24.18.0'
 
@@ -202,10 +202,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24.18.0'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: arc-happyvertical
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/node-runner-smoke.yml
+++ b/.github/workflows/node-runner-smoke.yml
@@ -26,7 +26,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Setup environment
         id: setup
@@ -103,7 +103,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Setup environment
         id: setup

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
@@ -189,7 +189,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
@@ -350,13 +350,13 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Get changed workflow files
         id: changed-files
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: .github/workflows/*.{yml,yaml}
 
@@ -414,13 +414,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Get changed markdown files
         id: changed-md
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: '**/*.md'
 
@@ -454,14 +454,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             packages/*/src/**
@@ -530,14 +530,14 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Get changed files
         id: changed-files
         if: github.event_name == 'pull_request_target'
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             docs/**
@@ -579,7 +579,7 @@ jobs:
     runs-on: arc-happyvertical
     steps:
       - name: Checkout PR history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
@@ -616,13 +616,13 @@ jobs:
       required: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.postgres }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
       - name: Detect PostgreSQL-sensitive changes
         id: filter
         if: github.event_name == 'pull_request_target'
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
           filters: |
             postgres:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -389,10 +389,17 @@ jobs:
       - name: Validate with actionlint
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          bash <(curl -sSfL \
-            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          # actionlint is part of the brokered runner tool contract. Using the
+          # image copy keeps validation deterministic and avoids an
+          # unauthenticated download during every workflow-changing PR.
+          if ! command -v actionlint >/dev/null 2>&1; then
+            echo '::error::actionlint is missing from the runner image; it is part of the runner tool contract'
+            exit 1
+          fi
+          actionlint --version
+
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            ./actionlint -config-file .github/actionlint.yaml \
+            actionlint -config-file .github/actionlint.yaml \
               -ignore 'SC2086|SC2094|SC2129' "$file"
           done
 

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -42,7 +42,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
       - name: Setup environment

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -27,7 +27,7 @@ jobs:
       validate: ${{ steps.version.outputs.validate }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
@@ -67,7 +67,7 @@ jobs:
           tar -cf publish-workspace.tar -T publish-workspace-files
       - name: Upload versioned workspace
         if: steps.version.outputs.validate == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: publish-dry-run-workspace
           path: publish-workspace.tar
@@ -86,11 +86,11 @@ jobs:
         shard: [1, 2]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
       - name: Download versioned workspace
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: publish-dry-run-workspace
           path: release-workspace
@@ -106,7 +106,7 @@ jobs:
           PUBLISH_PACK_SHARD_INDEX: ${{ matrix.shard }}
           PUBLISH_PACK_OUTPUT_DIR: publish-pack-output
       - name: Upload verified tarballs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: publish-dry-run-pack-${{ matrix.shard }}
           path: publish-pack-output/
@@ -122,12 +122,12 @@ jobs:
     steps:
       - name: Checkout repository
         if: needs.prepare.outputs.validate == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
       - name: Download verified tarballs
         if: needs.prepare.outputs.validate == 'true'
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: publish-dry-run-pack-*
           path: publish-pack-output

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -344,6 +344,8 @@ jobs:
         with:
           app-id: ${{ secrets.HAVE_RELEASE_APP_ID }}
           private-key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+          owner: happyvertical
+          repositories: smrt
       - name: Checkout SDK repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Checkout SMRT repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,12 +75,12 @@ jobs:
     steps:
       - name: Generate release token
         id: token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app_id: ${{ secrets.HAVE_RELEASE_APP_ID }}
-          private_key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.HAVE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
           token: ${{ steps.token.outputs.token }}
@@ -150,7 +150,7 @@ jobs:
           tar -cf publish-workspace.tar -T publish-workspace-files
       - name: Upload release patch
         if: steps.prepare.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: publish-release-version-patch
           path: release-version.patch
@@ -158,7 +158,7 @@ jobs:
           if-no-files-found: error
       - name: Upload versioned workspace
         if: steps.prepare.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: publish-release-workspace
           path: publish-workspace.tar
@@ -177,9 +177,9 @@ jobs:
         shard: [1, 2]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Download versioned workspace
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: publish-release-workspace
           path: release-workspace
@@ -196,7 +196,7 @@ jobs:
           PUBLISH_PACK_SHARD_INDEX: ${{ matrix.shard }}
           PUBLISH_PACK_OUTPUT_DIR: publish-pack-output
       - name: Upload verified tarballs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: publish-release-pack-${{ matrix.shard }}
           path: publish-pack-output/
@@ -215,31 +215,31 @@ jobs:
     steps:
       - name: Generate release token
         id: token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app_id: ${{ secrets.HAVE_RELEASE_APP_ID }}
-          private_key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.HAVE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
           token: ${{ steps.token.outputs.token }}
       - name: Download release patch
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: publish-release-version-patch
           path: release-patch
       - name: Apply release patch
         run: if [ -s release-patch/release-version.patch ]; then git apply --binary release-patch/release-version.patch; fi
       - name: Download versioned workspace
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: publish-release-workspace
           path: release-workspace
       - name: Extract versioned workspace
         run: tar -xf release-workspace/publish-workspace.tar
       - name: Download verified tarballs
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: publish-release-pack-*
           path: publish-pack-output
@@ -340,14 +340,14 @@ jobs:
     steps:
       - name: Generate release token
         id: token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app_id: ${{ secrets.HAVE_RELEASE_APP_ID }}
-          private_key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.HAVE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
       - name: Checkout SDK repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Checkout SMRT repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: happyvertical/smrt
           path: smrt
@@ -357,7 +357,7 @@ jobs:
         with:
           node-version: '24.18.0'
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           package_json_file: smrt/package.json
           run_install: false
@@ -410,7 +410,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:

--- a/.github/workflows/shared-direct-publish.yml
+++ b/.github/workflows/shared-direct-publish.yml
@@ -86,13 +86,13 @@ jobs:
     steps:
       - name: Generate token from GitHub App
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app_id: ${{ secrets.HAVE_RELEASE_APP_ID }}
-          private_key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.HAVE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
           # Use the release app token for tags, releases, and main-branch sync
@@ -105,7 +105,7 @@ jobs:
           install-deps: 'true'
 
       - name: Configure npm publish registry
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: ${{ inputs.registry-url }}

--- a/.github/workflows/shared-project-sync.yml
+++ b/.github/workflows/shared-project-sync.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: ${{ inputs.repo_owner }}/${{ inputs.repo_name }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       success: ${{ steps.result.outputs.success }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           # Affected validation diffs against the PR base SHA, so that commit must


### PR DESCRIPTION
## Summary

- upgrade every SDK-owned Node 20 JavaScript action to a SHA-pinned Node 24 release
- replace deprecated `tibdex/github-app-token` with GitHub’s maintained `actions/create-github-app-token` v3
- consume the canonical Node 24 ORAS policy pin released by happyvertical/have-config#431
- scope the SMRT sync token explicitly to `happyvertical/smrt` while retaining current-repository scope elsewhere
- use the brokered runner’s verified actionlint installation instead of downloading actionlint during each workflow run

Closes #1197

## Validation

- `pnpm test:ci-scripts`
- `pnpm agent:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- changed-workflow `yamllint` and `actionlint`
- exact action metadata/input compatibility audit (`NODE20_COUNT=0`)
- runner-contract verification for actionlint
- independent code review: CLEAR
- `git diff --check`

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019ff09f-2fcd-7060-ae59-c6731b4446d2","issue":1197,"linked_issue":"https://github.com/happyvertical/sdk/issues/1197","policy_revision":"1.0.0","status":"review","validation":["pnpm test:ci-scripts","pnpm agent:check","pnpm typecheck","pnpm lint","pnpm build","yamllint/actionlint","action metadata compatibility audit: NODE20_COUNT=0","runner-contract actionlint verification","independent review CLEAR","git diff --check"]}
```