### PR TITLE
fix(utils): make environment loading browser safe

### DIFF
--- a/.changeset/fuzzy-mice-smile.md
+++ b/.changeset/fuzzy-mice-smile.md
@@ -1,0 +1,6 @@
+---
+'@happyvertical/logger': patch
+'@happyvertical/utils': patch
+---
+
+Make environment-backed configuration and universal temporary-directory helpers safe when imported in browsers without a Node.js `process` global.

--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -33,6 +33,20 @@ describe('createLogger', () => {
   });
 
   describe('basic functionality', () => {
+    it('should create a logger when process is unavailable in a browser', () => {
+      const nodeProcess = globalThis.process;
+      vi.stubGlobal('process', undefined);
+
+      try {
+        const logger = createLogger(true);
+
+        expect(logger).toBeInstanceOf(ConsoleLogger);
+        expect(() => logger.info('browser log')).not.toThrow();
+      } finally {
+        vi.stubGlobal('process', nodeProcess);
+      }
+    });
+
     it('should create console logger with info level when config is true', () => {
       const logger = createLogger(true);
 

--- a/packages/utils/src/config/env-config.test.ts
+++ b/packages/utils/src/config/env-config.test.ts
@@ -142,6 +142,25 @@ describe('loadEnvConfig', () => {
   });
 
   describe('basic functionality', () => {
+    it('uses user options when process is unavailable in a browser', () => {
+      const nodeProcess = globalThis.process;
+      vi.stubGlobal('process', undefined);
+
+      try {
+        const config = loadEnvConfig(
+          { level: 'warn' },
+          {
+            packageName: 'logger',
+            schema: { level: 'string' },
+          },
+        );
+
+        expect(config).toEqual({ level: 'warn' });
+      } finally {
+        vi.stubGlobal('process', nodeProcess);
+      }
+    });
+
     it('returns user options when no env vars set', () => {
       const config = loadEnvConfig(
         { provider: 'openai' },

--- a/packages/utils/src/config/env-config.ts
+++ b/packages/utils/src/config/env-config.ts
@@ -184,6 +184,8 @@ export function loadEnvConfig<T extends Record<string, any>>(
 
   // Start with user options (highest precedence)
   const config: Record<string, any> = { ...userOptions };
+  const environment =
+    typeof process !== 'undefined' && process.env ? process.env : {};
 
   // Determine which fields to scan for
   const fieldsToScan = allowUnknown
@@ -191,7 +193,7 @@ export function loadEnvConfig<T extends Record<string, any>>(
       new Set([
         ...Object.keys(schema),
         // Also scan environment for any matching vars
-        ...Object.keys(process.env)
+        ...Object.keys(environment)
           .filter((key) => envPrefix && key.startsWith(envPrefix))
           .map((key) => {
             const fieldName = key.slice(envPrefix.length);
@@ -213,7 +215,7 @@ export function loadEnvConfig<T extends Record<string, any>>(
       ? envPrefix + toScreamingSnakeCase(fieldName)
       : fieldName;
 
-    const envValue = process.env[envVarName];
+    const envValue = environment[envVarName];
 
     // Skip if env var not set
     if (envValue === undefined) {

--- a/packages/utils/src/shared/universal.test.ts
+++ b/packages/utils/src/shared/universal.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getTempDirectory } from './universal';
+
+describe('getTempDirectory', () => {
+  it('uses the fallback path when process is unavailable in a browser', () => {
+    const processDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'process',
+    );
+    Reflect.deleteProperty(globalThis, 'process');
+
+    try {
+      expect(getTempDirectory('cache')).toBe('/tmp/.have-sdk/cache');
+    } finally {
+      if (processDescriptor) {
+        Object.defineProperty(globalThis, 'process', processDescriptor);
+      }
+    }
+  });
+});

--- a/packages/utils/src/shared/universal.ts
+++ b/packages/utils/src/shared/universal.ts
@@ -746,9 +746,9 @@ export const addInterval = add;
  */
 export const getTempDirectory = (subfolder?: string): string => {
   // Use Node.js os.tmpdir() or fallback
-  const tmpBase = process?.env
-    ? process.env.TMPDIR || process.env.TMP || process.env.TEMP || '/tmp'
-    : '/tmp';
+  const environment = typeof process !== 'undefined' ? process.env : undefined;
+  const tmpBase =
+    environment?.TMPDIR || environment?.TMP || environment?.TEMP || '/tmp';
 
   const basePath = `${tmpBase}/.have-sdk`;
   return subfolder ? `${basePath}/${subfolder}` : basePath;


### PR DESCRIPTION
## Summary

- guard `loadEnvConfig` environment scanning when browser runtimes do not define Node's `process` global
- audit the browser-exported universal utilities and make `getTempDirectory` use the same safe runtime detection
- add package-level regressions for `loadEnvConfig`, `createLogger`, and an actually absent global binding
- publish patch changes for `@happyvertical/utils` and `@happyvertical/logger`

## Validation

- Node 24.18.0: `@happyvertical/utils` suite, 193/193 passed
- Node 24.18.0: `@happyvertical/logger` suite, 40/40 passed
- built browser-condition smoke with `process` absent: `loadEnvConfig`, `getTempDirectory`, and `createLogger` passed
- emitted browser chunk audit: no executable unguarded `process` references remain
- `pnpm test:ci-scripts`
- `pnpm agent:check`
- `pnpm typecheck`
- `pnpm lint` (green; pre-existing `@happyvertical/json` warnings only)
- `pnpm build`
- independent correctness and test/security reviews: clear

Closes #1096

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-stale-prs-20260812","issue":1096,"linked_issue":"https://github.com/happyvertical/sdk/issues/1096","policy_revision":"1.0.0","status":"review","validation":["Node 24.18.0 utils 193/193","Node 24.18.0 logger 40/40","built browser-condition smoke","emitted browser chunk audit","pnpm test:ci-scripts","pnpm agent:check","pnpm typecheck","pnpm lint","pnpm build","independent correctness/test-security reviews clear"]}
```
