### PR TITLE
feat(secrets): add fail-closed credential custody

### DIFF
--- a/.changeset/quiet-pandas-guard.md
+++ b/.changeset/quiet-pandas-guard.md
@@ -1,0 +1,12 @@
+---
+'@happyvertical/secrets': minor
+---
+
+Add provider-neutral fail-closed credential custody orchestration with explicit
+ephemeral and durable modes, opaque secret material, attributable non-secret
+receipts, rotation and reconciliation history, bounded environment injection,
+bounded child-process injection and cleanup, structured errors, and token
+redaction. Receipts carry required Ed25519 attestations bound to the submitted
+credential and complete canonical custody locator.
+Issuance also requires a staged prepare/commit/abort finalizer with a durable
+recovery identity, keeping downstream activation inside the rollback boundary.

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -55,11 +55,11 @@ const store = await getSecretStore({
 await store.createTenantKey('tenant-123');
 
 // Encrypt a secret
-const envelope = await store.encrypt('tenant-123', 'api-key', 'sk_live_xxx');
+const envelope = await store.encrypt('tenant-123', 'api-key', 'synthetic-secret');
 
 // Decrypt the secret
 const { value } = await store.decrypt('tenant-123', envelope);
-console.log(value); // 'sk_live_xxx'
+// Use value without logging or retaining plaintext.
 ```
 
 ## Core Concepts
@@ -214,6 +214,131 @@ try {
   }
 }
 ```
+
+## Credential custody orchestration
+
+`CredentialCustody` coordinates a provider-neutral issuer, verifier, optional
+secret sink, and receipt ledger. It supports two explicit modes:
+
+- `ephemeral` keeps opaque `SecretMaterial` in memory for a bounded lifetime,
+  automatically revokes it at expiry, and never stores it in a sink.
+- `durable` requires a `CredentialSecretSink`, then completes
+  issue → store → retrieve → verify before returning a lease. Any failure
+  removes the stored value when present and revokes the issued credential.
+
+```typescript
+import {
+  CredentialCustody,
+  type CredentialReceiptAttestor,
+  type CredentialIssuer,
+  type CredentialCustodyFinalizer,
+  type CredentialSecretSink,
+  type CredentialVerifier,
+  type CustodyLedger,
+} from '@happyvertical/secrets';
+
+const custody = new CredentialCustody({
+  issuer: myIssuer satisfies CredentialIssuer,
+  verifier: myVerifier satisfies CredentialVerifier,
+  sink: mySink satisfies CredentialSecretSink,
+  ledger: myLedger satisfies CustodyLedger,
+  attestor: myAttestor satisfies CredentialReceiptAttestor,
+  finalizer: myFinalizer satisfies CredentialCustodyFinalizer,
+});
+
+const lease = await custody.issue({
+  mode: 'durable',
+  subject: 'deployment-agent',
+  attribution: {
+    actor: 'automation',
+    runtime: 'scheduler',
+    session: 'job-123',
+  },
+  metadata: { purpose: 'repository-maintenance' },
+});
+
+await lease.withEnvironment('SERVICE_CREDENTIAL', async () => {
+  // The variable exists only for this callback and is restored afterward.
+  await runAuthenticatedOperation();
+});
+
+const child = await lease.withChildProcess({
+  command: 'service-cli',
+  args: ['verify'],
+  environmentVariable: 'SERVICE_CREDENTIAL',
+  timeoutMs: 30_000,
+});
+```
+
+The returned `CustodyReceipt` contains identifiers, attribution, verification
+state, sink reference, rotation lineage, and an Ed25519 attestation only.
+Plaintext is represented by
+`SecretMaterial`, whose string, JSON, and inspection forms are always redacted.
+Adapters can access it only inside `SecretMaterial.use(...)` and should avoid
+copying or retaining the supplied string. Both `SecretMaterial.use(...)` and
+`withEnvironment(...)` return `Promise<void>` so callback code cannot return
+plaintext through the custody API. Environment callbacks are serialized and
+always restore the prior value. Because JavaScript callbacks cannot be forcibly
+cancelled, expiring credentials fail closed for `withEnvironment(...)`; use
+`withChildProcess(...)` for bounded execution.
+
+Attestation binds every receipt field—including the stable sink tuple
+`sinkName`, `reference`, `version`, and `storedAt`—to an internal SHA-256
+commitment of the credential. The commitment is signed but is not included in
+the receipt. `CredentialCustodyOptions.attestor` is required, so unsigned
+issuance fails closed. `Ed25519CustodyReceiptAttestor` accepts a Node `KeyObject`
+private key; remote signers can implement `CredentialReceiptAttestor` without
+exposing their key.
+
+Consumers verify a presented credential without issuer or sink access by
+constructing its `SecretMaterial` and calling
+`verifyCustodyReceiptAttestation(receipt, material, publicKey)`. Resolve
+`receipt.attestation.keyId` only through trusted configuration, never from
+receipt-supplied key material. Import a trusted PEM/SPKI public key with Node's
+`createPublicKey(...)`; verification requires the resulting public `KeyObject`.
+Always destroy the temporary `SecretMaterial` after verification.
+
+The required `CredentialCustodyFinalizer` is a staged, idempotent transaction.
+The signed receipt is first recorded as `finalization-pending`; `prepare` then
+receives it with bounded `SecretMaterial`. The receipt binds the finalizer name
+and SDK-generated `finalizationId`. `commit` activates the prepared record, and
+the ledger atomically marks it issued while recording any predecessor cleanup.
+Only then does rotation retire the predecessor. Cleanup failure keeps the new
+credential active and is retried by `recoverPendingRollbacks()`. The finalizer's
+`status` resolves crash ambiguity; `abort` and issuer/sink cleanup run
+independently. Implement `prepare`, `commit`, `abort`, and `status` idempotently
+by `finalizationId`. Fresh pending transactions are protected from concurrent
+takeover for `finalizationTakeoverMs` (30 seconds by default); a one-shot
+recovery call schedules takeover automatically at that deadline.
+
+Prefer `withChildProcess(...)` for command-line consumers. It injects the
+credential into the child environment without mutating the parent, disables
+shell interpretation, bounds runtime and captured output, owns a detached
+process group so descendants are terminated, and exact/token-redacts stdout
+and stderr before returning them. Process-group custody currently fails closed
+on Windows, where the required POSIX group semantics are unavailable.
+
+Use `rotate(receiptId, request)` to issue and verify a replacement before
+retiring its predecessor. `reconcile()` compares active durable receipts with
+the sink inventory; `recoverOrphans(report)` removes unowned sink records while
+retaining attributable history in the ledger. Missing records can be replaced
+through `rotate`, preserving `replacesReceiptId` and `rotationRootReceiptId`.
+The ledger's `recordIssuance` operation atomically persists the receipt with a
+`finalization-pending` event and rejects duplicate or branching replacements.
+`commitIssuance` idempotently appends the `issued` event and, for rotation, the
+`retirement-pending` event in the same transaction. Issuer revocation
+and exact-version sink removal must be idempotent so failed cleanup can retry.
+Sinks must also implement idempotent `removeByCredentialId(...)` for ambiguous
+store failures, and every inventory entry must identify its credential.
+Orphan recovery re-runs reconciliation and applies a configurable age grace
+before deleting an unchanged sink version. Failed pre-receipt rollback records a
+non-secret pending event, retries automatically, and can be resumed after a
+restart with `recoverPendingRollbacks()`.
+
+`redactCredentialText` and `redactCredentialValues` remove common bearer-token
+shapes and known plaintext values from strings, structured outputs, errors, and
+metadata. `CustodyError` serializes only its safe code, stage, redacted message,
+and redacted details; underlying provider causes are intentionally not retained.
 
 ## License
 

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -263,6 +263,7 @@ await lease.withEnvironment('SERVICE_CREDENTIAL', async () => {
 });
 
 const child = await lease.withChildProcess({
+  trust: 'cooperative-process-group',
   command: 'service-cli',
   args: ['verify'],
   environmentVariable: 'SERVICE_CREDENTIAL',
@@ -311,12 +312,18 @@ by `finalizationId`. Fresh pending transactions are protected from concurrent
 takeover for `finalizationTakeoverMs` (30 seconds by default); a one-shot
 recovery call schedules takeover automatically at that deadline.
 
-Prefer `withChildProcess(...)` for command-line consumers. It injects the
+Prefer `withChildProcess(...)` for trusted command-line consumers. It requires
+the explicit `trust: 'cooperative-process-group'` acknowledgement, injects the
 credential into the child environment without mutating the parent, disables
 shell interpretation, bounds runtime and captured output, owns a detached
-process group so descendants are terminated, and exact/token-redacts stdout
-and stderr before returning them. Process-group custody currently fails closed
-on Windows, where the required POSIX group semantics are unavailable.
+process group so descendants are terminated, confirms that group is gone
+before returning, and exact/token-redacts stdout and stderr. The trusted
+command and every credential-bearing descendant must remain in that group;
+daemonizing, calling `setsid`, or spawning a detached child violates this
+boundary because portable POSIX process groups cannot contain a process that
+creates a new session. Use only audited executables that honor this contract.
+Process-group custody fails closed on Windows, where the required POSIX group
+semantics are unavailable.
 
 Use `rotate(receiptId, request)` to issue and verify a replacement before
 retiring its predecessor. `reconcile()` compares active durable receipts with

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -323,7 +323,9 @@ daemonizing, calling `setsid`, or spawning a detached child violates this
 boundary because portable POSIX process groups cannot contain a process that
 creates a new session. Use only audited executables that honor this contract.
 Process-group custody fails closed on Windows, where the required POSIX group
-semantics are unavailable.
+semantics are unavailable. If group cleanup cannot be verified, the lease is
+immediately invalidated and finalizer/issuer/sink cleanup runs through the same
+persisted, restart-safe rollback path used by failed issuance.
 
 Use `rotate(receiptId, request)` to issue and verify a replacement before
 retiring its predecessor. `reconcile()` compares active durable receipts with
@@ -335,6 +337,12 @@ The ledger's `recordIssuance` operation atomically persists the receipt with a
 `commitIssuance` idempotently appends the `issued` event and, for rotation, the
 `retirement-pending` event in the same transaction. Issuer revocation
 and exact-version sink removal must be idempotent so failed cleanup can retry.
+`appendEvent` is idempotent by `eventId`: exact replay succeeds, while binding
+the same identifier to different content fails closed.
+Transient finalizer-status or ledger-commit errors retain
+`finalization-pending` state and retry ambiguity resolution; only an explicit
+non-committed finalizer status triggers rollback. Sink identity comparison uses
+the full attested `sinkName`, `reference`, `version`, and `storedAt` tuple.
 Sinks must also implement idempotent `removeByCredentialId(...)` for ambiguous
 store failures, and every inventory entry must identify its credential.
 Orphan recovery re-runs reconciliation and applies a configurable age grace

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "prepare": "pnpm --dir ../.. --filter @happyvertical/secrets build",
+    "prepare": "node scripts/prepare-git-dependency.mjs",
     "dev": "vite build --watch",
     "test": "vitest --config ../../vitest.package.config.ts run",
     "test:watch": "vitest --config ../../vitest.package.config.ts",

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "prepare": "pnpm --dir ../.. --filter @happyvertical/secrets build",
     "dev": "vite build --watch",
     "test": "vitest --config ../../vitest.package.config.ts run",
     "test:watch": "vitest --config ../../vitest.package.config.ts",

--- a/packages/secrets/pnpm-workspace.yaml
+++ b/packages/secrets/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - '.'
+  - '../sql'
+  - '../utils'

--- a/packages/secrets/scripts/prepare-git-dependency.mjs
+++ b/packages/secrets/scripts/prepare-git-dependency.mjs
@@ -1,0 +1,35 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+const packageDirectory = new URL('..', import.meta.url);
+const repositoryDirectory = new URL('../../..', import.meta.url);
+
+const build = spawnSync(
+  'pnpm',
+  ['--dir', repositoryDirectory.pathname, '--filter', '@happyvertical/secrets', 'build'],
+  { stdio: 'inherit' },
+);
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+const git = spawnSync(
+  'git',
+  ['-C', repositoryDirectory.pathname, 'rev-parse', '--is-inside-work-tree'],
+  { stdio: 'ignore' },
+);
+if (git.status === 0) process.exit(0);
+
+const manifestUrl = new URL('package.json', packageDirectory);
+const manifest = JSON.parse(await readFile(manifestUrl, 'utf8'));
+for (const dependencies of [
+  manifest.dependencies,
+  manifest.optionalDependencies,
+  manifest.peerDependencies,
+]) {
+  if (!dependencies) continue;
+  for (const [name, specifier] of Object.entries(dependencies)) {
+    if (typeof specifier === 'string' && specifier.startsWith('workspace:')) {
+      dependencies[name] = manifest.version;
+    }
+  }
+}
+await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/packages/secrets/scripts/prepare-git-dependency.mjs
+++ b/packages/secrets/scripts/prepare-git-dependency.mjs
@@ -7,9 +7,13 @@ const repositoryDirectory = new URL('../../..', import.meta.url);
 const build = spawnSync(
   'pnpm',
   ['--dir', repositoryDirectory.pathname, '--filter', '@happyvertical/secrets', 'build'],
-  { stdio: 'inherit' },
+  { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
 );
-if (build.status !== 0) process.exit(build.status ?? 1);
+if (build.status !== 0) {
+  process.stderr.write(build.stdout ?? '');
+  process.stderr.write(build.stderr ?? '');
+  process.exit(build.status ?? 1);
+}
 
 const git = spawnSync(
   'git',

--- a/packages/secrets/scripts/prepare-git-dependency.mjs
+++ b/packages/secrets/scripts/prepare-git-dependency.mjs
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, realpath, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 
 const packageDirectory = new URL('..', import.meta.url);
@@ -13,10 +13,16 @@ if (build.status !== 0) process.exit(build.status ?? 1);
 
 const git = spawnSync(
   'git',
-  ['-C', repositoryDirectory.pathname, 'rev-parse', '--is-inside-work-tree'],
-  { stdio: 'ignore' },
+  ['-C', repositoryDirectory.pathname, 'rev-parse', '--show-toplevel'],
+  { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
 );
-if (git.status === 0) process.exit(0);
+if (
+  git.status === 0 &&
+  (await realpath(git.stdout.trim())) ===
+    (await realpath(repositoryDirectory.pathname))
+) {
+  process.exit(0);
+}
 
 const manifestUrl = new URL('package.json', packageDirectory);
 const manifest = JSON.parse(await readFile(manifestUrl, 'utf8'));

--- a/packages/secrets/src/__tests__/custody.test.ts
+++ b/packages/secrets/src/__tests__/custody.test.ts
@@ -1,0 +1,1772 @@
+import { generateKeyPairSync, randomUUID } from 'node:crypto';
+import { inspect } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CredentialCustody,
+  type CredentialIssueRequest,
+  type CredentialIssuer,
+  type CredentialSecretSink,
+  type CredentialVerifier,
+  type CustodyAttribution,
+  CustodyError,
+  type CustodyEvent,
+  type CustodyLedger,
+  type CustodyReceipt,
+  Ed25519CustodyReceiptAttestor,
+  InMemoryCustodyLedger,
+  type IssuedCredential,
+  redactCredentialText,
+  redactCredentialValues,
+  SecretMaterial,
+  type SecretSinkInventoryEntry,
+  type SecretSinkRecord,
+  verifyCustodyReceiptAttestation,
+  withEnvironmentSecret,
+} from '../index.js';
+
+const SYNTHETIC_SECRET = ['synthetic', 'custody', 'value'].join('-');
+const TEST_KEY_PAIR = generateKeyPairSync('ed25519');
+const TEST_ATTESTOR = new Ed25519CustodyReceiptAttestor({
+  privateKey: TEST_KEY_PAIR.privateKey,
+  keyId: 'test-key-1',
+  name: 'test-attestor',
+});
+const TEST_FINALIZER = {
+  name: 'test-finalizer',
+  async prepare(): Promise<{ prepared: boolean }> {
+    return { prepared: true };
+  },
+  async commit(): Promise<void> {},
+  async abort(): Promise<void> {},
+  async status(): Promise<'committed'> {
+    return 'committed';
+  },
+};
+const ATTRIBUTION: CustodyAttribution = {
+  actor: 'test-actor',
+  runtime: 'test-runtime',
+  session: 'test-session',
+};
+
+class FakeIssuer implements CredentialIssuer {
+  readonly name = 'fake-issuer';
+  readonly revoked: Array<{ credentialId: string; reason: string }> = [];
+  issueFailure?: Error;
+  revokeFailure?: Error;
+  readonly revokeFailures = new Set<string>();
+  expiresAtOverride?: string;
+  onRevoke?: (credentialId: string) => void;
+  next = 1;
+
+  async issue(request: CredentialIssueRequest): Promise<IssuedCredential> {
+    if (this.issueFailure) throw this.issueFailure;
+    return {
+      credentialId: `credential-${this.next++}`,
+      secret: SecretMaterial.fromString(SYNTHETIC_SECRET),
+      issuedAt: '2026-08-14T17:00:00.000Z',
+      expiresAt: this.expiresAtOverride ?? request.expiresAt,
+    };
+  }
+
+  async revoke(credentialId: string, reason: string): Promise<void> {
+    this.onRevoke?.(credentialId);
+    this.revoked.push({ credentialId, reason });
+    if (this.revokeFailure || this.revokeFailures.has(credentialId)) {
+      throw (
+        this.revokeFailure ?? new Error('synthetic selective revoke failure')
+      );
+    }
+  }
+}
+
+class FakeVerifier implements CredentialVerifier {
+  readonly name = 'fake-verifier';
+  verified = true;
+  failure?: Error;
+
+  async verify(input: {
+    credentialId: string;
+    secret: SecretMaterial;
+  }): Promise<{ verified: boolean; verificationId?: string }> {
+    if (this.failure) throw this.failure;
+    let matches = false;
+    await input.secret.use((value) => {
+      matches = value === SYNTHETIC_SECRET;
+    });
+    return {
+      verified: this.verified && matches,
+      verificationId: 'verification-1',
+    };
+  }
+}
+
+class FakeSink implements CredentialSecretSink {
+  readonly name = 'fake-sink';
+  readonly values = new Map<string, string>();
+  readonly credentialIds = new Map<string, string>();
+  readonly removed: Array<{ reference: string; reason: string }> = [];
+  storeFailure?: Error;
+  storeFailureAfterWrite?: Error;
+  retrieveFailure?: Error;
+  removeFailure?: Error;
+  next = 1;
+  inventoryOverride?: SecretSinkInventoryEntry[];
+
+  async store(input: {
+    credentialId: string;
+    secret: SecretMaterial;
+    metadata: Readonly<Record<string, string>>;
+  }): Promise<SecretSinkRecord> {
+    if (this.storeFailure) throw this.storeFailure;
+    const reference = `sink-record-${this.next++}`;
+    let stored = '';
+    await input.secret.use((value) => {
+      stored = value;
+    });
+    this.values.set(reference, stored);
+    this.credentialIds.set(reference, input.credentialId);
+    if (this.storeFailureAfterWrite) throw this.storeFailureAfterWrite;
+    return {
+      sinkName: this.name,
+      reference,
+      version: '1',
+      storedAt: '2026-08-14T17:00:01.000Z',
+    };
+  }
+
+  async retrieve(record: SecretSinkRecord): Promise<SecretMaterial> {
+    if (this.retrieveFailure) throw this.retrieveFailure;
+    const value = this.values.get(record.reference);
+    if (!value) throw new Error('synthetic sink record missing');
+    return SecretMaterial.fromString(value);
+  }
+
+  async remove(record: SecretSinkRecord, reason: string): Promise<void> {
+    this.removed.push({ reference: record.reference, reason });
+    this.values.delete(record.reference);
+    this.credentialIds.delete(record.reference);
+    if (this.removeFailure) throw this.removeFailure;
+  }
+
+  async removeByCredentialId(
+    credentialId: string,
+    reason: string,
+  ): Promise<void> {
+    for (const [reference, storedCredentialId] of this.credentialIds) {
+      if (storedCredentialId === credentialId) {
+        await this.remove(
+          {
+            sinkName: this.name,
+            reference,
+            version: '1',
+            storedAt: '2026-08-14T17:00:01.000Z',
+          },
+          reason,
+        );
+      }
+    }
+  }
+
+  async inventory(): Promise<SecretSinkInventoryEntry[]> {
+    if (this.inventoryOverride) return structuredClone(this.inventoryOverride);
+    return [...this.values.keys()].map((reference) => ({
+      sinkName: this.name,
+      reference,
+      version: '1',
+      storedAt: '2026-08-14T17:00:01.000Z',
+      credentialId: this.credentialIds.get(reference) ?? 'unknown-credential',
+    }));
+  }
+}
+
+class FlakyLedger implements CustodyLedger {
+  readonly inner = new InMemoryCustodyLedger();
+  failEventType?: CustodyEvent['type'];
+
+  async recordIssuance(
+    receipt: CustodyReceipt,
+    event: CustodyEvent,
+  ): Promise<void> {
+    await this.inner.recordIssuance(receipt, event);
+  }
+
+  async commitIssuance(
+    receiptId: string,
+    event: CustodyEvent,
+    followup?: CustodyEvent,
+  ): Promise<void> {
+    await this.inner.commitIssuance(receiptId, event, followup);
+  }
+
+  async appendEvent(event: CustodyEvent): Promise<void> {
+    if (event.type === this.failEventType) {
+      this.failEventType = undefined;
+      throw new Error('synthetic ledger failure');
+    }
+    await this.inner.appendEvent(event);
+  }
+
+  async listReceipts(): Promise<CustodyReceipt[]> {
+    return this.inner.listReceipts();
+  }
+
+  async listEvents(): Promise<CustodyEvent[]> {
+    return this.inner.listEvents();
+  }
+}
+
+class TracingLedger extends InMemoryCustodyLedger {
+  readonly calls: string[] = [];
+
+  override async recordIssuance(
+    receipt: CustodyReceipt,
+    event: CustodyEvent,
+  ): Promise<void> {
+    this.calls.push(`record:${event.type}`);
+    await super.recordIssuance(receipt, event);
+  }
+
+  override async commitIssuance(
+    receiptId: string,
+    event: CustodyEvent,
+    followup?: CustodyEvent,
+  ): Promise<void> {
+    this.calls.push(`commit-ledger:${event.type}:${followup?.type ?? 'none'}`);
+    await super.commitIssuance(receiptId, event, followup);
+  }
+}
+
+describe('credential custody', () => {
+  let issuer: FakeIssuer;
+  let verifier: FakeVerifier;
+  let sink: FakeSink;
+  let ledger: InMemoryCustodyLedger;
+  let custody: CredentialCustody;
+
+  beforeEach(() => {
+    issuer = new FakeIssuer();
+    verifier = new FakeVerifier();
+    sink = new FakeSink();
+    ledger = new InMemoryCustodyLedger();
+    custody = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.CUSTODY_TEST_TOKEN;
+    delete process.env.UNRELATED_CUSTODY_TOKEN;
+  });
+
+  it('stores, retrieves, verifies, and returns only a safe durable receipt', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+      metadata: { purpose: 'integration-test' },
+    });
+
+    expect(lease.receipt).toMatchObject({
+      mode: 'durable',
+      credentialId: 'credential-1',
+      verificationState: 'verified',
+      verificationId: 'verification-1',
+      rotationRootReceiptId: lease.receipt.receiptId,
+    });
+    expect(lease.receipt.sink?.reference).toBe('sink-record-1');
+    expect(JSON.stringify(lease.receipt)).not.toContain(SYNTHETIC_SECRET);
+
+    await lease.withEnvironment('CUSTODY_TEST_TOKEN', () => {
+      expect(process.env.CUSTODY_TEST_TOKEN).toBe(SYNTHETIC_SECRET);
+    });
+    expect(process.env.CUSTODY_TEST_TOKEN).toBeUndefined();
+  });
+
+  it('cryptographically binds the receipt, sink locator, and submitted token', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const submitted = SecretMaterial.fromString(SYNTHETIC_SECRET);
+    await expect(
+      verifyCustodyReceiptAttestation(
+        lease.receipt,
+        submitted,
+        TEST_KEY_PAIR.publicKey,
+      ),
+    ).resolves.toBe(true);
+
+    const tampered = structuredClone(lease.receipt);
+    if (!tampered.sink) throw new Error('durable receipt has no sink');
+    tampered.sink.reference = 'different-locator';
+    await expect(
+      verifyCustodyReceiptAttestation(
+        tampered,
+        submitted,
+        TEST_KEY_PAIR.publicKey,
+      ),
+    ).resolves.toBe(false);
+
+    const noncanonical = structuredClone(lease.receipt);
+    const alphabet =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+    const last = noncanonical.attestation.signature.at(-1) ?? '';
+    const index = alphabet.indexOf(last);
+    noncanonical.attestation.signature = `${noncanonical.attestation.signature.slice(0, -1)}${alphabet[index ^ 1]}`;
+    expect(
+      Buffer.from(noncanonical.attestation.signature, 'base64url').equals(
+        Buffer.from(lease.receipt.attestation.signature, 'base64url'),
+      ),
+    ).toBe(true);
+    await expect(
+      verifyCustodyReceiptAttestation(
+        noncanonical,
+        submitted,
+        TEST_KEY_PAIR.publicKey,
+      ),
+    ).resolves.toBe(false);
+
+    const identityTampered = structuredClone(lease.receipt);
+    identityTampered.attestation.keyId = 'different-trusted-key';
+    await expect(
+      verifyCustodyReceiptAttestation(
+        identityTampered,
+        submitted,
+        TEST_KEY_PAIR.publicKey,
+      ),
+    ).resolves.toBe(false);
+
+    const different = SecretMaterial.fromString('synthetic-different-value');
+    await expect(
+      verifyCustodyReceiptAttestation(
+        lease.receipt,
+        different,
+        TEST_KEY_PAIR.publicKey,
+      ),
+    ).resolves.toBe(false);
+    submitted.destroy();
+    different.destroy();
+  });
+
+  it('fails closed and revokes when durable storage fails', async () => {
+    sink.storeFailure = new Error('synthetic store failure');
+
+    await expect(
+      custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_STORE_FAILED', stage: 'store' });
+
+    expect(issuer.revoked).toEqual([
+      {
+        credentialId: 'credential-1',
+        reason: 'rollback after store',
+      },
+    ]);
+    expect(sink.values.size).toBe(0);
+  });
+
+  it('removes the sink record and revokes when retrieval fails', async () => {
+    sink.retrieveFailure = new Error('synthetic retrieve failure');
+
+    await expect(
+      custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({
+      code: 'CUSTODY_RETRIEVE_FAILED',
+      stage: 'retrieve',
+    });
+
+    expect(sink.values.size).toBe(0);
+    expect(sink.removed).toHaveLength(1);
+    expect(issuer.revoked).toHaveLength(1);
+  });
+
+  it('exact-redacts arbitrary plaintext from retrieval CustodyErrors', async () => {
+    sink.retrieveFailure = new CustodyError(
+      SYNTHETIC_SECRET,
+      'retrieve',
+      SYNTHETIC_SECRET,
+      { details: { returned: SYNTHETIC_SECRET } },
+    );
+    let caught: unknown;
+    try {
+      await custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(JSON.stringify(caught)).not.toContain(SYNTHETIC_SECRET);
+    expect(inspect(caught, { showHidden: true })).not.toContain(
+      SYNTHETIC_SECRET,
+    );
+  });
+
+  it('removes an ambiguous partial store write by credential identity', async () => {
+    sink.storeFailureAfterWrite = new Error('synthetic response loss');
+
+    await expect(
+      custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_STORE_FAILED' });
+
+    expect(issuer.revoked).toHaveLength(1);
+    expect(sink.values.size).toBe(0);
+  });
+
+  it('removes the sink record and revokes on negative verification', async () => {
+    verifier.verified = false;
+
+    await expect(
+      custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({
+      code: 'CREDENTIAL_VERIFICATION_FAILED',
+      stage: 'verify',
+    });
+
+    expect(sink.values.size).toBe(0);
+    expect(issuer.revoked).toHaveLength(1);
+  });
+
+  it('revokes and removes custody when post-attestation activation rejects', async () => {
+    const calls: string[] = [];
+    const rejecting = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: {
+        name: 'rejecting-finalizer',
+        async prepare(input) {
+          calls.push('prepare');
+          expect(input.receipt.attestation.signature).not.toBe('');
+          return { prepared: false };
+        },
+        async commit() {},
+        async abort() {
+          calls.push('abort');
+        },
+        async status() {
+          return 'missing' as const;
+        },
+      },
+    });
+
+    await expect(
+      rejecting.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CREDENTIAL_ACTIVATION_FAILED' });
+    expect(issuer.revoked).toHaveLength(1);
+    expect(sink.values.size).toBe(0);
+    expect(await ledger.listReceipts()).toHaveLength(1);
+    expect((await ledger.listEvents()).at(-1)?.type).toBe('revoked');
+    expect(calls).toEqual(['prepare', 'abort']);
+  });
+
+  it('revokes and removes custody when post-attestation activation throws', async () => {
+    const calls: string[] = [];
+    const throwing = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: {
+        name: 'throwing-finalizer',
+        async prepare() {
+          calls.push('prepare');
+          throw new Error('synthetic activation failure');
+        },
+        async commit() {},
+        async abort() {
+          calls.push('abort');
+        },
+        async status() {
+          return 'missing' as const;
+        },
+      },
+    });
+
+    await expect(
+      throwing.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_ACTIVATE_FAILED' });
+    expect(issuer.revoked).toHaveLength(1);
+    expect(sink.values.size).toBe(0);
+    expect(await ledger.listReceipts()).toHaveLength(1);
+    expect((await ledger.listEvents()).at(-1)?.type).toBe('revoked');
+    expect(calls).toEqual(['prepare', 'abort']);
+  });
+
+  it('aborts a prepared activation when commit fails after ledger recording', async () => {
+    const calls: string[] = [];
+    const staged = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: {
+        name: 'staged-finalizer',
+        async prepare() {
+          calls.push('prepare');
+          return { prepared: true };
+        },
+        async commit() {
+          calls.push('commit');
+          throw new Error('synthetic commit failure');
+        },
+        async abort() {
+          calls.push('abort');
+        },
+        async status() {
+          return 'prepared' as const;
+        },
+      },
+    });
+
+    await expect(
+      staged.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_ACTIVATE_FAILED' });
+    expect(calls).toEqual(['prepare', 'commit', 'abort']);
+    expect(issuer.revoked).toHaveLength(1);
+    expect(sink.values.size).toBe(0);
+    expect((await ledger.listEvents()).at(-1)?.type).toBe('revoked');
+  });
+
+  it('requires a sink for durable issuance before invoking the issuer', async () => {
+    const withoutSink = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+
+    await expect(
+      withoutSink.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'DURABLE_SINK_REQUIRED' });
+    expect(issuer.next).toBe(1);
+  });
+
+  it('expires and cleans up ephemeral credentials automatically', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    const backgroundErrors: CustodyError[] = [];
+    const ephemeral = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      ephemeralTtlMs: 1_000,
+      onBackgroundError: (error) => backgroundErrors.push(error),
+    });
+
+    const lease = await ephemeral.issue({
+      mode: 'ephemeral',
+      subject: 'throwaway-agent',
+      attribution: ATTRIBUTION,
+    });
+    expect(lease.receipt.sink).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(issuer.revoked).toEqual([
+      { credentialId: 'credential-1', reason: 'expired' },
+    ]);
+    expect(backgroundErrors).toEqual([]);
+    await expect(
+      lease.withEnvironment('CUSTODY_TEST_TOKEN', () => undefined),
+    ).rejects.toMatchObject({ code: 'CREDENTIAL_REVOKED' });
+    expect((await ledger.listEvents()).map((event) => event.type)).toEqual([
+      'finalization-pending',
+      'issued',
+      'expired',
+    ]);
+  });
+
+  it('reports and retries failed ephemeral expiry revocation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    const backgroundErrors: CustodyError[] = [];
+    const ephemeral = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      ephemeralTtlMs: 1_000,
+      ephemeralRevokeRetryMs: 500,
+      onBackgroundError: (error) => backgroundErrors.push(error),
+    });
+    await ephemeral.issue({
+      mode: 'ephemeral',
+      subject: 'throwaway-agent',
+      attribution: ATTRIBUTION,
+    });
+    issuer.revokeFailure = new Error('synthetic revoke failure');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(backgroundErrors).toHaveLength(1);
+    issuer.revokeFailure = undefined;
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(issuer.revoked).toHaveLength(2);
+    expect((await ledger.listEvents()).map((event) => event.type)).toContain(
+      'expired',
+    );
+  });
+
+  it('persists and automatically retries failed pre-receipt rollback', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    const ephemeral = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      ephemeralRevokeRetryMs: 500,
+    });
+    verifier.verified = false;
+    issuer.revokeFailure = new Error('synthetic revoke failure');
+
+    await expect(
+      ephemeral.issue({
+        mode: 'ephemeral',
+        subject: 'throwaway-agent',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_ROLLBACK_FAILED' });
+    expect((await ledger.listEvents()).map((event) => event.type)).toContain(
+      'rollback-pending',
+    );
+
+    issuer.revokeFailure = undefined;
+    await vi.advanceTimersByTimeAsync(500);
+    expect(issuer.revoked).toHaveLength(2);
+    const completion = (await ledger.listEvents()).find(
+      (event) => event.type === 'rollback-complete',
+    );
+    expect(completion?.recoveryId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(completion?.receiptId).toBeUndefined();
+  });
+
+  it('recovers a committed finalization-pending receipt after restart', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    const issuedLease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const restartLedger = new InMemoryCustodyLedger();
+    await restartLedger.recordIssuance(issuedLease.receipt, {
+      eventId: issuedLease.receipt.finalizationId,
+      type: 'finalization-pending',
+      occurredAt: new Date().toISOString(),
+      receiptId: issuedLease.receipt.receiptId,
+    });
+    const restarted = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger: restartLedger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+
+    await restarted.recoverPendingRollbacks();
+    expect(
+      (await restartLedger.listEvents()).map((event) => event.type),
+    ).toEqual(['finalization-pending']);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(
+      (await restartLedger.listEvents()).map((event) => event.type),
+    ).toEqual(['finalization-pending', 'issued']);
+  });
+
+  it('resumes a persisted pre-receipt rollback after restart', async () => {
+    vi.useFakeTimers();
+    verifier.verified = false;
+    issuer.revokeFailure = new Error('synthetic revoke failure');
+    const firstProcess = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      ephemeralRevokeRetryMs: 500,
+    });
+    await expect(
+      firstProcess.issue({
+        mode: 'ephemeral',
+        subject: 'throwaway-agent',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_ROLLBACK_FAILED' });
+
+    issuer.revokeFailure = undefined;
+    const recoveredProcess = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    await recoveredProcess.recoverPendingRollbacks();
+
+    expect(issuer.revoked).toHaveLength(2);
+    expect((await ledger.listEvents()).map((event) => event.type)).toContain(
+      'rollback-complete',
+    );
+  });
+
+  it('requires the durable sink before completing persisted rollback recovery', async () => {
+    vi.useFakeTimers();
+    verifier.verified = false;
+    issuer.revokeFailure = new Error('synthetic revoke failure');
+    const firstProcess = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    await expect(
+      firstProcess.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_ROLLBACK_FAILED' });
+    issuer.revokeFailure = undefined;
+
+    const missingSinkProcess = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    await expect(
+      missingSinkProcess.recoverPendingRollbacks(),
+    ).rejects.toMatchObject({ code: 'PENDING_ROLLBACK_RECOVERY_FAILED' });
+    expect(sink.values.size).toBe(1);
+
+    const recoveredProcess = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    await recoveredProcess.recoverPendingRollbacks();
+    expect(sink.values.size).toBe(0);
+  });
+
+  it('continues recovering later pending credentials after one failure', async () => {
+    vi.useFakeTimers();
+    verifier.verified = false;
+    issuer.revokeFailure = new Error('synthetic revoke failure');
+    for (const subject of ['throwaway-one', 'throwaway-two']) {
+      await expect(
+        custody.issue({ mode: 'ephemeral', subject, attribution: ATTRIBUTION }),
+      ).rejects.toMatchObject({ code: 'CUSTODY_ROLLBACK_FAILED' });
+    }
+    issuer.revokeFailure = undefined;
+    issuer.revokeFailures.add('credential-1');
+
+    await expect(custody.recoverPendingRollbacks()).rejects.toMatchObject({
+      code: 'PENDING_ROLLBACK_RECOVERY_FAILED',
+    });
+
+    const events = await ledger.listEvents();
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'rollback-complete' &&
+          event.credentialId === 'credential-2',
+      ),
+    ).toBe(true);
+  });
+
+  it('retries expiry revocation even when the background observer throws', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    const ephemeral = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      ephemeralTtlMs: 1_000,
+      ephemeralRevokeRetryMs: 500,
+      onBackgroundError: () => {
+        throw new Error('synthetic observer failure');
+      },
+    });
+    await ephemeral.issue({
+      mode: 'ephemeral',
+      subject: 'throwaway-agent',
+      attribution: ATTRIBUTION,
+    });
+    issuer.revokeFailure = new Error('synthetic revoke failure');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    issuer.revokeFailure = undefined;
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(issuer.revoked).toHaveLength(2);
+  });
+
+  it('invalidates a live ephemeral lease when revoked through custody', async () => {
+    const ephemeral = new CredentialCustody({
+      issuer,
+      verifier,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    const lease = await ephemeral.issue({
+      mode: 'ephemeral',
+      subject: 'throwaway-agent',
+      attribution: ATTRIBUTION,
+    });
+
+    await ephemeral.revoke(lease.receipt.receiptId);
+
+    await expect(
+      lease.withChildProcess({
+        command: process.execPath,
+        args: ['-e', 'process.exit(0)'],
+        environmentVariable: 'CUSTODY_TEST_TOKEN',
+      }),
+    ).rejects.toMatchObject({ code: 'CREDENTIAL_REVOKED' });
+  });
+
+  it('restores an existing environment value after success', async () => {
+    process.env.CUSTODY_TEST_TOKEN = 'previous-safe-value';
+    const material = SecretMaterial.fromString(SYNTHETIC_SECRET);
+
+    await withEnvironmentSecret(material, 'CUSTODY_TEST_TOKEN', () => {
+      expect(process.env.CUSTODY_TEST_TOKEN).toBe(SYNTHETIC_SECRET);
+    });
+
+    expect(process.env.CUSTODY_TEST_TOKEN).toBe('previous-safe-value');
+    material.destroy();
+  });
+
+  it('restores an absent environment value when the callback throws', async () => {
+    const material = SecretMaterial.fromString(SYNTHETIC_SECRET);
+
+    await expect(
+      withEnvironmentSecret(material, 'CUSTODY_TEST_TOKEN', () => {
+        throw new Error('synthetic callback failure');
+      }),
+    ).rejects.toMatchObject({ code: 'SECRET_MATERIAL_OPERATION_FAILED' });
+
+    expect(process.env.CUSTODY_TEST_TOKEN).toBeUndefined();
+    material.destroy();
+  });
+
+  it('serializes overlapping injection for the same environment variable', async () => {
+    const first = SecretMaterial.fromString('synthetic-first-value');
+    const second = SecretMaterial.fromString('synthetic-second-value');
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstStarted: () => void = () => undefined;
+    const firstReady = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let secondEntered = false;
+
+    const firstOperation = withEnvironmentSecret(
+      first,
+      'CUSTODY_TEST_TOKEN',
+      async () => {
+        expect(process.env.CUSTODY_TEST_TOKEN).toBe('synthetic-first-value');
+        firstStarted();
+        await firstGate;
+        expect(process.env.CUSTODY_TEST_TOKEN).toBe('synthetic-first-value');
+      },
+    );
+    await firstReady;
+    const secondOperation = withEnvironmentSecret(
+      second,
+      'CUSTODY_TEST_TOKEN',
+      () => {
+        secondEntered = true;
+        expect(process.env.CUSTODY_TEST_TOKEN).toBe('synthetic-second-value');
+      },
+    );
+    await Promise.resolve();
+    expect(secondEntered).toBe(false);
+    releaseFirst();
+    await Promise.all([firstOperation, secondOperation]);
+
+    expect(process.env.CUSTODY_TEST_TOKEN).toBeUndefined();
+    first.destroy();
+    second.destroy();
+  });
+
+  it('rejects nested environment or child injection instead of deadlocking', async () => {
+    const outer = SecretMaterial.fromString('synthetic-outer-value');
+    const inner = SecretMaterial.fromString('synthetic-inner-value');
+    const nestedLease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    await withEnvironmentSecret(outer, 'CUSTODY_TEST_TOKEN', async () => {
+      await expect(
+        withEnvironmentSecret(
+          inner,
+          'UNRELATED_CUSTODY_TOKEN',
+          () => undefined,
+        ),
+      ).rejects.toMatchObject({ code: 'REENTRANT_ENVIRONMENT_INJECTION' });
+      await expect(
+        nestedLease.withChildProcess({
+          command: process.execPath,
+          environmentVariable: 'UNRELATED_CUSTODY_TOKEN',
+        }),
+      ).rejects.toMatchObject({ code: 'REENTRANT_ENVIRONMENT_INJECTION' });
+    });
+    await nestedLease.revoke('test cleanup');
+    outer.destroy();
+    inner.destroy();
+  });
+
+  it('discards callback return values instead of returning plaintext', async () => {
+    const material = SecretMaterial.fromString(SYNTHETIC_SECRET);
+    const result = await withEnvironmentSecret(
+      material,
+      'CUSTODY_TEST_TOKEN',
+      () => process.env.CUSTODY_TEST_TOKEN,
+    );
+    expect(result).toBeUndefined();
+    material.destroy();
+  });
+
+  it('rejects uncancellable callbacks for expiring credentials', async () => {
+    const material = SecretMaterial.fromString(SYNTHETIC_SECRET);
+    await expect(
+      withEnvironmentSecret(
+        material,
+        'CUSTODY_TEST_TOKEN',
+        async () => undefined,
+        { expiresAt: new Date(Date.now() + 1_000).toISOString() },
+      ),
+    ).rejects.toMatchObject({
+      code: 'EXPIRING_ENVIRONMENT_CALLBACK_UNSAFE',
+    });
+    expect(process.env.CUSTODY_TEST_TOKEN).toBeUndefined();
+    material.destroy();
+  });
+
+  it('retries a failed external revocation', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    issuer.revokeFailure = new Error('synthetic revoke failure');
+    await expect(lease.revoke()).rejects.toMatchObject({
+      code: 'CREDENTIAL_REVOCATION_FAILED',
+    });
+
+    issuer.revokeFailure = undefined;
+    await lease.revoke();
+
+    expect(issuer.revoked.map((item) => item.credentialId)).toEqual([
+      'credential-1',
+      'credential-1',
+    ]);
+  });
+
+  it('bounds child-only injection and redacts child output', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    const result = await lease.withChildProcess({
+      command: process.execPath,
+      args: [
+        '-e',
+        'process.stdout.write(process.env.CUSTODY_TEST_TOKEN); process.stderr.write(process.env.CUSTODY_TEST_TOKEN)',
+      ],
+      environmentVariable: 'CUSTODY_TEST_TOKEN',
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stdout: '[REDACTED]',
+      stderr: '[REDACTED]',
+      timedOut: false,
+    });
+    expect(process.env.CUSTODY_TEST_TOKEN).toBeUndefined();
+  });
+
+  it('does not snapshot another in-flight environment credential into a child', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const unrelated = SecretMaterial.fromString('synthetic-unrelated-value');
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started: () => void = () => undefined;
+    const ready = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const injection = withEnvironmentSecret(
+      unrelated,
+      'UNRELATED_CUSTODY_TOKEN',
+      async () => {
+        started();
+        await gate;
+      },
+    );
+    await ready;
+    const childResult = lease.withChildProcess({
+      command: process.execPath,
+      args: [
+        '-e',
+        'process.stdout.write(String(Boolean(process.env.UNRELATED_CUSTODY_TOKEN)))',
+      ],
+      environmentVariable: 'CUSTODY_TEST_TOKEN',
+    });
+    await Promise.resolve();
+    release();
+    await injection;
+
+    await expect(childResult).resolves.toMatchObject({ stdout: 'false' });
+    unrelated.destroy();
+  });
+
+  it('discards all captured output when the output bound is exceeded', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    const result = await lease.withChildProcess({
+      command: process.execPath,
+      args: ['-e', "process.stdout.write('synthetic-credential-fragment')"],
+      environmentVariable: 'CUSTODY_TEST_TOKEN',
+      maxOutputBytes: 8,
+    });
+
+    expect(result.stdout).toBe('[REDACTED]');
+    expect(result.timedOut).toBe(true);
+  });
+
+  it('rejects non-finite child-process bounds', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    await expect(
+      lease.withChildProcess({
+        command: process.execPath,
+        environmentVariable: 'CUSTODY_TEST_TOKEN',
+        maxOutputBytes: Number.NaN,
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_CHILD_PROCESS_BOUNDS' });
+  });
+
+  it('terminates an over-time child process group', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    const result = await lease.withChildProcess({
+      command: process.execPath,
+      args: [
+        '-e',
+        [
+          "const { spawn } = require('node:child_process')",
+          "spawn(process.execPath, ['-e', `process.on('SIGTERM', () => { console.log('descendant-stopped'); process.exit(0) }); setInterval(() => undefined, 1000)`], { stdio: ['ignore', 'inherit', 'inherit'] })",
+          'setInterval(() => undefined, 1000)',
+        ].join(';'),
+      ],
+      environmentVariable: 'CUSTODY_TEST_TOKEN',
+      timeoutMs: 50,
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.signal).not.toBeNull();
+    expect(result.stdout).toContain('descendant-stopped');
+  });
+
+  it('kills a stubborn descendant before returning after normal leader exit', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const result = await lease.withChildProcess({
+      command: process.execPath,
+      args: [
+        '-e',
+        [
+          "const { spawn } = require('node:child_process')",
+          "const child = spawn(process.execPath, ['-e', `process.on('SIGTERM', () => undefined); setInterval(() => undefined, 1000)`], { stdio: 'ignore' })",
+          'child.unref()',
+          'process.stdout.write(String(child.pid))',
+        ].join(';'),
+      ],
+      environmentVariable: 'CUSTODY_TEST_TOKEN',
+      timeoutMs: 5_000,
+    });
+    const descendantPid = Number(result.stdout);
+    expect(Number.isInteger(descendantPid)).toBe(true);
+    expect(() => process.kill(descendantPid, 0)).toThrow();
+  });
+
+  it('rejects invalid and provider-extended expiry bounds fail closed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    await expect(
+      custody.issue({
+        mode: 'ephemeral',
+        subject: 'throwaway-agent',
+        attribution: ATTRIBUTION,
+        expiresAt: 'not-a-timestamp',
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_CUSTODY_TIMESTAMP' });
+    expect(issuer.next).toBe(1);
+
+    issuer.expiresAtOverride = '2026-08-14T19:00:00.000Z';
+    await expect(
+      custody.issue({
+        mode: 'ephemeral',
+        subject: 'throwaway-agent',
+        attribution: ATTRIBUTION,
+        expiresAt: '2026-08-14T18:00:00.000Z',
+      }),
+    ).rejects.toMatchObject({ code: 'EXPIRY_BOUND_EXCEEDED' });
+    expect(issuer.revoked).toHaveLength(1);
+  });
+
+  it('detects missing and orphaned sink records and safely removes orphans', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const issuedSink = lease.receipt.sink;
+    expect(issuedSink).toBeDefined();
+    if (!issuedSink) throw new Error('durable receipt has no sink');
+    sink.values.delete(issuedSink.reference);
+    sink.values.set('orphan-record-1', SYNTHETIC_SECRET);
+
+    const report = await custody.reconcile();
+
+    expect(report.missing.map((receipt) => receipt.receiptId)).toEqual([
+      lease.receipt.receiptId,
+    ]);
+    expect(report.orphaned.map((entry) => entry.reference)).toEqual([
+      'orphan-record-1',
+    ]);
+
+    await custody.recoverOrphans(report);
+    expect(sink.values.has('orphan-record-1')).toBe(false);
+    expect((await ledger.listEvents()).map((event) => event.type)).toEqual([
+      'finalization-pending',
+      'issued',
+      'orphan-detected',
+      'orphan-removed',
+    ]);
+  });
+
+  it('records rotation lineage and retires the replaced credential', async () => {
+    const first = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    const replacement = await custody.rotate(first.receipt.receiptId, {
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    expect(replacement.receipt.replacesReceiptId).toBe(first.receipt.receiptId);
+    expect(replacement.receipt.rotationRootReceiptId).toBe(
+      first.receipt.receiptId,
+    );
+    expect(issuer.revoked).toContainEqual({
+      credentialId: first.receipt.credentialId,
+      reason: 'replaced',
+    });
+    const firstSink = first.receipt.sink;
+    expect(firstSink).toBeDefined();
+    if (!firstSink) throw new Error('durable receipt has no sink');
+    expect(sink.values.has(firstSink.reference)).toBe(false);
+    expect(await ledger.listReceipts()).toHaveLength(2);
+    await expect(
+      first.withEnvironment('CUSTODY_TEST_TOKEN', () => undefined),
+    ).rejects.toMatchObject({ code: 'CREDENTIAL_REVOKED' });
+  });
+
+  it('replaces a missing durable sink record and reconciles cleanly', async () => {
+    const first = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const firstSink = first.receipt.sink;
+    if (!firstSink) throw new Error('durable receipt has no sink');
+    sink.values.delete(firstSink.reference);
+    expect((await custody.reconcile()).missing).toHaveLength(1);
+
+    const replacement = await custody.rotate(first.receipt.receiptId, {
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    expect(replacement.receipt.replacesReceiptId).toBe(first.receipt.receiptId);
+    await expect(custody.reconcile()).resolves.toMatchObject({
+      missing: [],
+      orphaned: [],
+    });
+  });
+
+  it('linearizes concurrent rotations through the ledger', async () => {
+    const first = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    const results = await Promise.allSettled([
+      custody.rotate(first.receipt.receiptId, {
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+      custody.rotate(first.receipt.receiptId, {
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      }),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === 'fulfilled'),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === 'rejected'),
+    ).toHaveLength(1);
+  });
+
+  it('keeps a verified replacement when terminal event persistence retries', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    const flakyLedger = new FlakyLedger();
+    const rotatingCustody = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger: flakyLedger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      ephemeralRevokeRetryMs: 500,
+    });
+    const first = await rotatingCustody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    flakyLedger.failEventType = 'replaced';
+
+    const replacement = await rotatingCustody.rotate(first.receipt.receiptId, {
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    expect(replacement.receipt.replacesReceiptId).toBe(first.receipt.receiptId);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(
+      (await flakyLedger.listEvents()).map((event) => event.type),
+    ).toContain('replaced');
+  });
+
+  it('rejects direct replacement of an ephemeral predecessor', async () => {
+    const ephemeral = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    const first = await ephemeral.issue({
+      mode: 'ephemeral',
+      subject: 'throwaway-agent',
+      attribution: ATTRIBUTION,
+    });
+
+    await expect(
+      ephemeral.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+        replacesReceiptId: first.receipt.receiptId,
+      }),
+    ).rejects.toMatchObject({ code: 'DURABLE_ROTATION_REQUIRED' });
+    expect(issuer.next).toBe(2);
+  });
+
+  it('does not remove an owned record from a stale or fabricated orphan report', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const owned = lease.receipt.sink;
+    if (!owned) throw new Error('durable receipt has no sink');
+
+    await custody.recoverOrphans({
+      checkedAt: '2026-08-14T17:05:00.000Z',
+      missing: [],
+      orphaned: [{ ...owned, credentialId: lease.receipt.credentialId }],
+    });
+
+    expect(sink.values.has(owned.reference)).toBe(true);
+    expect(issuer.revoked).toEqual([]);
+  });
+
+  it('treats sink version or credential ownership mismatches fail closed', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const owned = lease.receipt.sink;
+    if (!owned) throw new Error('durable receipt has no sink');
+    sink.inventoryOverride = [
+      { ...owned, version: '2', credentialId: 'credential-other' },
+    ];
+
+    const report = await custody.reconcile();
+    expect(report.missing).toHaveLength(1);
+    expect(report.orphaned).toHaveLength(1);
+  });
+
+  it('retains an orphan until issuer revocation can be retried', async () => {
+    const orphan: SecretSinkInventoryEntry = {
+      sinkName: sink.name,
+      reference: 'orphan-record',
+      version: '1',
+      storedAt: '2026-08-14T17:00:01.000Z',
+      credentialId: 'orphan-credential',
+    };
+    sink.values.set(orphan.reference, SYNTHETIC_SECRET);
+    sink.credentialIds.set(orphan.reference, orphan.credentialId);
+    const report = await custody.reconcile();
+    issuer.revokeFailures.add(orphan.credentialId);
+
+    await expect(custody.recoverOrphans(report)).rejects.toMatchObject({
+      code: 'ORPHAN_REVOCATION_FAILED',
+    });
+    expect(sink.values.has(orphan.reference)).toBe(true);
+
+    issuer.revokeFailures.delete(orphan.credentialId);
+    await custody.recoverOrphans(report);
+    expect(sink.values.has(orphan.reference)).toBe(false);
+    expect(
+      issuer.revoked.filter(
+        (item) => item.credentialId === orphan.credentialId,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('keeps the replacement active while predecessor retirement retries', async () => {
+    const first = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    issuer.revokeFailures.add(first.receipt.credentialId);
+
+    const replacement = await custody.rotate(first.receipt.receiptId, {
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    expect(issuer.revoked.map((entry) => entry.credentialId)).toEqual([
+      'credential-1',
+    ]);
+    expect(sink.values.size).toBe(2);
+    expect(replacement.receipt.replacesReceiptId).toBe(first.receipt.receiptId);
+    expect(
+      (await ledger.listEvents()).some(
+        (event) => event.type === 'retirement-pending',
+      ),
+    ).toBe(true);
+
+    issuer.revokeFailures.delete(first.receipt.credentialId);
+    await custody.recoverPendingRollbacks();
+    expect(sink.values.size).toBe(1);
+  });
+
+  it('orders staged rotation across finalizer, ledger, and issuer adapters', async () => {
+    const tracingLedger = new TracingLedger();
+    const calls = tracingLedger.calls;
+    const tracingCustody = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger: tracingLedger,
+      attestor: TEST_ATTESTOR,
+      finalizer: {
+        name: 'tracing-finalizer',
+        async prepare() {
+          calls.push('prepare');
+          return { prepared: true };
+        },
+        async commit() {
+          calls.push('commit-finalizer');
+        },
+        async abort() {
+          calls.push('abort');
+        },
+        async status() {
+          return 'committed' as const;
+        },
+      },
+    });
+    const first = await tracingCustody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    calls.length = 0;
+    issuer.onRevoke = (credentialId) => {
+      if (credentialId === first.receipt.credentialId) calls.push('retire');
+    };
+
+    await tracingCustody.rotate(first.receipt.receiptId, {
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+
+    expect(calls).toEqual([
+      'record:finalization-pending',
+      'prepare',
+      'commit-finalizer',
+      'commit-ledger:issued:retirement-pending',
+      'retire',
+    ]);
+  });
+
+  it('recovers a committed pending rotation and then retires its predecessor', async () => {
+    const first = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const replacement = await custody.rotate(first.receipt.receiptId, {
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const restartLedger = new InMemoryCustodyLedger();
+    await restartLedger.recordIssuance(first.receipt, {
+      eventId: first.receipt.finalizationId,
+      type: 'finalization-pending',
+      occurredAt: '2026-08-14T17:00:00.000Z',
+      receiptId: first.receipt.receiptId,
+    });
+    await restartLedger.commitIssuance(first.receipt.receiptId, {
+      eventId: randomUUID(),
+      type: 'issued',
+      occurredAt: '2026-08-14T17:00:01.000Z',
+      receiptId: first.receipt.receiptId,
+    });
+    await restartLedger.recordIssuance(replacement.receipt, {
+      eventId: replacement.receipt.finalizationId,
+      type: 'finalization-pending',
+      occurredAt: '2026-08-14T17:00:02.000Z',
+      receiptId: replacement.receipt.receiptId,
+    });
+    const restarted = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger: restartLedger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      finalizationTakeoverMs: 0,
+    });
+
+    await restarted.recoverPendingRollbacks();
+    await restarted.recoverPendingRollbacks();
+    const events = await restartLedger.listEvents();
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'issued' &&
+          event.receiptId === replacement.receipt.receiptId,
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.type === 'retirement-complete')).toBe(
+      true,
+    );
+  });
+});
+
+describe('custody redaction', () => {
+  it('replaces an unsafe structured error code', () => {
+    const tokenLikeCode = ['hvwk', 'syntheticsegmentvalue'].join('_');
+    const error = new CustodyError(tokenLikeCode, 'issue', 'safe message');
+    expect(error.code).toBe('INVALID_CUSTODY_ERROR_CODE');
+    expect(JSON.stringify(error)).not.toContain(tokenLikeCode);
+    expect(inspect(error)).not.toContain(tokenLikeCode);
+  });
+  it('keeps secret material opaque across string, JSON, and inspection', () => {
+    const material = SecretMaterial.fromString(SYNTHETIC_SECRET);
+
+    expect(String(material)).toBe('[REDACTED]');
+    expect(JSON.stringify(material)).toBe('"[REDACTED]"');
+    expect(inspect(material)).toBe('[REDACTED]');
+    expect(JSON.stringify({ material })).not.toContain(SYNTHETIC_SECRET);
+    material.destroy();
+  });
+
+  it('redacts constructed token-shaped text without retaining it in source fixtures', () => {
+    const shaped = ['gh', 'p', '_', 'x'.repeat(24)].join('');
+    const jwt = ['a'.repeat(12), 'b'.repeat(12), 'c'.repeat(12)].join('.');
+
+    expect(redactCredentialText(`credential=${shaped}`)).toBe(
+      'credential=[REDACTED]',
+    );
+    expect(redactCredentialText(jwt)).toBe('[REDACTED]');
+    expect(
+      redactCredentialValues({ nested: [`Authorization: Bearer ${shaped}`] }),
+    ).toEqual({ nested: ['Authorization: Bearer [REDACTED]'] });
+  });
+
+  it('redacts a segmented Work-token shape from results, errors, and receipts', async () => {
+    const shaped = ['hv', 'wk', '_', 'x'.repeat(24)].join('');
+
+    expect(redactCredentialText(shaped)).toBe('[REDACTED]');
+    expect(redactCredentialValues({ result: shaped })).toEqual({
+      result: '[REDACTED]',
+    });
+    expect(
+      JSON.stringify(
+        new CustodyError('SYNTHETIC', 'verify', `credential=${shaped}`),
+      ),
+    ).not.toContain(shaped);
+
+    const custody = new CredentialCustody({
+      issuer: new FakeIssuer(),
+      verifier: new FakeVerifier(),
+      sink: new FakeSink(),
+      ledger: new InMemoryCustodyLedger(),
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+      metadata: { accidental: shaped },
+    });
+    expect(JSON.stringify(lease.receipt)).not.toContain(shaped);
+    expect(lease.receipt.metadata.accidental).toBe('[REDACTED]');
+  });
+
+  it('serializes structured errors without causes or token-shaped details', () => {
+    const shaped = ['sk', '_', 'x'.repeat(24)].join('');
+    const error = new CustodyError(
+      'SYNTHETIC_FAILURE',
+      'verify',
+      `token=${shaped}`,
+      {
+        cause: new Error(shaped),
+        details: { authorization: `Bearer ${shaped}` },
+      },
+    );
+
+    const serialized = JSON.stringify(error);
+    expect(serialized).not.toContain(shaped);
+    expect(serialized).toContain('[REDACTED]');
+    expect(serialized).not.toContain('cause');
+    expect(inspect(error)).not.toContain(shaped);
+  });
+
+  it('does not retain token-shaped adapter causes for Node inspection', async () => {
+    const shaped = ['hv', 'wk', '_', 'x'.repeat(24)].join('');
+    const verifier = new FakeVerifier();
+    verifier.failure = new Error(shaped);
+    const custody = new CredentialCustody({
+      issuer: new FakeIssuer(),
+      verifier,
+      sink: new FakeSink(),
+      ledger: new InMemoryCustodyLedger(),
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+
+    let caught: unknown;
+    try {
+      await custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(inspect(caught)).not.toContain(shaped);
+    expect(JSON.stringify(caught)).not.toContain(shaped);
+  });
+
+  it('exact-redacts arbitrary-format plaintext from adapter CustodyErrors', async () => {
+    const verifier = new FakeVerifier();
+    verifier.failure = new CustodyError(
+      'SYNTHETIC_FAILURE',
+      'verify',
+      SYNTHETIC_SECRET,
+      { details: { returned: SYNTHETIC_SECRET } },
+    );
+    const custody = new CredentialCustody({
+      issuer: new FakeIssuer(),
+      verifier,
+      sink: new FakeSink(),
+      ledger: new InMemoryCustodyLedger(),
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+
+    let caught: unknown;
+    try {
+      await custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(JSON.stringify(caught)).not.toContain(SYNTHETIC_SECRET);
+    expect(inspect(caught, { showHidden: true })).not.toContain(
+      SYNTHETIC_SECRET,
+    );
+  });
+
+  it('rejects token-shaped adapter names and metadata keys', async () => {
+    const shaped = ['hv', 'wk', '_', 'x'.repeat(24)].join('');
+    const unsafeIssuer = new FakeIssuer();
+    Object.defineProperty(unsafeIssuer, 'name', { value: shaped });
+    expect(
+      () =>
+        new CredentialCustody({
+          issuer: unsafeIssuer,
+          verifier: new FakeVerifier(),
+          sink: new FakeSink(),
+          ledger: new InMemoryCustodyLedger(),
+          attestor: TEST_ATTESTOR,
+          finalizer: TEST_FINALIZER,
+        }),
+    ).toThrow(CustodyError);
+
+    const custody = new CredentialCustody({
+      issuer: new FakeIssuer(),
+      verifier: new FakeVerifier(),
+      sink: new FakeSink(),
+      ledger: new InMemoryCustodyLedger(),
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+    await expect(
+      custody.issue({
+        mode: 'durable',
+        subject: 'service-account-1',
+        attribution: ATTRIBUTION,
+        metadata: { [shaped]: 'safe-value' },
+      }),
+    ).rejects.toMatchObject({ code: 'UNSAFE_CUSTODY_METADATA_KEY' });
+  });
+
+  it('redacts token-shaped metadata before it reaches a receipt', async () => {
+    const shaped = ['xox', 'b', '_', 'x'.repeat(24)].join('');
+    const custody = new CredentialCustody({
+      issuer: new FakeIssuer(),
+      verifier: new FakeVerifier(),
+      sink: new FakeSink(),
+      ledger: new InMemoryCustodyLedger(),
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+    });
+
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+      metadata: { accidental: shaped },
+    });
+
+    expect(lease.receipt.metadata).toEqual({ accidental: '[REDACTED]' });
+    expect(JSON.stringify(lease.receipt)).not.toContain(shaped);
+  });
+});

--- a/packages/secrets/src/__tests__/custody.test.ts
+++ b/packages/secrets/src/__tests__/custody.test.ts
@@ -1147,7 +1147,7 @@ describe('credential custody', () => {
         ].join(';'),
       ],
       environmentVariable: 'CUSTODY_TEST_TOKEN',
-      timeoutMs: 50,
+      timeoutMs: 500,
     });
 
     expect(result.timedOut).toBe(true);

--- a/packages/secrets/src/__tests__/custody.test.ts
+++ b/packages/secrets/src/__tests__/custody.test.ts
@@ -2,6 +2,7 @@ import { generateKeyPairSync, randomUUID } from 'node:crypto';
 import { inspect } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  type CredentialChildProcessOptions,
   CredentialCustody,
   type CredentialIssueRequest,
   type CredentialIssuer,
@@ -881,6 +882,7 @@ describe('credential custody', () => {
 
     await expect(
       lease.withChildProcess({
+        trust: 'cooperative-process-group',
         command: process.execPath,
         args: ['-e', 'process.exit(0)'],
         environmentVariable: 'CUSTODY_TEST_TOKEN',
@@ -973,6 +975,7 @@ describe('credential custody', () => {
       ).rejects.toMatchObject({ code: 'REENTRANT_ENVIRONMENT_INJECTION' });
       await expect(
         nestedLease.withChildProcess({
+          trust: 'cooperative-process-group',
           command: process.execPath,
           environmentVariable: 'UNRELATED_CUSTODY_TOKEN',
         }),
@@ -1038,6 +1041,7 @@ describe('credential custody', () => {
     });
 
     const result = await lease.withChildProcess({
+      trust: 'cooperative-process-group',
       command: process.execPath,
       args: [
         '-e',
@@ -1081,6 +1085,7 @@ describe('credential custody', () => {
     );
     await ready;
     const childResult = lease.withChildProcess({
+      trust: 'cooperative-process-group',
       command: process.execPath,
       args: [
         '-e',
@@ -1104,6 +1109,7 @@ describe('credential custody', () => {
     });
 
     const result = await lease.withChildProcess({
+      trust: 'cooperative-process-group',
       command: process.execPath,
       args: ['-e', "process.stdout.write('synthetic-credential-fragment')"],
       environmentVariable: 'CUSTODY_TEST_TOKEN',
@@ -1122,11 +1128,26 @@ describe('credential custody', () => {
     });
     await expect(
       lease.withChildProcess({
+        trust: 'cooperative-process-group',
         command: process.execPath,
         environmentVariable: 'CUSTODY_TEST_TOKEN',
         maxOutputBytes: Number.NaN,
       }),
     ).rejects.toMatchObject({ code: 'INVALID_CHILD_PROCESS_BOUNDS' });
+  });
+
+  it('requires explicit cooperative process-group trust', async () => {
+    const lease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    await expect(
+      lease.withChildProcess({
+        command: process.execPath,
+        environmentVariable: 'CUSTODY_TEST_TOKEN',
+      } as CredentialChildProcessOptions),
+    ).rejects.toMatchObject({ code: 'INVALID_CHILD_PROCESS_OPTIONS' });
   });
 
   it('terminates an over-time child process group', async () => {
@@ -1137,6 +1158,7 @@ describe('credential custody', () => {
     });
 
     const result = await lease.withChildProcess({
+      trust: 'cooperative-process-group',
       command: process.execPath,
       args: [
         '-e',
@@ -1162,6 +1184,7 @@ describe('credential custody', () => {
       attribution: ATTRIBUTION,
     });
     const result = await lease.withChildProcess({
+      trust: 'cooperative-process-group',
       command: process.execPath,
       args: [
         '-e',

--- a/packages/secrets/src/__tests__/custody.test.ts
+++ b/packages/secrets/src/__tests__/custody.test.ts
@@ -183,6 +183,8 @@ class FakeSink implements CredentialSecretSink {
 class FlakyLedger implements CustodyLedger {
   readonly inner = new InMemoryCustodyLedger();
   failEventType?: CustodyEvent['type'];
+  failEventAfterWriteType?: CustodyEvent['type'];
+  conflictingReadbackOnce = false;
 
   async recordIssuance(
     receipt: CustodyReceipt,
@@ -204,6 +206,12 @@ class FlakyLedger implements CustodyLedger {
       this.failEventType = undefined;
       throw new Error('synthetic ledger failure');
     }
+    if (event.type === this.failEventAfterWriteType) {
+      this.failEventAfterWriteType = undefined;
+      await this.inner.appendEvent(event);
+      this.conflictingReadbackOnce = true;
+      throw new Error('synthetic ledger acknowledgement loss');
+    }
     await this.inner.appendEvent(event);
   }
 
@@ -212,7 +220,14 @@ class FlakyLedger implements CustodyLedger {
   }
 
   async listEvents(): Promise<CustodyEvent[]> {
-    return this.inner.listEvents();
+    const events = await this.inner.listEvents();
+    if (!this.conflictingReadbackOnce) return events;
+    this.conflictingReadbackOnce = false;
+    return events.map((event) =>
+      event.type === 'rollback-pending'
+        ? { ...event, credentialId: 'conflicting-credential' }
+        : event,
+    );
   }
 }
 
@@ -728,6 +743,74 @@ describe('credential custody', () => {
     ).toEqual(['finalization-pending', 'issued']);
   });
 
+  it('accepts exact event replay and rejects conflicting event IDs', async () => {
+    const event: CustodyEvent = {
+      eventId: randomUUID(),
+      type: 'orphan-detected',
+      occurredAt: '2026-08-14T17:00:00.000Z',
+      credentialId: 'orphan-credential',
+    };
+    await ledger.appendEvent(event);
+    await ledger.appendEvent(structuredClone(event));
+    expect(await ledger.listEvents()).toHaveLength(1);
+
+    await expect(
+      ledger.appendEvent({ ...event, credentialId: 'different-credential' }),
+    ).rejects.toMatchObject({ code: 'CUSTODY_EVENT_ID_CONFLICT' });
+    expect(await ledger.listEvents()).toHaveLength(1);
+  });
+
+  it('retries ambiguous finalization status without revoking custody', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T17:00:00.000Z'));
+    const issuedLease = await custody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    const restartLedger = new InMemoryCustodyLedger();
+    await restartLedger.recordIssuance(issuedLease.receipt, {
+      eventId: issuedLease.receipt.finalizationId,
+      type: 'finalization-pending',
+      occurredAt: new Date().toISOString(),
+      receiptId: issuedLease.receipt.receiptId,
+    });
+    let statusAttempts = 0;
+    const restarted = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger: restartLedger,
+      attestor: TEST_ATTESTOR,
+      finalizer: {
+        ...TEST_FINALIZER,
+        async status() {
+          statusAttempts += 1;
+          if (statusAttempts === 1) {
+            throw new Error('synthetic transient status failure');
+          }
+          return 'committed';
+        },
+      },
+      ephemeralRevokeRetryMs: 500,
+    });
+
+    await restarted.recoverPendingRollbacks();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(issuer.revoked).toEqual([]);
+    expect(sink.values.size).toBe(1);
+    expect(
+      (await restartLedger.listEvents()).map((event) => event.type),
+    ).toEqual(['finalization-pending']);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(statusAttempts).toBe(2);
+    expect(issuer.revoked).toEqual([]);
+    expect(
+      (await restartLedger.listEvents()).map((event) => event.type),
+    ).toEqual(['finalization-pending', 'issued']);
+  });
+
   it('resumes a persisted pre-receipt rollback after restart', async () => {
     vi.useFakeTimers();
     verifier.verified = false;
@@ -1059,6 +1142,140 @@ describe('credential custody', () => {
     });
     expect(process.env.CUSTODY_TEST_TOKEN).toBeUndefined();
   });
+
+  it.each([
+    'durable',
+    'ephemeral',
+  ] as const)('invalidates and durably retries %s custody when child cleanup is unverified', async (mode) => {
+    const lease = await custody.issue({
+      mode,
+      subject: mode === 'durable' ? 'service-account-1' : 'throwaway-agent',
+      attribution: ATTRIBUTION,
+    });
+    issuer.revokeFailure = new Error('synthetic transient revoke failure');
+    const originalKill = process.kill.bind(process);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      if (pid < 0 && signal === 0) return true;
+      return originalKill(pid, signal);
+    }) as typeof process.kill);
+
+    try {
+      await expect(
+        lease.withChildProcess({
+          trust: 'cooperative-process-group',
+          command: process.execPath,
+          args: ['-e', 'process.exit(0)'],
+          environmentVariable: 'CUSTODY_TEST_TOKEN',
+        }),
+      ).rejects.toMatchObject({
+        code: 'CREDENTIAL_CHILD_PROCESS_CLEANUP_FAILED',
+      });
+    } finally {
+      killSpy.mockRestore();
+    }
+
+    await expect(
+      lease.withEnvironment('CUSTODY_TEST_TOKEN', () => undefined),
+    ).rejects.toMatchObject({ code: 'CREDENTIAL_REVOKED' });
+    const pending = (await ledger.listEvents()).find(
+      (event) =>
+        event.type === 'rollback-pending' &&
+        event.receiptId === lease.receipt.receiptId,
+    );
+    expect(pending?.recoveryId).toBeDefined();
+
+    issuer.revokeFailure = undefined;
+    await custody.recoverPendingRollbacks();
+    expect(
+      (await ledger.listEvents()).some(
+        (event) =>
+          event.type === 'rollback-complete' &&
+          event.recoveryId === pending?.recoveryId,
+      ),
+    ).toBe(true);
+    expect(
+      issuer.revoked.filter(
+        (entry) => entry.credentialId === lease.receipt.credentialId,
+      ),
+    ).toHaveLength(2);
+    if (mode === 'durable') expect(sink.values.size).toBe(0);
+  }, 10_000);
+
+  it('persists child-cleanup recovery identity before returning', async () => {
+    const retryLedger = new FlakyLedger();
+    const backgroundErrors: CustodyError[] = [];
+    const retryingCustody = new CredentialCustody({
+      issuer,
+      verifier,
+      sink,
+      ledger: retryLedger,
+      attestor: TEST_ATTESTOR,
+      finalizer: TEST_FINALIZER,
+      ephemeralRevokeRetryMs: 10,
+      onBackgroundError: (error) => backgroundErrors.push(error),
+    });
+    const lease = await retryingCustody.issue({
+      mode: 'durable',
+      subject: 'service-account-1',
+      attribution: ATTRIBUTION,
+    });
+    issuer.revokeFailure = new Error('synthetic transient revoke failure');
+    retryLedger.failEventAfterWriteType = 'rollback-pending';
+    const originalKill = process.kill.bind(process);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      if (pid < 0 && signal === 0) return true;
+      return originalKill(pid, signal);
+    }) as typeof process.kill);
+
+    try {
+      await expect(
+        lease.withChildProcess({
+          trust: 'cooperative-process-group',
+          command: process.execPath,
+          args: ['-e', 'process.exit(0)'],
+          environmentVariable: 'CUSTODY_TEST_TOKEN',
+        }),
+      ).rejects.toMatchObject({
+        code: 'CREDENTIAL_CHILD_PROCESS_CLEANUP_FAILED',
+      });
+    } finally {
+      killSpy.mockRestore();
+    }
+
+    expect(
+      backgroundErrors.some(
+        (error) => error.code === 'ROLLBACK_INTENT_PERSISTENCE_FAILED',
+      ),
+    ).toBe(true);
+    const pending = (await retryLedger.listEvents()).find(
+      (event) =>
+        event.type === 'rollback-pending' &&
+        event.receiptId === lease.receipt.receiptId,
+    );
+    expect(pending?.recoveryId).toBeDefined();
+    expect(
+      (await retryLedger.listEvents()).filter(
+        (event) => event.type === 'rollback-pending',
+      ),
+    ).toHaveLength(1);
+
+    issuer.revokeFailure = undefined;
+    await retryingCustody.recoverPendingRollbacks();
+    expect(sink.values.size).toBe(0);
+    expect(
+      (await retryLedger.listEvents()).some(
+        (event) =>
+          event.type === 'rollback-complete' &&
+          event.recoveryId === pending?.recoveryId,
+      ),
+    ).toBe(true);
+  }, 10_000);
 
   it('does not snapshot another in-flight environment credential into a child', async () => {
     const lease = await custody.issue({
@@ -1415,7 +1632,37 @@ describe('credential custody', () => {
     expect(issuer.revoked).toEqual([]);
   });
 
-  it('treats sink version or credential ownership mismatches fail closed', async () => {
+  it('does not authorize orphan recovery from a stale storedAt identity', async () => {
+    const orphan: SecretSinkInventoryEntry = {
+      sinkName: sink.name,
+      reference: 'orphan-record',
+      version: '1',
+      storedAt: '2026-08-14T17:00:01.000Z',
+      credentialId: 'orphan-credential',
+    };
+    sink.values.set(orphan.reference, SYNTHETIC_SECRET);
+    sink.credentialIds.set(orphan.reference, orphan.credentialId);
+    sink.inventoryOverride = [
+      { ...orphan, storedAt: '2026-08-14T17:00:02.000Z' },
+    ];
+
+    await custody.recoverOrphans({
+      checkedAt: '2026-08-14T17:05:00.000Z',
+      missing: [],
+      orphaned: [orphan],
+    });
+
+    expect(sink.values.has(orphan.reference)).toBe(true);
+    expect(sink.removed).toEqual([]);
+    expect(issuer.revoked).toEqual([]);
+    expect(
+      (await ledger.listEvents()).some(
+        (event) => event.type === 'orphan-removed',
+      ),
+    ).toBe(false);
+  });
+
+  it('treats sink tuple or credential ownership mismatches fail closed', async () => {
     const lease = await custody.issue({
       mode: 'durable',
       subject: 'service-account-1',
@@ -1430,6 +1677,17 @@ describe('credential custody', () => {
     const report = await custody.reconcile();
     expect(report.missing).toHaveLength(1);
     expect(report.orphaned).toHaveLength(1);
+
+    sink.inventoryOverride = [
+      {
+        ...owned,
+        storedAt: '2026-08-14T17:00:02.000Z',
+        credentialId: lease.receipt.credentialId,
+      },
+    ];
+    const timestampReport = await custody.reconcile();
+    expect(timestampReport.missing).toHaveLength(1);
+    expect(timestampReport.orphaned).toHaveLength(1);
   });
 
   it('retains an orphan until issuer revocation can be retried', async () => {

--- a/packages/secrets/src/__tests__/database-store.test.ts
+++ b/packages/secrets/src/__tests__/database-store.test.ts
@@ -62,7 +62,7 @@ describe('DatabaseSecretStore', () => {
     });
 
     it('encrypts and decrypts a secret', async () => {
-      const secretValue = 'sk_live_xxx123';
+      const secretValue = 'synthetic-secret-value';
 
       const envelope = await store.encrypt(
         testTenantId,

--- a/packages/secrets/src/adapters/database.ts
+++ b/packages/secrets/src/adapters/database.ts
@@ -50,7 +50,7 @@ const DEFAULT_ROTATION_PERIOD_MS = 90 * 24 * 60 * 60 * 1000;
  * await store.initialize();
  *
  * // Encrypt a secret for a tenant
- * const envelope = await store.encrypt('tenant-123', 'api-key', 'sk_live_xxx');
+ * const envelope = await store.encrypt('tenant-123', 'api-key', 'synthetic-secret');
  *
  * // Decrypt
  * const { value } = await store.decrypt('tenant-123', envelope);

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -23,11 +23,11 @@
  * });
  *
  * // Encrypt a secret for a tenant
- * const envelope = await store.encrypt('tenant-123', 'api-key', 'sk_live_xxx');
+ * const envelope = await store.encrypt('tenant-123', 'api-key', 'synthetic-secret');
  *
  * // Decrypt the secret
  * const { value } = await store.decrypt('tenant-123', envelope);
- * console.log(value); // 'sk_live_xxx'
+ * // Use value without logging or retaining plaintext.
  *
  * // Rotate tenant's encryption key
  * await store.rotateTenantKey('tenant-123');
@@ -38,6 +38,43 @@
 
 // Direct adapter exports (for advanced usage)
 export { DatabaseSecretStore } from './adapters/database.js';
+export type {
+  CredentialChildProcessOptions,
+  CredentialChildProcessResult,
+  CredentialCustodyFinalizer,
+  CredentialCustodyOptions,
+  CredentialIssuanceMode,
+  CredentialIssueRequest,
+  CredentialIssuer,
+  CredentialLease,
+  CredentialReceiptAttestor,
+  CredentialSecretSink,
+  CredentialVerifier,
+  CustodyAttribution,
+  CustodyEvent,
+  CustodyEventType,
+  CustodyIssuanceRequest,
+  CustodyLedger,
+  CustodyReceipt,
+  CustodyReceiptAttestation,
+  CustodyReconciliation,
+  CustodyStage,
+  IssuedCredential,
+  SecretSinkInventoryEntry,
+  SecretSinkRecord,
+} from './shared/custody.js';
+export {
+  CredentialCustody,
+  CustodyError,
+  Ed25519CustodyReceiptAttestor,
+  InMemoryCustodyLedger,
+  redactCredentialText,
+  redactCredentialValues,
+  runCredentialChildProcess,
+  SecretMaterial,
+  verifyCustodyReceiptAttestation,
+  withEnvironmentSecret,
+} from './shared/custody.js';
 // Envelope encryption primitives
 export { EnvelopeEncryption } from './shared/envelope.js';
 // Error classes
@@ -52,7 +89,6 @@ export {
   StoreNotInitializedError,
   TenantKeyMissingError,
 } from './shared/errors.js';
-
 // Factory function
 export {
   getSecretStore,

--- a/packages/secrets/src/shared/custody.ts
+++ b/packages/secrets/src/shared/custody.ts
@@ -501,6 +501,11 @@ export interface CredentialLease {
 }
 
 export interface CredentialChildProcessOptions {
+  /**
+   * Acknowledges that the command and every credential-bearing descendant are
+   * trusted to remain in the SDK-owned POSIX process group.
+   */
+  trust: 'cooperative-process-group';
   command: string;
   args?: readonly string[];
   environmentVariable: string;
@@ -1894,6 +1899,7 @@ export async function runCredentialChildProcess(
   bounds?: { expiresAt?: string },
 ): Promise<CredentialChildProcessResult> {
   if (
+    options.trust !== 'cooperative-process-group' ||
     !options.command ||
     !ENVIRONMENT_VARIABLE.test(options.environmentVariable)
   ) {
@@ -1973,6 +1979,20 @@ export async function runCredentialChildProcess(
           }
           child.kill(signal);
         };
+        const waitForGroupExit = async (): Promise<boolean> => {
+          if (!child.pid) return true;
+          const deadline = Date.now() + 2_000;
+          while (Date.now() < deadline) {
+            try {
+              process.kill(-child.pid, 0);
+            } catch (cause) {
+              if ((cause as NodeJS.ErrnoException).code === 'ESRCH')
+                return true;
+            }
+            await new Promise((next) => setTimeout(next, 10));
+          }
+          return false;
+        };
         const beginTermination = (): void => {
           terminateGroup('SIGTERM');
           if (!escalationTimer) {
@@ -2019,7 +2039,7 @@ export async function runCredentialChildProcess(
             ),
           );
         });
-        child.once('close', (exitCode, signal) => {
+        child.once('close', async (exitCode, signal) => {
           if (settled) return;
           settled = true;
           clearTimeout(timer);
@@ -2028,6 +2048,16 @@ export async function runCredentialChildProcess(
           // Kill the original process group before returning any output.
           terminateGroup('SIGTERM');
           terminateGroup('SIGKILL');
+          if (!(await waitForGroupExit())) {
+            reject(
+              new CustodyError(
+                'CREDENTIAL_CHILD_PROCESS_CLEANUP_FAILED',
+                'inject',
+                'Credential child process group cleanup could not be verified',
+              ),
+            );
+            return;
+          }
           resolve({
             exitCode,
             signal,

--- a/packages/secrets/src/shared/custody.ts
+++ b/packages/secrets/src/shared/custody.ts
@@ -376,6 +376,10 @@ export interface CustodyLedger {
     event: CustodyEvent,
     followup?: CustodyEvent,
   ): Promise<void>;
+  /**
+   * Idempotently appends an event by eventId. Replaying the same event must
+   * succeed; reusing an eventId for different content must fail closed.
+   */
   appendEvent(event: CustodyEvent): Promise<void>;
   listReceipts(): Promise<CustodyReceipt[]>;
   listEvents(): Promise<CustodyEvent[]>;
@@ -444,6 +448,17 @@ export class InMemoryCustodyLedger implements CustodyLedger {
   }
 
   async appendEvent(event: CustodyEvent): Promise<void> {
+    const existing = this.#events.find(
+      (item) => item.eventId === event.eventId,
+    );
+    if (existing) {
+      if (sameCustodyEvent(existing, event)) return;
+      throw new CustodyError(
+        'CUSTODY_EVENT_ID_CONFLICT',
+        'record',
+        'Custody event ID is already bound to different content',
+      );
+    }
     this.#events.push(structuredClone(event));
   }
 
@@ -1101,14 +1116,9 @@ export class CredentialCustody {
         }
       } catch {
         failures.push(receipt.finalizationId);
-        this.#scheduleRollback(
+        this.#scheduleFinalizationTakeover(
           receipt.finalizationId,
-          receipt.credentialId,
-          receipt.sink,
-          'revoke',
-          receipt.mode === 'durable',
-          receipt,
-          true,
+          this.#now().getTime() + this.#ephemeralRevokeRetryMs,
         );
       }
     }
@@ -1143,12 +1153,17 @@ export class CredentialCustody {
         .filter((event) => event.type === 'rollback-complete')
         .map((event) => event.recoveryId),
     );
-    for (const pending of events.filter(
-      (event) =>
-        event.type === 'rollback-pending' &&
-        event.recoveryId &&
-        !completed.has(event.recoveryId),
-    )) {
+    const pendingRollbacks = new Map(
+      events
+        .filter(
+          (event) =>
+            event.type === 'rollback-pending' &&
+            event.recoveryId &&
+            !completed.has(event.recoveryId),
+        )
+        .map((event) => [event.recoveryId, event]),
+    );
+    for (const pending of pendingRollbacks.values()) {
       if (!pending.credentialId || !pending.recoveryId) continue;
       const timer = this.#pendingTimers.get(pending.recoveryId);
       if (timer) clearTimeout(timer);
@@ -1173,7 +1188,10 @@ export class CredentialCustody {
           pending.credentialId,
           pending.sinkReference,
         );
-        if (pending.receiptId) terminalIds.add(pending.receiptId);
+        if (pending.receiptId) {
+          terminalIds.add(pending.receiptId);
+          this.#leaseInvalidators.delete(pending.receiptId);
+        }
       } catch {
         failures.push(pending.recoveryId);
         this.#scheduleRollback(
@@ -1490,6 +1508,15 @@ export class CredentialCustody {
           return await runCredentialChildProcess(material, options, {
             expiresAt: receipt.expiresAt,
           });
+        } catch (cause) {
+          if (
+            cause instanceof CustodyError &&
+            cause.code === 'CREDENTIAL_CHILD_PROCESS_CLEANUP_FAILED'
+          ) {
+            invalidate();
+            await this.#recoverChildProcessCleanupFailure(receipt);
+          }
+          throw cause;
         } finally {
           if (!ephemeralMaterial) material.destroy();
         }
@@ -1610,6 +1637,95 @@ export class CredentialCustody {
     }
   }
 
+  async #recoverChildProcessCleanupFailure(
+    receipt: CustodyReceipt,
+  ): Promise<void> {
+    const reason = 'child process cleanup could not be verified';
+    try {
+      await this.#abortAndRevoke(receipt, reason);
+      this.#leaseInvalidators.delete(receipt.receiptId);
+      return;
+    } catch (cause) {
+      const recoveryId = randomUUID();
+      const pendingEvent: CustodyEvent = {
+        ...this.#event(
+          'rollback-pending',
+          receipt.receiptId,
+          receipt.sink?.reference,
+          reason,
+        ),
+        eventId: recoveryId,
+        recoveryId,
+        credentialId: receipt.credentialId,
+        requiresSink: receipt.mode === 'durable',
+        finalizationReceipt: structuredClone(receipt),
+      };
+      await this.#persistRollbackIntent(pendingEvent);
+      this.#scheduleRollback(
+        recoveryId,
+        receipt.credentialId,
+        receipt.sink,
+        'inject',
+        receipt.mode === 'durable',
+        receipt,
+        true,
+      );
+      try {
+        this.#onBackgroundError?.(
+          new CustodyError(
+            'CREDENTIAL_CHILD_PROCESS_CLEANUP_PENDING',
+            'revoke',
+            'Credential revocation is pending after child process cleanup failure',
+            { cause, details: { recoveryId } },
+          ),
+        );
+      } catch {
+        // Observability cannot interrupt cleanup retry.
+      }
+    }
+  }
+
+  async #persistRollbackIntent(event: CustodyEvent): Promise<void> {
+    for (;;) {
+      try {
+        await this.#ledger.appendEvent(event);
+        return;
+      } catch (cause) {
+        try {
+          if (
+            (await this.#ledger.listEvents()).some(
+              (existing) =>
+                existing.eventId === event.eventId &&
+                sameCustodyEvent(existing, event),
+            )
+          ) {
+            return;
+          }
+        } catch {
+          // Retry persistence when acknowledgement state is unavailable.
+        }
+        try {
+          this.#onBackgroundError?.(
+            new CustodyError(
+              'ROLLBACK_INTENT_PERSISTENCE_FAILED',
+              'record',
+              'Credential rollback intent persistence is retrying',
+              { cause, details: { recoveryId: event.recoveryId } },
+            ),
+          );
+        } catch {
+          // Observability cannot interrupt durable recovery persistence.
+        }
+        await new Promise<void>((resolve) => {
+          // This timer deliberately remains referenced: returning or allowing
+          // normal process exit before the recovery identity is durable would
+          // strand a credential that may have escaped child-process custody.
+          setTimeout(resolve, this.#ephemeralRevokeRetryMs);
+        });
+      }
+    }
+  }
+
   #scheduleRollback(
     recoveryId: string,
     credentialId: string,
@@ -1645,6 +1761,11 @@ export class CredentialCustody {
             sinkRecord?.reference,
           ),
         )
+        .then(() => {
+          if (receiptRecorded && finalizationReceipt) {
+            this.#leaseInvalidators.delete(finalizationReceipt.receiptId);
+          }
+        })
         .catch((cause) => {
           try {
             this.#onBackgroundError?.(
@@ -2228,6 +2349,12 @@ function canonicalize(value: unknown): unknown {
   return value;
 }
 
+function sameCustodyEvent(left: CustodyEvent, right: CustodyEvent): boolean {
+  return (
+    JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right))
+  );
+}
+
 function assertAttribution(attribution: CustodyAttribution): void {
   assertSafeIdentifier(attribution.actor, 'attribution.actor', 'issue');
   assertSafeIdentifier(attribution.runtime, 'attribution.runtime', 'issue');
@@ -2310,7 +2437,8 @@ function sameSinkRecord(
   return (
     left.sinkName === right.sinkName &&
     left.reference === right.reference &&
-    left.version === right.version
+    left.version === right.version &&
+    left.storedAt === right.storedAt
   );
 }
 
@@ -2319,6 +2447,7 @@ function sinkIdentity(record: SecretSinkRecord, credentialId?: string): string {
     record.sinkName,
     record.reference,
     record.version,
+    record.storedAt,
     credentialId ?? '',
   ].join('\u0000');
 }

--- a/packages/secrets/src/shared/custody.ts
+++ b/packages/secrets/src/shared/custody.ts
@@ -1,0 +1,2294 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { spawn } from 'node:child_process';
+import {
+  createHash,
+  type KeyObject,
+  randomUUID,
+  sign as signPayload,
+  verify as verifyPayload,
+} from 'node:crypto';
+
+const REDACTED = '[REDACTED]';
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
+const ENVIRONMENT_VARIABLE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const CREDENTIAL_PATTERNS: Array<{
+  pattern: RegExp;
+  replacement: string;
+}> = [
+  {
+    pattern:
+      /\b(?:gh[pousr]|github_pat|hvwk|sk|xox[baprs])_[A-Za-z0-9_-]{16,}\b/gi,
+    replacement: REDACTED,
+  },
+  {
+    pattern: /\b[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    pattern:
+      /((?:authorization|credential|password|secret|token)\s*[:=]\s*(?:bearer\s+)?)[^\s,;]+/gi,
+    replacement: `$1${REDACTED}`,
+  },
+];
+let environmentLock: Promise<void> = Promise.resolve();
+const environmentLockContext = new AsyncLocalStorage<boolean>();
+
+async function withEnvironmentLock<T>(
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  if (environmentLockContext.getStore()) {
+    throw new CustodyError(
+      'REENTRANT_ENVIRONMENT_INJECTION',
+      'inject',
+      'Nested environment credential injection is not allowed',
+    );
+  }
+  const previous = environmentLock;
+  let release: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  environmentLock = queued;
+  await previous;
+  try {
+    return await environmentLockContext.run(true, operation);
+  } finally {
+    release();
+    if (environmentLock === queued) environmentLock = Promise.resolve();
+  }
+}
+
+export type CredentialIssuanceMode = 'ephemeral' | 'durable';
+export type CustodyStage =
+  | 'issue'
+  | 'store'
+  | 'retrieve'
+  | 'verify'
+  | 'activate'
+  | 'record'
+  | 'inject'
+  | 'revoke'
+  | 'reconcile';
+
+export class CustodyError extends Error {
+  readonly code: string;
+  readonly stage: CustodyStage;
+  readonly details?: Readonly<Record<string, unknown>>;
+
+  constructor(
+    code: string,
+    stage: CustodyStage,
+    message: string,
+    options?: { cause?: unknown; details?: Record<string, unknown> },
+  ) {
+    super(redactCredentialText(message));
+    this.name = 'CustodyError';
+    this.code =
+      SAFE_IDENTIFIER.test(code) && redactCredentialText(code) === code
+        ? code
+        : 'INVALID_CUSTODY_ERROR_CODE';
+    this.stage = stage;
+    this.details = options?.details
+      ? (redactCredentialValues(options.details) as Record<string, unknown>)
+      : undefined;
+    // Raw provider causes are deliberately not retained: Node's Error
+    // inspection prints non-enumerable causes and can expose credentials.
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      name: this.name,
+      code: this.code,
+      stage: this.stage,
+      message: this.message,
+      ...(this.details ? { details: this.details } : {}),
+    };
+  }
+}
+
+export class SecretMaterial {
+  #bytes: Buffer;
+  #destroyed = false;
+
+  private constructor(value: string) {
+    this.#bytes = Buffer.from(value, 'utf8');
+  }
+
+  static fromString(value: string): SecretMaterial {
+    if (!value) {
+      throw new CustodyError(
+        'EMPTY_SECRET_MATERIAL',
+        'issue',
+        'Secret material must not be empty',
+      );
+    }
+    return new SecretMaterial(value);
+  }
+
+  get destroyed(): boolean {
+    return this.#destroyed;
+  }
+
+  async use(operation: (value: string) => void | Promise<void>): Promise<void> {
+    if (this.#destroyed) {
+      throw new CustodyError(
+        'SECRET_MATERIAL_DESTROYED',
+        'inject',
+        'Secret material is no longer available',
+      );
+    }
+    const plaintext = this.#bytes.toString('utf8');
+    try {
+      await operation(plaintext);
+    } catch (cause) {
+      if (cause instanceof CustodyError) {
+        throw new CustodyError(
+          redactCredentialText(cause.code, [plaintext]) === cause.code
+            ? cause.code
+            : 'INVALID_CUSTODY_ERROR_CODE',
+          cause.stage,
+          redactCredentialText(cause.message, [plaintext]),
+          {
+            details: redactCredentialValues(cause.details, [plaintext]) as
+              | Record<string, unknown>
+              | undefined,
+          },
+        );
+      }
+      throw new CustodyError(
+        'SECRET_MATERIAL_OPERATION_FAILED',
+        'inject',
+        'Secret material operation failed',
+        { cause },
+      );
+    }
+  }
+
+  destroy(): void {
+    this.#bytes.fill(0);
+    this.#destroyed = true;
+  }
+
+  toJSON(): string {
+    return REDACTED;
+  }
+
+  toString(): string {
+    return REDACTED;
+  }
+
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
+    return REDACTED;
+  }
+}
+
+export interface CredentialIssueRequest {
+  mode: CredentialIssuanceMode;
+  subject: string;
+  expiresAt?: string;
+  metadata?: Readonly<Record<string, string>>;
+}
+
+export interface IssuedCredential {
+  credentialId: string;
+  secret: SecretMaterial;
+  issuedAt?: string;
+  expiresAt?: string;
+}
+
+export interface CredentialIssuer {
+  readonly name: string;
+  issue(request: CredentialIssueRequest): Promise<IssuedCredential>;
+  /** Must be idempotent so failed custody transitions can be retried. */
+  revoke(credentialId: string, reason: string): Promise<void>;
+}
+
+export interface CredentialVerifier {
+  readonly name: string;
+  verify(input: {
+    credentialId: string;
+    secret: SecretMaterial;
+  }): Promise<{ verified: boolean; verificationId?: string }>;
+}
+
+export interface SecretSinkRecord {
+  sinkName: string;
+  reference: string;
+  version: string;
+  storedAt: string;
+}
+
+export interface SecretSinkInventoryEntry extends SecretSinkRecord {
+  credentialId: string;
+}
+
+export interface CredentialSecretSink {
+  readonly name: string;
+  store(input: {
+    credentialId: string;
+    secret: SecretMaterial;
+    metadata: Readonly<Record<string, string>>;
+  }): Promise<SecretSinkRecord>;
+  retrieve(record: SecretSinkRecord): Promise<SecretMaterial>;
+  /**
+   * Removes any write for this credential, including a store that persisted
+   * data but failed before returning its record. Must be idempotent.
+   */
+  removeByCredentialId(credentialId: string, reason: string): Promise<void>;
+  /** Must conditionally remove this exact version and be idempotent. */
+  remove(record: SecretSinkRecord, reason: string): Promise<void>;
+  inventory(): Promise<SecretSinkInventoryEntry[]>;
+}
+
+export interface CustodyAttribution {
+  actor: string;
+  runtime: string;
+  session: string;
+}
+
+export interface CustodyReceipt {
+  receiptId: string;
+  mode: CredentialIssuanceMode;
+  credentialId: string;
+  subject: string;
+  issuer: string;
+  verifier: string;
+  verificationId?: string;
+  verificationState: 'verified';
+  issuedAt: string;
+  verifiedAt: string;
+  expiresAt?: string;
+  sink?: SecretSinkRecord;
+  replacesReceiptId?: string;
+  rotationRootReceiptId: string;
+  attribution: CustodyAttribution;
+  metadata: Readonly<Record<string, string>>;
+  finalizer: string;
+  finalizationId: string;
+  attestation: CustodyReceiptAttestation;
+}
+
+export interface CustodyReceiptAttestation {
+  algorithm: 'Ed25519';
+  attestor: string;
+  keyId: string;
+  signature: string;
+}
+
+export interface CredentialReceiptAttestor {
+  readonly name: string;
+  readonly keyId: string;
+  attest(payload: string): Promise<string>;
+}
+
+export interface CredentialCustodyFinalizer {
+  readonly name: string;
+  prepare(input: {
+    receipt: CustodyReceipt;
+    secret: SecretMaterial;
+  }): Promise<{ prepared: boolean }>;
+  commit(input: { receipt: CustodyReceipt }): Promise<void>;
+  abort(input: { receipt: CustodyReceipt; reason: string }): Promise<void>;
+  status(input: {
+    receipt: CustodyReceipt;
+  }): Promise<'missing' | 'prepared' | 'committed' | 'aborted'>;
+}
+
+export class Ed25519CustodyReceiptAttestor
+  implements CredentialReceiptAttestor
+{
+  readonly name: string;
+  readonly keyId: string;
+  readonly #privateKey: KeyObject;
+
+  constructor(options: {
+    privateKey: KeyObject;
+    keyId: string;
+    name?: string;
+  }) {
+    if (
+      options.privateKey.type !== 'private' ||
+      options.privateKey.asymmetricKeyType !== 'ed25519'
+    ) {
+      throw new CustodyError(
+        'INVALID_ATTESTATION_KEY',
+        'record',
+        'Custody attestation requires a private signing key',
+      );
+    }
+    this.#privateKey = options.privateKey;
+    this.name = options.name ?? 'ed25519';
+    this.keyId = options.keyId;
+    assertSafeIdentifier(this.name, 'attestor.name', 'record');
+    assertSafeIdentifier(this.keyId, 'attestor.keyId', 'record');
+  }
+
+  async attest(payload: string): Promise<string> {
+    return signPayload(null, Buffer.from(payload), this.#privateKey).toString(
+      'base64url',
+    );
+  }
+}
+
+export type CustodyEventType =
+  | 'issued'
+  | 'revoked'
+  | 'expired'
+  | 'replaced'
+  | 'rollback-pending'
+  | 'rollback-complete'
+  | 'finalization-pending'
+  | 'retirement-pending'
+  | 'retirement-complete'
+  | 'orphan-detected'
+  | 'orphan-removed';
+
+export interface CustodyEvent {
+  eventId: string;
+  type: CustodyEventType;
+  occurredAt: string;
+  receiptId?: string;
+  recoveryId?: string;
+  credentialId?: string;
+  requiresSink?: boolean;
+  finalizationReceipt?: CustodyReceipt;
+  recoveryReceipt?: CustodyReceipt;
+  replacementReceiptId?: string;
+  sinkReference?: string;
+  reason?: string;
+}
+
+export interface CustodyLedger {
+  /**
+   * Atomically records a receipt and its finalization-pending event.
+   * Implementations must reject duplicate receipt IDs, terminal predecessors,
+   * a second child for the same replacesReceiptId, and any other event type.
+   */
+  recordIssuance(receipt: CustodyReceipt, event: CustodyEvent): Promise<void>;
+  /**
+   * Idempotently appends the issued event and optional retirement-pending
+   * followup in one transaction. No other event types are accepted.
+   */
+  commitIssuance(
+    receiptId: string,
+    event: CustodyEvent,
+    followup?: CustodyEvent,
+  ): Promise<void>;
+  appendEvent(event: CustodyEvent): Promise<void>;
+  listReceipts(): Promise<CustodyReceipt[]>;
+  listEvents(): Promise<CustodyEvent[]>;
+}
+
+export class InMemoryCustodyLedger implements CustodyLedger {
+  readonly #receipts: CustodyReceipt[] = [];
+  readonly #events: CustodyEvent[] = [];
+
+  async recordIssuance(
+    receipt: CustodyReceipt,
+    event: CustodyEvent,
+  ): Promise<void> {
+    if (event.type !== 'finalization-pending') {
+      throw new CustodyError(
+        'INVALID_CUSTODY_EVENT',
+        'record',
+        'Prepared receipt requires a finalization-pending event',
+      );
+    }
+    if (this.#receipts.some((item) => item.receiptId === receipt.receiptId)) {
+      throw new CustodyError(
+        'DUPLICATE_CUSTODY_RECEIPT',
+        'record',
+        'Custody receipt already exists',
+      );
+    }
+    if (receipt.replacesReceiptId) {
+      const predecessor = this.#receipts.find(
+        (item) => item.receiptId === receipt.replacesReceiptId,
+      );
+      const predecessorTerminal = this.#events.some(
+        (item) =>
+          item.receiptId === receipt.replacesReceiptId &&
+          ['revoked', 'expired', 'replaced'].includes(item.type),
+      );
+      const predecessorIssued = this.#events.some(
+        (item) =>
+          item.receiptId === receipt.replacesReceiptId &&
+          item.type === 'issued',
+      );
+      const existingChild = this.#receipts.some(
+        (item) =>
+          item.replacesReceiptId === receipt.replacesReceiptId &&
+          !this.#events.some(
+            (event) =>
+              event.receiptId === item.receiptId &&
+              ['revoked', 'expired', 'replaced'].includes(event.type),
+          ),
+      );
+      if (
+        !predecessor ||
+        !predecessorIssued ||
+        predecessorTerminal ||
+        existingChild
+      ) {
+        throw new CustodyError(
+          'CUSTODY_ROTATION_CONFLICT',
+          'record',
+          'Custody predecessor is not active and replaceable',
+        );
+      }
+    }
+    this.#receipts.push(structuredClone(receipt));
+    this.#events.push(structuredClone(event));
+  }
+
+  async appendEvent(event: CustodyEvent): Promise<void> {
+    this.#events.push(structuredClone(event));
+  }
+
+  async commitIssuance(
+    receiptId: string,
+    event: CustodyEvent,
+    followup?: CustodyEvent,
+  ): Promise<void> {
+    if (
+      event.type !== 'issued' ||
+      (followup !== undefined && followup.type !== 'retirement-pending')
+    ) {
+      throw new CustodyError(
+        'INVALID_CUSTODY_EVENT',
+        'record',
+        'Issuance commit requires issued and optional retirement-pending events',
+      );
+    }
+    if (!this.#receipts.some((receipt) => receipt.receiptId === receiptId)) {
+      throw new CustodyError(
+        'CUSTODY_RECEIPT_NOT_FOUND',
+        'record',
+        'Prepared custody receipt was not found',
+      );
+    }
+    if (
+      !this.#events.some(
+        (item) => item.receiptId === receiptId && item.type === 'issued',
+      )
+    ) {
+      this.#events.push(structuredClone(event));
+      if (followup) this.#events.push(structuredClone(followup));
+    }
+  }
+
+  async listReceipts(): Promise<CustodyReceipt[]> {
+    return structuredClone(this.#receipts);
+  }
+
+  async listEvents(): Promise<CustodyEvent[]> {
+    return structuredClone(this.#events);
+  }
+}
+
+export interface CredentialLease {
+  readonly receipt: CustodyReceipt;
+  withEnvironment(
+    variableName: string,
+    operation: () => void | Promise<void>,
+  ): Promise<void>;
+  withChildProcess(
+    options: CredentialChildProcessOptions,
+  ): Promise<CredentialChildProcessResult>;
+  revoke(reason?: string): Promise<void>;
+}
+
+export interface CredentialChildProcessOptions {
+  command: string;
+  args?: readonly string[];
+  environmentVariable: string;
+  environment?: Readonly<Record<string, string>>;
+  cwd?: string;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+export interface CredentialChildProcessResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+export interface CustodyReconciliation {
+  checkedAt: string;
+  orphaned: SecretSinkInventoryEntry[];
+  missing: CustodyReceipt[];
+}
+
+export interface CredentialCustodyOptions {
+  issuer: CredentialIssuer;
+  verifier: CredentialVerifier;
+  ledger: CustodyLedger;
+  attestor: CredentialReceiptAttestor;
+  finalizer: CredentialCustodyFinalizer;
+  sink?: CredentialSecretSink;
+  ephemeralTtlMs?: number;
+  ephemeralRevokeRetryMs?: number;
+  orphanGraceMs?: number;
+  finalizationTakeoverMs?: number;
+  now?: () => Date;
+  onBackgroundError?: (error: CustodyError) => void;
+}
+
+export interface CustodyIssuanceRequest {
+  mode: CredentialIssuanceMode;
+  subject: string;
+  attribution: CustodyAttribution;
+  expiresAt?: string;
+  metadata?: Readonly<Record<string, string>>;
+  replacesReceiptId?: string;
+}
+
+export class CredentialCustody {
+  readonly #issuer: CredentialIssuer;
+  readonly #verifier: CredentialVerifier;
+  readonly #ledger: CustodyLedger;
+  readonly #attestor: CredentialReceiptAttestor;
+  readonly #finalizer: CredentialCustodyFinalizer;
+  readonly #sink?: CredentialSecretSink;
+  readonly #ephemeralTtlMs: number;
+  readonly #ephemeralRevokeRetryMs: number;
+  readonly #orphanGraceMs: number;
+  readonly #finalizationTakeoverMs: number;
+  readonly #now: () => Date;
+  readonly #onBackgroundError?: (error: CustodyError) => void;
+  readonly #leaseInvalidators = new Map<string, () => void>();
+  readonly #pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(options: CredentialCustodyOptions) {
+    assertSafeIdentifier(options.issuer.name, 'issuer.name', 'issue');
+    assertSafeIdentifier(options.verifier.name, 'verifier.name', 'verify');
+    assertSafeIdentifier(options.attestor.name, 'attestor.name', 'record');
+    assertSafeIdentifier(options.attestor.keyId, 'attestor.keyId', 'record');
+    assertSafeIdentifier(options.finalizer.name, 'finalizer.name', 'activate');
+    if (options.sink) {
+      assertSafeIdentifier(options.sink.name, 'sink.name', 'store');
+    }
+    this.#issuer = options.issuer;
+    this.#verifier = options.verifier;
+    this.#ledger = options.ledger;
+    this.#attestor = options.attestor;
+    this.#finalizer = options.finalizer;
+    this.#sink = options.sink;
+    this.#ephemeralTtlMs = options.ephemeralTtlMs ?? 5 * 60_000;
+    this.#ephemeralRevokeRetryMs = options.ephemeralRevokeRetryMs ?? 1_000;
+    this.#orphanGraceMs = options.orphanGraceMs ?? 5 * 60_000;
+    this.#finalizationTakeoverMs = options.finalizationTakeoverMs ?? 30_000;
+    if (
+      !Number.isFinite(this.#ephemeralTtlMs) ||
+      !Number.isFinite(this.#ephemeralRevokeRetryMs) ||
+      !Number.isFinite(this.#orphanGraceMs) ||
+      !Number.isFinite(this.#finalizationTakeoverMs) ||
+      this.#ephemeralTtlMs <= 0 ||
+      this.#ephemeralRevokeRetryMs <= 0 ||
+      this.#orphanGraceMs < 0 ||
+      this.#finalizationTakeoverMs < 0
+    ) {
+      throw new CustodyError(
+        'INVALID_CUSTODY_DURATION',
+        'issue',
+        'Custody durations must be positive',
+      );
+    }
+    this.#now = options.now ?? (() => new Date());
+    this.#onBackgroundError = options.onBackgroundError;
+  }
+
+  async issue(request: CustodyIssuanceRequest): Promise<CredentialLease> {
+    if (request.mode === 'durable' && !this.#sink) {
+      throw new CustodyError(
+        'DURABLE_SINK_REQUIRED',
+        'store',
+        'Durable credential issuance requires a secret sink',
+      );
+    }
+    if (request.replacesReceiptId && request.mode !== 'durable') {
+      throw new CustodyError(
+        'DURABLE_ROTATION_REQUIRED',
+        'issue',
+        'Credential replacement requires durable mode',
+      );
+    }
+    assertSafeIdentifier(request.subject, 'subject', 'issue');
+    assertAttribution(request.attribution);
+    const replacedReceipt = request.replacesReceiptId
+      ? await this.#findReceipt(request.replacesReceiptId)
+      : undefined;
+    if (
+      replacedReceipt?.mode !== undefined &&
+      replacedReceipt.mode !== 'durable'
+    ) {
+      throw new CustodyError(
+        'DURABLE_ROTATION_REQUIRED',
+        'issue',
+        'Only durable credentials can be replaced',
+      );
+    }
+
+    const now = this.#now();
+    const expiresAt =
+      request.expiresAt ??
+      (request.mode === 'ephemeral'
+        ? new Date(now.getTime() + this.#ephemeralTtlMs).toISOString()
+        : undefined);
+    const requestedExpiryMs = expiresAt
+      ? parseTimestamp(expiresAt, 'expiresAt', 'issue')
+      : undefined;
+    if (requestedExpiryMs !== undefined && requestedExpiryMs <= now.getTime())
+      throw new CustodyError(
+        'INVALID_EXPIRY',
+        'issue',
+        'Credential expiry must be in the future',
+      );
+
+    const metadata = sanitizeMetadata(request.metadata);
+    let issued: IssuedCredential | undefined;
+    let sinkRecord: SecretSinkRecord | undefined;
+    let retrieved: SecretMaterial | undefined;
+    let preparedReceipt: CustodyReceipt | undefined;
+    let receiptRecorded = false;
+    let stage: CustodyStage = 'issue';
+
+    try {
+      issued = await this.#issuer.issue({
+        mode: request.mode,
+        subject: request.subject,
+        expiresAt,
+        metadata,
+      });
+      assertSafeIdentifier(issued.credentialId, 'credentialId', 'issue');
+      if (issued.issuedAt) parseTimestamp(issued.issuedAt, 'issuedAt', 'issue');
+      if (issued.expiresAt) {
+        const providerExpiryMs = parseTimestamp(
+          issued.expiresAt,
+          'provider expiresAt',
+          'issue',
+        );
+        if (providerExpiryMs <= now.getTime()) {
+          throw new CustodyError(
+            'INVALID_EXPIRY',
+            'issue',
+            'Credential provider returned an expired credential',
+          );
+        }
+        if (
+          requestedExpiryMs !== undefined &&
+          providerExpiryMs > requestedExpiryMs
+        ) {
+          throw new CustodyError(
+            'EXPIRY_BOUND_EXCEEDED',
+            'issue',
+            'Credential provider exceeded the requested expiry bound',
+          );
+        }
+      }
+
+      let material = issued.secret;
+      if (request.mode === 'durable') {
+        const sink = this.#sink;
+        if (!sink) {
+          throw new CustodyError(
+            'DURABLE_SINK_REQUIRED',
+            'store',
+            'Durable credential issuance requires a secret sink',
+          );
+        }
+        stage = 'store';
+        sinkRecord = await sink.store({
+          credentialId: issued.credentialId,
+          secret: issued.secret,
+          metadata,
+        });
+        assertSinkRecord(sinkRecord, sink.name);
+
+        stage = 'retrieve';
+        retrieved = await sink.retrieve(sinkRecord);
+        material = retrieved;
+      }
+
+      stage = 'verify';
+      const verification = await this.#verifier.verify({
+        credentialId: issued.credentialId,
+        secret: material,
+      });
+      if (!verification.verified) {
+        throw new CustodyError(
+          'CREDENTIAL_VERIFICATION_FAILED',
+          'verify',
+          'Credential verification failed',
+        );
+      }
+      if (verification.verificationId) {
+        assertSafeIdentifier(
+          verification.verificationId,
+          'verificationId',
+          'verify',
+        );
+      }
+      const receiptId = randomUUID();
+      const finalizationId = randomUUID();
+      const unsignedReceipt: Omit<CustodyReceipt, 'attestation'> = {
+        receiptId,
+        mode: request.mode,
+        credentialId: issued.credentialId,
+        subject: request.subject,
+        issuer: this.#issuer.name,
+        verifier: this.#verifier.name,
+        ...(verification.verificationId
+          ? { verificationId: verification.verificationId }
+          : {}),
+        verificationState: 'verified',
+        issuedAt: issued.issuedAt ?? now.toISOString(),
+        verifiedAt: this.#now().toISOString(),
+        ...((issued.expiresAt ?? expiresAt)
+          ? { expiresAt: issued.expiresAt ?? expiresAt }
+          : {}),
+        ...(sinkRecord ? { sink: sinkRecord } : {}),
+        ...(request.replacesReceiptId
+          ? { replacesReceiptId: request.replacesReceiptId }
+          : {}),
+        rotationRootReceiptId:
+          replacedReceipt?.rotationRootReceiptId ?? receiptId,
+        attribution: { ...request.attribution },
+        metadata,
+        finalizer: this.#finalizer.name,
+        finalizationId,
+      };
+
+      stage = 'record';
+      let signature = '';
+      await material.use(async (plaintext) => {
+        signature = await this.#attestor.attest(
+          custodyAttestationPayload(
+            unsignedReceipt,
+            credentialCommitment(plaintext),
+            {
+              algorithm: 'Ed25519',
+              attestor: this.#attestor.name,
+              keyId: this.#attestor.keyId,
+            },
+          ),
+        );
+      });
+      if (
+        !/^[A-Za-z0-9_-]{86}$/.test(signature) ||
+        Buffer.from(signature, 'base64url').byteLength !== 64 ||
+        Buffer.from(signature, 'base64url').toString('base64url') !==
+          signature ||
+        redactCredentialText(signature) !== signature
+      ) {
+        throw new CustodyError(
+          'INVALID_CUSTODY_ATTESTATION',
+          'record',
+          'Custody attestor returned an invalid signature',
+        );
+      }
+      const receipt: CustodyReceipt = {
+        ...unsignedReceipt,
+        attestation: {
+          algorithm: 'Ed25519',
+          attestor: this.#attestor.name,
+          keyId: this.#attestor.keyId,
+          signature,
+        },
+      };
+      stage = 'record';
+      await this.#ledger.recordIssuance(
+        receipt,
+        this.#event('finalization-pending', receiptId),
+      );
+      receiptRecorded = true;
+      stage = 'activate';
+      preparedReceipt = receipt;
+      const activation = await this.#finalizer.prepare({
+        receipt: structuredClone(receipt),
+        secret: material,
+      });
+      if (!activation.prepared) {
+        throw new CustodyError(
+          'CREDENTIAL_ACTIVATION_FAILED',
+          'activate',
+          'Credential post-attestation activation failed',
+        );
+      }
+      retrieved?.destroy();
+      retrieved = undefined;
+      if (request.mode === 'durable') issued.secret.destroy();
+      stage = 'activate';
+      await this.#finalizer.commit({ receipt: structuredClone(receipt) });
+      stage = 'record';
+      const retirementRecoveryId = replacedReceipt ? randomUUID() : undefined;
+      const retirementPending =
+        replacedReceipt && retirementRecoveryId
+          ? {
+              ...this.#event(
+                'retirement-pending' as const,
+                replacedReceipt.receiptId,
+              ),
+              eventId: retirementRecoveryId,
+              recoveryId: retirementRecoveryId,
+              credentialId: replacedReceipt.credentialId,
+              recoveryReceipt: structuredClone(replacedReceipt),
+              replacementReceiptId: receipt.receiptId,
+            }
+          : undefined;
+      await this.#ledger.commitIssuance(
+        receipt.receiptId,
+        this.#event('issued', receipt.receiptId),
+        retirementPending,
+      );
+      const lease = this.#createLease(
+        receipt,
+        request.mode === 'ephemeral' ? issued.secret : undefined,
+      );
+      if (replacedReceipt) {
+        try {
+          this.#leaseInvalidators.get(replacedReceipt.receiptId)?.();
+          await this.#revokeReceipt(replacedReceipt, 'replaced', 'replaced');
+          this.#leaseInvalidators.delete(replacedReceipt.receiptId);
+          await this.#ledger.appendEvent({
+            ...this.#event('retirement-complete', replacedReceipt.receiptId),
+            recoveryId: retirementRecoveryId,
+          });
+        } catch (cause) {
+          if (retirementRecoveryId) {
+            this.#scheduleRetirement(
+              retirementRecoveryId,
+              replacedReceipt,
+              receipt.receiptId,
+            );
+          }
+          try {
+            this.#onBackgroundError?.(
+              new CustodyError(
+                'PREDECESSOR_RETIREMENT_PENDING',
+                'revoke',
+                'Replacement is active while predecessor retirement retries',
+                { cause, details: { recoveryId: retirementRecoveryId } },
+              ),
+            );
+          } catch {
+            // Observability cannot interrupt the active replacement.
+          }
+        }
+      }
+      preparedReceipt = undefined;
+      return lease;
+    } catch (cause) {
+      const safeCause = await sanitizeCustodyCause(cause, [
+        retrieved,
+        issued?.secret,
+      ]);
+      retrieved?.destroy();
+      issued?.secret.destroy();
+      if (issued) {
+        const requiresSink = request.mode === 'durable';
+        try {
+          if (receiptRecorded && preparedReceipt) {
+            await this.#abortAndRevoke(
+              preparedReceipt,
+              `rollback after ${stage}`,
+            );
+          } else {
+            await this.#rollback(
+              issued.credentialId,
+              sinkRecord,
+              stage,
+              requiresSink,
+            );
+          }
+        } catch (rollbackCause) {
+          const recoveryId = randomUUID();
+          const pendingEvent: CustodyEvent = {
+            ...this.#event(
+              'rollback-pending',
+              receiptRecorded ? preparedReceipt?.receiptId : undefined,
+              sinkRecord?.reference,
+              `rollback after ${stage}`,
+            ),
+            eventId: recoveryId,
+            recoveryId,
+            credentialId: issued.credentialId,
+            requiresSink,
+            finalizationReceipt: preparedReceipt
+              ? structuredClone(preparedReceipt)
+              : undefined,
+          };
+          try {
+            await this.#ledger.appendEvent(pendingEvent);
+          } catch {
+            // Automatic in-process retry still proceeds if persistence fails.
+          }
+          this.#scheduleRollback(
+            recoveryId,
+            issued.credentialId,
+            sinkRecord,
+            stage,
+            requiresSink,
+            preparedReceipt,
+            receiptRecorded,
+          );
+          throw new CustodyError(
+            'CUSTODY_ROLLBACK_FAILED',
+            'revoke',
+            'Credential rollback is pending automatic retry',
+            {
+              cause: rollbackCause,
+              details: {
+                recoveryId,
+                credentialId: issued.credentialId,
+                requiresSink,
+                failedStage: stage,
+              },
+            },
+          );
+        }
+      }
+      if (safeCause instanceof CustodyError) throw safeCause;
+      throw new CustodyError(
+        `CUSTODY_${stage.toUpperCase()}_FAILED`,
+        stage,
+        `Credential custody failed during ${stage}`,
+        { cause: safeCause },
+      );
+    }
+  }
+
+  async rotate(
+    receiptId: string,
+    request: Omit<CustodyIssuanceRequest, 'mode' | 'replacesReceiptId'>,
+  ): Promise<CredentialLease> {
+    const previous = await this.#findReceipt(receiptId);
+    if (previous.mode !== 'durable') {
+      throw new CustodyError(
+        'DURABLE_ROTATION_REQUIRED',
+        'issue',
+        'Only durable credentials can be rotated',
+      );
+    }
+    return this.issue({
+      ...request,
+      mode: 'durable',
+      replacesReceiptId: receiptId,
+    });
+  }
+
+  async revoke(receiptId: string, reason = 'recovery'): Promise<void> {
+    const receipt = await this.#findReceipt(receiptId);
+    this.#leaseInvalidators.get(receiptId)?.();
+    await this.#revokeReceipt(receipt, reason);
+    this.#leaseInvalidators.delete(receiptId);
+  }
+
+  async recoverPendingRollbacks(): Promise<void> {
+    const events = await this.#ledger.listEvents();
+    const receipts = await this.#ledger.listReceipts();
+    const activeIds = new Set(
+      events
+        .filter((event) => event.type === 'issued')
+        .map((event) => event.receiptId),
+    );
+    const terminalIds = new Set(
+      events
+        .filter((event) =>
+          ['revoked', 'expired', 'replaced'].includes(event.type),
+        )
+        .map((event) => event.receiptId),
+    );
+    const completedRollbackIds = new Set(
+      events
+        .filter((event) => event.type === 'rollback-complete')
+        .map((event) => event.recoveryId),
+    );
+    const rollbackReceiptIds = new Set(
+      events
+        .filter(
+          (event) =>
+            event.type === 'rollback-pending' &&
+            !completedRollbackIds.has(event.recoveryId),
+        )
+        .map((event) => event.receiptId),
+    );
+    const pendingByReceipt = new Map(
+      events
+        .filter(
+          (event) => event.type === 'finalization-pending' && event.receiptId,
+        )
+        .map((event) => [event.receiptId, event]),
+    );
+    const takeoverCutoff = this.#now().getTime() - this.#finalizationTakeoverMs;
+    const failures: string[] = [];
+    for (const receipt of receipts.filter(
+      (item) =>
+        !activeIds.has(item.receiptId) &&
+        !terminalIds.has(item.receiptId) &&
+        !rollbackReceiptIds.has(item.receiptId) &&
+        (() => {
+          const pending = pendingByReceipt.get(item.receiptId);
+          if (pending) {
+            const pendingAt = parseTimestamp(
+              pending.occurredAt,
+              'occurredAt',
+              'reconcile',
+            );
+            if (pendingAt > takeoverCutoff) {
+              this.#scheduleFinalizationTakeover(
+                item.finalizationId,
+                pendingAt + this.#finalizationTakeoverMs,
+              );
+              return false;
+            }
+          }
+          return (
+            pending !== undefined &&
+            parseTimestamp(pending.occurredAt, 'occurredAt', 'reconcile') <=
+              takeoverCutoff
+          );
+        })(),
+    )) {
+      try {
+        const status = await this.#finalizer.status({
+          receipt: structuredClone(receipt),
+        });
+        if (status === 'committed') {
+          const predecessor = receipt.replacesReceiptId
+            ? receipts.find(
+                (item) => item.receiptId === receipt.replacesReceiptId,
+              )
+            : undefined;
+          const recoveryId = predecessor ? randomUUID() : undefined;
+          await this.#ledger.commitIssuance(
+            receipt.receiptId,
+            this.#event('issued', receipt.receiptId),
+            predecessor && recoveryId
+              ? {
+                  ...this.#event('retirement-pending', predecessor.receiptId),
+                  eventId: recoveryId,
+                  recoveryId,
+                  credentialId: predecessor.credentialId,
+                  recoveryReceipt: structuredClone(predecessor),
+                  replacementReceiptId: receipt.receiptId,
+                }
+              : undefined,
+          );
+          activeIds.add(receipt.receiptId);
+          if (predecessor && recoveryId) {
+            this.#scheduleRetirement(
+              recoveryId,
+              predecessor,
+              receipt.receiptId,
+            );
+          }
+        } else {
+          await this.#abortAndRevoke(
+            receipt,
+            'incomplete finalization recovery',
+          );
+        }
+      } catch {
+        failures.push(receipt.finalizationId);
+        this.#scheduleRollback(
+          receipt.finalizationId,
+          receipt.credentialId,
+          receipt.sink,
+          'revoke',
+          receipt.mode === 'durable',
+          receipt,
+          true,
+        );
+      }
+    }
+    for (const receipt of receipts.filter(
+      (item) =>
+        item.mode === 'ephemeral' &&
+        activeIds.has(item.receiptId) &&
+        !terminalIds.has(item.receiptId) &&
+        item.expiresAt !== undefined,
+    )) {
+      try {
+        const deadline = parseTimestamp(
+          receipt.expiresAt ?? '',
+          'expiresAt',
+          'revoke',
+        );
+        if (deadline <= this.#now().getTime()) {
+          await this.#revokeReceipt(
+            receipt,
+            'restart expiry recovery',
+            'expired',
+          );
+        } else {
+          this.#scheduleReceiptExpiry(receipt, deadline);
+        }
+      } catch {
+        failures.push(receipt.receiptId);
+      }
+    }
+    const completed = new Set(
+      events
+        .filter((event) => event.type === 'rollback-complete')
+        .map((event) => event.recoveryId),
+    );
+    for (const pending of events.filter(
+      (event) =>
+        event.type === 'rollback-pending' &&
+        event.recoveryId &&
+        !completed.has(event.recoveryId),
+    )) {
+      if (!pending.credentialId || !pending.recoveryId) continue;
+      const timer = this.#pendingTimers.get(pending.recoveryId);
+      if (timer) clearTimeout(timer);
+      this.#pendingTimers.delete(pending.recoveryId);
+      try {
+        assertSafeIdentifier(pending.credentialId, 'credentialId', 'revoke');
+        if (pending.receiptId && pending.finalizationReceipt) {
+          await this.#abortAndRevoke(
+            pending.finalizationReceipt,
+            'pending rollback recovery',
+          );
+        } else {
+          await this.#rollback(
+            pending.credentialId,
+            undefined,
+            'revoke',
+            pending.requiresSink === true,
+          );
+        }
+        await this.#completeRollback(
+          pending.recoveryId,
+          pending.credentialId,
+          pending.sinkReference,
+        );
+        if (pending.receiptId) terminalIds.add(pending.receiptId);
+      } catch {
+        failures.push(pending.recoveryId);
+        this.#scheduleRollback(
+          pending.recoveryId,
+          pending.credentialId,
+          undefined,
+          'revoke',
+          pending.requiresSink === true,
+          pending.finalizationReceipt,
+          Boolean(pending.receiptId),
+        );
+      }
+    }
+    const retired = new Set(
+      events
+        .filter((event) => event.type === 'retirement-complete')
+        .map((event) => event.recoveryId),
+    );
+    for (const pending of events.filter(
+      (event) =>
+        event.type === 'retirement-pending' &&
+        event.recoveryId &&
+        !retired.has(event.recoveryId),
+    )) {
+      if (!pending.recoveryId || !pending.recoveryReceipt) continue;
+      if (
+        pending.replacementReceiptId &&
+        (!activeIds.has(pending.replacementReceiptId) ||
+          terminalIds.has(pending.replacementReceiptId))
+      ) {
+        await this.#ledger.appendEvent({
+          ...this.#event(
+            'retirement-complete',
+            pending.recoveryReceipt.receiptId,
+          ),
+          recoveryId: pending.recoveryId,
+          reason: 'replacement is not active',
+        });
+        continue;
+      }
+      try {
+        await this.#revokeReceipt(
+          pending.recoveryReceipt,
+          'replacement retirement recovery',
+          'replaced',
+        );
+        await this.#ledger.appendEvent({
+          ...this.#event(
+            'retirement-complete',
+            pending.recoveryReceipt.receiptId,
+          ),
+          recoveryId: pending.recoveryId,
+        });
+        this.#leaseInvalidators.delete(pending.recoveryReceipt.receiptId);
+      } catch {
+        failures.push(pending.recoveryId);
+        this.#scheduleRetirement(
+          pending.recoveryId,
+          pending.recoveryReceipt,
+          pending.replacementReceiptId,
+        );
+      }
+    }
+    if (failures.length) {
+      throw new CustodyError(
+        'PENDING_ROLLBACK_RECOVERY_FAILED',
+        'revoke',
+        'One or more pending credential rollbacks could not be recovered',
+        { details: { recoveryIds: failures } },
+      );
+    }
+  }
+
+  async recoverCredential(
+    credentialId: string,
+    options: { requiresSink?: boolean } = {},
+  ): Promise<void> {
+    assertSafeIdentifier(credentialId, 'credentialId', 'revoke');
+    await this.#rollback(
+      credentialId,
+      undefined,
+      'revoke',
+      options.requiresSink === true,
+    );
+  }
+
+  async reconcile(): Promise<CustodyReconciliation> {
+    if (!this.#sink) {
+      throw new CustodyError(
+        'DURABLE_SINK_REQUIRED',
+        'reconcile',
+        'Reconciliation requires a secret sink',
+      );
+    }
+    const [receipts, events, inventory] = await Promise.all([
+      this.#ledger.listReceipts(),
+      this.#ledger.listEvents(),
+      this.#sink.inventory(),
+    ]);
+    for (const entry of inventory) {
+      assertSinkRecord(entry, this.#sink.name);
+      assertSafeIdentifier(entry.credentialId, 'credentialId', 'reconcile');
+    }
+    const terminal = new Set(
+      events
+        .filter((event) =>
+          ['revoked', 'expired', 'replaced'].includes(event.type),
+        )
+        .map((event) => event.receiptId),
+    );
+    const issued = new Set(
+      events
+        .filter((event) => event.type === 'issued')
+        .map((event) => event.receiptId),
+    );
+    for (const replacement of receipts) {
+      if (
+        replacement.replacesReceiptId &&
+        issued.has(replacement.receiptId) &&
+        !terminal.has(replacement.receiptId)
+      ) {
+        terminal.add(replacement.replacesReceiptId);
+      }
+    }
+    const active = receipts.filter(
+      (receipt): receipt is CustodyReceipt & { sink: SecretSinkRecord } =>
+        receipt.mode === 'durable' &&
+        receipt.sink !== undefined &&
+        issued.has(receipt.receiptId) &&
+        !terminal.has(receipt.receiptId),
+    );
+    const orphanCutoff = this.#now().getTime() - this.#orphanGraceMs;
+    return {
+      checkedAt: this.#now().toISOString(),
+      orphaned: inventory.filter(
+        (entry) =>
+          parseTimestamp(entry.storedAt, 'storedAt', 'reconcile') <=
+            orphanCutoff &&
+          !active.some(
+            (receipt) =>
+              sameSinkRecord(receipt.sink, entry) &&
+              entry.credentialId === receipt.credentialId,
+          ),
+      ),
+      missing: active.filter(
+        (receipt) =>
+          !inventory.some(
+            (entry) =>
+              sameSinkRecord(receipt.sink, entry) &&
+              entry.credentialId === receipt.credentialId,
+          ),
+      ),
+    };
+  }
+
+  async recoverOrphans(report: CustodyReconciliation): Promise<void> {
+    if (!this.#sink) {
+      throw new CustodyError(
+        'DURABLE_SINK_REQUIRED',
+        'reconcile',
+        'Orphan recovery requires a secret sink',
+      );
+    }
+    const current = await this.reconcile();
+    const requested = new Set(
+      report.orphaned.map((entry) => sinkIdentity(entry, entry.credentialId)),
+    );
+    const confirmed = current.orphaned.filter((entry) =>
+      requested.has(sinkIdentity(entry, entry.credentialId)),
+    );
+    for (const orphan of confirmed) {
+      assertSinkRecord(orphan, this.#sink.name);
+      await this.#ledger.appendEvent(
+        this.#event('orphan-detected', undefined, orphan.reference),
+      );
+      assertSafeIdentifier(orphan.credentialId, 'credentialId', 'reconcile');
+      try {
+        await this.#issuer.revoke(orphan.credentialId, 'orphan recovery');
+      } catch {
+        throw new CustodyError(
+          'ORPHAN_REVOCATION_FAILED',
+          'reconcile',
+          'Orphan credential revocation failed',
+        );
+      }
+      await this.#sink.remove(orphan, 'orphan recovery');
+      await this.#ledger.appendEvent(
+        this.#event('orphan-removed', undefined, orphan.reference),
+      );
+    }
+  }
+
+  #createLease(
+    receipt: CustodyReceipt,
+    ephemeralMaterial?: SecretMaterial,
+  ): CredentialLease {
+    let unavailable = false;
+    let revocationComplete = false;
+    let revocationInFlight: Promise<void> | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const revoke = async (
+      reason = 'requested',
+      terminalType: 'revoked' | 'expired' = 'revoked',
+    ): Promise<void> => {
+      unavailable = true;
+      if (timer) clearTimeout(timer);
+      ephemeralMaterial?.destroy();
+      if (revocationComplete) return;
+      if (revocationInFlight) return revocationInFlight;
+      revocationInFlight = this.#revokeReceipt(receipt, reason, terminalType)
+        .then(() => {
+          revocationComplete = true;
+          this.#leaseInvalidators.delete(receipt.receiptId);
+        })
+        .finally(() => {
+          revocationInFlight = undefined;
+        });
+      return revocationInFlight;
+    };
+    const invalidate = (): void => {
+      unavailable = true;
+      if (timer) clearTimeout(timer);
+      ephemeralMaterial?.destroy();
+    };
+    this.#leaseInvalidators.set(receipt.receiptId, invalidate);
+
+    if (receipt.mode === 'ephemeral' && receipt.expiresAt) {
+      const deadline = parseTimestamp(receipt.expiresAt, 'expiresAt', 'issue');
+      const schedule = (delay: number): void => {
+        timer = setTimeout(
+          () => {
+            const remaining = deadline - this.#now().getTime();
+            if (remaining > 0) {
+              schedule(Math.min(remaining, MAX_TIMER_DELAY_MS));
+              return;
+            }
+            revoke('expired', 'expired').catch((cause) => {
+              try {
+                this.#onBackgroundError?.(
+                  cause instanceof CustodyError
+                    ? cause
+                    : new CustodyError(
+                        'EPHEMERAL_CLEANUP_FAILED',
+                        'revoke',
+                        'Ephemeral credential cleanup failed',
+                        { cause },
+                      ),
+                );
+              } catch {
+                // Observability hooks must never interrupt revocation retry.
+              } finally {
+                schedule(this.#ephemeralRevokeRetryMs);
+              }
+            });
+          },
+          Math.min(Math.max(0, delay), MAX_TIMER_DELAY_MS),
+        );
+        timer.unref?.();
+      };
+      schedule(deadline - this.#now().getTime());
+    }
+
+    return {
+      receipt: structuredClone(receipt),
+      withEnvironment: async (
+        variableName: string,
+        operation: () => void | Promise<void>,
+      ): Promise<void> => {
+        this.#assertLeaseAvailable(receipt, unavailable);
+        if (!ENVIRONMENT_VARIABLE.test(variableName)) {
+          throw new CustodyError(
+            'INVALID_ENVIRONMENT_VARIABLE',
+            'inject',
+            'Environment variable name is invalid',
+          );
+        }
+        let material = ephemeralMaterial;
+        if (!material) {
+          if (!this.#sink || !receipt.sink) {
+            throw new CustodyError(
+              'DURABLE_SINK_REQUIRED',
+              'retrieve',
+              'Durable credential retrieval requires a secret sink record',
+            );
+          }
+          material = await this.#sink.retrieve(receipt.sink);
+        }
+        try {
+          this.#assertLeaseAvailable(receipt, unavailable);
+          await withEnvironmentSecret(material, variableName, operation, {
+            expiresAt: receipt.expiresAt,
+          });
+        } finally {
+          if (!ephemeralMaterial) material.destroy();
+        }
+      },
+      withChildProcess: async (
+        options: CredentialChildProcessOptions,
+      ): Promise<CredentialChildProcessResult> => {
+        this.#assertLeaseAvailable(receipt, unavailable);
+        let material = ephemeralMaterial;
+        if (!material) {
+          if (!this.#sink || !receipt.sink) {
+            throw new CustodyError(
+              'DURABLE_SINK_REQUIRED',
+              'retrieve',
+              'Durable credential retrieval requires a secret sink record',
+            );
+          }
+          material = await this.#sink.retrieve(receipt.sink);
+        }
+        try {
+          this.#assertLeaseAvailable(receipt, unavailable);
+          return await runCredentialChildProcess(material, options, {
+            expiresAt: receipt.expiresAt,
+          });
+        } finally {
+          if (!ephemeralMaterial) material.destroy();
+        }
+      },
+      revoke: (reason?: string) => revoke(reason),
+    };
+  }
+
+  #assertLeaseAvailable(receipt: CustodyReceipt, unavailable: boolean): void {
+    const expired =
+      receipt.expiresAt !== undefined &&
+      parseTimestamp(receipt.expiresAt, 'expiresAt', 'inject') <=
+        this.#now().getTime();
+    if (unavailable || expired) {
+      throw new CustodyError(
+        'CREDENTIAL_REVOKED',
+        'inject',
+        'Credential is no longer available',
+      );
+    }
+  }
+
+  async #revokeReceipt(
+    receipt: CustodyReceipt,
+    reason: string,
+    terminalType: 'revoked' | 'expired' | 'replaced' = 'revoked',
+  ): Promise<void> {
+    const failures: string[] = [];
+    try {
+      await this.#issuer.revoke(receipt.credentialId, reason);
+    } catch {
+      failures.push('issuer');
+    }
+    if (!failures.length && receipt.sink && this.#sink) {
+      try {
+        await this.#sink.remove(receipt.sink, reason);
+      } catch {
+        failures.push('sink');
+      }
+    }
+    if (failures.length) {
+      throw new CustodyError(
+        'CREDENTIAL_REVOCATION_FAILED',
+        'revoke',
+        'Credential revocation did not complete',
+        { details: { failedOperations: failures } },
+      );
+    }
+    await this.#appendEventEventually(
+      this.#event(terminalType, receipt.receiptId, undefined, reason),
+    );
+  }
+
+  async #rollback(
+    credentialId: string,
+    sinkRecord: SecretSinkRecord | undefined,
+    failedStage: CustodyStage,
+    requiresSink = false,
+  ): Promise<void> {
+    const failures: string[] = [];
+    try {
+      await this.#issuer.revoke(credentialId, `rollback after ${failedStage}`);
+    } catch {
+      failures.push('issuer');
+    }
+    if (!failures.length && requiresSink && !this.#sink) {
+      failures.push('sink');
+    }
+    if (!failures.length && requiresSink && this.#sink) {
+      try {
+        if (sinkRecord) {
+          await this.#sink.remove(sinkRecord, `rollback after ${failedStage}`);
+        } else {
+          await this.#sink.removeByCredentialId(
+            credentialId,
+            `rollback after ${failedStage}`,
+          );
+        }
+      } catch {
+        failures.push('sink');
+      }
+    }
+    if (failures.length) {
+      throw new CustodyError(
+        'CUSTODY_ROLLBACK_FAILED',
+        'revoke',
+        'Credential rollback did not complete',
+        { details: { failedOperations: failures, failedStage } },
+      );
+    }
+  }
+
+  async #abortAndRevoke(
+    receipt: CustodyReceipt,
+    reason: string,
+  ): Promise<void> {
+    const failures: string[] = [];
+    try {
+      await this.#finalizer.abort({
+        receipt: structuredClone(receipt),
+        reason,
+      });
+    } catch {
+      failures.push('finalizer');
+    }
+    try {
+      await this.#revokeReceipt(receipt, reason);
+    } catch {
+      failures.push('credential');
+    }
+    if (failures.length) {
+      throw new CustodyError(
+        'CUSTODY_ROLLBACK_FAILED',
+        'revoke',
+        'Finalization rollback did not complete',
+        { details: { failedOperations: failures } },
+      );
+    }
+  }
+
+  #scheduleRollback(
+    recoveryId: string,
+    credentialId: string,
+    sinkRecord: SecretSinkRecord | undefined,
+    failedStage: CustodyStage,
+    requiresSink: boolean,
+    finalizationReceipt?: CustodyReceipt,
+    receiptRecorded = false,
+  ): void {
+    if (this.#pendingTimers.has(recoveryId)) return;
+    const timer = setTimeout(() => {
+      this.#pendingTimers.delete(recoveryId);
+      Promise.resolve()
+        .then(async () => {
+          if (receiptRecorded && finalizationReceipt) {
+            await this.#abortAndRevoke(
+              finalizationReceipt,
+              `rollback after ${failedStage}`,
+            );
+          } else {
+            await this.#rollback(
+              credentialId,
+              sinkRecord,
+              failedStage,
+              requiresSink,
+            );
+          }
+        })
+        .then(() =>
+          this.#completeRollback(
+            recoveryId,
+            credentialId,
+            sinkRecord?.reference,
+          ),
+        )
+        .catch((cause) => {
+          try {
+            this.#onBackgroundError?.(
+              cause instanceof CustodyError
+                ? cause
+                : new CustodyError(
+                    'CUSTODY_ROLLBACK_FAILED',
+                    'revoke',
+                    'Credential rollback retry failed',
+                    { cause },
+                  ),
+            );
+          } catch {
+            // Observability hooks must never interrupt cleanup retry.
+          } finally {
+            this.#scheduleRollback(
+              recoveryId,
+              credentialId,
+              sinkRecord,
+              failedStage,
+              requiresSink,
+              finalizationReceipt,
+              receiptRecorded,
+            );
+          }
+        });
+    }, this.#ephemeralRevokeRetryMs);
+    this.#pendingTimers.set(recoveryId, timer);
+    timer.unref?.();
+  }
+
+  #scheduleRetirement(
+    recoveryId: string,
+    receipt: CustodyReceipt,
+    replacementReceiptId?: string,
+  ): void {
+    if (this.#pendingTimers.has(recoveryId)) return;
+    const timer = setTimeout(() => {
+      this.#pendingTimers.delete(recoveryId);
+      this.#ledger
+        .listEvents()
+        .then(async (events) => {
+          if (
+            replacementReceiptId &&
+            (!events.some(
+              (event) =>
+                event.receiptId === replacementReceiptId &&
+                event.type === 'issued',
+            ) ||
+              events.some(
+                (event) =>
+                  event.receiptId === replacementReceiptId &&
+                  ['revoked', 'expired', 'replaced'].includes(event.type),
+              ))
+          ) {
+            return;
+          }
+          await this.#revokeReceipt(
+            receipt,
+            'replacement retirement retry',
+            'replaced',
+          );
+          this.#leaseInvalidators.delete(receipt.receiptId);
+        })
+        .then(() =>
+          this.#ledger.appendEvent({
+            ...this.#event('retirement-complete', receipt.receiptId),
+            recoveryId,
+          }),
+        )
+        .catch(() =>
+          this.#scheduleRetirement(recoveryId, receipt, replacementReceiptId),
+        );
+    }, this.#ephemeralRevokeRetryMs);
+    this.#pendingTimers.set(recoveryId, timer);
+    timer.unref?.();
+  }
+
+  #scheduleReceiptExpiry(receipt: CustodyReceipt, deadline: number): void {
+    if (this.#pendingTimers.has(receipt.receiptId)) return;
+    const delay = Math.min(
+      Math.max(0, deadline - this.#now().getTime()),
+      MAX_TIMER_DELAY_MS,
+    );
+    const timer = setTimeout(() => {
+      this.#pendingTimers.delete(receipt.receiptId);
+      if (deadline > this.#now().getTime()) {
+        this.#scheduleReceiptExpiry(receipt, deadline);
+        return;
+      }
+      this.#revokeReceipt(receipt, 'restart expiry recovery', 'expired').catch(
+        () => this.#scheduleReceiptExpiry(receipt, deadline),
+      );
+    }, delay);
+    this.#pendingTimers.set(receipt.receiptId, timer);
+    timer.unref?.();
+  }
+
+  #scheduleFinalizationTakeover(recoveryId: string, deadline: number): void {
+    if (this.#pendingTimers.has(recoveryId)) return;
+    const timer = setTimeout(
+      () => {
+        this.#pendingTimers.delete(recoveryId);
+        this.recoverPendingRollbacks().catch((cause) => {
+          try {
+            this.#onBackgroundError?.(
+              cause instanceof CustodyError
+                ? cause
+                : new CustodyError(
+                    'PENDING_ROLLBACK_RECOVERY_FAILED',
+                    'revoke',
+                    'Finalization takeover recovery failed',
+                    { cause },
+                  ),
+            );
+          } catch {
+            // Observability cannot interrupt takeover recovery.
+          }
+        });
+      },
+      Math.min(
+        Math.max(0, deadline - this.#now().getTime()),
+        MAX_TIMER_DELAY_MS,
+      ),
+    );
+    this.#pendingTimers.set(recoveryId, timer);
+    timer.unref?.();
+  }
+
+  async #completeRollback(
+    recoveryId: string,
+    credentialId: string,
+    sinkReference?: string,
+  ): Promise<void> {
+    await this.#ledger.appendEvent({
+      ...this.#event(
+        'rollback-complete',
+        undefined,
+        sinkReference,
+        'credential rollback completed',
+      ),
+      recoveryId,
+      credentialId,
+    });
+  }
+
+  async #appendEventEventually(event: CustodyEvent): Promise<void> {
+    try {
+      await this.#ledger.appendEvent(event);
+    } catch (cause) {
+      const recoveryId = `event-${event.eventId}`;
+      if (this.#pendingTimers.has(recoveryId)) return;
+      const timer = setTimeout(() => {
+        this.#pendingTimers.delete(recoveryId);
+        this.#appendEventEventually(event).catch(() => undefined);
+      }, this.#ephemeralRevokeRetryMs);
+      this.#pendingTimers.set(recoveryId, timer);
+      try {
+        this.#onBackgroundError?.(
+          new CustodyError(
+            'CUSTODY_EVENT_RECORD_FAILED',
+            'record',
+            'Custody terminal event recording is pending retry',
+            { cause },
+          ),
+        );
+      } catch {
+        // Observability hooks must never interrupt event retry.
+      }
+    }
+  }
+
+  async #findReceipt(receiptId: string): Promise<CustodyReceipt> {
+    assertSafeIdentifier(receiptId, 'receiptId', 'record');
+    const receipt = (await this.#ledger.listReceipts()).find(
+      (candidate) => candidate.receiptId === receiptId,
+    );
+    if (!receipt) {
+      throw new CustodyError(
+        'CUSTODY_RECEIPT_NOT_FOUND',
+        'record',
+        'Custody receipt was not found',
+      );
+    }
+    return receipt;
+  }
+
+  #event(
+    type: CustodyEventType,
+    receiptId?: string,
+    sinkReference?: string,
+    reason?: string,
+  ): CustodyEvent {
+    return {
+      eventId: randomUUID(),
+      type,
+      occurredAt: this.#now().toISOString(),
+      ...(receiptId ? { receiptId } : {}),
+      ...(sinkReference ? { sinkReference } : {}),
+      ...(reason ? { reason: redactCredentialText(reason) } : {}),
+    };
+  }
+}
+
+export async function withEnvironmentSecret(
+  material: SecretMaterial,
+  variableName: string,
+  operation: () => void | Promise<void>,
+  bounds?: { expiresAt?: string },
+): Promise<void> {
+  if (!ENVIRONMENT_VARIABLE.test(variableName)) {
+    throw new CustodyError(
+      'INVALID_ENVIRONMENT_VARIABLE',
+      'inject',
+      'Environment variable name is invalid',
+    );
+  }
+  if (bounds?.expiresAt) {
+    parseTimestamp(bounds.expiresAt, 'expiresAt', 'inject');
+    throw new CustodyError(
+      'EXPIRING_ENVIRONMENT_CALLBACK_UNSAFE',
+      'inject',
+      'Expiring credentials require bounded child-process injection',
+    );
+  }
+  await withEnvironmentLock(async () => {
+    const existed = Object.hasOwn(process.env, variableName);
+    const previous = process.env[variableName];
+    try {
+      await material.use(async (value) => {
+        process.env[variableName] = value;
+        await operation();
+      });
+    } catch (cause) {
+      if (cause instanceof CustodyError) throw cause;
+      throw new CustodyError(
+        'SECRET_OPERATION_FAILED',
+        'inject',
+        'Bounded secret operation failed',
+        { cause },
+      );
+    } finally {
+      if (existed) process.env[variableName] = previous;
+      else delete process.env[variableName];
+    }
+  });
+}
+
+export async function runCredentialChildProcess(
+  material: SecretMaterial,
+  options: CredentialChildProcessOptions,
+  bounds?: { expiresAt?: string },
+): Promise<CredentialChildProcessResult> {
+  if (
+    !options.command ||
+    !ENVIRONMENT_VARIABLE.test(options.environmentVariable)
+  ) {
+    throw new CustodyError(
+      'INVALID_CHILD_PROCESS_OPTIONS',
+      'inject',
+      'Credential child-process options are invalid',
+    );
+  }
+  if (process.platform === 'win32') {
+    throw new CustodyError(
+      'CREDENTIAL_CHILD_PROCESS_UNSUPPORTED',
+      'inject',
+      'Credential child-process group custody is unavailable on this platform',
+    );
+  }
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const maxOutputBytes = options.maxOutputBytes ?? 1024 * 1024;
+  if (
+    !Number.isFinite(timeoutMs) ||
+    !Number.isFinite(maxOutputBytes) ||
+    timeoutMs <= 0 ||
+    timeoutMs > MAX_TIMER_DELAY_MS ||
+    maxOutputBytes <= 0
+  ) {
+    throw new CustodyError(
+      'INVALID_CHILD_PROCESS_BOUNDS',
+      'inject',
+      'Credential child-process bounds must be positive',
+    );
+  }
+
+  let result: CredentialChildProcessResult | undefined;
+  await material.use(async (secret) => {
+    const expiryLimit = bounds?.expiresAt
+      ? parseTimestamp(bounds.expiresAt, 'expiresAt', 'inject') - Date.now()
+      : Number.POSITIVE_INFINITY;
+    const effectiveTimeout = Math.min(timeoutMs, expiryLimit);
+    if (effectiveTimeout <= 0) {
+      throw new CustodyError(
+        'CREDENTIAL_EXPIRED',
+        'inject',
+        'Credential expired before child-process launch',
+      );
+    }
+
+    const childEnvironment = await withEnvironmentLock(() => ({
+      ...process.env,
+      ...options.environment,
+      [options.environmentVariable]: secret,
+    }));
+    result = await new Promise<CredentialChildProcessResult>(
+      (resolve, reject) => {
+        const child = spawn(options.command, [...(options.args ?? [])], {
+          cwd: options.cwd,
+          detached: true,
+          env: childEnvironment,
+          shell: false,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const stdout: Buffer[] = [];
+        const stderr: Buffer[] = [];
+        let outputBytes = 0;
+        let outputExceeded = false;
+        let timedOut = false;
+        let settled = false;
+        let escalationTimer: ReturnType<typeof setTimeout> | undefined;
+
+        const terminateGroup = (signal: NodeJS.Signals): void => {
+          if (child.pid) {
+            try {
+              process.kill(-child.pid, signal);
+              return;
+            } catch {
+              // The group may already have exited; use the child handle.
+            }
+          }
+          child.kill(signal);
+        };
+        const beginTermination = (): void => {
+          terminateGroup('SIGTERM');
+          if (!escalationTimer) {
+            escalationTimer = setTimeout(() => {
+              escalationTimer = undefined;
+              terminateGroup('SIGKILL');
+            }, 1_000);
+            escalationTimer.unref?.();
+          }
+        };
+        const timer = setTimeout(() => {
+          timedOut = true;
+          beginTermination();
+        }, effectiveTimeout);
+        timer.unref?.();
+
+        const capture =
+          (target: Buffer[]) =>
+          (chunk: Buffer): void => {
+            outputBytes += chunk.length;
+            if (outputBytes > maxOutputBytes) {
+              timedOut = true;
+              outputExceeded = true;
+              target.length = 0;
+              beginTermination();
+              return;
+            }
+            if (outputExceeded) return;
+            target.push(Buffer.from(chunk));
+          };
+        child.stdout.on('data', capture(stdout));
+        child.stderr.on('data', capture(stderr));
+        child.once('error', () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (escalationTimer) clearTimeout(escalationTimer);
+          terminateGroup('SIGKILL');
+          reject(
+            new CustodyError(
+              'CREDENTIAL_CHILD_PROCESS_FAILED',
+              'inject',
+              'Credential child process could not start',
+            ),
+          );
+        });
+        child.once('close', (exitCode, signal) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (escalationTimer) clearTimeout(escalationTimer);
+          // The leader may have exited while descendants retained the secret.
+          // Kill the original process group before returning any output.
+          terminateGroup('SIGTERM');
+          terminateGroup('SIGKILL');
+          resolve({
+            exitCode,
+            signal,
+            stdout: outputExceeded
+              ? REDACTED
+              : redactCredentialText(Buffer.concat(stdout).toString('utf8'), [
+                  secret,
+                ]),
+            stderr: outputExceeded
+              ? REDACTED
+              : redactCredentialText(Buffer.concat(stderr).toString('utf8'), [
+                  secret,
+                ]),
+            timedOut,
+          });
+        });
+      },
+    );
+  });
+
+  if (!result) {
+    throw new CustodyError(
+      'CREDENTIAL_CHILD_PROCESS_FAILED',
+      'inject',
+      'Credential child process did not return a result',
+    );
+  }
+  return result;
+}
+
+export async function verifyCustodyReceiptAttestation(
+  receipt: CustodyReceipt,
+  material: SecretMaterial,
+  publicKey: KeyObject,
+): Promise<boolean> {
+  if (
+    receipt.attestation.algorithm !== 'Ed25519' ||
+    publicKey.type !== 'public' ||
+    publicKey.asymmetricKeyType !== 'ed25519' ||
+    !/^[A-Za-z0-9_-]{86}$/.test(receipt.attestation.signature) ||
+    Buffer.from(receipt.attestation.signature, 'base64url').byteLength !== 64 ||
+    Buffer.from(receipt.attestation.signature, 'base64url').toString(
+      'base64url',
+    ) !== receipt.attestation.signature
+  ) {
+    return false;
+  }
+  let verified = false;
+  await material.use((plaintext) => {
+    const payload = custodyAttestationPayload(
+      receipt,
+      credentialCommitment(plaintext),
+    );
+    try {
+      verified = verifyPayload(
+        null,
+        Buffer.from(payload),
+        publicKey,
+        Buffer.from(receipt.attestation.signature, 'base64url'),
+      );
+    } catch {
+      verified = false;
+    }
+  });
+  return verified;
+}
+
+export function redactCredentialText(
+  input: string,
+  knownSecrets: readonly string[] = [],
+): string {
+  let output = input;
+  for (const secret of knownSecrets.filter(Boolean)) {
+    output = output.replaceAll(secret, REDACTED);
+  }
+  for (const { pattern, replacement } of CREDENTIAL_PATTERNS) {
+    output = output.replace(pattern, replacement);
+  }
+  return output;
+}
+
+export function redactCredentialValues(
+  value: unknown,
+  knownSecrets: readonly string[] = [],
+): unknown {
+  if (value instanceof SecretMaterial) return REDACTED;
+  if (typeof value === 'string') {
+    return redactCredentialText(value, knownSecrets);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactCredentialValues(entry, knownSecrets));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        redactCredentialText(key, knownSecrets),
+        redactCredentialValues(entry, knownSecrets),
+      ]),
+    );
+  }
+  return value;
+}
+
+async function sanitizeCustodyCause(
+  cause: unknown,
+  materials: ReadonlyArray<SecretMaterial | undefined>,
+): Promise<unknown> {
+  if (!(cause instanceof CustodyError)) return cause;
+  const knownSecrets: string[] = [];
+  for (const material of materials) {
+    if (!material || material.destroyed) continue;
+    await material.use((value) => {
+      knownSecrets.push(value);
+    });
+  }
+  const safeCode =
+    redactCredentialText(cause.code, knownSecrets) === cause.code
+      ? cause.code
+      : 'INVALID_CUSTODY_ERROR_CODE';
+  return new CustodyError(
+    safeCode,
+    cause.stage,
+    redactCredentialText(cause.message, knownSecrets),
+    cause.details
+      ? {
+          details: redactCredentialValues(
+            cause.details,
+            knownSecrets,
+          ) as Record<string, unknown>,
+        }
+      : undefined,
+  );
+}
+
+function credentialCommitment(plaintext: string): string {
+  return createHash('sha256').update(plaintext).digest('base64url');
+}
+
+function custodyAttestationPayload(
+  receipt: Omit<CustodyReceipt, 'attestation'> | CustodyReceipt,
+  commitment: string,
+  identity?: Omit<CustodyReceiptAttestation, 'signature'>,
+): string {
+  const { attestation, ...unsigned } = receipt as CustodyReceipt;
+  return JSON.stringify(
+    canonicalize({
+      schema: 'happyvertical.credential-custody-attestation.v1',
+      receipt: unsigned,
+      attestation: identity ?? {
+        algorithm: attestation.algorithm,
+        attestor: attestation.attestor,
+        keyId: attestation.keyId,
+      },
+      credentialCommitment: commitment,
+    }),
+  );
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  return value;
+}
+
+function assertAttribution(attribution: CustodyAttribution): void {
+  assertSafeIdentifier(attribution.actor, 'attribution.actor', 'issue');
+  assertSafeIdentifier(attribution.runtime, 'attribution.runtime', 'issue');
+  assertSafeIdentifier(attribution.session, 'attribution.session', 'issue');
+}
+
+function assertSinkRecord(record: SecretSinkRecord, sinkName: string): void {
+  if (record.sinkName !== sinkName) {
+    throw new CustodyError(
+      'SINK_IDENTITY_MISMATCH',
+      'store',
+      'Secret sink returned a mismatched identity',
+    );
+  }
+  assertSafeIdentifier(record.sinkName, 'sinkName', 'store');
+  assertSafeIdentifier(record.reference, 'sinkReference', 'store');
+  assertSafeIdentifier(record.version, 'sinkVersion', 'store');
+  if (!Number.isFinite(new Date(record.storedAt).getTime())) {
+    throw new CustodyError(
+      'INVALID_SINK_TIMESTAMP',
+      'store',
+      'Secret sink returned an invalid timestamp',
+    );
+  }
+}
+
+function assertSafeIdentifier(
+  value: string,
+  field: string,
+  stage: CustodyStage,
+): void {
+  if (!SAFE_IDENTIFIER.test(value) || redactCredentialText(value) !== value) {
+    throw new CustodyError(
+      'UNSAFE_CUSTODY_IDENTIFIER',
+      stage,
+      `Custody ${field} must be a non-secret identifier`,
+    );
+  }
+}
+
+function sanitizeMetadata(
+  metadata: Readonly<Record<string, string>> | undefined,
+): Readonly<Record<string, string>> {
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(metadata ?? {}).map(([key, value]) => {
+        if (redactCredentialText(key) !== key) {
+          throw new CustodyError(
+            'UNSAFE_CUSTODY_METADATA_KEY',
+            'issue',
+            'Custody metadata key must not contain credential material',
+          );
+        }
+        return [key, redactCredentialText(value)];
+      }),
+    ),
+  );
+}
+
+function parseTimestamp(
+  value: string,
+  field: string,
+  stage: CustodyStage,
+): number {
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) {
+    throw new CustodyError(
+      'INVALID_CUSTODY_TIMESTAMP',
+      stage,
+      `Custody ${field} timestamp is invalid`,
+    );
+  }
+  return timestamp;
+}
+
+function sameSinkRecord(
+  left: SecretSinkRecord,
+  right: SecretSinkRecord,
+): boolean {
+  return (
+    left.sinkName === right.sinkName &&
+    left.reference === right.reference &&
+    left.version === right.version
+  );
+}
+
+function sinkIdentity(record: SecretSinkRecord, credentialId?: string): string {
+  return [
+    record.sinkName,
+    record.reference,
+    record.version,
+    credentialId ?? '',
+  ].join('\u0000');
+}

