### PR TITLE
chore(ci): align SDK smoke workflow with gen24

### DIFF
--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       # cosign-installer v4 shells out to envsubst, which is not part of the
       # provider-neutral general runner contract. Download the publisher-
       # compatible cosign v3 binary directly and verify its pinned SHA-256 so


### PR DESCRIPTION
Closes #1205

Aligns only the managed diagnostic workflow with exact signed generation-24 bytes for revision-30 smoke validation.

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-sdk-1205-smoke-gen24-20260821",
  "issue": 1205,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": ["cmp signed gen24 diagnostic template", "actionlint", "git diff --check", "hv-agent audit", "pnpm test:ci-scripts", "pnpm agent:check", "pnpm typecheck", "pnpm lint", "pnpm build", "independent review"]
}