### PR TITLE
feat(ai): add Seevio Seedance video provider

### DIFF
--- a/.changeset/bright-seevio-video.md
+++ b/.changeset/bright-seevio-video.md
@@ -1,0 +1,7 @@
+---
+'@happyvertical/ai': minor
+---
+
+Add the provider-neutral Seevio asynchronous video adapter, pinned to Seedance
+2.5, with multimodal reference media, safe result downloads, and normalized
+credit reservation status.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,6 +1,6 @@
 # @happyvertical/ai
 
-Unified interface for AI model interactions across multiple providers. Supports OpenAI, LiteLLM, Bifrost, Ollama, Anthropic Claude, Google Gemini, AWS Bedrock, Hugging Face, Claude CLI, Qwen3-TTS, and video-generation providers (Gemini Veo, BytePlus ModelArk/Seedance, OpenAI-compatible `/v1/videos` gateways) with a consistent API for chat, completions, embeddings, streaming, function calling, image operations, asynchronous video generation, text-to-speech, and gateway admin provisioning where available.
+Unified interface for AI model interactions across multiple providers. Supports OpenAI, LiteLLM, Bifrost, Ollama, Anthropic Claude, Google Gemini, AWS Bedrock, Hugging Face, Claude CLI, Qwen3-TTS, and video-generation providers (Gemini Veo, BytePlus ModelArk/Seedance, Seevio/Seedance 2.5, OpenAI-compatible `/v1/videos` gateways) with a consistent API for chat, completions, embeddings, streaming, function calling, image operations, asynchronous video generation, text-to-speech, and gateway admin provisioning where available.
 
 ## Installation
 
@@ -106,6 +106,13 @@ const modelark = await getAI({
   apiKey: process.env.MODELARK_API_KEY!, // or ARK_API_KEY
 });
 