--- a/packages/secrets/src/shared/factory.ts
+++ b/packages/secrets/src/shared/factory.ts
@@ -62,7 +62,7 @@ export function isAzureKeyVaultOptions(
  * });
  *
  * // Encrypt a secret
- * const envelope = await store.encrypt('tenant-123', 'api-key', 'sk_live_xxx');
+ * const envelope = await store.encrypt('tenant-123', 'api-key', 'synthetic-secret');
  *
  * // Decrypt
  * const decrypted = await store.decrypt('tenant-123', envelope);

--- a/scripts/secrets-git-dependency.test.mjs
+++ b/scripts/secrets-git-dependency.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const secretsDirectory = new URL('../packages/secrets/', import.meta.url);
+
+test('secrets git preparation remains package-local', async () => {
+  const manifest = JSON.parse(
+    await readFile(new URL('package.json', secretsDirectory), 'utf8'),
+  );
+  const workspace = await readFile(
+    new URL('pnpm-workspace.yaml', secretsDirectory),
+    'utf8',
+  );
+
+  assert.equal(
+    manifest.scripts.prepare,
+    'node scripts/prepare-git-dependency.mjs',
+  );
+  assert.equal(
+    workspace,
+    "packages:\n  - '.'\n  - '../sql'\n  - '../utils'\n",
+  );
+
+  const projects = JSON.parse(
+    execFileSync(
+      'pnpm',
+      [
+        '--dir',
+        fileURLToPath(secretsDirectory),
+        'list',
+        '--recursive',
+        '--depth',
+        '-1',
+        '--json',
+      ],
+      { encoding: 'utf8' },
+    ),
+  );
+  assert.deepEqual(
+    projects.map(({ name }) => name).sort(),
+    ['@happyvertical/secrets', '@happyvertical/sql', '@happyvertical/utils'],
+  );
+});