+// Seevio / Seedance 2.5 (video generation only)
+const seevio = await getAI({
+  type: 'seevio',
+  apiKey: process.env.SEEVIO_API_KEY!,
+  // Default model is pinned to seedance-2-5.
+});
+
 // OpenAI-compatible /v1/videos gateway (video generation only)
 const video = await getAI({
   type: 'openai-compat-video',
@@ -151,7 +158,8 @@ await ai.cancelVideoGenerationJob(job).catch((error) => {
 ```
 
 Supported providers: `gemini` (Veo, via `@google/genai` long-running operations),
-`byteplus-modelark` (Seedance, raw-HTTP ModelArk task API), and `openai-compat-video`
+`byteplus-modelark` (Seedance, raw-HTTP ModelArk task API), `seevio` (native
+Seedance 2.5 task API), and `openai-compat-video`
 (thin adapter over a `/v1/videos`-shaped REST surface — LiteLLM's Veo passthrough,
 Sora-shaped gateways). Providers without video support throw `NOT_IMPLEMENTED`, and
 `ai.getCapabilities()` reports `videoGeneration: false` for them.
@@ -179,6 +187,56 @@ Gemini/ModelArk, a single-resource probe for `openai-compat-video` since LiteLLM
 list route requires a parameter this generic adapter can't supply). It is not free —
 callers on a hot path must cache the result themselves rather than calling it on every
 iteration.
+
+### Seevio / Seedance 2.5
+
+`seevio` is an independent adapter, not a ModelArk compatibility mode. It pins
+generation to `seedance-2-5`, which supports 4–30 second 480p/720p video,
+native audio, adaptive aspect ratio, first/last-frame image-to-video, and up
+to 50 multimodal reference assets. It rejects floating or alternate model IDs
+so an application does not silently move to a different billed model.
+
+Use the generic `referenceMedia` extension for public HTTPS image, video, and
+audio URLs. Existing `referenceImages` remains available; Seevio accepts it
+only when every value is a public HTTPS URL because its API retrieves media
+directly and has no upload endpoint. Buffers and data URLs are intentionally
+rejected. One or two image-only references select first/last-frame
+image-to-video; otherwise media references select reference-to-video.
+
+```typescript
+const job = await seevio.submitVideoGenerationJob({
+  prompt: 'Use the product image and camera movement reference',
+  durationSeconds: 8,
+  resolution: '720p',
+  aspectRatio: 'adaptive',
+  generateAudio: true,
+  referenceMedia: [
+    { type: 'image', url: 'https://assets.example.com/product.jpg' },
+    { type: 'video', url: 'https://assets.example.com/motion.mp4', durationSeconds: 4 },
+  ],
+});
+```
+
+Seevio reserves credits on submission. The serialized job handle preserves the
+reserved credit metadata; status results expose normalized `billing` data and
+result URL expiry metadata. Submit transport failures are never retried because
+Seevio documents no idempotency key. Polling is enforced at no more than once
+per task every 10 seconds. Seevio does not document task cancellation, so
+`cancelVideoGenerationJob` explicitly throws `NOT_IMPLEMENTED`.
+
+Generated URLs are accepted only from `https://cdn.seevio.ai` by default (or
+from `resultUrlOrigins` you explicitly review); `fetchVideoGenerationResult`
+checks every redirect against that allow-list before downloading bytes. The
+unbilled access check is a random `GET /v1/tasks/:id`: an authenticated 404 is
+considered valid access, while 401, 403, 402, and 429 retain distinct errors.
+
+`fetchVideoGenerationResult` limits downloads to 200 MiB by default (override
+with `maxResultBytes`), verifies a `video/*` response type, and enforces the
+provider timeout while streaming—before buffering the result. For a Node
+deployment behind an HTTPS proxy, enable Node's environment-proxy support
+before startup (for example `NODE_USE_ENV_PROXY=1` or `node --use-env-proxy`
+on supported Node releases); this adapter uses standard `fetch` and does not
+silently configure a proxy dispatcher.
 
 ## Gateway Admin
 

--- a/packages/ai/src/node/factory.ts
+++ b/packages/ai/src/node/factory.ts
@@ -20,6 +20,7 @@ import type {
   OllamaOptions,
   OpenAICompatVideoOptions,
   OpenAIOptions,
+  SeevioOptions,
 } from '../shared/types';
 import { AI_PROVIDER_TYPES } from '../shared/types';
 
@@ -45,12 +46,13 @@ export { getAI } from '../shared/factory';
  * - AWS_* → AWS Bedrock credentials
  * - OPENAI_COMPAT_VIDEO_BASE_URL / OPENAI_COMPAT_VIDEO_API_KEY → openai-compat-video gateway config (checked last)
  * - MODELARK_API_KEY / ARK_API_KEY / MODELARK_BASE_URL → BytePlus ModelArk (Seedance) config (checked last)
+ * - SEEVIO_API_KEY / SEEVIO_BASE_URL → Seevio Seedance config (checked last)
  *
  * The two video-only provider types above are intentionally checked *after*
  * every general-purpose provider: they throw `NOT_IMPLEMENTED` for chat()
  * and everything else, so their env signals must never hijack a bare
  * `getAIAuto()` call away from a general-purpose provider. Prefer explicit
- * `type: 'byteplus-modelark'` / `type: 'openai-compat-video'` when you want
+ * `type: 'byteplus-modelark'` / `type: 'openai-compat-video'` / `type: 'seevio'` when you want
  * one of these on purpose.
  *
  * @param options - Configuration options that may contain provider-specific credentials
@@ -120,6 +122,14 @@ export async function getAIAuto(
         apiKey: config.apiKey || process.env.OPENAI_COMPAT_VIDEO_API_KEY,
         baseUrl: config.baseUrl || process.env.OPENAI_COMPAT_VIDEO_BASE_URL,
       } as OpenAICompatVideoOptions);
+    }
+
+    if (config.type === 'seevio') {
+      return getAIUniversal({
+        ...config,
+        apiKey: config.apiKey || process.env.SEEVIO_API_KEY,
+        baseUrl: config.baseUrl || process.env.SEEVIO_BASE_URL,
+      } as SeevioOptions);
     }
 
     if (config.type === 'bifrost') {
@@ -292,6 +302,9 @@ export async function getAIAuto(
   const hasOpenAICompatVideoSignal = Boolean(
     process.env.OPENAI_COMPAT_VIDEO_BASE_URL,
   );
+  const hasSeevioSignal = Boolean(
+    process.env.SEEVIO_API_KEY || process.env.SEEVIO_BASE_URL,
+  );
 
   if (hasModelArkSignal && !config.type) {
     return getAIUniversal({
@@ -312,6 +325,15 @@ export async function getAIAuto(
       apiKey: config.apiKey || process.env.OPENAI_COMPAT_VIDEO_API_KEY,
       baseUrl: config.baseUrl || process.env.OPENAI_COMPAT_VIDEO_BASE_URL,
     } as OpenAICompatVideoOptions);
+  }
+
+  if (hasSeevioSignal && !config.type) {
+    return getAIUniversal({
+      ...config,
+      type: 'seevio',
+      apiKey: config.apiKey || process.env.SEEVIO_API_KEY,
+      baseUrl: config.baseUrl || process.env.SEEVIO_BASE_URL,
+    } as SeevioOptions);
   }
 
   throw new ValidationError(
@@ -341,6 +363,8 @@ export async function getAIAuto(
         'MODELARK_API_KEY',
         'ARK_API_KEY',
         'MODELARK_BASE_URL',
+        'SEEVIO_API_KEY',
+        'SEEVIO_BASE_URL',
       ],
     },
   );

--- a/packages/ai/src/shared/factory.ts
+++ b/packages/ai/src/shared/factory.ts
@@ -24,6 +24,7 @@ import type {
   OpenAICompatVideoOptions,
   OpenAIOptions,
   Qwen3TTSOptions,
+  SeevioOptions,
 } from './types';
 import { AI_PROVIDER_TYPES } from './types';
 
@@ -163,6 +164,13 @@ function isByteplusModelArkOptions(
   return options.type === 'byteplus-modelark';
 }
 
+/** Checks if options select Seevio's native Seedance task API. */
+function isSeevioOptions(
+  options: GetAIOptions | AIClientOptions,
+): options is SeevioOptions {
+  return options.type === 'seevio';
+}
+
 /**
  * Creates an AI provider instance based on the provided options.
  * Universal version that works in both browser and Node.js environments.
@@ -287,6 +295,9 @@ export async function getAI(
       './providers/byteplus-modelark.js'
     );
     client = new ByteplusModelArkProvider(options);
+  } else if (isSeevioOptions(options)) {
+    const { SeevioProvider } = await import('./providers/seevio.js');
+    client = new SeevioProvider(options);
   } else {
     throw new ValidationError('Unsupported AI provider type', {
       supportedTypes: [...AI_PROVIDER_TYPES],

--- a/packages/ai/src/shared/providers/seevio.ts
+++ b/packages/ai/src/shared/providers/seevio.ts
@@ -246,6 +246,10 @@ export class SeevioProvider implements AIInterface {
     }, timeoutMs);
     const abort = () => controller.abort(options.signal?.reason);
     options.signal?.addEventListener('abort', abort, { once: true });
+    // An abort may occur between the preflight check and listener
+    // registration. Re-check after registration so that race still reaches
+    // the fetch signal rather than allowing a paid request to continue.
+    if (options.signal?.aborted) abort();
     try {
       let response: Response;
       try {

--- a/packages/ai/src/shared/providers/seevio.ts
+++ b/packages/ai/src/shared/providers/seevio.ts
@@ -366,8 +366,8 @@ export class SeevioProvider implements AIInterface {
             'SEEVIO_RESULT_DOWNLOAD_FAILED',
             'seevio',
           );
-        const contentType = response.headers.get('content-type') || 'video/mp4';
-        if (!contentType.toLowerCase().startsWith('video/'))
+        const contentType = response.headers.get('content-type');
+        if (!contentType?.toLowerCase().startsWith('video/'))
           throw new AIError(
             `Seevio result download returned non-video content type ${contentType}`,
             'SEEVIO_RESULT_MIME_INVALID',
@@ -491,11 +491,12 @@ export class SeevioProvider implements AIInterface {
     ] as const) {
       const durations = references
         .filter((reference) => reference.type === type)
-        .map((reference) => reference.durationSeconds);
-      if (
-        durations.every((duration) => duration !== undefined) &&
-        durations.reduce((total, duration) => total + (duration ?? 0), 0) > 30
-      ) {
+        .flatMap((reference) =>
+          reference.durationSeconds === undefined
+            ? []
+            : [reference.durationSeconds],
+        );
+      if (durations.reduce((total, duration) => total + duration, 0) > 30) {
         throw new ValidationError(
           `Seevio ${label} reference durations must total no more than 30 seconds`,
           { provider: 'seevio' },
@@ -507,6 +508,9 @@ export class SeevioProvider implements AIInterface {
 
   private async pollTask(jobId: string): Promise<SeevioTask> {
     const now = Date.now();
+    for (const [knownJobId, expiry] of this.nextPollAt) {
+      if (expiry <= now) this.nextPollAt.delete(knownJobId);
+    }
     const next = this.nextPollAt.get(jobId);
     if (next && now < next)
       throw new AIError(
@@ -514,7 +518,14 @@ export class SeevioProvider implements AIInterface {
         'VIDEO_POLL_TOO_FREQUENT',
         'seevio',
       );
-    this.nextPollAt.set(jobId, now + MIN_POLL_INTERVAL_MS);
+    const expiry = now + MIN_POLL_INTERVAL_MS;
+    this.nextPollAt.set(jobId, expiry);
+    const cleanup = setTimeout(() => {
+      if (this.nextPollAt.get(jobId) === expiry) this.nextPollAt.delete(jobId);
+    }, MIN_POLL_INTERVAL_MS);
+    // Let idle Node workers exit rather than keeping the process alive for a
+    // cadence cleanup timer. Browser timer handles do not expose `unref`.
+    if (typeof cleanup === 'object' && 'unref' in cleanup) cleanup.unref();
     const task = await this.request<SeevioTask>(
       `/v1/tasks/${encodeURIComponent(jobId)}`,
     );

--- a/packages/ai/src/shared/providers/seevio.ts
+++ b/packages/ai/src/shared/providers/seevio.ts
@@ -1,0 +1,895 @@
+/**
+ * Seevio's native asynchronous Seedance 2.5 video-generation provider.
+ *
+ * Seevio is deliberately implemented as its own raw-HTTP adapter rather than
+ * being shaped to ModelArk. Both services can run Seedance, but their task,
+ * billing, and media contracts differ.
+ *
+ * @see https://seevio.ai/api-docs
+ */
+
+import { ValidationError } from '@happyvertical/utils';
+import { extractRetryAfterSeconds } from '../rate-limit';
+import { normalizeBaseAIOptions } from '../safety';
+import type {
+  AICapabilities,
+  AIInterface,
+  AIMessage,
+  AIModel,
+  AIResponse,
+  ChatOptions,
+  CompletionOptions,
+  EmbeddingOptions,
+  EmbeddingResponse,
+  ImageDescriptionOptions,
+  ImageEmbeddingOptions,
+  ImageGenerationOptions,
+  ImageGenerationResponse,
+  MessageOptions,
+  SeevioOptions,
+  TTSOptions,
+  TTSResponse,
+  VideoGenerationBillingMetadata,
+  VideoGenerationJob,
+  VideoGenerationOptions,
+  VideoGenerationReferenceMedia,
+  VideoGenerationResult,
+  VideoGenerationStatusResult,
+  Voice,
+  VoiceCloneOptions,
+  VoiceDesignOptions,
+  VoiceListOptions,
+} from '../types';
+import { AIError, AuthenticationError, RateLimitError } from '../types';
+import { emitUsage } from './usage';
+
+const DEFAULT_BASE_URL = 'https://api.seevio.ai';
+const DEFAULT_RESULT_ORIGIN = 'https://cdn.seevio.ai';
+const MODEL = 'seedance-2-5';
+const MIN_POLL_INTERVAL_MS = 10_000;
+const MAX_REDIRECTS = 5;
+const DEFAULT_MAX_RESULT_BYTES = 200 * 1024 * 1024;
+const COMPLETED_SNAPSHOT_TTL_MS = MIN_POLL_INTERVAL_MS;
+const MAX_COMPLETED_SNAPSHOTS = 128;
+
+interface SeevioTask {
+  id: string;
+  status: string;
+  model?: string;
+  billing_status?: string;
+  credits?: number;
+  failed_reason?: string | null;
+  data?: {
+    results?: string[];
+    video_expires_at?: string;
+    last_frame_url?: string | null;
+    processing_time?: number;
+  };
+}
+
+interface SeevioErrorResponse {
+  error?: {
+    code?: string;
+    message?: string;
+    required?: number;
+    available?: number;
+  };
+}
+
+interface SeevioCreateResponse {
+  taskId: string;
+  credits?: number;
+}
+
+interface SeevioInput {
+  prompt: string;
+  generation_type: 'text-to-video' | 'image-to-video' | 'reference-to-video';
+  image_urls?: string[];
+  video_urls?: string[];
+  audio_urls?: string[];
+  duration: number;
+  aspect_ratio: 'adaptive' | '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | '21:9';
+  resolution: '480p' | '720p';
+  generate_audio: boolean;
+  return_last_frame: boolean;
+}
+
+function ensureOptions(options: SeevioOptions): SeevioOptions {
+  const baseUrl = (options.baseUrl || DEFAULT_BASE_URL)
+    .trim()
+    .replace(/\/+$/, '');
+  const parsedBaseUrl = new URL(baseUrl);
+  if (parsedBaseUrl.protocol !== 'https:') {
+    throw new ValidationError('seevio baseUrl must use HTTPS', {
+      provider: 'seevio',
+    });
+  }
+  const origins = options.resultUrlOrigins?.length
+    ? options.resultUrlOrigins
+    : [DEFAULT_RESULT_ORIGIN];
+  for (const origin of origins) {
+    const parsed = new URL(origin);
+    if (
+      parsed.protocol !== 'https:' ||
+      parsed.origin !== origin.replace(/\/+$/, '')
+    ) {
+      throw new ValidationError(
+        'seevio resultUrlOrigins must contain HTTPS origins only',
+        {
+          provider: 'seevio',
+        },
+      );
+    }
+  }
+  if (
+    options.maxResultBytes !== undefined &&
+    (!Number.isSafeInteger(options.maxResultBytes) ||
+      options.maxResultBytes <= 0)
+  ) {
+    throw new ValidationError(
+      'seevio maxResultBytes must be a positive safe integer',
+      { provider: 'seevio' },
+    );
+  }
+  return {
+    ...options,
+    baseUrl,
+    resultUrlOrigins: origins.map((origin) => origin.replace(/\/+$/, '')),
+  };
+}
+
+function validatedHttpsUrl(value: string, label: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new ValidationError(`${label} must be a valid public HTTPS URL`, {
+      provider: 'seevio',
+    });
+  }
+  if (url.protocol !== 'https:') {
+    throw new ValidationError(`${label} must use HTTPS`, {
+      provider: 'seevio',
+    });
+  }
+  const host = url.hostname.toLowerCase();
+  if (
+    url.username ||
+    url.password ||
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.includes(':') ||
+    /^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)
+  ) {
+    throw new ValidationError(
+      `${label} must not use credentials, localhost, or an IP-literal host`,
+      { provider: 'seevio' },
+    );
+  }
+  return url.toString();
+}
+
+function normalizeBilling(
+  task: SeevioTask,
+): VideoGenerationBillingMetadata | undefined {
+  if (task.credits === undefined && !task.billing_status) return undefined;
+  const normalized = [
+    'reserved',
+    'charged',
+    'refunded',
+    'refund_failed',
+  ].includes(task.billing_status || '')
+    ? (task.billing_status as VideoGenerationBillingMetadata['status'])
+    : undefined;
+  return {
+    ...(task.credits !== undefined ? { credits: task.credits } : {}),
+    ...(normalized ? { status: normalized } : {}),
+    ...(!normalized && task.billing_status
+      ? { rawStatus: task.billing_status }
+      : {}),
+  };
+}
+
+/** Native Seevio adapter for the pinned `seedance-2-5` model. */
+export class SeevioProvider implements AIInterface {
+  private readonly options: SeevioOptions;
+  private readonly resultOrigins: Set<string>;
+  private readonly nextPollAt = new Map<string, number>();
+  private readonly completedSnapshots = new Map<
+    string,
+    { task: SeevioTask; recordedAt: number }
+  >();
+
+  /** Creates a Seevio task client using the documented HTTPS API root. */
+  constructor(options: SeevioOptions) {
+    this.options = normalizeBaseAIOptions(ensureOptions(options));
+    this.resultOrigins = new Set(this.options.resultUrlOrigins);
+  }
+
+  private async request<T>(
+    path: string,
+    options: {
+      method?: 'GET' | 'POST';
+      body?: unknown;
+      signal?: AbortSignal;
+      timeout?: number;
+      allowNotFound?: boolean;
+    } = {},
+  ): Promise<T> {
+    const response = await this.rawRequest(path, options);
+    const text = await response.text();
+    return text ? (JSON.parse(text) as T) : ({} as T);
+  }
+
+  private async rawRequest(
+    path: string,
+    options: {
+      method?: 'GET' | 'POST';
+      body?: unknown;
+      signal?: AbortSignal;
+      timeout?: number;
+      allowNotFound?: boolean;
+    } = {},
+  ): Promise<Response> {
+    if (options.signal?.aborted)
+      throw new AIError(
+        'Seevio request aborted by caller',
+        'AI_ABORTED',
+        'seevio',
+      );
+    const controller = new AbortController();
+    const timeoutMs = options.timeout ?? this.options.timeout;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+    const abort = () => controller.abort(options.signal?.reason);
+    options.signal?.addEventListener('abort', abort, { once: true });
+    try {
+      let response: Response;
+      try {
+        response = await fetch(`${this.options.baseUrl}${path}`, {
+          method: options.method || 'GET',
+          headers: {
+            Authorization: `Bearer ${this.options.apiKey ?? ''}`,
+            ...(options.body !== undefined
+              ? { 'Content-Type': 'application/json' }
+              : {}),
+            ...(this.options.headers || {}),
+          },
+          body:
+            options.body === undefined
+              ? undefined
+              : JSON.stringify(options.body),
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (timedOut)
+          throw new AIError(
+            `Seevio request to ${path} timed out after ${timeoutMs}ms`,
+            'AI_TIMEOUT',
+            'seevio',
+            undefined,
+            options.method !== 'POST',
+          );
+        if (options.signal?.aborted)
+          throw new AIError(
+            'Seevio request aborted by caller',
+            'AI_ABORTED',
+            'seevio',
+          );
+        throw new AIError(
+          `Network error calling Seevio ${path}: ${error instanceof Error ? error.message : String(error)}`,
+          'NETWORK_ERROR',
+          'seevio',
+          undefined,
+          options.method !== 'POST',
+        );
+      }
+      if (response.status === 404 && options.allowNotFound) return response;
+      if (response.ok) return response;
+      const errorText = await response.text();
+      let payload: SeevioErrorResponse = {};
+      try {
+        payload = JSON.parse(errorText) as SeevioErrorResponse;
+      } catch {
+        /* preserve status fallback below */
+      }
+      const message =
+        payload.error?.message ||
+        `Seevio request to ${path} failed with HTTP ${response.status}`;
+      if (response.status === 401) throw new AuthenticationError('seevio');
+      if (response.status === 403)
+        throw new AIError(message, 'SEEVIO_FORBIDDEN', 'seevio');
+      if (response.status === 402)
+        throw new AIError(message, 'INSUFFICIENT_CREDITS', 'seevio');
+      if (response.status === 429)
+        throw new RateLimitError(
+          'seevio',
+          extractRetryAfterSeconds({ headers: response.headers }),
+        );
+      throw new AIError(
+        message,
+        'SEEVIO_REQUEST_FAILED',
+        'seevio',
+        undefined,
+        response.status >= 500 && options.method !== 'POST',
+      );
+    } finally {
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', abort);
+    }
+  }
+
+  private assertReviewedResultUrl(value: string): string {
+    const url = validatedHttpsUrl(value, 'Seevio result URL');
+    if (!this.resultOrigins.has(new URL(url).origin)) {
+      throw new AIError(
+        'Seevio returned a result URL outside configured reviewed origins',
+        'UNTRUSTED_RESULT_URL',
+        'seevio',
+      );
+    }
+    return url;
+  }
+
+  private async downloadReviewedResult(
+    initialUrl: string,
+  ): Promise<{ data: Buffer; mimeType: string; url: string }> {
+    let current = this.assertReviewedResultUrl(initialUrl);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.options.timeout);
+    const maxBytes = this.options.maxResultBytes ?? DEFAULT_MAX_RESULT_BYTES;
+    try {
+      for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+        const response = await fetch(current, {
+          redirect: 'manual',
+          signal: controller.signal,
+        });
+        if (response.status >= 300 && response.status < 400) {
+          const location = response.headers.get('location');
+          if (!location)
+            throw new AIError(
+              'Seevio result redirect omitted Location',
+              'SEEVIO_RESULT_DOWNLOAD_FAILED',
+              'seevio',
+            );
+          current = this.assertReviewedResultUrl(
+            new URL(location, current).toString(),
+          );
+          continue;
+        }
+        if (!response.ok)
+          throw new AIError(
+            `Seevio result download failed with HTTP ${response.status}`,
+            'SEEVIO_RESULT_DOWNLOAD_FAILED',
+            'seevio',
+          );
+        const contentType = response.headers.get('content-type') || 'video/mp4';
+        if (!contentType.toLowerCase().startsWith('video/'))
+          throw new AIError(
+            `Seevio result download returned non-video content type ${contentType}`,
+            'SEEVIO_RESULT_MIME_INVALID',
+            'seevio',
+          );
+        const contentLength = response.headers.get('content-length');
+        if (contentLength && Number(contentLength) > maxBytes)
+          throw new AIError(
+            `Seevio result exceeds configured ${maxBytes}-byte download limit`,
+            'SEEVIO_RESULT_TOO_LARGE',
+            'seevio',
+          );
+        if (!response.body)
+          throw new AIError(
+            'Seevio result download had no response body',
+            'SEEVIO_RESULT_DOWNLOAD_FAILED',
+            'seevio',
+          );
+        const chunks: Uint8Array[] = [];
+        let size = 0;
+        const reader = response.body.getReader();
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          size += value.byteLength;
+          if (size > maxBytes) {
+            await reader.cancel();
+            throw new AIError(
+              `Seevio result exceeds configured ${maxBytes}-byte download limit`,
+              'SEEVIO_RESULT_TOO_LARGE',
+              'seevio',
+            );
+          }
+          chunks.push(value);
+        }
+        return {
+          data: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))),
+          mimeType: contentType,
+          url: current,
+        };
+      }
+      throw new AIError(
+        'Seevio result exceeded the maximum redirect count',
+        'SEEVIO_RESULT_DOWNLOAD_FAILED',
+        'seevio',
+      );
+    } catch (error) {
+      if (controller.signal.aborted)
+        throw new AIError(
+          `Seevio result download timed out after ${this.options.timeout}ms`,
+          'AI_TIMEOUT',
+          'seevio',
+          undefined,
+          true,
+        );
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private mediaUrls(options: VideoGenerationOptions): {
+    images: string[];
+    videos: string[];
+    audio: string[];
+  } {
+    const images = (options.referenceImages ?? []).map((reference) => {
+      if (
+        typeof reference.image !== 'string' ||
+        reference.image.startsWith('data:')
+      ) {
+        throw new ValidationError(
+          'Seevio referenceImages must be public HTTPS URLs; it cannot retrieve bytes or data URLs',
+          { provider: 'seevio' },
+        );
+      }
+      return validatedHttpsUrl(reference.image, 'Seevio reference image');
+    });
+    const references = options.referenceMedia ?? [];
+    if (references.length + images.length > 50)
+      throw new ValidationError(
+        'Seevio accepts at most 50 total reference assets',
+        { provider: 'seevio' },
+      );
+    const collect = (type: VideoGenerationReferenceMedia['type']) =>
+      references
+        .filter((reference) => reference.type === type)
+        .map((reference) =>
+          validatedHttpsUrl(reference.url, `Seevio ${type} reference`),
+        );
+    const mediaImages = collect('image');
+    const videos = collect('video');
+    const audio = collect('audio');
+    if (
+      images.length + mediaImages.length > 30 ||
+      videos.length > 10 ||
+      audio.length > 10
+    ) {
+      throw new ValidationError(
+        'Seevio reference limits are 30 images, 10 videos, and 10 audio files',
+        { provider: 'seevio' },
+      );
+    }
+    for (const reference of references) {
+      if (
+        (reference.type === 'video' || reference.type === 'audio') &&
+        reference.durationSeconds !== undefined &&
+        (!Number.isFinite(reference.durationSeconds) ||
+          reference.durationSeconds < 2 ||
+          reference.durationSeconds > 30)
+      ) {
+        throw new ValidationError(
+          'Seevio video/audio reference durations must be 2-30 seconds when supplied',
+          { provider: 'seevio' },
+        );
+      }
+    }
+    for (const [label, type] of [
+      ['video', 'video'],
+      ['audio', 'audio'],
+    ] as const) {
+      const durations = references
+        .filter((reference) => reference.type === type)
+        .map((reference) => reference.durationSeconds);
+      if (
+        durations.every((duration) => duration !== undefined) &&
+        durations.reduce((total, duration) => total + (duration ?? 0), 0) > 30
+      ) {
+        throw new ValidationError(
+          `Seevio ${label} reference durations must total no more than 30 seconds`,
+          { provider: 'seevio' },
+        );
+      }
+    }
+    return { images: [...images, ...mediaImages], videos, audio };
+  }
+
+  private async pollTask(jobId: string): Promise<SeevioTask> {
+    const now = Date.now();
+    const next = this.nextPollAt.get(jobId);
+    if (next && now < next)
+      throw new AIError(
+        `Seevio tasks may be polled no more than once every 10 seconds; retry after ${Math.ceil((next - now) / 1000)} seconds`,
+        'VIDEO_POLL_TOO_FREQUENT',
+        'seevio',
+      );
+    this.nextPollAt.set(jobId, now + MIN_POLL_INTERVAL_MS);
+    const task = await this.request<SeevioTask>(
+      `/v1/tasks/${encodeURIComponent(jobId)}`,
+    );
+    if (task.status === 'completed') {
+      // This is a bounded, short-lived handoff cache, not task history. A
+      // completed task can be fetched without another status request only
+      // within the provider's ten-second cadence window.
+      if (!this.completedSnapshots.has(jobId)) {
+        const oldestJobId = this.completedSnapshots.keys().next().value;
+        if (
+          this.completedSnapshots.size >= MAX_COMPLETED_SNAPSHOTS &&
+          oldestJobId !== undefined
+        ) {
+          this.completedSnapshots.delete(oldestJobId);
+        }
+      }
+      this.completedSnapshots.set(jobId, { task, recordedAt: Date.now() });
+    }
+    return task;
+  }
+
+  private completedSnapshot(jobId: string): SeevioTask | undefined {
+    const snapshot = this.completedSnapshots.get(jobId);
+    if (!snapshot) return undefined;
+    if (Date.now() - snapshot.recordedAt >= COMPLETED_SNAPSHOT_TTL_MS) {
+      this.completedSnapshots.delete(jobId);
+      return undefined;
+    }
+    return snapshot.task;
+  }
+
+  /** Submits one unambiguous, non-retried Seedance 2.5 task. */
+  async submitVideoGenerationJob(
+    options: VideoGenerationOptions,
+  ): Promise<VideoGenerationJob> {
+    const startTime = Date.now();
+    const model = options.model || this.options.defaultModel || MODEL;
+    if (model !== MODEL)
+      throw new ValidationError(
+        `Seevio provider supports the pinned model ${MODEL}`,
+        { provider: 'seevio' },
+      );
+    if (!options.prompt?.trim())
+      throw new ValidationError('Seevio requires a non-empty prompt', {
+        provider: 'seevio',
+      });
+    if (options.seed !== undefined)
+      throw new ValidationError(
+        'seed is not supported by Seevio Seedance 2.5',
+        { provider: 'seevio' },
+      );
+    const duration = options.durationSeconds ?? 5;
+    if (!Number.isInteger(duration) || duration < 4 || duration > 30)
+      throw new ValidationError(
+        'Seevio durationSeconds must be an integer from 4 through 30',
+        { provider: 'seevio' },
+      );
+    const resolution = options.resolution ?? '720p';
+    if (resolution !== '480p' && resolution !== '720p')
+      throw new ValidationError('Seevio resolution must be 480p or 720p', {
+        provider: 'seevio',
+      });
+    const { images, videos, audio } = this.mediaUrls(options);
+    const isImageToVideo =
+      images.length >= 1 &&
+      images.length <= 2 &&
+      videos.length === 0 &&
+      audio.length === 0;
+    const generationType = isImageToVideo
+      ? 'image-to-video'
+      : images.length || videos.length || audio.length
+        ? 'reference-to-video'
+        : 'text-to-video';
+    const aspectRatio = options.aspectRatio ?? 'adaptive';
+    const supportedRatios: SeevioInput['aspect_ratio'][] = [
+      'adaptive',
+      '16:9',
+      '9:16',
+      '1:1',
+      '4:3',
+      '3:4',
+      '21:9',
+    ];
+    if (!supportedRatios.includes(aspectRatio as SeevioInput['aspect_ratio']))
+      throw new ValidationError('Unsupported Seevio aspectRatio', {
+        provider: 'seevio',
+      });
+    if (isImageToVideo && aspectRatio !== 'adaptive')
+      throw new ValidationError(
+        'Seevio image-to-video requires aspectRatio: adaptive',
+        { provider: 'seevio' },
+      );
+    const input: SeevioInput = {
+      prompt: options.prompt.trim(),
+      generation_type: generationType,
+      duration,
+      aspect_ratio: aspectRatio as SeevioInput['aspect_ratio'],
+      resolution: resolution as '480p' | '720p',
+      generate_audio: options.generateAudio ?? true,
+      return_last_frame: options.returnLastFrame ?? false,
+      ...(images.length ? { image_urls: images } : {}),
+      ...(videos.length ? { video_urls: videos } : {}),
+      ...(audio.length ? { audio_urls: audio } : {}),
+    };
+    const created = await this.request<SeevioCreateResponse>(
+      '/v1/videos/generations',
+      {
+        method: 'POST',
+        body: { model: MODEL, input },
+        signal: options.signal,
+        timeout: options.timeout,
+      },
+    );
+    if (!created.taskId)
+      throw new AIError(
+        'Seevio accepted submission without a taskId',
+        'SEEVIO_INVALID_RESPONSE',
+        'seevio',
+      );
+    emitUsage(
+      this.options,
+      'seevio',
+      'submitVideoGenerationJob',
+      MODEL,
+      undefined,
+      startTime,
+      {
+        durationSeconds: String(duration),
+        resolution,
+        aspectRatio,
+        ...options.usageTags,
+      },
+    );
+    return {
+      jobId: created.taskId,
+      provider: 'seevio',
+      model: MODEL,
+      createdAt: new Date().toISOString(),
+      raw:
+        created.credits === undefined
+          ? undefined
+          : { credits: created.credits, billingStatus: 'reserved' },
+    };
+  }
+
+  /** Returns a normalized task snapshot, enforcing Seevio's 10-second poll cadence. */
+  async getVideoGenerationJob(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationStatusResult> {
+    return this.mapTask(await this.pollTask(handle.jobId));
+  }
+
+  /** Downloads a completed video while validating the initial URL and every redirect. */
+  async fetchVideoGenerationResult(
+    handle: VideoGenerationJob,
+  ): Promise<VideoGenerationResult> {
+    const task =
+      this.completedSnapshot(handle.jobId) ??
+      (await this.pollTask(handle.jobId));
+    const status = this.mapTask(task);
+    if (status.status !== 'succeeded' || !status.result?.url)
+      throw new AIError(
+        `Seevio job ${handle.jobId} has not succeeded (status: ${status.status})`,
+        'VIDEO_JOB_NOT_READY',
+        'seevio',
+        handle.model,
+      );
+    try {
+      const downloaded = await this.downloadReviewedResult(status.result.url);
+      return { ...status.result, ...downloaded };
+    } finally {
+      // The handoff cache exists only to make an immediate status → fetch
+      // flow cadence-safe. Do not retain expired signed URLs after any fetch
+      // attempt; a later fetch will authenticate a fresh task snapshot.
+      this.completedSnapshots.delete(handle.jobId);
+    }
+  }
+
+  /** Reports cancellation as unsupported because Seevio documents no cancellation endpoint. */
+  async cancelVideoGenerationJob(_handle: VideoGenerationJob): Promise<void> {
+    throw new AIError(
+      'Seevio does not document a video-task cancellation endpoint',
+      'NOT_IMPLEMENTED',
+      'seevio',
+    );
+  }
+
+  /** Performs an unbilled random task-id probe; an authenticated 404 is valid access. */
+  async validateVideoGenerationAccess(): Promise<boolean> {
+    const response = await this.rawRequest(
+      `/v1/tasks/have-ai-access-probe-${crypto.randomUUID()}`,
+      { allowNotFound: true },
+    );
+    return response.ok || response.status === 404;
+  }
+
+  private mapTask(task: SeevioTask): VideoGenerationStatusResult {
+    const billing = normalizeBilling(task);
+    if (task.status === 'queued')
+      return { status: 'queued', ...(billing ? { billing } : {}) };
+    if (task.status === 'generating')
+      return { status: 'running', ...(billing ? { billing } : {}) };
+    if (task.status === 'failed')
+      return {
+        status: 'failed',
+        error: task.failed_reason || 'Seevio video generation failed',
+        ...(billing ? { billing } : {}),
+      };
+    if (task.status !== 'completed')
+      return {
+        status: 'running',
+        rawStatus: task.status,
+        ...(billing ? { billing } : {}),
+      };
+    const url = task.data?.results?.[0];
+    if (!url)
+      return {
+        status: 'failed',
+        error: 'Seevio reported completion with no result URL',
+        ...(billing ? { billing } : {}),
+      };
+    const result: VideoGenerationResult = {
+      url: this.assertReviewedResultUrl(url),
+      mimeType: 'video/mp4',
+      ...(task.data?.video_expires_at
+        ? { expiresAt: task.data.video_expires_at }
+        : {}),
+      ...(task.data?.last_frame_url
+        ? {
+            lastFrameUrl: this.assertReviewedResultUrl(
+              task.data.last_frame_url,
+            ),
+          }
+        : {}),
+    };
+    return { status: 'succeeded', result, ...(billing ? { billing } : {}) };
+  }
+
+  /** Lists the single intentional Seevio model selection. */
+  async getModels(): Promise<AIModel[]> {
+    return [
+      {
+        id: MODEL,
+        name: 'Seedance 2.5',
+        description: 'Seevio Seedance 2.5 async video generation',
+        contextLength: 0,
+        capabilities: ['video_generation'],
+        supportsFunctions: false,
+        supportsVision: true,
+      },
+    ];
+  }
+  /** Reports Seevio's video-only capability surface. */
+  async getCapabilities(): Promise<AICapabilities> {
+    return {
+      chat: false,
+      completion: false,
+      embeddings: false,
+      streaming: false,
+      functions: false,
+      vision: false,
+      fineTuning: false,
+      imageEmbeddings: false,
+      imageGeneration: false,
+      videoGeneration: true,
+      tts: false,
+      voiceCloning: false,
+      voiceDesign: false,
+      maxContextLength: 0,
+      supportedOperations: [
+        'submitVideoGenerationJob',
+        'getVideoGenerationJob',
+        'fetchVideoGenerationResult',
+      ],
+    };
+  }
+
+  private unsupported(): never {
+    throw new AIError(
+      'This operation is not supported by the Seevio video-only provider.',
+      'NOT_IMPLEMENTED',
+      'seevio',
+    );
+  }
+  /** @inheritdoc */ async chat(
+    _messages: AIMessage[],
+    _options?: ChatOptions,
+  ): Promise<AIResponse> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async complete(
+    _prompt: string,
+    _options?: CompletionOptions,
+  ): Promise<AIResponse> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async message(
+    _text: string,
+    _options?: MessageOptions,
+  ): Promise<string> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async embed(
+    _text: string | string[],
+    _options?: EmbeddingOptions,
+  ): Promise<EmbeddingResponse> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async embedImage(
+    _image: string | Buffer,
+    _options?: ImageEmbeddingOptions,
+  ): Promise<EmbeddingResponse> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async describeImage(
+    _image: string | Buffer,
+    _prompt?: string,
+    _options?: ImageDescriptionOptions,
+  ): Promise<string> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async generateImage(
+    _prompt: string,
+    _options?: ImageGenerationOptions,
+  ): Promise<ImageGenerationResponse> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ stream(
+    _messages: AIMessage[],
+    _options?: ChatOptions,
+  ): AsyncIterable<string> {
+    const error = new AIError(
+      'Chat streaming is not supported by the Seevio video-only provider.',
+      'NOT_IMPLEMENTED',
+      'seevio',
+    );
+    return {
+      [Symbol.asyncIterator]: () => ({ next: () => Promise.reject(error) }),
+    };
+  }
+  /** @inheritdoc */ async countTokens(_text: string): Promise<number> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async synthesizeSpeech(
+    _text: string,
+    _options?: TTSOptions,
+  ): Promise<TTSResponse> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ streamSpeech(
+    _text: string,
+    _options?: TTSOptions,
+  ): AsyncIterable<Buffer> {
+    const error = new AIError(
+      'TTS streaming is not supported by the Seevio video-only provider.',
+      'NOT_IMPLEMENTED',
+      'seevio',
+    );
+    return {
+      [Symbol.asyncIterator]: () => ({ next: () => Promise.reject(error) }),
+    };
+  }
+  /** @inheritdoc */ async cloneVoice(
+    _options: VoiceCloneOptions,
+  ): Promise<Voice> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async designVoice(
+    _options: VoiceDesignOptions,
+  ): Promise<Voice> {
+    return this.unsupported();
+  }
+  /** @inheritdoc */ async getVoices(
+    _options?: VoiceListOptions,
+  ): Promise<Voice[]> {
+    return this.unsupported();
+  }
+}

--- a/packages/ai/src/shared/rate-limit.ts
+++ b/packages/ai/src/shared/rate-limit.ts
@@ -351,6 +351,9 @@ export function createRateLimitedAI<T extends AIInterface>(
   }
 
   const wrappedMethods = new Map<PropertyKey, unknown>();
+  // Seevio does not document idempotency for billed video-task submission.
+  // Existing providers retain their established pacing-retry behavior.
+  const allowSeevioSubmitRetry = options.type !== 'seevio';
 
   return new Proxy(client, {
     get(target, property, receiver) {
@@ -376,11 +379,7 @@ export function createRateLimitedAI<T extends AIInterface>(
               () => Reflect.apply(value, target, args) as Promise<unknown>,
               coordinator,
               config,
-              // A video-submit response can be lost after the provider has
-              // accepted and billed the task. Providers without documented
-              // idempotency must never turn that ambiguity into a duplicate
-              // paid submission, even when generic pacing retries are enabled.
-              property !== 'submitVideoGenerationJob',
+              property !== 'submitVideoGenerationJob' || allowSeevioSubmitRetry,
             ),
           );
         });

--- a/packages/ai/src/shared/rate-limit.ts
+++ b/packages/ai/src/shared/rate-limit.ts
@@ -233,6 +233,7 @@ async function invokeWithPacing<T>(
   execute: () => Promise<T>,
   coordinator: BudgetCoordinator,
   config: NormalizedRateLimitConfig,
+  allowRetry = true,
 ): Promise<T> {
   let attempt = 1;
 
@@ -247,7 +248,7 @@ async function invokeWithPacing<T>(
       if (error instanceof RateLimitError) {
         coordinator.delayFor(getRetryDelayMs(error, config));
 
-        if (error.retryable && attempt < config.maxAttempts) {
+        if (allowRetry && error.retryable && attempt < config.maxAttempts) {
           attempt += 1;
           continue;
         }
@@ -375,6 +376,11 @@ export function createRateLimitedAI<T extends AIInterface>(
               () => Reflect.apply(value, target, args) as Promise<unknown>,
               coordinator,
               config,
+              // A video-submit response can be lost after the provider has
+              // accepted and billed the task. Providers without documented
+              // idempotency must never turn that ambiguity into a duplicate
+              // paid submission, even when generic pacing retries are enabled.
+              property !== 'submitVideoGenerationJob',
             ),
           );
         });

--- a/packages/ai/src/shared/types.ts
+++ b/packages/ai/src/shared/types.ts
@@ -106,6 +106,7 @@ export const AI_PROVIDER_TYPES = [
   'qwen3-tts',
   'openai-compat-video',
   'byteplus-modelark',
+  'seevio',
 ] as const;
 
 /**
@@ -2041,6 +2042,29 @@ export interface ByteplusModelArkOptions extends BaseAIOptions {
 }
 
 /**
+ * Seevio Seedance video-generation provider options.
+ *
+ * This provider is intentionally distinct from BytePlus ModelArk: Seevio
+ * exposes its own asynchronous task API and credit-reservation semantics.
+ */
+export interface SeevioOptions extends BaseAIOptions {
+  /** Selects Seevio's native asynchronous video API. */
+  type: 'seevio';
+  /** API key. Falls back to `SEEVIO_API_KEY` in the Node factory. */
+  apiKey?: string;
+  /** API root. Defaults to `https://api.seevio.ai`. */
+  baseUrl?: string;
+  /**
+   * Reviewed HTTPS origins that may serve generated videos. Defaults to the
+   * official `https://cdn.seevio.ai` origin. Redirect targets are checked
+   * against this same allow-list before bytes are downloaded.
+   */
+  resultUrlOrigins?: string[];
+  /** Maximum generated-video download size in bytes. Defaults to 200 MiB. */
+  maxResultBytes?: number;
+}
+
+/**
  * Union type for all provider options
  */
 export type GetAIOptions =
@@ -2055,7 +2079,8 @@ export type GetAIOptions =
   | ClaudeCliOptions
   | Qwen3TTSOptions
   | OpenAICompatVideoOptions
-  | ByteplusModelArkOptions;
+  | ByteplusModelArkOptions
+  | SeevioOptions;
 
 /**
  * Base error class for all AI operations.
@@ -2207,6 +2232,18 @@ export interface VideoGenerationReferenceImage {
   role?: string;
 }
 
+/** A URL-based image, video, or audio asset used to guide video generation. */
+export interface VideoGenerationReferenceMedia {
+  /** Media category understood by providers that support multimodal references. */
+  type: 'image' | 'video' | 'audio';
+  /** Public URL the provider can retrieve. */
+  url: string;
+  /** Optional media MIME type retained for provider-specific validation. */
+  mimeType?: string;
+  /** Optional playback duration used by providers with media-duration limits. */
+  durationSeconds?: number;
+}
+
 /**
  * Options for submitting an asynchronous video-generation job.
  */
@@ -2234,6 +2271,14 @@ export interface VideoGenerationOptions extends AIRequestControls {
   referenceImages?: VideoGenerationReferenceImage[];
 
   /**
+   * Provider-neutral URL-based image, video, and audio reference assets.
+   * Existing `referenceImages` remains supported for providers that accept
+   * bytes or data URLs; providers such as Seevio that retrieve public assets
+   * directly require HTTPS URLs here.
+   */
+  referenceMedia?: VideoGenerationReferenceMedia[];
+
+  /**
    * Duration of the generated clip in seconds.
    */
   durationSeconds?: number;
@@ -2247,6 +2292,12 @@ export interface VideoGenerationOptions extends AIRequestControls {
    * Aspect ratio such as `'16:9'`, `'9:16'`, or `'1:1'`.
    */
   aspectRatio?: string;
+
+  /** Whether a provider that supports native audio should generate it. */
+  generateAudio?: boolean;
+
+  /** Whether a provider that supports it should return a final-frame URL. */
+  returnLastFrame?: boolean;
 
   /**
    * Frames per second for the generated video. Support varies by provider.
@@ -2346,6 +2397,22 @@ export interface VideoGenerationResult {
    * Height of the generated video in pixels, where reported.
    */
   height?: number;
+
+  /** Time at which a temporary result URL expires, when the provider reports it. */
+  expiresAt?: string;
+
+  /** Optional URL for a returned final frame, when requested and supported. */
+  lastFrameUrl?: string;
+}
+
+/** Provider-neutral credit reservation and settlement metadata for a video job. */
+export interface VideoGenerationBillingMetadata {
+  /** Credits reserved or settled for the task, when the provider reports them. */
+  credits?: number;
+  /** Normalized reservation lifecycle state. */
+  status?: 'reserved' | 'charged' | 'refunded' | 'refund_failed';
+  /** An unrecognized provider billing state retained for diagnostics. */
+  rawStatus?: string;
 }
 
 /**
@@ -2390,6 +2457,9 @@ export interface VideoGenerationStatusResult {
    * `fetchVideoGenerationResult` is called explicitly.
    */
   result?: VideoGenerationResult;
+
+  /** Provider-reported credit reservation or settlement metadata. */
+  billing?: VideoGenerationBillingMetadata;
 }
 
 // ============================================================================

--- a/packages/ai/src/video-generation.test.ts
+++ b/packages/ai/src/video-generation.test.ts
@@ -10,6 +10,7 @@ import { writeFile } from 'node:fs/promises';
 import { GenerateVideosOperation } from '@google/genai';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getAIAuto } from './node/factory';
+import { getAI } from './shared/factory';
 import {
   __resetByteplusModelArkRateLimitersForTests,
   ByteplusModelArkProvider,
@@ -17,6 +18,7 @@ import {
 import { GeminiProvider } from './shared/providers/gemini';
 import { OpenAIProvider } from './shared/providers/openai';
 import { OpenAICompatVideoProvider } from './shared/providers/openai-compat-video';
+import { SeevioProvider } from './shared/providers/seevio';
 import { createRateLimitedAI } from './shared/rate-limit';
 import { createObservedAI } from './shared/safety';
 import {
@@ -1110,6 +1112,594 @@ describe('BytePlus ModelArk video generation (Seedance)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('Seevio video generation (Seedance 2.5)', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('is selectable through the provider-neutral factory', async () => {
+    await expect(
+      getAI({ type: 'seevio', apiKey: 'seevio-key' }),
+    ).resolves.toBeInstanceOf(SeevioProvider);
+  });
+
+  it('submits the documented, pinned Seedance 2.5 request without retry metadata', async () => {
+    global.fetch = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe(
+          'https://api.seevio.ai/v1/videos/generations',
+        );
+        expect(init?.method).toBe('POST');
+        expect(new Headers(init?.headers).get('Authorization')).toBe(
+          'Bearer seevio-key',
+        );
+        expect(JSON.parse(String(init?.body))).toEqual({
+          model: 'seedance-2-5',
+          input: {
+            prompt: 'A cinematic sunrise',
+            generation_type: 'text-to-video',
+            duration: 5,
+            aspect_ratio: '16:9',
+            resolution: '720p',
+            generate_audio: true,
+            return_last_frame: false,
+          },
+        });
+        return jsonResponse({ taskId: 'seevio-task-1', credits: 100 });
+      },
+    ) as any;
+
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    const job = await provider.submitVideoGenerationJob({
+      prompt: 'A cinematic sunrise',
+      aspectRatio: '16:9',
+    });
+
+    expect(job).toEqual({
+      jobId: 'seevio-task-1',
+      provider: 'seevio',
+      model: 'seedance-2-5',
+      createdAt: expect.any(String),
+      raw: { credits: 100, billingStatus: 'reserved' },
+    });
+    expect(JSON.parse(JSON.stringify(job))).toEqual(job);
+  });
+
+  it('normalizes first/last-frame and multimodal references without changing the generic input contract', async () => {
+    const bodies: unknown[] = [];
+    global.fetch = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return jsonResponse({ taskId: `task-${bodies.length}` });
+      },
+    ) as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+
+    await provider.submitVideoGenerationJob({
+      prompt: 'animate product',
+      referenceImages: [
+        { image: 'https://assets.example.com/first.jpg' },
+        { image: 'https://assets.example.com/last.jpg' },
+      ],
+    });
+    await provider.submitVideoGenerationJob({
+      prompt: 'use the product and motion',
+      referenceMedia: [
+        { type: 'image', url: 'https://assets.example.com/product.jpg' },
+        {
+          type: 'video',
+          url: 'https://assets.example.com/motion.mp4',
+          durationSeconds: 4,
+        },
+        {
+          type: 'audio',
+          url: 'https://assets.example.com/music.mp3',
+          durationSeconds: 5,
+        },
+      ],
+    });
+
+    expect(bodies).toEqual([
+      expect.objectContaining({
+        input: expect.objectContaining({
+          generation_type: 'image-to-video',
+          aspect_ratio: 'adaptive',
+          image_urls: [
+            'https://assets.example.com/first.jpg',
+            'https://assets.example.com/last.jpg',
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        input: expect.objectContaining({
+          generation_type: 'reference-to-video',
+          image_urls: ['https://assets.example.com/product.jpg'],
+          video_urls: ['https://assets.example.com/motion.mp4'],
+          audio_urls: ['https://assets.example.com/music.mp3'],
+        }),
+      }),
+    ]);
+  });
+
+  it('rejects reference video or audio durations over Seevio’s 30-second category limit before POST', async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        referenceMedia: [
+          {
+            type: 'video',
+            url: 'https://assets.example.com/a.mp4',
+            durationSeconds: 20,
+          },
+          {
+            type: 'video',
+            url: 'https://assets.example.com/b.mp4',
+            durationSeconds: 20,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        referenceMedia: [
+          {
+            type: 'audio',
+            url: 'https://assets.example.com/a.mp3',
+            durationSeconds: 20,
+          },
+          {
+            type: 'audio',
+            url: 'https://assets.example.com/b.mp3',
+            durationSeconds: 20,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects unpinned models, local media, invalid image-mode ratio, and unsupported seed before a paid POST', async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+
+    await expect(
+      provider.submitVideoGenerationJob({ prompt: 'x', model: 'latest' }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        referenceImages: [{ image: Buffer.from([1]) }],
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        referenceImages: [{ image: 'https://assets.example.com/x.jpg' }],
+        aspectRatio: '16:9',
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    await expect(
+      provider.submitVideoGenerationJob({ prompt: 'x', seed: 1 }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        referenceMedia: [
+          {
+            type: 'image',
+            url: 'https://user:password@assets.example.com/x.jpg',
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        referenceMedia: [{ type: 'image', url: 'https://127.0.0.1/x.jpg' }],
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    await expect(
+      provider.submitVideoGenerationJob({
+        prompt: 'x',
+        referenceMedia: [{ type: 'image', url: 'https://localhost/x.jpg' }],
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps task state, credit reservation, expiry, and reviewed result URLs', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        id: 'seevio-task-1',
+        status: 'completed',
+        model: 'seedance-2-5',
+        billing_status: 'charged',
+        credits: 100,
+        data: {
+          results: ['https://cdn.seevio.ai/renders/video.mp4'],
+          video_expires_at: '2026-08-14T00:00:00Z',
+          last_frame_url: 'https://cdn.seevio.ai/renders/final.jpg',
+        },
+      }),
+    ) as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    await expect(
+      provider.getVideoGenerationJob({
+        jobId: 'seevio-task-1',
+        provider: 'seevio',
+        model: 'seedance-2-5',
+        createdAt: new Date().toISOString(),
+      }),
+    ).resolves.toEqual({
+      status: 'succeeded',
+      result: {
+        url: 'https://cdn.seevio.ai/renders/video.mp4',
+        mimeType: 'video/mp4',
+        expiresAt: '2026-08-14T00:00:00Z',
+        lastFrameUrl: 'https://cdn.seevio.ai/renders/final.jpg',
+      },
+      billing: { status: 'charged', credits: 100 },
+    });
+  });
+
+  it('enforces the documented 10-second polling cadence before another network request', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ id: 'task', status: 'queued' }));
+      global.fetch = fetchMock as any;
+      const provider = new SeevioProvider({
+        type: 'seevio',
+        apiKey: 'seevio-key',
+      });
+      const handle = {
+        jobId: 'task',
+        provider: 'seevio',
+        model: 'seedance-2-5',
+        createdAt: new Date().toISOString(),
+      };
+      await provider.getVideoGenerationJob(handle);
+      await expect(
+        provider.getVideoGenerationJob(handle),
+      ).rejects.toMatchObject({ code: 'VIDEO_POLL_TOO_FREQUENT' });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reuses a completed task snapshot for immediate result download without a second task poll', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'task',
+          status: 'completed',
+          data: { results: ['https://cdn.seevio.ai/render.mp4'] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1]), {
+          status: 200,
+          headers: { 'content-type': 'video/mp4' },
+        }),
+      );
+    global.fetch = fetchMock as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    const handle = {
+      jobId: 'task',
+      provider: 'seevio',
+      model: 'seedance-2-5',
+      createdAt: new Date().toISOString(),
+    };
+    await expect(provider.getVideoGenerationJob(handle)).resolves.toMatchObject(
+      {
+        status: 'succeeded',
+      },
+    );
+    await expect(
+      provider.fetchVideoGenerationResult(handle),
+    ).resolves.toMatchObject({
+      data: Buffer.from([1]),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1][0])).toBe(
+      'https://cdn.seevio.ai/render.mp4',
+    );
+  });
+
+  it('expires a completed handoff snapshot after 10 seconds and fetches a fresh authenticated task state', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: 'task',
+            status: 'completed',
+            data: { results: ['https://cdn.seevio.ai/old.mp4'] },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: 'task',
+            status: 'completed',
+            data: { results: ['https://cdn.seevio.ai/fresh.mp4'] },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(new Uint8Array([2]), {
+            status: 200,
+            headers: { 'content-type': 'video/mp4' },
+          }),
+        );
+      global.fetch = fetchMock as any;
+      const provider = new SeevioProvider({
+        type: 'seevio',
+        apiKey: 'seevio-key',
+      });
+      const handle = {
+        jobId: 'task',
+        provider: 'seevio',
+        model: 'seedance-2-5',
+        createdAt: new Date().toISOString(),
+      };
+      await provider.getVideoGenerationJob(handle);
+      vi.advanceTimersByTime(10_000);
+      await expect(
+        provider.fetchVideoGenerationResult(handle),
+      ).resolves.toMatchObject({
+        url: 'https://cdn.seevio.ai/fresh.mp4',
+        data: Buffer.from([2]),
+      });
+      expect(String(fetchMock.mock.calls[1][0])).toBe(
+        'https://api.seevio.ai/v1/tasks/task',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses an unbilled GET probe and classifies authenticated 404 as access', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'not_found' } }), {
+        status: 404,
+      }),
+    );
+    global.fetch = fetchMock as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    await expect(provider.validateVideoGenerationAccess()).resolves.toBe(true);
+    expect(String(fetchMock.mock.calls[0][0])).toMatch(
+      /^https:\/\/api\.seevio\.ai\/v1\/tasks\/have-ai-access-probe-/,
+    );
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('GET');
+  });
+
+  it('preserves 401, 403, 402, and 429 as distinct normalized errors', async () => {
+    const cases = [
+      [401, 'AUTH_ERROR'],
+      [403, 'SEEVIO_FORBIDDEN'],
+      [402, 'INSUFFICIENT_CREDITS'],
+      [429, 'RATE_LIMIT'],
+    ] as const;
+    for (const [httpStatus, code] of cases) {
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: 'nope' } }), {
+          status: httpStatus,
+          headers: httpStatus === 429 ? { 'retry-after': '3' } : undefined,
+        }),
+      ) as any;
+      const provider = new SeevioProvider({
+        type: 'seevio',
+        apiKey: 'seevio-key',
+      });
+      await expect(
+        provider.validateVideoGenerationAccess(),
+      ).rejects.toMatchObject({ code });
+    }
+  });
+
+  it('never retries a billable POST after a rate limit, even if generic pacing permits retries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'slow down' } }), {
+        status: 429,
+        headers: { 'retry-after': '0' },
+      }),
+    );
+    global.fetch = fetchMock as any;
+    const provider = createRateLimitedAI(
+      new SeevioProvider({ type: 'seevio', apiKey: 'seevio-key' }),
+      {
+        type: 'seevio',
+        apiKey: 'seevio-key',
+        rateLimit: { enabled: true, maxAttempts: 2 },
+      },
+    );
+    await expect(
+      provider.submitVideoGenerationJob({ prompt: 'x' }),
+    ).rejects.toMatchObject({ code: 'RATE_LIMIT' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('validates each redirect before downloading a completed video and rejects unreviewed targets', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'task',
+          status: 'completed',
+          data: { results: ['https://cdn.seevio.ai/render.mp4'] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://cdn.seevio.ai/signed/render.mp4' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { 'content-type': 'video/mp4' },
+        }),
+      );
+    global.fetch = fetchMock as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    const handle = {
+      jobId: 'task',
+      provider: 'seevio',
+      model: 'seedance-2-5',
+      createdAt: new Date().toISOString(),
+    };
+    await expect(
+      provider.fetchVideoGenerationResult(handle),
+    ).resolves.toMatchObject({
+      url: 'https://cdn.seevio.ai/signed/render.mp4',
+      mimeType: 'video/mp4',
+      data: Buffer.from([1, 2, 3]),
+    });
+    expect(fetchMock.mock.calls[1][1]?.redirect).toBe('manual');
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'task-2',
+          status: 'completed',
+          data: { results: ['https://cdn.seevio.ai/render.mp4'] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://evil.example/render.mp4' },
+        }),
+      ) as any;
+    await expect(
+      provider.fetchVideoGenerationResult({ ...handle, jobId: 'task-2' }),
+    ).rejects.toMatchObject({ code: 'UNTRUSTED_RESULT_URL' });
+  });
+
+  it('rejects an oversized or non-video download before buffering it', async () => {
+    const handle = {
+      jobId: 'task',
+      provider: 'seevio',
+      model: 'seedance-2-5',
+      createdAt: new Date().toISOString(),
+    };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'task',
+          status: 'completed',
+          data: { results: ['https://cdn.seevio.ai/render.mp4'] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-type': 'video/mp4', 'content-length': '11' },
+        }),
+      ) as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+      maxResultBytes: 10,
+    });
+    await expect(
+      provider.fetchVideoGenerationResult(handle),
+    ).rejects.toMatchObject({ code: 'SEEVIO_RESULT_TOO_LARGE' });
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'task',
+          status: 'completed',
+          data: { results: ['https://cdn.seevio.ai/render.mp4'] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('not a video', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+      ) as any;
+    const mimeProvider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+      maxResultBytes: 10,
+    });
+    await expect(
+      mimeProvider.fetchVideoGenerationResult(handle),
+    ).rejects.toMatchObject({ code: 'SEEVIO_RESULT_MIME_INVALID' });
+  });
+
+  it('reports cancellation as explicitly unsupported', async () => {
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    await expect(
+      provider.cancelVideoGenerationJob({
+        jobId: 'task',
+        provider: 'seevio',
+        model: 'seedance-2-5',
+        createdAt: new Date().toISOString(),
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' });
+  });
+
+  it('does not advertise unsupported cancellation as a capability', async () => {
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    await expect(provider.getCapabilities()).resolves.toMatchObject({
+      supportedOperations: [
+        'submitVideoGenerationJob',
+        'getVideoGenerationJob',
+        'fetchVideoGenerationResult',
+      ],
+    });
   });
 });
 

--- a/packages/ai/src/video-generation.test.ts
+++ b/packages/ai/src/video-generation.test.ts
@@ -25,6 +25,7 @@ import {
   AIError,
   type AIInterface,
   AuthenticationError,
+  RateLimitError,
   type VideoGenerationJob,
 } from './shared/types';
 
@@ -1113,6 +1114,33 @@ describe('BytePlus ModelArk video generation (Seedance)', () => {
       vi.useRealTimers();
     }
   });
+
+  it('preserves configured video-submit retries for non-Seevio providers', async () => {
+    let attempts = 0;
+    const stub: Partial<AIInterface> = {
+      submitVideoGenerationJob: vi.fn(async () => {
+        attempts += 1;
+        if (attempts === 1) throw new RateLimitError('byteplus-modelark', 0);
+        return {
+          jobId: 'job',
+          provider: 'byteplus-modelark',
+          model: 'seedance-1-0-lite-t2v-250428',
+          createdAt: new Date().toISOString(),
+        };
+      }),
+    };
+    const ai = createRateLimitedAI(stub as AIInterface, {
+      type: 'byteplus-modelark',
+      apiKey: 'test-key',
+      rateLimit: { enabled: true, initialDelayMs: 0, maxAttempts: 2 },
+    });
+    await expect(
+      ai.submitVideoGenerationJob({ prompt: 'retry' }),
+    ).resolves.toMatchObject({
+      jobId: 'job',
+    });
+    expect(attempts).toBe(2);
+  });
 });
 
 describe('Seevio video generation (Seedance 2.5)', () => {
@@ -1253,6 +1281,7 @@ describe('Seevio video generation (Seedance 2.5)', () => {
             url: 'https://assets.example.com/b.mp4',
             durationSeconds: 20,
           },
+          { type: 'video', url: 'https://assets.example.com/unknown.mp4' },
         ],
       }),
     ).rejects.toMatchObject({ name: 'ValidationError' });