### PR DESCRIPTION
Closes #1202

## Summary
- add provider-neutral ephemeral/durable credential custody with Warden/SOPS-compatible sink adapters
- add Ed25519-attested non-secret receipts and staged prepare/commit/abort/status activation
- add durable rollback, rotation, retirement, orphan, expiry, and restart recovery
- add bounded environment/child injection and credential redaction
- close review recovery gaps for ambiguous finalization, exact sink identity, and child cleanup failure
- keep git-subdirectory preparation package-local to secrets, sql, and utils

## Validation
- Node 24.18: `pnpm --filter @happyvertical/secrets test` (108/108)
- `pnpm build` (32/32), `pnpm typecheck` (20/20), `pnpm lint`
- `pnpm test:ci-scripts` (36/36), `pnpm agent:check`
- clean exact-SHA git consumer under Work CI registry layeringn- final exact-head review-cycle clean

Coordinates happyvertical/happyvertical.com#240 and its #164 credential provisioning path. No Work-specific endpoints or scopes are included.

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-01a0012c-sdk1202-ci7","issue":1202,"policy_revision":"1.0.0","status":"complete","validation":["Node 24 secrets 108/108","CI scripts 36/36","build 32/32","typecheck 20/20","lint","exact git consumer","exact-head review-cycle clean"]}