@@ -1477,6 +1506,7 @@ describe('Seevio video generation (Seedance 2.5)', () => {
       };
       await provider.getVideoGenerationJob(handle);
       vi.advanceTimersByTime(10_000);
+      expect((provider as any).nextPollAt.size).toBe(0);
       await expect(
         provider.fetchVideoGenerationResult(handle),
       ).resolves.toMatchObject({
@@ -1670,6 +1700,26 @@ describe('Seevio video generation (Seedance 2.5)', () => {
     });
     await expect(
       mimeProvider.fetchVideoGenerationResult(handle),
+    ).rejects.toMatchObject({ code: 'SEEVIO_RESULT_MIME_INVALID' });
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'task',
+          status: 'completed',
+          data: { results: ['https://cdn.seevio.ai/render.mp4'] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('not a video', { status: 200 }),
+      ) as any;
+    const missingTypeProvider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+    await expect(
+      missingTypeProvider.fetchVideoGenerationResult(handle),
     ).rejects.toMatchObject({ code: 'SEEVIO_RESULT_MIME_INVALID' });
   });
 

--- a/packages/ai/src/video-generation.test.ts
+++ b/packages/ai/src/video-generation.test.ts
@@ -1260,6 +1260,38 @@ describe('Seevio video generation (Seedance 2.5)', () => {
     ]);
   });
 
+  it('honors an abort that races listener registration', async () => {
+    let aborted = false;
+    const signal = {
+      get aborted() {
+        return aborted;
+      },
+      reason: new DOMException('aborted', 'AbortError'),
+      addEventListener() {
+        aborted = true;
+      },
+      removeEventListener() {},
+    } as unknown as AbortSignal;
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      init?.signal?.aborted
+        ? Promise.reject(new DOMException('aborted', 'AbortError'))
+        : Promise.resolve(jsonResponse({ taskId: 'unexpected' })),
+    );
+    global.fetch = fetchMock as any;
+    const provider = new SeevioProvider({
+      type: 'seevio',
+      apiKey: 'seevio-key',
+    });
+
+    await expect(
+      provider.submitVideoGenerationJob({ prompt: 'x', signal }),
+    ).rejects.toMatchObject({ code: 'AI_ABORTED' });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal?.aborted).toBe(
+      true,
+    );
+  });
+
   it('rejects reference video or audio durations over Seevio’s 30-second category limit before POST', async () => {
     const fetchMock = vi.fn();
     global.fetch = fetchMock as any;


### PR DESCRIPTION
Closes #1200

## Summary

- add the native, pinned `seedance-2-5` async video provider behind the generic AI interface
- add provider-neutral URL reference media, normalized task/billing results, and no-cost credentials validation
- enforce 10-second polling, no ambiguous submission retries, and safe bounded HTTPS result downloads
- document Node 24 proxy setup using `NODE_USE_ENV_PROXY=1` with `HTTPS_PROXY`

## Validation

- `pnpm exec vitest --config vitest.package.config.ts run packages/ai/src/video-generation.test.ts` (82 passed)
- `pnpm --filter @happyvertical/ai exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @happyvertical/ai build`
- `pnpm test:ci-scripts`
- `pnpm agent:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm validate-build`

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"b04b589f-7674-4a1e-99e5-13850918f217","issue":"1200","linked_issue":"1200","policy_revision":"1.0.0","status":"complete","validation":["focused video 82/82","package TypeScript/build","repository validation gates"]}